### PR TITLE
Auto-install Node.js when a Node-dependent agent CLI is selected

### DIFF
--- a/sing-core/src/main/java/ai/singlr/sing/config/SingYaml.java
+++ b/sing-core/src/main/java/ai/singlr/sing/config/SingYaml.java
@@ -399,6 +399,60 @@ public record SingYaml(
     }
   }
 
+  /** Returns a copy of this config with Node.js added to the runtimes. */
+  public SingYaml withNodeRuntime(String nodeVersion) {
+    var newRuntimes =
+        runtimes != null
+            ? new Runtimes(runtimes.jdk(), nodeVersion, runtimes.maven())
+            : new Runtimes(0, nodeVersion, null);
+    return new SingYaml(
+        name,
+        description,
+        resources,
+        image,
+        packages,
+        newRuntimes,
+        git,
+        repos,
+        services,
+        processes,
+        agent,
+        agentContext,
+        ssh);
+  }
+
+  /** Returns a copy of this config with the agent install list replaced. */
+  public SingYaml withAgentInstall(List<String> install) {
+    var newAgent =
+        new Agent(
+            agent.type(),
+            agent.autoBranch(),
+            agent.branchPrefix(),
+            agent.autoSnapshot(),
+            install,
+            agent.config(),
+            agent.guardrails(),
+            agent.specsDir(),
+            agent.securityAudit(),
+            agent.codeReview(),
+            agent.notifications(),
+            agent.methodology());
+    return new SingYaml(
+        name,
+        description,
+        resources,
+        image,
+        packages,
+        runtimes,
+        git,
+        repos,
+        services,
+        processes,
+        newAgent,
+        agentContext,
+        ssh);
+  }
+
   /** Returns the SSH username from config, defaulting to "dev". */
   public String sshUser() {
     return ssh != null && ssh.user() != null ? ssh.user() : "dev";

--- a/sing-core/src/main/java/ai/singlr/sing/engine/AgentCli.java
+++ b/sing-core/src/main/java/ai/singlr/sing/engine/AgentCli.java
@@ -78,6 +78,15 @@ public enum AgentCli {
     return method == InstallMethod.NPM;
   }
 
+  /** Human-readable display name including the package identifier. */
+  public String displayName() {
+    return switch (this) {
+      case CLAUDE_CODE -> "Claude Code";
+      case CODEX -> "Codex CLI (@openai/codex)";
+      case GEMINI -> "Gemini CLI (@google/gemini-cli)";
+    };
+  }
+
   /**
    * Returns the shell command fragment for headless (non-interactive) task execution. The task is
    * read from the given file path inside the container via {@code $(cat ...)}.

--- a/sing-core/src/main/java/ai/singlr/sing/engine/ProjectDefaults.java
+++ b/sing-core/src/main/java/ai/singlr/sing/engine/ProjectDefaults.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.engine;
+
+/** Default values used during project provisioning. */
+public final class ProjectDefaults {
+
+  public static final String DEFAULT_NODE_VERSION = "24.14.1";
+
+  private ProjectDefaults() {}
+}

--- a/sing-core/src/test/java/ai/singlr/sing/config/SingYamlTest.java
+++ b/sing-core/src/test/java/ai/singlr/sing/config/SingYamlTest.java
@@ -682,4 +682,64 @@ class SingYamlTest {
     assertTrue(roundTripped.agent().securityAudit().enabled());
     assertEquals("codex", roundTripped.agent().securityAudit().auditor());
   }
+
+  @Test
+  void withNodeRuntimeAddsNodeToExistingRuntimes() throws Exception {
+    var yaml =
+        """
+        name: test
+        resources:
+          cpu: 2
+          memory: 4GB
+          disk: 20GB
+        runtimes:
+          jdk: 25
+          maven: "3.9.9"
+        agent:
+          type: codex
+        """;
+    var config = SingYaml.fromMap(YamlUtil.parseMap(yaml));
+
+    var updated = config.withNodeRuntime("24.14.1");
+
+    assertEquals(25, updated.runtimes().jdk());
+    assertEquals("24.14.1", updated.runtimes().node());
+    assertEquals("3.9.9", updated.runtimes().maven());
+    assertEquals("test", updated.name());
+    assertEquals("codex", updated.agent().type());
+  }
+
+  @Test
+  void withNodeRuntimeCreatesRuntimesWhenNull() {
+    var config = SingYaml.fromMap(YamlUtil.parseMap("name: test"));
+
+    var updated = config.withNodeRuntime("22.0.0");
+
+    assertNotNull(updated.runtimes());
+    assertEquals("22.0.0", updated.runtimes().node());
+    assertEquals(0, updated.runtimes().jdk());
+    assertNull(updated.runtimes().maven());
+  }
+
+  @Test
+  void withAgentInstallReplacesInstallList() throws Exception {
+    var yaml =
+        """
+        name: test
+        agent:
+          type: claude-code
+          auto_branch: true
+          install:
+            - claude-code
+            - codex
+            - gemini
+        """;
+    var config = SingYaml.fromMap(YamlUtil.parseMap(yaml));
+
+    var updated = config.withAgentInstall(java.util.List.of("claude-code"));
+
+    assertEquals(java.util.List.of("claude-code"), updated.agent().install());
+    assertEquals("claude-code", updated.agent().type());
+    assertTrue(updated.agent().autoBranch());
+  }
 }

