### PR TITLE
Fix unmasked git token prompt when System.console() is null

### DIFF
--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ConsoleHelper.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ConsoleHelper.java
@@ -6,8 +6,10 @@
 package ai.singlr.sing.commands;
 
 import java.io.BufferedReader;
+import java.io.Console;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
 
 /**
  * Shared utilities for interactive CLI commands — stdin reading, confirmation prompts, and
@@ -16,6 +18,8 @@ import java.nio.charset.StandardCharsets;
 final class ConsoleHelper {
 
   private static BufferedReader stdinReader;
+
+  static Supplier<Console> consoleSupplier = System::console;
 
   private ConsoleHelper() {}
 
@@ -47,18 +51,19 @@ final class ConsoleHelper {
   }
 
   /**
-   * Reads a password from the console with echo disabled. Falls back to {@link #readLine()} if
-   * {@code System.console()} is null (e.g., piped input).
+   * Reads a password from the console with echo disabled. Throws {@link
+   * EchoDisabledUnavailableException} if {@code System.console()} is null — never falls back to
+   * echoed input.
    */
   static String readPassword(String prompt) {
+    var console = consoleSupplier.get();
+    if (console == null) {
+      throw new EchoDisabledUnavailableException();
+    }
     System.out.print(prompt);
     System.out.flush();
-    var console = System.console();
-    if (console != null) {
-      var chars = console.readPassword();
-      return chars != null ? new String(chars) : null;
-    }
-    return readLine();
+    var chars = console.readPassword();
+    return chars != null ? new String(chars) : null;
   }
 
   /**

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/EchoDisabledUnavailableException.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/EchoDisabledUnavailableException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.commands;
+
+final class EchoDisabledUnavailableException extends RuntimeException {
+
+  EchoDisabledUnavailableException() {
+    super(
+        "Cannot read secret with echo disabled (System.console() is unavailable). "
+            + "This can happen when running sing through certain SSH thin clients "
+            + "or non-TTY environments. "
+            + "Provide the secret non-interactively instead.");
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectCreateCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectCreateCommand.java
@@ -242,10 +242,19 @@ public final class ProjectCreateCommand implements Runnable {
     }
 
     for (var host : missingHosts) {
-      var prompted =
-          ConsoleHelper.readPassword("  Git access token for " + host + " (blank to skip): ");
-      if (prompted != null && !prompted.isBlank()) {
-        tokens.put(host, prompted);
+      try {
+        var prompted =
+            ConsoleHelper.readPassword("  Git access token for " + host + " (blank to skip): ");
+        if (prompted != null && !prompted.isBlank()) {
+          tokens.put(host, prompted);
+        }
+      } catch (EchoDisabledUnavailableException e) {
+        throw new IllegalArgumentException(
+            "Unable to read git access token interactively in this terminal.\n\n"
+                + "Provide the token via one of:\n"
+                + "  --git-token <token>\n"
+                + "  GITHUB_TOKEN environment variable\n\n"
+                + "Then re-run: sing project create <name>");
       }
     }
 

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectPullCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectPullCommand.java
@@ -280,12 +280,21 @@ public final class ProjectPullCommand implements Runnable {
     if (envToken != null && !envToken.isBlank()) {
       return envToken;
     }
-    var prompted =
-        ConsoleHelper.readPassword("  GitHub personal access token (needs 'repo' scope): ");
-    if (prompted == null || prompted.isBlank()) {
+    try {
+      var prompted =
+          ConsoleHelper.readPassword("  GitHub personal access token (needs 'repo' scope): ");
+      if (prompted == null || prompted.isBlank()) {
+        throw new IllegalArgumentException(
+            "GitHub token required. Pass --github-token, set GITHUB_TOKEN, or enter interactively.");
+      }
+      return prompted;
+    } catch (EchoDisabledUnavailableException e) {
       throw new IllegalArgumentException(
-          "GitHub token required. Pass --github-token, set GITHUB_TOKEN, or enter interactively.");
+          "Unable to read GitHub token interactively in this terminal.\n\n"
+              + "Provide the token via one of:\n"
+              + "  --github-token <token>\n"
+              + "  GITHUB_TOKEN environment variable\n\n"
+              + "Then re-run: sing project pull <name>");
     }
-    return prompted;
   }
 }

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectPushCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectPushCommand.java
@@ -238,12 +238,21 @@ public final class ProjectPushCommand implements Runnable {
     if (envToken != null && !envToken.isBlank()) {
       return envToken;
     }
-    var prompted =
-        ConsoleHelper.readPassword("  GitHub personal access token (needs 'repo' scope): ");
-    if (prompted == null || prompted.isBlank()) {
+    try {
+      var prompted =
+          ConsoleHelper.readPassword("  GitHub personal access token (needs 'repo' scope): ");
+      if (prompted == null || prompted.isBlank()) {
+        throw new IllegalArgumentException(
+            "GitHub token required. Pass --github-token, set GITHUB_TOKEN, or enter interactively.");
+      }
+      return prompted;
+    } catch (EchoDisabledUnavailableException e) {
       throw new IllegalArgumentException(
-          "GitHub token required. Pass --github-token, set GITHUB_TOKEN, or enter interactively.");
+          "Unable to read GitHub token interactively in this terminal.\n\n"
+              + "Provide the token via one of:\n"
+              + "  --github-token <token>\n"
+              + "  GITHUB_TOKEN environment variable\n\n"
+              + "Then re-run: sing project push <name>");
     }
-    return prompted;
   }
 }

--- a/sing-infra/src/test/java/ai/singlr/sing/commands/ConsoleHelperTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/commands/ConsoleHelperTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.commands;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class ConsoleHelperTest {
+
+  @AfterEach
+  void restoreConsoleSupplier() {
+    ConsoleHelper.consoleSupplier = System::console;
+  }
+
+  @Test
+  void readPasswordThrowsWhenConsoleIsNull() {
+    ConsoleHelper.consoleSupplier = () -> null;
+
+    var ex =
+        assertThrows(
+            EchoDisabledUnavailableException.class, () -> ConsoleHelper.readPassword("Token: "));
+
+    assertTrue(ex.getMessage().contains("System.console() is unavailable"));
+  }
+
+  @Test
+  void readPasswordNeverFallsBackToEchoedInput() {
+    ConsoleHelper.consoleSupplier = () -> null;
+
+    assertThrows(
+        EchoDisabledUnavailableException.class, () -> ConsoleHelper.readPassword("Secret: "));
+  }
+}


### PR DESCRIPTION
readPassword() silently fell back to echoed readLine() when System.console() returned null (SSH thin clients, non-TTY envs), leaking secrets to the terminal. Now throws
EchoDisabledUnavailableException instead, and all three callers (ProjectCreateCommand, ProjectPushCommand, ProjectPullCommand) catch it with actionable messages pointing to --git-token / --github-token and GITHUB_TOKEN env var.