--- a/sing-core/src/test/java/ai/singlr/sing/engine/AgentCliTest.java
+++ b/sing-core/src/test/java/ai/singlr/sing/engine/AgentCliTest.java
@@ -172,4 +172,19 @@ class AgentCliTest {
   void interactiveCommandGeminiWithoutPermissions() {
     assertEquals("gemini", AgentCli.GEMINI.interactiveCommand(false));
   }
+
+  @Test
+  void displayNameClaudeCode() {
+    assertEquals("Claude Code", AgentCli.CLAUDE_CODE.displayName());
+  }
+
+  @Test
+  void displayNameCodex() {
+    assertEquals("Codex CLI (@openai/codex)", AgentCli.CODEX.displayName());
+  }
+
+  @Test
+  void displayNameGemini() {
+    assertEquals("Gemini CLI (@google/gemini-cli)", AgentCli.GEMINI.displayName());
+  }
 }

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/NodeDependencyCheck.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/NodeDependencyCheck.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.commands;
+
+import ai.singlr.sing.config.SingYaml;
+import ai.singlr.sing.engine.AgentCli;
+import ai.singlr.sing.engine.ProjectDefaults;
+import java.util.List;
+
+/**
+ * Detects when selected agent CLIs require Node.js but Node is not in the project runtimes, and
+ * resolves the mismatch interactively before provisioning begins.
+ */
+final class NodeDependencyCheck {
+
+  sealed interface Resolution {
+    record Unchanged(SingYaml config) implements Resolution {}
+
+    record NodeAdded(SingYaml config) implements Resolution {}
+
+    record AgentsDropped(SingYaml config, List<AgentCli> dropped) implements Resolution {}
+
+    record Aborted() implements Resolution {}
+  }
+
+  private NodeDependencyCheck() {}
+
+  static List<AgentCli> findNodeDependentAgents(SingYaml config) {
+    if (config.agent() == null) {
+      return List.of();
+    }
+    var installNames = config.agent().install();
+    if (installNames == null || installNames.isEmpty()) {
+      installNames = List.of(config.agent().type());
+    }
+    return installNames.stream()
+        .map(AgentCli::fromYamlName)
+        .filter(AgentCli::requiresNode)
+        .toList();
+  }
+
+  static boolean hasNodeRuntime(SingYaml config) {
+    return config.runtimes() != null && config.runtimes().node() != null;
+  }
+
+  static Resolution resolve(SingYaml config, boolean autoAccept) {
+    var nodeAgents = findNodeDependentAgents(config);
+    if (nodeAgents.isEmpty() || hasNodeRuntime(config)) {
+      return new Resolution.Unchanged(config);
+    }
+
+    if (autoAccept) {
+      var updated = config.withNodeRuntime(ProjectDefaults.DEFAULT_NODE_VERSION);
+      System.out.println(
+          "  Node.js "
+              + ProjectDefaults.DEFAULT_NODE_VERSION
+              + " added automatically (required by "
+              + formatAgentNames(nodeAgents)
+              + ").");
+      return new Resolution.NodeAdded(updated);
+    }
+
+    System.out.println();
+    System.out.println("  The following agent CLIs require Node.js:");
+    for (var agent : nodeAgents) {
+      System.out.println("    - " + agent.displayName());
+    }
+    System.out.println();
+    System.out.println("  Node.js is not in the selected runtimes for this project.");
+
+    if (ConsoleHelper.confirm(
+        "Add Node.js " + ProjectDefaults.DEFAULT_NODE_VERSION + " to this project?")) {
+      var updated = config.withNodeRuntime(ProjectDefaults.DEFAULT_NODE_VERSION);
+      return new Resolution.NodeAdded(updated);
+    }
+
+    var droppedNames = nodeAgents.stream().map(AgentCli::displayName).toList();
+    System.out.println(
+        "  The following agents will be skipped: " + String.join(", ", droppedNames) + ".");
+
+    if (!ConsoleHelper.confirmNo("Continue without them?")) {
+      return new Resolution.Aborted();
+    }
+
+    var nodeAgentYamlNames = nodeAgents.stream().map(AgentCli::yamlName).toList();
+    var allInstall = resolveInstallList(config);
+    var filteredInstall = allInstall.stream().filter(n -> !nodeAgentYamlNames.contains(n)).toList();
+    var updated = config.withAgentInstall(filteredInstall);
+    return new Resolution.AgentsDropped(updated, nodeAgents);
+  }
+
+  static void failNonInteractive(SingYaml config) {
+    var nodeAgents = findNodeDependentAgents(config);
+    if (nodeAgents.isEmpty() || hasNodeRuntime(config)) {
+      return;
+    }
+    var agentNames = formatAgentNames(nodeAgents);
+    throw new IllegalStateException(
+        agentNames
+            + " require(s) Node.js, but Node is not in the project runtimes."
+            + "\n  Either add 'node: "
+            + ProjectDefaults.DEFAULT_NODE_VERSION
+            + "' under 'runtimes:' in sing.yaml,"
+            + "\n  or remove the Node-dependent agent(s) from 'agent.install'.");
+  }
+
+  private static List<String> resolveInstallList(SingYaml config) {
+    if (config.agent() == null) {
+      return List.of();
+    }
+    var install = config.agent().install();
+    if (install == null || install.isEmpty()) {
+      return List.of(config.agent().type());
+    }
+    return install;
+  }
+
+  private static String formatAgentNames(List<AgentCli> agents) {
+    return String.join(", ", agents.stream().map(AgentCli::displayName).toList());
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectApplyCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectApplyCommand.java
@@ -12,6 +12,7 @@ import ai.singlr.sing.engine.ContainerManager;
 import ai.singlr.sing.engine.ContainerState;
 import ai.singlr.sing.engine.NameValidator;
 import ai.singlr.sing.engine.ProjectApplier;
+import ai.singlr.sing.engine.ProjectDefaults;
 import ai.singlr.sing.engine.ProjectProvisioner;
 import ai.singlr.sing.engine.ShellExecutor;
 import ai.singlr.sing.engine.SingPaths;
@@ -78,7 +79,7 @@ public final class ProjectApplyCommand implements Runnable {
               + name
               + "/sing.yaml exists.");
     }
-    var config = SingYaml.fromMap(YamlUtil.parseFile(singYamlPath));
+    SingYaml config = SingYaml.fromMap(YamlUtil.parseFile(singYamlPath));
 
     var shell = new ShellExecutor(dryRun);
     var mgr = new ContainerManager(shell);
@@ -100,6 +101,10 @@ public final class ProjectApplyCommand implements Runnable {
           throw new IllegalStateException("Container error: " + e.message());
     }
 
+    var nodeResolution = resolveNodeDependency(config);
+    config = nodeResolution.config();
+    var installNodeVersion = nodeResolution.nodeVersionToInstall();
+
     var ansi = Ansi.AUTO;
     if (!json) {
       Banner.printBranding(System.out, ansi);
@@ -115,6 +120,12 @@ public final class ProjectApplyCommand implements Runnable {
     var totalAdded = 0;
     var totalRemoved = 0;
     var totalSkipped = 0;
+
+    if (installNodeVersion != null) {
+      var nodeResult = applier.applyNodeRuntime(name, installNodeVersion);
+      totalAdded += nodeResult.added();
+      totalSkipped += nodeResult.skipped();
+    }
 
     var warnings = applier.checkUnsupportedChanges(config);
 
@@ -186,5 +197,32 @@ public final class ProjectApplyCommand implements Runnable {
                 + " removed, "
                 + totalSkipped
                 + " skipped"));
+  }
+
+  private record ApplyNodeResolution(SingYaml config, String nodeVersionToInstall) {}
+
+  private ApplyNodeResolution resolveNodeDependency(SingYaml config) {
+    var nodeAgents = NodeDependencyCheck.findNodeDependentAgents(config);
+    if (nodeAgents.isEmpty() || NodeDependencyCheck.hasNodeRuntime(config)) {
+      return new ApplyNodeResolution(config, null);
+    }
+
+    if (json) {
+      NodeDependencyCheck.failNonInteractive(config);
+    }
+
+    var resolution = NodeDependencyCheck.resolve(config, false);
+    return switch (resolution) {
+      case NodeDependencyCheck.Resolution.Unchanged r -> new ApplyNodeResolution(r.config(), null);
+      case NodeDependencyCheck.Resolution.NodeAdded r ->
+          new ApplyNodeResolution(r.config(), ProjectDefaults.DEFAULT_NODE_VERSION);
+      case NodeDependencyCheck.Resolution.AgentsDropped r ->
+          new ApplyNodeResolution(r.config(), null);
+      case NodeDependencyCheck.Resolution.Aborted ignored -> {
+        System.out.println("  Aborted.");
+        throw new IllegalStateException(
+            "Aborted: Node-dependent agents require Node.js in the project runtimes.");
+      }
+    };
   }
 }

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectCreateCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectCreateCommand.java
@@ -100,7 +100,7 @@ public final class ProjectCreateCommand implements Runnable {
       throw new IllegalStateException(hint.toString());
     }
 
-    var config = SingYaml.fromMap(YamlUtil.parseFile(singYamlPath));
+    SingYaml config = SingYaml.fromMap(YamlUtil.parseFile(singYamlPath));
 
     if (config.name() == null || config.name().isBlank()) {
       throw new IllegalStateException("sing.yaml must have a 'name' field.");
@@ -109,6 +109,12 @@ public final class ProjectCreateCommand implements Runnable {
     if (config.resources() == null) {
       throw new IllegalStateException(
           "sing.yaml must have a 'resources' section with cpu, memory, and disk.");
+    }
+
+    if (yes || json) {
+      config = resolveNodeDependencyAuto(config);
+    } else if (!dryRun) {
+      config = resolveNodeDependencyInteractive(config);
     }
 
     var projectDir = SingPaths.projectDir(config.name());
@@ -259,6 +265,28 @@ public final class ProjectCreateCommand implements Runnable {
     }
 
     return Map.copyOf(tokens);
+  }
+
+  private SingYaml resolveNodeDependencyAuto(SingYaml config) {
+    var resolution = NodeDependencyCheck.resolve(config, true);
+    return switch (resolution) {
+      case NodeDependencyCheck.Resolution.NodeAdded r -> r.config();
+      default -> config;
+    };
+  }
+
+  private SingYaml resolveNodeDependencyInteractive(SingYaml config) {
+    var resolution = NodeDependencyCheck.resolve(config, false);
+    return switch (resolution) {
+      case NodeDependencyCheck.Resolution.Unchanged r -> r.config();
+      case NodeDependencyCheck.Resolution.NodeAdded r -> r.config();
+      case NodeDependencyCheck.Resolution.AgentsDropped r -> r.config();
+      case NodeDependencyCheck.Resolution.Aborted ignored -> {
+        System.out.println("  Aborted.");
+        throw new IllegalStateException(
+            "Aborted: Node-dependent agents require Node.js in the project runtimes.");
+      }
+    };
   }
 
   /**

--- a/sing-infra/src/main/java/ai/singlr/sing/engine/ProjectApplier.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/engine/ProjectApplier.java
@@ -124,6 +124,64 @@ public final class ProjectApplier {
     return new ApplyResult(added, 0, skipped, List.of());
   }
 
+  /**
+   * Installs Node.js in the container if not already present. Used when a Node-dependent agent is
+   * added to an already-provisioned project that did not originally include Node.
+   */
+  public ApplyResult applyNodeRuntime(String name, String version)
+      throws IOException, InterruptedException, TimeoutException {
+    var check = shell.exec(rootExec(name, List.of("node", "--version")));
+    if (check.ok() && check.stdout().strip().startsWith("v" + version)) {
+      out.println("  [skip] Node.js " + version + " already installed");
+      return new ApplyResult(0, 0, 1, List.of());
+    }
+    out.println("  [add] Installing Node.js " + version + "...");
+    var majorVersion = version.contains(".") ? version.substring(0, version.indexOf('.')) : version;
+    var prereqs =
+        shell.exec(
+            rootExec(
+                name,
+                List.of("apt-get", "install", "-y", "-qq", "ca-certificates", "curl", "gnupg")),
+            null,
+            INSTALL_TIMEOUT);
+    if (!prereqs.ok()) {
+      throw new IOException("Failed to install Node.js prerequisites: " + prereqs.stderr());
+    }
+    var setup =
+        shell.exec(
+            rootExec(
+                name,
+                List.of(
+                    "bash",
+                    "-c",
+                    "curl -fsSL https://deb.nodesource.com/setup_" + majorVersion + ".x | bash -")),
+            null,
+            INSTALL_TIMEOUT);
+    if (!setup.ok()) {
+      throw new IOException(
+          "Failed to configure NodeSource repository for Node "
+              + majorVersion
+              + ": "
+              + setup.stderr());
+    }
+    var result =
+        shell.exec(
+            rootExec(name, List.of("apt-get", "install", "-y", "-qq", "nodejs")),
+            null,
+            INSTALL_TIMEOUT);
+    if (!result.ok()) {
+      throw new IOException("Failed to install Node.js " + version + ": " + result.stderr());
+    }
+    out.println("  [done] Node.js " + version + " installed");
+    return new ApplyResult(1, 0, 0, List.of());
+  }
+
+  private static List<String> rootExec(String containerName, List<String> args) {
+    var full = new java.util.ArrayList<>(List.of("incus", "exec", containerName, "--"));
+    full.addAll(args);
+    return List.copyOf(full);
+  }
+
   /** Installs missing agent CLI tools. Tools already on PATH are skipped. */
   public ApplyResult applyAgentTools(String name, List<String> install, SingYaml.Runtimes runtimes)
       throws IOException, InterruptedException, TimeoutException {
@@ -145,11 +203,11 @@ public final class ProjectApplier {
       if (tool.requiresNode()) {
         var nodeCheck = shell.exec(ContainerExec.asDevUser(name, List.of("which", "node")));
         if (!nodeCheck.ok()) {
-          throw new IOException(
-              "Agent '"
+          throw new IllegalStateException(
+              "Bug: agent '"
                   + agentName
                   + "' requires Node.js but it is not installed."
-                  + "\n  Add a 'runtimes.node' entry to sing.yaml and re-run.");
+                  + " The command layer should have resolved this before applying.");
         }
       }
       out.println("  [add] Installing agent '" + agentName + "'...");

--- a/sing-infra/src/main/java/ai/singlr/sing/engine/ProjectProvisioner.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/engine/ProjectProvisioner.java
@@ -960,11 +960,11 @@ public final class ProjectProvisioner {
       if (tool.requiresNode()) {
         var nodeCheck = execInContainer(name, List.of("which", "node"));
         if (!nodeCheck.ok()) {
-          throw new IOException(
-              "Agent CLI '"
+          throw new IllegalStateException(
+              "Bug: agent '"
                   + tool.yamlName()
                   + "' requires Node.js, but Node is not installed."
-                  + "\n  Add a 'node' version under 'runtimes:' in sing.yaml.");
+                  + " The command layer should have resolved this before provisioning.");
         }
       }
 

--- a/sing-infra/src/test/java/ai/singlr/sing/commands/NodeDependencyCheckTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/commands/NodeDependencyCheckTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.commands;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sing.config.SingYaml;
+import ai.singlr.sing.config.YamlUtil;
+import ai.singlr.sing.engine.AgentCli;
+import ai.singlr.sing.engine.ProjectDefaults;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class NodeDependencyCheckTest {
+
+  private InputStream originalStdin = System.in;
+
+  @AfterEach
+  void restoreStdin() {
+    System.setIn(originalStdin);
+  }
+
+  @Test
+  void noAgentConfigReturnsEmpty() {
+    var config = parseConfig(YAML_NO_AGENT);
+
+    var result = NodeDependencyCheck.findNodeDependentAgents(config);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void claudeCodeAloneNeverTriggersCheck() {
+    var config = parseConfig(YAML_CLAUDE_ONLY);
+
+    var result = NodeDependencyCheck.findNodeDependentAgents(config);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void claudeCodeWithNodeDoesNotTrigger() {
+    var config = parseConfig(YAML_CLAUDE_WITH_NODE);
+
+    assertTrue(NodeDependencyCheck.hasNodeRuntime(config));
+    assertTrue(NodeDependencyCheck.findNodeDependentAgents(config).isEmpty());
+  }
+
+  @Test
+  void codexWithoutNodeDetected() {
+    var config = parseConfig(YAML_CODEX_NO_NODE);
+
+    var agents = NodeDependencyCheck.findNodeDependentAgents(config);
+
+    assertEquals(1, agents.size());
+    assertEquals(AgentCli.CODEX, agents.getFirst());
+    assertFalse(NodeDependencyCheck.hasNodeRuntime(config));
+  }
+
+  @Test
+  void geminiWithoutNodeDetected() {
+    var config = parseConfig(YAML_GEMINI_NO_NODE);
+
+    var agents = NodeDependencyCheck.findNodeDependentAgents(config);
+
+    assertEquals(1, agents.size());
+    assertEquals(AgentCli.GEMINI, agents.getFirst());
+  }
+
+  @Test
+  void multipleNodeAgentsDetected() {
+    var config = parseConfig(YAML_MULTI_AGENT_NO_NODE);
+
+    var agents = NodeDependencyCheck.findNodeDependentAgents(config);
+
+    assertEquals(2, agents.size());
+    assertTrue(agents.contains(AgentCli.CODEX));
+    assertTrue(agents.contains(AgentCli.GEMINI));
+  }
+
+  @Test
+  void codexWithNodeReturnsUnchanged() {
+    var config = parseConfig(YAML_CODEX_WITH_NODE);
+
+    var resolution = NodeDependencyCheck.resolve(config, false);
+
+    assertInstanceOf(NodeDependencyCheck.Resolution.Unchanged.class, resolution);
+  }
+
+  @Test
+  void autoAcceptAddsNode() {
+    var config = parseConfig(YAML_CODEX_NO_NODE);
+
+    var resolution = NodeDependencyCheck.resolve(config, true);
+
+    assertInstanceOf(NodeDependencyCheck.Resolution.NodeAdded.class, resolution);
+    var added = (NodeDependencyCheck.Resolution.NodeAdded) resolution;
+    assertEquals(ProjectDefaults.DEFAULT_NODE_VERSION, added.config().runtimes().node());
+  }
+
+  @Test
+  void interactiveAcceptAddsNode() {
+    simulateStdin("y\n");
+    var config = parseConfig(YAML_CODEX_NO_NODE);
+
+    var resolution = NodeDependencyCheck.resolve(config, false);
+
+    assertInstanceOf(NodeDependencyCheck.Resolution.NodeAdded.class, resolution);
+    var added = (NodeDependencyCheck.Resolution.NodeAdded) resolution;
+    assertEquals(ProjectDefaults.DEFAULT_NODE_VERSION, added.config().runtimes().node());
+  }
+
+  @Test
+  void interactiveDeclineThenAcceptDropsAgents() {
+    simulateStdin("n\ny\n");
+    var config = parseConfig(YAML_CODEX_NO_NODE);
+
+    var resolution = NodeDependencyCheck.resolve(config, false);
+
+    assertInstanceOf(NodeDependencyCheck.Resolution.AgentsDropped.class, resolution);
+    var dropped = (NodeDependencyCheck.Resolution.AgentsDropped) resolution;
+    assertEquals(List.of(AgentCli.CODEX), dropped.dropped());
+    assertNull(dropped.config().runtimes().node());
+  }
+
+  @Test
+  void interactiveDeclineBothAborts() {
+    simulateStdin("n\nn\n");
+    var config = parseConfig(YAML_CODEX_NO_NODE);
+
+    var resolution = NodeDependencyCheck.resolve(config, false);
+
+    assertInstanceOf(NodeDependencyCheck.Resolution.Aborted.class, resolution);
+  }
+
+  @Test
+  void failNonInteractiveThrowsWhenMismatch() {
+    var config = parseConfig(YAML_CODEX_NO_NODE);
+
+    var ex =
+        assertThrows(
+            IllegalStateException.class, () -> NodeDependencyCheck.failNonInteractive(config));
+
+    assertTrue(ex.getMessage().contains("Node.js"));
+    assertTrue(ex.getMessage().contains(ProjectDefaults.DEFAULT_NODE_VERSION));
+  }
+
+  @Test
+  void failNonInteractiveDoesNothingWhenNoMismatch() {
+    var config = parseConfig(YAML_CODEX_WITH_NODE);
+
+    assertDoesNotThrow(() -> NodeDependencyCheck.failNonInteractive(config));
+  }
+
+  @Test
+  void withNodeRuntimePreservesExistingRuntimes() {
+    var config = parseConfig(YAML_CODEX_NO_NODE);
+    var updated = config.withNodeRuntime("22.0.0");
+
+    assertEquals(25, updated.runtimes().jdk());
+    assertEquals("22.0.0", updated.runtimes().node());
+  }
+
+  @Test
+  void withAgentInstallFiltersAgents() {
+    var config = parseConfig(YAML_MULTI_AGENT_NO_NODE);
+    var updated = config.withAgentInstall(List.of("claude-code"));
+
+    assertEquals(List.of("claude-code"), updated.agent().install());
+    assertEquals("claude-code", updated.agent().type());
+  }
+
+  @Test
+  void defaultInstallListUsesAgentType() {
+    var config = parseConfig(YAML_CODEX_DEFAULT_INSTALL);
+
+    var agents = NodeDependencyCheck.findNodeDependentAgents(config);
+
+    assertEquals(1, agents.size());
+    assertEquals(AgentCli.CODEX, agents.getFirst());
+  }
+
+  private void simulateStdin(String input) {
+    System.setIn(new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
+    try {
+      var field = ConsoleHelper.class.getDeclaredField("stdinReader");
+      field.setAccessible(true);
+      field.set(null, null);
+    } catch (Exception ignored) {
+    }
+  }
+
+  private static SingYaml parseConfig(String yaml) {
+    return SingYaml.fromMap(YamlUtil.parseMap(yaml));
+  }
+
+  private static final String YAML_NO_AGENT =
+      """
+      name: test
+      resources:
+        cpu: 2
+        memory: 4GB
+        disk: 20GB
+      """;
+
+  private static final String YAML_CLAUDE_ONLY =
+      """
+      name: test
+      resources:
+        cpu: 2
+        memory: 4GB
+        disk: 20GB
+      agent:
+        type: claude-code
+      """;
+
+  private static final String YAML_CLAUDE_WITH_NODE =
+      """
+      name: test
+      resources:
+        cpu: 2
+        memory: 4GB
+        disk: 20GB
+      runtimes:
+        node: "22.0.0"
+      agent:
+        type: claude-code
+      """;
+
+  private static final String YAML_CODEX_NO_NODE =
+      """
+      name: test
+      resources:
+        cpu: 2
+        memory: 4GB
+        disk: 20GB
+      runtimes:
+        jdk: 25
+      agent:
+        type: codex
+        install:
+          - codex
+      """;
+
+  private static final String YAML_CODEX_DEFAULT_INSTALL =
+      """
+      name: test
+      resources:
+        cpu: 2
+        memory: 4GB
+        disk: 20GB
+      agent:
+        type: codex
+      """;
+
+  private static final String YAML_GEMINI_NO_NODE =
+      """
+      name: test
+      resources:
+        cpu: 2
+        memory: 4GB
+        disk: 20GB
+      agent:
+        type: gemini
+        install:
+          - gemini
+      """;
+
+  private static final String YAML_MULTI_AGENT_NO_NODE =
+      """
+      name: test
+      resources:
+        cpu: 2
+        memory: 4GB
+        disk: 20GB
+      runtimes:
+        jdk: 25
+      agent:
+        type: claude-code
+        install:
+          - claude-code
+          - codex
+          - gemini
+      """;
+
+  private static final String YAML_CODEX_WITH_NODE =
+      """
+      name: test
+      resources:
+        cpu: 2
+        memory: 4GB
+        disk: 20GB
+      runtimes:
+        jdk: 25
+        node: "24.14.1"
+      agent:
+        type: codex
+        install:
+          - codex
+      """;
+}

--- a/sing-infra/src/test/java/ai/singlr/sing/engine/ProjectProvisionerTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/engine/ProjectProvisionerTest.java
@@ -1926,11 +1926,10 @@ class ProjectProvisionerTest {
 
     var ex =
         assertThrows(
-            IOException.class,
+            IllegalStateException.class,
             () -> provisioner.provision(configWithCodex, hostYaml(), null, null));
     assertTrue(ex.getMessage().contains("requires Node.js"));
     assertTrue(ex.getMessage().contains("codex"));
-    assertEquals("AGENT_TOOLS_INSTALLED", tracker.currentState().error().failedPhase());
   }
 
   @Test


### PR DESCRIPTION
Detect when selected agent CLIs (Codex, Gemini) require Node.js but Node is not in the project runtimes. Prompt the user to add Node.js during `sing project create` and `sing project apply`, before any container work begins. In non-interactive/--yes mode, auto-add Node 24.14.1 and log a notice.

Also converts the late-stage IOException in ProjectProvisioner and ProjectApplier to IllegalStateException, since the command layer now guarantees config consistency before provisioning.