### PR TITLE
Add authenticated local sing API server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,35 @@
                             <goal>report</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>api-coverage-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>CLASS</element>
+                                    <includes>
+                                        <include>ai.singlr.sing.api.*</include>
+                                    </includes>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>METHOD</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/sing-infra/src/main/java/ai/singlr/sing/Sing.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/Sing.java
@@ -6,6 +6,7 @@
 package ai.singlr.sing;
 
 import ai.singlr.sing.commands.AgentCommand;
+import ai.singlr.sing.commands.ApiCommand;
 import ai.singlr.sing.commands.ClientInitCommand;
 import ai.singlr.sing.commands.ConnectCommand;
 import ai.singlr.sing.commands.DispatchCommand;
@@ -49,6 +50,7 @@ import picocli.CommandLine.Help.Ansi;
       SnapsPruneCommand.class,
       RunCommand.class,
       AgentCommand.class,
+      ApiCommand.class,
       DispatchCommand.class,
       SpecCommand.class,
       ExecCommand.class,

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ApiError.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ApiError.java
@@ -5,18 +5,23 @@
 
 package ai.singlr.sing.api;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.List;
 
-public record ApiError(String code, String message, String action) {
+public record ApiError(String code, String message, String action, List<FieldError> fieldErrors) {
+  public ApiError(String code, String message, String action) {
+    this(code, message, action, List.of());
+  }
 
-  public Map<String, Object> toMap() {
-    var map = new LinkedHashMap<String, Object>();
-    map.put("code", code);
-    map.put("message", message);
-    if (action != null && !action.isBlank()) {
-      map.put("action", action);
-    }
-    return map;
+  public ApiError {
+    action = action == null || action.isBlank() ? null : action;
+    fieldErrors = fieldErrors == null ? List.of() : List.copyOf(fieldErrors);
+  }
+
+  static ApiError from(Result.Failure<?> failure) {
+    return new ApiError(
+        failure.errorCode().code(),
+        failure.errorMessage(),
+        failure.action(),
+        failure.fieldErrors());
   }
 }

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ApiError.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ApiError.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public record ApiError(String code, String message, String action) {
+
+  public Map<String, Object> toMap() {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("code", code);
+    map.put("message", message);
+    if (action != null && !action.isBlank()) {
+      map.put("action", action);
+    }
+    return map;
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ApiException.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ApiException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+public final class ApiException extends RuntimeException {
+
+  private final int status;
+  private final ApiError error;
+
+  public ApiException(int status, String code, String message, String action) {
+    super(message);
+    this.status = status;
+    this.error = new ApiError(code, message, action);
+  }
+
+  public int status() {
+    return status;
+  }
+
+  public ApiError error() {
+    return error;
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ApiException.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ApiException.java
@@ -7,20 +7,34 @@ package ai.singlr.sing.api;
 
 public final class ApiException extends RuntimeException {
 
-  private final int status;
-  private final ApiError error;
+  private final Result.Failure<?> failure;
 
-  public ApiException(int status, String code, String message, String action) {
-    super(message);
-    this.status = status;
-    this.error = new ApiError(code, message, action);
+  public ApiException(ErrorCode errorCode, String message) {
+    this(errorCode, message, null, null);
+  }
+
+  public ApiException(ErrorCode errorCode, String message, String action) {
+    this(errorCode, message, action, null);
+  }
+
+  public ApiException(ErrorCode errorCode, String message, Throwable cause) {
+    this(errorCode, message, null, cause);
+  }
+
+  private ApiException(ErrorCode errorCode, String message, String action, Throwable cause) {
+    super(message, cause);
+    failure = new Result.Failure<>(errorCode, message, action, null, cause);
   }
 
   public int status() {
-    return status;
+    return failure.errorCode().httpCode();
   }
 
   public ApiError error() {
-    return error;
+    return ApiError.from(failure);
+  }
+
+  public Result.Failure<?> failure() {
+    return failure;
   }
 }

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ApiJson.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ApiJson.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import java.lang.reflect.RecordComponent;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class ApiJson {
+
+  private ApiJson() {}
+
+  static Map<String, Object> withSchema(Object value) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("schema_version", 1);
+    var encoded = encode(value);
+    if (encoded instanceof Map<?, ?> encodedMap) {
+      for (var entry : encodedMap.entrySet()) {
+        map.put(entry.getKey().toString(), entry.getValue());
+      }
+      return map;
+    }
+    map.put("data", encoded);
+    return map;
+  }
+
+  @SuppressWarnings("unchecked")
+  static Object encode(Object value) {
+    return switch (value) {
+      case null -> null;
+      case String ignored -> value;
+      case Number ignored -> value;
+      case Boolean ignored -> value;
+      case Enum<?> enumValue -> enumValue.name().toLowerCase();
+      case List<?> list -> list.stream().map(ApiJson::encode).toList();
+      case Map<?, ?> map -> encodeMap((Map<Object, Object>) map);
+      default -> value.getClass().isRecord() ? encodeRecord(value) : value.toString();
+    };
+  }
+
+  private static Map<String, Object> encodeMap(Map<Object, Object> source) {
+    var map = new LinkedHashMap<String, Object>();
+    for (var entry : source.entrySet()) {
+      var value = encode(entry.getValue());
+      if (value != null) {
+        map.put(entry.getKey().toString(), value);
+      }
+    }
+    return map;
+  }
+
+  private static Map<String, Object> encodeRecord(Object record) {
+    var map = new LinkedHashMap<String, Object>();
+    for (var component : record.getClass().getRecordComponents()) {
+      var value = componentValue(record, component);
+      if (value != null) {
+        map.put(toSnakeCase(component.getName()), encode(value));
+      }
+    }
+    return map;
+  }
+
+  private static Object componentValue(Object record, RecordComponent component) {
+    try {
+      return component.getAccessor().invoke(record);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Failed to serialize API response", e);
+    }
+  }
+
+  private static String toSnakeCase(String name) {
+    var builder = new StringBuilder();
+    for (var i = 0; i < name.length(); i++) {
+      var c = name.charAt(i);
+      if (Character.isUpperCase(c)) {
+        builder.append('_').append(Character.toLowerCase(c));
+      } else {
+        builder.append(c);
+      }
+    }
+    return builder.toString();
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ApiModels.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ApiModels.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import java.util.List;
+
+record HealthResponse(String status) {}
+
+record ProjectResponse(String name, String containerStatus, AgentConfigView agent) {}
+
+record AgentConfigView(String type, boolean autoSnapshot, boolean autoBranch, String specsDir) {}
+
+record SpecsResponse(
+    String name, List<SpecView> specs, SpecSummaryView counts, BoardSummaryView summary) {}
+
+record SpecResponse(
+    String name, SpecView spec, String specPath, boolean contentAvailable, String content) {}
+
+record DispatchRequest(String specId, String mode, boolean dryRun) {
+  DispatchRequest {
+    mode = mode == null || mode.isBlank() ? "background" : mode;
+  }
+}
+
+record DispatchResponse(
+    String name,
+    boolean dispatched,
+    String reason,
+    DispatchedSpecView spec,
+    AgentStatusView agent,
+    String snapshot,
+    boolean branchCreated) {}
+
+record AgentStatusResponse(
+    String name,
+    boolean agentRunning,
+    Integer pid,
+    String task,
+    String startedAt,
+    String branch,
+    String logPath) {}
+
+record AgentLogResponse(String name, List<String> lines, String error) {}
+
+record StopAgentResponse(String name, boolean stopped, String reason, Integer pid) {}
+
+record AgentReportResponse(
+    String name,
+    String sessionStatus,
+    String startedAt,
+    String endedAt,
+    String duration,
+    String branch,
+    List<SpecView> specs,
+    int commitsSinceLaunch,
+    Long lastCommitMinutesAgo,
+    boolean guardrailTriggered,
+    String guardrailReason,
+    String guardrailAction,
+    boolean rolledBack,
+    String rollbackSnapshot) {}
+
+record SpecView(
+    String id,
+    String title,
+    String status,
+    String assignee,
+    List<String> dependsOn,
+    String branch,
+    boolean ready,
+    boolean blocked,
+    List<String> unmetDependencies) {
+  public SpecView {
+    dependsOn = dependsOn == null ? List.of() : List.copyOf(dependsOn);
+    unmetDependencies = unmetDependencies == null ? List.of() : List.copyOf(unmetDependencies);
+  }
+}
+
+record DispatchedSpecView(String id, String title, String status, String branch) {}
+
+record AgentStatusView(
+    String type,
+    String mode,
+    boolean running,
+    Integer pid,
+    String task,
+    String startedAt,
+    String branch,
+    String logPath) {}
+
+record SpecSummaryView(int pending, int inProgress, int review, int done) {}
+
+record BoardSummaryView(
+    SpecSummaryView counts, int readyCount, int blockedCount, String nextReadyId) {}
+
+record ErrorResponse(ApiError error) {}

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ApiOperations.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ApiOperations.java
@@ -5,24 +5,22 @@
 
 package ai.singlr.sing.api;
 
-import java.util.Map;
-
 public interface ApiOperations {
-  Map<String, Object> health();
+  Result<HealthResponse> health();
 
-  Map<String, Object> project(String project);
+  Result<ProjectResponse> project(String project);
 
-  Map<String, Object> specs(String project);
+  Result<SpecsResponse> specs(String project);
 
-  Map<String, Object> spec(String project, String specId);
+  Result<SpecResponse> spec(String project, String specId);
 
-  Map<String, Object> dispatch(String project, Map<String, Object> request);
+  Result<DispatchResponse> dispatch(String project, DispatchRequest request);
 
-  Map<String, Object> agentStatus(String project);
+  Result<AgentStatusResponse> agentStatus(String project);
 
-  Map<String, Object> agentLog(String project, int tail);
+  Result<AgentLogResponse> agentLog(String project, int tail);
 
-  Map<String, Object> stopAgent(String project);
+  Result<StopAgentResponse> stopAgent(String project);
 
-  Map<String, Object> agentReport(String project);
+  Result<AgentReportResponse> agentReport(String project);
 }

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ApiOperations.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ApiOperations.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import java.util.Map;
+
+public interface ApiOperations {
+  Map<String, Object> health();
+
+  Map<String, Object> project(String project);
+
+  Map<String, Object> specs(String project);
+
+  Map<String, Object> spec(String project, String specId);
+
+  Map<String, Object> dispatch(String project, Map<String, Object> request);
+
+  Map<String, Object> agentStatus(String project);
+
+  Map<String, Object> agentLog(String project, int tail);
+
+  Map<String, Object> stopAgent(String project);
+
+  Map<String, Object> agentReport(String project);
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ApiResponse.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ApiResponse.java
@@ -5,30 +5,29 @@
 
 package ai.singlr.sing.api;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 public record ApiResponse(int status, Map<String, Object> body) {
 
-  public static ApiResponse ok(Map<String, Object> body) {
-    return new ApiResponse(200, withSchema(body));
+  public static ApiResponse from(Result<?> result) {
+    return switch (result) {
+      case Result.Success<?> success ->
+          new ApiResponse(success.code(), ApiJson.withSchema(success.value()));
+      case Result.Failure<?> failure -> error(failure);
+    };
   }
 
-  public static ApiResponse created(Map<String, Object> body) {
-    return new ApiResponse(201, withSchema(body));
+  public static ApiResponse ok(Object body) {
+    return new ApiResponse(200, ApiJson.withSchema(body));
   }
 
-  public static ApiResponse error(int status, ApiError error) {
-    var body = new LinkedHashMap<String, Object>();
-    body.put("schema_version", 1);
-    body.put("error", error.toMap());
-    return new ApiResponse(status, body);
+  public static ApiResponse created(Object body) {
+    return new ApiResponse(201, ApiJson.withSchema(body));
   }
 
-  private static Map<String, Object> withSchema(Map<String, Object> source) {
-    var body = new LinkedHashMap<String, Object>();
-    body.put("schema_version", 1);
-    body.putAll(source);
-    return body;
+  public static ApiResponse error(Result.Failure<?> failure) {
+    return new ApiResponse(
+        failure.errorCode().httpCode(),
+        ApiJson.withSchema(new ErrorResponse(ApiError.from(failure))));
   }
 }

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ApiResponse.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ApiResponse.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public record ApiResponse(int status, Map<String, Object> body) {
+
+  public static ApiResponse ok(Map<String, Object> body) {
+    return new ApiResponse(200, withSchema(body));
+  }
+
+  public static ApiResponse created(Map<String, Object> body) {
+    return new ApiResponse(201, withSchema(body));
+  }
+
+  public static ApiResponse error(int status, ApiError error) {
+    var body = new LinkedHashMap<String, Object>();
+    body.put("schema_version", 1);
+    body.put("error", error.toMap());
+    return new ApiResponse(status, body);
+  }
+
+  private static Map<String, Object> withSchema(Map<String, Object> source) {
+    var body = new LinkedHashMap<String, Object>();
+    body.put("schema_version", 1);
+    body.putAll(source);
+    return body;
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ApiRouter.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ApiRouter.java
@@ -30,16 +30,22 @@ public final class ApiRouter implements HttpHandler {
       var response = route(exchange);
       write(exchange, response);
     } catch (ApiException e) {
-      write(exchange, ApiResponse.error(e.status(), e.error()));
+      write(exchange, ApiResponse.error(e.failure()));
     } catch (IllegalArgumentException e) {
       write(
-          exchange, ApiResponse.error(422, new ApiError("invalid_request", e.getMessage(), null)));
+          exchange,
+          ApiResponse.error(
+              new Result.Failure<>(ErrorCode.INVALID_REQUEST, e.getMessage(), null, null, e)));
     } catch (Exception e) {
       write(
           exchange,
           ApiResponse.error(
-              500,
-              new ApiError("internal_error", "sing API request failed.", "Check sing API logs.")));
+              new Result.Failure<>(
+                  ErrorCode.INTERNAL,
+                  "sing API request failed.",
+                  "Check sing API logs.",
+                  null,
+                  e)));
     } finally {
       exchange.close();
     }
@@ -49,7 +55,7 @@ public final class ApiRouter implements HttpHandler {
     var method = exchange.getRequestMethod();
     var path = cleanPath(exchange.getRequestURI());
     if (method.equals("GET") && path.equals("/v1/health")) {
-      return ApiResponse.ok(operations.health());
+      return ApiResponse.from(operations.health());
     }
     auth.require(exchange);
     var segments = path.substring(1).split("/");
@@ -59,42 +65,42 @@ public final class ApiRouter implements HttpHandler {
     var project = segments[2];
     NameValidator.requireValidProjectName(project);
     if (segments.length == 3 && method.equals("GET")) {
-      return ApiResponse.ok(operations.project(project));
+      return ApiResponse.from(operations.project(project));
     }
     if (segments.length == 4 && segments[3].equals("specs") && method.equals("GET")) {
-      return ApiResponse.ok(operations.specs(project));
+      return ApiResponse.from(operations.specs(project));
     }
     if (segments.length == 5 && segments[3].equals("specs") && method.equals("GET")) {
       NameValidator.requireValidSpecId(segments[4]);
-      return ApiResponse.ok(operations.spec(project, segments[4]));
+      return ApiResponse.from(operations.spec(project, segments[4]));
     }
     if (segments.length == 4 && segments[3].equals("dispatch") && method.equals("POST")) {
-      return ApiResponse.ok(operations.dispatch(project, JsonBody.read(exchange)));
+      return ApiResponse.from(operations.dispatch(project, JsonBody.readDispatchRequest(exchange)));
     }
     if (segments.length == 4 && segments[3].equals("agent") && method.equals("GET")) {
-      return ApiResponse.ok(operations.agentStatus(project));
+      return ApiResponse.from(operations.agentStatus(project));
     }
     if (segments.length == 5
         && segments[3].equals("agent")
         && segments[4].equals("log")
         && method.equals("GET")) {
-      return ApiResponse.ok(operations.agentLog(project, tail(exchange.getRequestURI())));
+      return ApiResponse.from(operations.agentLog(project, tail(exchange.getRequestURI())));
     }
     if (segments.length == 5
         && segments[3].equals("agent")
         && segments[4].equals("stop")
         && method.equals("POST")) {
-      return ApiResponse.ok(operations.stopAgent(project));
+      return ApiResponse.from(operations.stopAgent(project));
     }
     if (segments.length == 5
         && segments[3].equals("agent")
         && segments[4].equals("report")
         && method.equals("POST")) {
-      return ApiResponse.ok(operations.agentReport(project));
+      return ApiResponse.from(operations.agentReport(project));
     }
     if (knownPath(segments)) {
       throw new ApiException(
-          405, "method_not_allowed", "HTTP method is not allowed for this endpoint.", null);
+          ErrorCode.METHOD_NOT_ALLOWED, "HTTP method is not allowed for this endpoint.");
     }
     throw notFound();
   }
@@ -123,7 +129,7 @@ public final class ApiRouter implements HttpHandler {
           }
         } catch (NumberFormatException ignored) {
         }
-        throw new ApiException(422, "invalid_tail", "tail must be between 1 and 5000.", null);
+        throw new ApiException(ErrorCode.INVALID_TAIL, "tail must be between 1 and 5000.");
       }
     }
     return 200;
@@ -135,7 +141,7 @@ public final class ApiRouter implements HttpHandler {
   }
 
   private static ApiException notFound() {
-    return new ApiException(404, "not_found", "API endpoint was not found.", null);
+    return new ApiException(ErrorCode.NOT_FOUND, "API endpoint was not found.");
   }
 
   private static void write(HttpExchange exchange, ApiResponse response) throws IOException {

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ApiRouter.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ApiRouter.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import ai.singlr.sing.config.YamlUtil;
+import ai.singlr.sing.engine.NameValidator;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+
+public final class ApiRouter implements HttpHandler {
+
+  private final ApiOperations operations;
+  private final BearerAuth auth;
+
+  public ApiRouter(ApiOperations operations, BearerAuth auth) {
+    this.operations = operations;
+    this.auth = auth;
+  }
+
+  @Override
+  public void handle(HttpExchange exchange) throws IOException {
+    try {
+      var response = route(exchange);
+      write(exchange, response);
+    } catch (ApiException e) {
+      write(exchange, ApiResponse.error(e.status(), e.error()));
+    } catch (IllegalArgumentException e) {
+      write(
+          exchange, ApiResponse.error(422, new ApiError("invalid_request", e.getMessage(), null)));
+    } catch (Exception e) {
+      write(
+          exchange,
+          ApiResponse.error(
+              500,
+              new ApiError("internal_error", "sing API request failed.", "Check sing API logs.")));
+    } finally {
+      exchange.close();
+    }
+  }
+
+  ApiResponse route(HttpExchange exchange) throws IOException {
+    var method = exchange.getRequestMethod();
+    var path = cleanPath(exchange.getRequestURI());
+    if (method.equals("GET") && path.equals("/v1/health")) {
+      return ApiResponse.ok(operations.health());
+    }
+    auth.require(exchange);
+    var segments = path.substring(1).split("/");
+    if (segments.length < 3 || !segments[0].equals("v1") || !segments[1].equals("projects")) {
+      throw notFound();
+    }
+    var project = segments[2];
+    NameValidator.requireValidProjectName(project);
+    if (segments.length == 3 && method.equals("GET")) {
+      return ApiResponse.ok(operations.project(project));
+    }
+    if (segments.length == 4 && segments[3].equals("specs") && method.equals("GET")) {
+      return ApiResponse.ok(operations.specs(project));
+    }
+    if (segments.length == 5 && segments[3].equals("specs") && method.equals("GET")) {
+      NameValidator.requireValidSpecId(segments[4]);
+      return ApiResponse.ok(operations.spec(project, segments[4]));
+    }
+    if (segments.length == 4 && segments[3].equals("dispatch") && method.equals("POST")) {
+      return ApiResponse.ok(operations.dispatch(project, JsonBody.read(exchange)));
+    }
+    if (segments.length == 4 && segments[3].equals("agent") && method.equals("GET")) {
+      return ApiResponse.ok(operations.agentStatus(project));
+    }
+    if (segments.length == 5
+        && segments[3].equals("agent")
+        && segments[4].equals("log")
+        && method.equals("GET")) {
+      return ApiResponse.ok(operations.agentLog(project, tail(exchange.getRequestURI())));
+    }
+    if (segments.length == 5
+        && segments[3].equals("agent")
+        && segments[4].equals("stop")
+        && method.equals("POST")) {
+      return ApiResponse.ok(operations.stopAgent(project));
+    }
+    if (segments.length == 5
+        && segments[3].equals("agent")
+        && segments[4].equals("report")
+        && method.equals("POST")) {
+      return ApiResponse.ok(operations.agentReport(project));
+    }
+    if (knownPath(segments)) {
+      throw new ApiException(
+          405, "method_not_allowed", "HTTP method is not allowed for this endpoint.", null);
+    }
+    throw notFound();
+  }
+
+  private static boolean knownPath(String[] segments) {
+    return segments.length >= 4
+        && segments[0].equals("v1")
+        && segments[1].equals("projects")
+        && (segments[3].equals("specs")
+            || segments[3].equals("dispatch")
+            || segments[3].equals("agent"));
+  }
+
+  private static int tail(URI uri) {
+    var query = uri.getRawQuery();
+    if (query == null || query.isBlank()) {
+      return 200;
+    }
+    for (var part : query.split("&")) {
+      var pair = part.split("=", 2);
+      if (pair.length == 2 && pair[0].equals("tail")) {
+        try {
+          var value = Integer.parseInt(pair[1]);
+          if (value >= 1 && value <= 5000) {
+            return value;
+          }
+        } catch (NumberFormatException ignored) {
+        }
+        throw new ApiException(422, "invalid_tail", "tail must be between 1 and 5000.", null);
+      }
+    }
+    return 200;
+  }
+
+  private static String cleanPath(URI uri) {
+    var path = uri.getPath();
+    return path == null || path.isBlank() ? "/" : path;
+  }
+
+  private static ApiException notFound() {
+    return new ApiException(404, "not_found", "API endpoint was not found.", null);
+  }
+
+  private static void write(HttpExchange exchange, ApiResponse response) throws IOException {
+    var body =
+        YamlUtil.dumpJson(new LinkedHashMap<>(response.body())).getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+    exchange.sendResponseHeaders(response.status(), body.length);
+    try (var output = exchange.getResponseBody()) {
+      output.write(body);
+    }
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ApiRouter.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ApiRouter.java
@@ -11,10 +11,30 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public final class ApiRouter implements HttpHandler {
+
+  private static final String GET = "GET";
+  private static final String POST = "POST";
+  private static final String V1 = "v1";
+  private static final String HEALTH = "health";
+  private static final String PROJECTS = "projects";
+  private static final String SPECS = "specs";
+  private static final String DISPATCH = "dispatch";
+  private static final String AGENT = "agent";
+  private static final String LOG = "log";
+  private static final String STOP = "stop";
+  private static final String REPORT = "report";
+  private static final String TAIL = "tail";
+  private static final int DEFAULT_TAIL = 200;
+  private static final int MIN_TAIL = 1;
+  private static final int MAX_TAIL = 5000;
 
   private final ApiOperations operations;
   private final BearerAuth auth;
@@ -52,87 +72,95 @@ public final class ApiRouter implements HttpHandler {
   }
 
   ApiResponse route(HttpExchange exchange) throws IOException {
-    var method = exchange.getRequestMethod();
-    var path = cleanPath(exchange.getRequestURI());
-    if (method.equals("GET") && path.equals("/v1/health")) {
+    var request = RouteRequest.from(exchange);
+    if (request.matches(GET, V1, HEALTH)) {
       return ApiResponse.from(operations.health());
     }
+
     auth.require(exchange);
-    var segments = path.substring(1).split("/");
-    if (segments.length < 3 || !segments[0].equals("v1") || !segments[1].equals("projects")) {
+    if (!request.hasProjectPrefix()) {
       throw notFound();
     }
-    var project = segments[2];
+
+    var project = request.project();
     NameValidator.requireValidProjectName(project);
-    if (segments.length == 3 && method.equals("GET")) {
+    if (request.isProjectRoot()) {
+      return routeProject(request, project);
+    }
+
+    return switch (request.resource()) {
+      case SPECS -> routeSpecs(request, project);
+      case DISPATCH -> routeDispatch(exchange, request, project);
+      case AGENT -> routeAgent(request, project);
+      default -> throw notFound();
+    };
+  }
+
+  private ApiResponse routeProject(RouteRequest request, String project) {
+    if (request.is(GET)) {
       return ApiResponse.from(operations.project(project));
     }
-    if (segments.length == 4 && segments[3].equals("specs") && method.equals("GET")) {
+    throw methodNotAllowed();
+  }
+
+  private ApiResponse routeSpecs(RouteRequest request, String project) {
+    if (request.size() == 4) {
+      requireMethod(request, GET);
       return ApiResponse.from(operations.specs(project));
     }
-    if (segments.length == 5 && segments[3].equals("specs") && method.equals("GET")) {
-      NameValidator.requireValidSpecId(segments[4]);
-      return ApiResponse.from(operations.spec(project, segments[4]));
+    if (request.size() == 5) {
+      requireMethod(request, GET);
+      var specId = request.subResource();
+      NameValidator.requireValidSpecId(specId);
+      return ApiResponse.from(operations.spec(project, specId));
     }
-    if (segments.length == 4 && segments[3].equals("dispatch") && method.equals("POST")) {
-      return ApiResponse.from(operations.dispatch(project, JsonBody.readDispatchRequest(exchange)));
+    throw methodNotAllowed();
+  }
+
+  private ApiResponse routeDispatch(HttpExchange exchange, RouteRequest request, String project)
+      throws IOException {
+    if (request.size() != 4) {
+      throw methodNotAllowed();
     }
-    if (segments.length == 4 && segments[3].equals("agent") && method.equals("GET")) {
+    requireMethod(request, POST);
+    return ApiResponse.from(operations.dispatch(project, JsonBody.readDispatchRequest(exchange)));
+  }
+
+  private ApiResponse routeAgent(RouteRequest request, String project) {
+    if (request.size() == 4) {
+      requireMethod(request, GET);
       return ApiResponse.from(operations.agentStatus(project));
     }
-    if (segments.length == 5
-        && segments[3].equals("agent")
-        && segments[4].equals("log")
-        && method.equals("GET")) {
-      return ApiResponse.from(operations.agentLog(project, tail(exchange.getRequestURI())));
+    if (request.size() != 5) {
+      throw methodNotAllowed();
     }
-    if (segments.length == 5
-        && segments[3].equals("agent")
-        && segments[4].equals("stop")
-        && method.equals("POST")) {
-      return ApiResponse.from(operations.stopAgent(project));
-    }
-    if (segments.length == 5
-        && segments[3].equals("agent")
-        && segments[4].equals("report")
-        && method.equals("POST")) {
-      return ApiResponse.from(operations.agentReport(project));
-    }
-    if (knownPath(segments)) {
-      throw new ApiException(
-          ErrorCode.METHOD_NOT_ALLOWED, "HTTP method is not allowed for this endpoint.");
-    }
-    throw notFound();
-  }
-
-  private static boolean knownPath(String[] segments) {
-    return segments.length >= 4
-        && segments[0].equals("v1")
-        && segments[1].equals("projects")
-        && (segments[3].equals("specs")
-            || segments[3].equals("dispatch")
-            || segments[3].equals("agent"));
-  }
-
-  private static int tail(URI uri) {
-    var query = uri.getRawQuery();
-    if (query == null || query.isBlank()) {
-      return 200;
-    }
-    for (var part : query.split("&")) {
-      var pair = part.split("=", 2);
-      if (pair.length == 2 && pair[0].equals("tail")) {
-        try {
-          var value = Integer.parseInt(pair[1]);
-          if (value >= 1 && value <= 5000) {
-            return value;
-          }
-        } catch (NumberFormatException ignored) {
-        }
-        throw new ApiException(ErrorCode.INVALID_TAIL, "tail must be between 1 and 5000.");
+    return switch (request.subResource()) {
+      case LOG -> {
+        requireMethod(request, GET);
+        yield ApiResponse.from(
+            operations.agentLog(project, QueryParameters.from(request.uri()).tail()));
       }
+      case STOP -> {
+        requireMethod(request, POST);
+        yield ApiResponse.from(operations.stopAgent(project));
+      }
+      case REPORT -> {
+        requireMethod(request, POST);
+        yield ApiResponse.from(operations.agentReport(project));
+      }
+      default -> throw notFound();
+    };
+  }
+
+  private static void requireMethod(RouteRequest request, String method) {
+    if (!request.is(method)) {
+      throw methodNotAllowed();
     }
-    return 200;
+  }
+
+  private static ApiException methodNotAllowed() {
+    return new ApiException(
+        ErrorCode.METHOD_NOT_ALLOWED, "HTTP method is not allowed for this endpoint.");
   }
 
   private static String cleanPath(URI uri) {
@@ -151,6 +179,90 @@ public final class ApiRouter implements HttpHandler {
     exchange.sendResponseHeaders(response.status(), body.length);
     try (var output = exchange.getResponseBody()) {
       output.write(body);
+    }
+  }
+
+  private record RouteRequest(String method, URI uri, List<String> segments) {
+    static RouteRequest from(HttpExchange exchange) {
+      var uri = exchange.getRequestURI();
+      return new RouteRequest(exchange.getRequestMethod(), uri, segments(cleanPath(uri)));
+    }
+
+    boolean matches(String method, String... path) {
+      return is(method) && segments.equals(List.of(path));
+    }
+
+    boolean is(String method) {
+      return this.method.equals(method);
+    }
+
+    boolean hasProjectPrefix() {
+      return segments.size() >= 3 && V1.equals(segments.get(0)) && PROJECTS.equals(segments.get(1));
+    }
+
+    boolean isProjectRoot() {
+      return segments.size() == 3;
+    }
+
+    String project() {
+      return segments.get(2);
+    }
+
+    String resource() {
+      return segments.get(3);
+    }
+
+    String subResource() {
+      return segments.get(4);
+    }
+
+    int size() {
+      return segments.size();
+    }
+
+    private static List<String> segments(String path) {
+      if (path.equals("/")) {
+        return List.of();
+      }
+      return Arrays.stream(path.substring(1).split("/"))
+          .filter(segment -> !segment.isBlank())
+          .toList();
+    }
+  }
+
+  private record QueryParameters(Map<String, String> values) {
+    static QueryParameters from(URI uri) {
+      var query = uri.getRawQuery();
+      if (query == null || query.isBlank()) {
+        return new QueryParameters(Map.of());
+      }
+      var values = new LinkedHashMap<String, String>();
+      for (var part : query.split("&")) {
+        var separator = part.indexOf('=');
+        var name = separator >= 0 ? part.substring(0, separator) : part;
+        var value = separator >= 0 ? part.substring(separator + 1) : "";
+        values.put(decode(name), decode(value));
+      }
+      return new QueryParameters(values);
+    }
+
+    int tail() {
+      var value = values.get(TAIL);
+      if (value == null) {
+        return DEFAULT_TAIL;
+      }
+      try {
+        var tail = Integer.parseInt(value);
+        if (tail >= MIN_TAIL && tail <= MAX_TAIL) {
+          return tail;
+        }
+      } catch (NumberFormatException ignored) {
+      }
+      throw new ApiException(ErrorCode.INVALID_TAIL, "tail must be between 1 and 5000.");
+    }
+
+    private static String decode(String value) {
+      return URLDecoder.decode(value, StandardCharsets.UTF_8);
     }
   }
 }

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ApiTokenStore.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ApiTokenStore.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import ai.singlr.sing.engine.SingPaths;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Set;
+
+public final class ApiTokenStore {
+
+  private final Path path;
+  private final SecureRandom random;
+
+  public ApiTokenStore(Path path, SecureRandom random) {
+    this.path = path;
+    this.random = random;
+  }
+
+  public static ApiTokenStore defaultStore() {
+    return new ApiTokenStore(SingPaths.singDir().resolve("api-token"), new SecureRandom());
+  }
+
+  public Path path() {
+    return path;
+  }
+
+  public String readOrCreate() throws IOException {
+    if (Files.exists(path)) {
+      var token = Files.readString(path).strip();
+      if (token.isBlank()) {
+        throw new IOException("API token file is empty: " + path);
+      }
+      return token;
+    }
+    Files.createDirectories(path.getParent());
+    var bytes = new byte[32];
+    random.nextBytes(bytes);
+    var token = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    Files.writeString(path, token + System.lineSeparator());
+    restrictOwner(path);
+    return token;
+  }
+
+  private static void restrictOwner(Path path) throws IOException {
+    try {
+      Files.setPosixFilePermissions(path, Set.of(PosixFilePermission.OWNER_READ));
+    } catch (UnsupportedOperationException ignored) {
+    }
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ApiTokenStore.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ApiTokenStore.java
@@ -18,10 +18,16 @@ public final class ApiTokenStore {
 
   private final Path path;
   private final SecureRandom random;
+  private final OwnerPermissionSetter permissionSetter;
 
   public ApiTokenStore(Path path, SecureRandom random) {
+    this(path, random, ApiTokenStore::setOwnerReadOnly);
+  }
+
+  ApiTokenStore(Path path, SecureRandom random, OwnerPermissionSetter permissionSetter) {
     this.path = path;
     this.random = random;
+    this.permissionSetter = permissionSetter;
   }
 
   public static ApiTokenStore defaultStore() {
@@ -45,14 +51,23 @@ public final class ApiTokenStore {
     random.nextBytes(bytes);
     var token = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     Files.writeString(path, token + System.lineSeparator());
-    restrictOwner(path);
+    restrictOwner();
     return token;
   }
 
-  private static void restrictOwner(Path path) throws IOException {
+  private void restrictOwner() throws IOException {
     try {
-      Files.setPosixFilePermissions(path, Set.of(PosixFilePermission.OWNER_READ));
+      permissionSetter.restrict(path);
     } catch (UnsupportedOperationException ignored) {
     }
+  }
+
+  private static void setOwnerReadOnly(Path path) throws IOException {
+    Files.setPosixFilePermissions(path, Set.of(PosixFilePermission.OWNER_READ));
+  }
+
+  @FunctionalInterface
+  interface OwnerPermissionSetter {
+    void restrict(Path path) throws IOException;
   }
 }

--- a/sing-infra/src/main/java/ai/singlr/sing/api/BearerAuth.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/BearerAuth.java
@@ -24,14 +24,13 @@ public final class BearerAuth {
     var header = exchange.getRequestHeaders().getFirst("Authorization");
     if (header == null || !header.startsWith("Bearer ")) {
       throw new ApiException(
-          401,
-          "missing_bearer_token",
+          ErrorCode.MISSING_BEARER_TOKEN,
           "Missing bearer token.",
           "Send Authorization: Bearer <token>.");
     }
     var actual = header.substring("Bearer ".length()).getBytes(StandardCharsets.UTF_8);
     if (!MessageDigest.isEqual(expected, actual)) {
-      throw new ApiException(403, "invalid_bearer_token", "Bearer token is invalid.", null);
+      throw new ApiException(ErrorCode.INVALID_BEARER_TOKEN, "Bearer token is invalid.");
     }
   }
 }

--- a/sing-infra/src/main/java/ai/singlr/sing/api/BearerAuth.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/BearerAuth.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import com.sun.net.httpserver.HttpExchange;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+public final class BearerAuth {
+
+  private final byte[] expected;
+
+  public BearerAuth(String token) {
+    if (token == null || token.isBlank()) {
+      throw new IllegalArgumentException("API token must not be blank.");
+    }
+    expected = token.getBytes(StandardCharsets.UTF_8);
+  }
+
+  public void require(HttpExchange exchange) {
+    var header = exchange.getRequestHeaders().getFirst("Authorization");
+    if (header == null || !header.startsWith("Bearer ")) {
+      throw new ApiException(
+          401,
+          "missing_bearer_token",
+          "Missing bearer token.",
+          "Send Authorization: Bearer <token>.");
+    }
+    var actual = header.substring("Bearer ".length()).getBytes(StandardCharsets.UTF_8);
+    if (!MessageDigest.isEqual(expected, actual)) {
+      throw new ApiException(403, "invalid_bearer_token", "Bearer token is invalid.", null);
+    }
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/api/ErrorCode.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/ErrorCode.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+public enum ErrorCode {
+  INVALID_REQUEST(422),
+  INVALID_JSON(400),
+  INVALID_MODE(422),
+  INVALID_TAIL(422),
+  MISSING_BEARER_TOKEN(401),
+  INVALID_BEARER_TOKEN(403),
+  UNSUPPORTED_MEDIA_TYPE(415),
+  REQUEST_TOO_LARGE(413),
+  NOT_FOUND(404),
+  CONFLICT(409),
+  METHOD_NOT_ALLOWED(405),
+  PROJECT_DESCRIPTOR_NOT_FOUND(404),
+  PROJECT_NOT_CREATED(404),
+  PROJECT_STOPPED(409),
+  CONTAINER_ERROR(500),
+  SPECS_NOT_CONFIGURED(422),
+  SPECS_READ_FAILED(500),
+  SPEC_NOT_FOUND(404),
+  SPEC_NOT_READY(409),
+  SPEC_READ_FAILED(500),
+  SPEC_STATUS_UPDATE_FAILED(500),
+  AGENT_ALREADY_RUNNING(409),
+  AGENT_STATUS_FAILED(500),
+  AGENT_LOG_FAILED(500),
+  AGENT_STOP_FAILED(500),
+  AGENT_REPORT_FAILED(500),
+  AGENT_LAUNCH_FAILED(500),
+  SNAPSHOT_FAILED(500),
+  BRANCH_CREATE_FAILED(500),
+  PROJECT_LOAD_FAILED(500),
+  COMMAND_FAILED(500),
+  INTERNAL(500);
+
+  private final int httpCode;
+
+  ErrorCode(int httpCode) {
+    this.httpCode = httpCode;
+  }
+
+  public int httpCode() {
+    return httpCode;
+  }
+
+  public String code() {
+    return name().toLowerCase();
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/api/FieldError.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/FieldError.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+public record FieldError(String field, String message) {
+  public static FieldError of(String field, String message) {
+    return new FieldError(field, message);
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/api/JsonBody.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/JsonBody.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import ai.singlr.sing.config.YamlUtil;
+import com.sun.net.httpserver.HttpExchange;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+public final class JsonBody {
+
+  private static final int MAX_BYTES = 64 * 1024;
+
+  private JsonBody() {}
+
+  public static Map<String, Object> read(HttpExchange exchange) throws IOException {
+    var contentType = exchange.getRequestHeaders().getFirst("Content-Type");
+    if (contentType != null && !contentType.toLowerCase().startsWith("application/json")) {
+      throw new ApiException(
+          415,
+          "unsupported_media_type",
+          "Requests with a body must use application/json.",
+          "Set Content-Type to application/json.");
+    }
+    var bytes = exchange.getRequestBody().readNBytes(MAX_BYTES + 1);
+    if (bytes.length > MAX_BYTES) {
+      throw new ApiException(
+          413,
+          "request_too_large",
+          "Request body exceeds 65536 bytes.",
+          "Send a smaller JSON body.");
+    }
+    if (bytes.length == 0) {
+      return Map.of();
+    }
+    try {
+      return YamlUtil.parseMap(new String(bytes, StandardCharsets.UTF_8));
+    } catch (RuntimeException e) {
+      throw new ApiException(400, "invalid_json", "Request body is not valid JSON.", null);
+    }
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/api/JsonBody.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/JsonBody.java
@@ -10,6 +10,7 @@ import com.sun.net.httpserver.HttpExchange;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Objects;
 
 public final class JsonBody {
 
@@ -17,20 +18,26 @@ public final class JsonBody {
 
   private JsonBody() {}
 
-  public static Map<String, Object> read(HttpExchange exchange) throws IOException {
+  public static DispatchRequest readDispatchRequest(HttpExchange exchange) throws IOException {
+    var map = read(exchange);
+    return new DispatchRequest(
+        optionalString(map, "spec_id"),
+        optionalString(map, "mode"),
+        Boolean.TRUE.equals(map.get("dry_run")));
+  }
+
+  private static Map<String, Object> read(HttpExchange exchange) throws IOException {
     var contentType = exchange.getRequestHeaders().getFirst("Content-Type");
     if (contentType != null && !contentType.toLowerCase().startsWith("application/json")) {
       throw new ApiException(
-          415,
-          "unsupported_media_type",
+          ErrorCode.UNSUPPORTED_MEDIA_TYPE,
           "Requests with a body must use application/json.",
           "Set Content-Type to application/json.");
     }
     var bytes = exchange.getRequestBody().readNBytes(MAX_BYTES + 1);
     if (bytes.length > MAX_BYTES) {
       throw new ApiException(
-          413,
-          "request_too_large",
+          ErrorCode.REQUEST_TOO_LARGE,
           "Request body exceeds 65536 bytes.",
           "Send a smaller JSON body.");
     }
@@ -40,7 +47,12 @@ public final class JsonBody {
     try {
       return YamlUtil.parseMap(new String(bytes, StandardCharsets.UTF_8));
     } catch (RuntimeException e) {
-      throw new ApiException(400, "invalid_json", "Request body is not valid JSON.", null);
+      throw new ApiException(ErrorCode.INVALID_JSON, "Request body is not valid JSON.", e);
     }
+  }
+
+  private static String optionalString(Map<String, Object> map, String key) {
+    var value = map.get(key);
+    return value == null ? null : Objects.toString(value);
   }
 }

--- a/sing-infra/src/main/java/ai/singlr/sing/api/Result.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/Result.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@SuppressWarnings("unchecked")
+public sealed interface Result<T> permits Result.Success, Result.Failure {
+
+  record Success<T>(T value, int code) implements Result<T> {}
+
+  record Failure<T>(
+      ErrorCode errorCode,
+      String errorMessage,
+      String action,
+      List<FieldError> fieldErrors,
+      Throwable cause)
+      implements Result<T> {
+    public Failure {
+      fieldErrors = fieldErrors == null ? List.of() : List.copyOf(fieldErrors);
+    }
+
+    public String fullError() {
+      if (errorMessage == null) {
+        return null;
+      }
+      if (fieldErrors.isEmpty()) {
+        return errorMessage;
+      }
+      var details =
+          fieldErrors.stream()
+              .map(fieldError -> fieldError.field() + ": " + fieldError.message())
+              .collect(Collectors.joining(", "));
+      return errorMessage + " - Field errors: [" + details + "]";
+    }
+  }
+
+  default boolean isSuccess() {
+    return this instanceof Success<?>;
+  }
+
+  default boolean isFailure() {
+    return this instanceof Failure<?>;
+  }
+
+  default T orThrow() {
+    if (this instanceof Success<?>) {
+      return ((Success<T>) this).value();
+    }
+    var failure = (Failure<T>) this;
+    throw new IllegalStateException(failure.fullError(), failure.cause());
+  }
+
+  default T value() {
+    return null;
+  }
+
+  default int code() {
+    var failure = (Failure<T>) this;
+    return failure.errorCode().httpCode();
+  }
+
+  default ErrorCode errorCode() {
+    return null;
+  }
+
+  default String errorMessage() {
+    return null;
+  }
+
+  default String action() {
+    return null;
+  }
+
+  default List<FieldError> fieldErrors() {
+    return List.of();
+  }
+
+  default Throwable cause() {
+    return null;
+  }
+
+  default <U> Result<U> asFailure() {
+    if (this instanceof Failure<?>) {
+      var failure = (Failure<T>) this;
+      return new Failure<>(
+          failure.errorCode(),
+          failure.errorMessage(),
+          failure.action(),
+          failure.fieldErrors(),
+          failure.cause());
+    }
+    throw new IllegalStateException("Cannot convert a success result to a failure");
+  }
+
+  default String fullError() {
+    return null;
+  }
+
+  static <T> Result<T> success(T value) {
+    return new Success<>(value, 200);
+  }
+
+  static <T> Result<T> success(T value, int code) {
+    return new Success<>(value, code);
+  }
+
+  static <T> Result<T> failure(ErrorCode errorCode, String errorMessage) {
+    return new Failure<>(errorCode, errorMessage, null, List.of(), null);
+  }
+
+  static <T> Result<T> failure(ErrorCode errorCode, String errorMessage, String action) {
+    return new Failure<>(errorCode, errorMessage, action, List.of(), null);
+  }
+
+  static <T> Result<T> failure(ErrorCode errorCode, String errorMessage, Throwable cause) {
+    return new Failure<>(errorCode, errorMessage, null, List.of(), cause);
+  }
+
+  static <T> Result<T> failure(
+      ErrorCode errorCode, String errorMessage, List<FieldError> fieldErrors) {
+    return new Failure<>(errorCode, errorMessage, null, fieldErrors, null);
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/api/SingApiOperations.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/SingApiOperations.java
@@ -22,6 +22,7 @@ import ai.singlr.sing.engine.SnapshotManager;
 import ai.singlr.sing.engine.SpecWorkspace;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -37,14 +38,20 @@ public final class SingApiOperations implements ApiOperations {
 
   private final ShellExec shell;
   private final String file;
+  private final WatcherLauncher watcherLauncher;
 
   public SingApiOperations() {
     this(new ShellExecutor(false), "sing.yaml");
   }
 
   public SingApiOperations(ShellExec shell, String file) {
+    this(shell, file, SingApiOperations::launchWatcherProcess);
+  }
+
+  SingApiOperations(ShellExec shell, String file, WatcherLauncher watcherLauncher) {
     this.shell = shell;
     this.file = file;
+    this.watcherLauncher = watcherLauncher;
   }
 
   @Override
@@ -294,8 +301,6 @@ public final class SingApiOperations implements ApiOperations {
       var config = SingYaml.fromMap(YamlUtil.parseFile(singYamlPath));
       var state = new ContainerManager(shell).queryState(project);
       return new LoadedProject(config, state);
-    } catch (ApiException e) {
-      throw e;
     } catch (Exception e) {
       throw new ApiException(500, "project_load_failed", "Failed to load project.", null);
     }
@@ -460,8 +465,12 @@ public final class SingApiOperations implements ApiOperations {
             SingPaths.resolveSingYaml(project, file).toAbsolutePath().toString());
     var watchLog = SingPaths.projectDir(project).resolve("watch.log");
     Files.createDirectories(watchLog.getParent());
-    new ProcessBuilder(cmd)
-        .redirectOutput(ProcessBuilder.Redirect.to(watchLog.toFile()))
+    watcherLauncher.launch(cmd, watchLog);
+  }
+
+  static void launchWatcherProcess(List<String> command, Path logPath) throws IOException {
+    new ProcessBuilder(command)
+        .redirectOutput(ProcessBuilder.Redirect.to(logPath.toFile()))
         .redirectErrorStream(true)
         .start();
   }
@@ -523,4 +532,9 @@ public final class SingApiOperations implements ApiOperations {
   }
 
   private record LoadedProject(SingYaml config, ContainerState state) {}
+
+  @FunctionalInterface
+  interface WatcherLauncher {
+    void launch(List<String> command, Path logPath) throws IOException;
+  }
 }

--- a/sing-infra/src/main/java/ai/singlr/sing/api/SingApiOperations.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/SingApiOperations.java
@@ -1,0 +1,526 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import ai.singlr.sing.config.SingYaml;
+import ai.singlr.sing.config.Spec;
+import ai.singlr.sing.config.SpecDirectory;
+import ai.singlr.sing.config.YamlUtil;
+import ai.singlr.sing.engine.AgentCli;
+import ai.singlr.sing.engine.AgentReporter;
+import ai.singlr.sing.engine.AgentSession;
+import ai.singlr.sing.engine.ContainerExec;
+import ai.singlr.sing.engine.ContainerManager;
+import ai.singlr.sing.engine.ContainerState;
+import ai.singlr.sing.engine.ShellExec;
+import ai.singlr.sing.engine.ShellExecutor;
+import ai.singlr.sing.engine.SingPaths;
+import ai.singlr.sing.engine.SnapshotManager;
+import ai.singlr.sing.engine.SpecWorkspace;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class SingApiOperations implements ApiOperations {
+
+  private static final Duration SNAPSHOT_INTERVAL = Duration.ofHours(24);
+
+  private final ShellExec shell;
+  private final String file;
+
+  public SingApiOperations() {
+    this(new ShellExecutor(false), "sing.yaml");
+  }
+
+  public SingApiOperations(ShellExec shell, String file) {
+    this.shell = shell;
+    this.file = file;
+  }
+
+  @Override
+  public Map<String, Object> health() {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("status", "ok");
+    return map;
+  }
+
+  @Override
+  public Map<String, Object> project(String project) {
+    var loaded = loadProject(project);
+    var map = new LinkedHashMap<String, Object>();
+    map.put("name", project);
+    map.put("container_status", statusName(loaded.state()));
+    if (loaded.config().agent() != null) {
+      var agent = new LinkedHashMap<String, Object>();
+      agent.put("type", loaded.config().agent().type());
+      agent.put("auto_snapshot", loaded.config().agent().autoSnapshot());
+      agent.put("auto_branch", loaded.config().agent().autoBranch());
+      agent.put("specs_dir", loaded.config().agent().specsDir());
+      map.put("agent", agent);
+    }
+    return map;
+  }
+
+  @Override
+  public Map<String, Object> specs(String project) {
+    var loaded = loadRunningProject(project);
+    var specs = readIndex(workspace(loaded));
+    var summary = SpecDirectory.summarize(specs);
+    var map = new LinkedHashMap<String, Object>();
+    map.put("name", project);
+    map.put("specs", specs.stream().map(spec -> specMap(specs, spec)).toList());
+    map.put("counts", summary.counts());
+    map.put("summary", summary.toMap());
+    return map;
+  }
+
+  @Override
+  public Map<String, Object> spec(String project, String specId) {
+    var loaded = loadRunningProject(project);
+    var workspace = workspace(loaded);
+    var specs = readIndex(workspace);
+    var spec = SpecDirectory.findById(specs, specId);
+    if (spec == null) {
+      throw new ApiException(404, "spec_not_found", "Spec '" + specId + "' was not found.", null);
+    }
+    var content = readSpecBody(workspace, specId);
+    var map = new LinkedHashMap<String, Object>();
+    map.put("name", project);
+    map.put("spec", specMap(specs, spec));
+    map.put("spec_path", workspace.specMarkdownPath(specId));
+    map.put("content_available", content != null);
+    if (content != null) {
+      map.put("content", content);
+    }
+    return map;
+  }
+
+  @Override
+  public Map<String, Object> dispatch(String project, Map<String, Object> request) {
+    var loaded = loadRunningProject(project);
+    var specId = optionalString(request, "spec_id");
+    var mode = Objects.toString(request.getOrDefault("mode", "background"));
+    var dryRun = Boolean.TRUE.equals(request.get("dry_run"));
+    if (!mode.equals("background") && !mode.equals("foreground")) {
+      throw new ApiException(
+          422, "invalid_mode", "Dispatch mode must be background or foreground.", null);
+    }
+
+    var agentSession = new AgentSession(shell);
+    var existing = querySession(agentSession, project);
+    if (existing != null && existing.running()) {
+      throw new ApiException(
+          409,
+          "agent_already_running",
+          "Agent is already running for project '" + project + "'.",
+          "Stop the active agent before dispatching another spec.");
+    }
+
+    var workspace = workspace(loaded);
+    var specs = readIndex(workspace);
+    var nextSpec = resolveSpec(specs, specId);
+    if (nextSpec == null) {
+      var map = new LinkedHashMap<String, Object>();
+      map.put("name", project);
+      map.put("dispatched", false);
+      map.put("reason", "no_pending_specs");
+      return map;
+    }
+
+    updateStatus(workspace, nextSpec.id(), "in_progress");
+    var specBody = Objects.requireNonNullElse(readSpecBody(workspace, nextSpec.id()), "");
+    var task = buildTaskPrompt(nextSpec, specBody.isBlank() ? nextSpec.title() : specBody);
+    var branch = branchName(loaded.config(), nextSpec);
+    var snapshot = createSnapshotIfNeeded(project, loaded.config());
+    var branchCreated = createBranchIfNeeded(project, loaded.config(), branch);
+
+    if (!dryRun) {
+      launchAgent(project, loaded.config(), task, branch, mode);
+    }
+
+    var status = dryRun ? null : querySession(agentSession, project);
+    var map = new LinkedHashMap<String, Object>();
+    map.put("name", project);
+    map.put("dispatched", true);
+    map.put("spec", dispatchedSpecMap(nextSpec, branch));
+    map.put("agent", agentMap(loaded.config(), mode, status));
+    map.put("snapshot", snapshot);
+    map.put("branch_created", branchCreated);
+    return map;
+  }
+
+  @Override
+  public Map<String, Object> agentStatus(String project) {
+    requireProjectExists(project);
+    var info = querySession(new AgentSession(shell), project);
+    var map = new LinkedHashMap<String, Object>();
+    map.put("name", project);
+    map.put("agent_running", info != null && info.running());
+    if (info != null) {
+      map.putAll(sessionMap(info));
+    }
+    return map;
+  }
+
+  @Override
+  public Map<String, Object> agentLog(String project, int tail) {
+    requireProjectExists(project);
+    var cmd =
+        ContainerExec.asDevUser(
+            project, List.of("tail", "-n", String.valueOf(tail), AgentSession.logPath()));
+    var result = exec(cmd);
+    var map = new LinkedHashMap<String, Object>();
+    map.put("name", project);
+    if (!result.ok()) {
+      if (result.stderr().contains("No such file")) {
+        map.put("lines", List.of());
+        map.put("error", "No agent log found");
+        return map;
+      }
+      throw new ApiException(500, "agent_log_failed", "Failed to read agent log.", null);
+    }
+    map.put(
+        "lines",
+        Arrays.stream(result.stdout().split("\n")).filter(line -> !line.isEmpty()).toList());
+    return map;
+  }
+
+  @Override
+  public Map<String, Object> stopAgent(String project) {
+    requireProjectExists(project);
+    var agentSession = new AgentSession(shell);
+    var info = querySession(agentSession, project);
+    var map = new LinkedHashMap<String, Object>();
+    map.put("name", project);
+    if (info == null || !info.running()) {
+      map.put("stopped", false);
+      map.put("reason", "no_agent_running");
+      return map;
+    }
+    try {
+      agentSession.killAgent(project);
+    } catch (Exception e) {
+      throw new ApiException(500, "agent_stop_failed", "Failed to stop agent.", null);
+    }
+    map.put("stopped", true);
+    map.put("pid", info.pid());
+    return map;
+  }
+
+  @Override
+  public Map<String, Object> agentReport(String project) {
+    var loaded = loadProject(project);
+    try {
+      return new AgentReporter(shell).generate(project, loaded.config()).toMap();
+    } catch (Exception e) {
+      throw new ApiException(500, "agent_report_failed", "Failed to generate agent report.", null);
+    }
+  }
+
+  private static List<Spec> readIndex(SpecWorkspace workspace) {
+    try {
+      return workspace.readIndex();
+    } catch (Exception e) {
+      throw new ApiException(500, "specs_read_failed", "Failed to read specs index.", null);
+    }
+  }
+
+  private static String readSpecBody(SpecWorkspace workspace, String specId) {
+    try {
+      return workspace.readSpecBody(specId);
+    } catch (Exception e) {
+      throw new ApiException(500, "spec_read_failed", "Failed to read spec content.", null);
+    }
+  }
+
+  private static void updateStatus(SpecWorkspace workspace, String specId, String status) {
+    try {
+      workspace.updateStatus(specId, status);
+    } catch (Exception e) {
+      throw new ApiException(
+          500, "spec_status_update_failed", "Failed to update spec status.", null);
+    }
+  }
+
+  private static String statusName(ContainerState state) {
+    return switch (state) {
+      case ContainerState.Running ignored -> "running";
+      case ContainerState.Stopped ignored -> "stopped";
+      case ContainerState.NotCreated ignored -> "not_created";
+      case ContainerState.Error ignored -> "error";
+    };
+  }
+
+  private LoadedProject loadRunningProject(String project) {
+    var loaded = loadProject(project);
+    switch (loaded.state()) {
+      case ContainerState.Running ignored -> {
+        return loaded;
+      }
+      case ContainerState.Stopped ignored ->
+          throw new ApiException(
+              409,
+              "project_stopped",
+              "Project '" + project + "' is stopped.",
+              "Start it with sing up " + project + ".");
+      case ContainerState.NotCreated ignored ->
+          throw new ApiException(
+              404, "project_not_created", "Project '" + project + "' does not exist.", null);
+      case ContainerState.Error e ->
+          throw new ApiException(500, "container_error", e.message(), null);
+    }
+  }
+
+  private LoadedProject loadProject(String project) {
+    var singYamlPath = SingPaths.resolveSingYaml(project, file);
+    if (!Files.exists(singYamlPath)) {
+      throw new ApiException(
+          404,
+          "project_descriptor_not_found",
+          "Project descriptor was not found: " + singYamlPath.toAbsolutePath(),
+          null);
+    }
+    try {
+      var config = SingYaml.fromMap(YamlUtil.parseFile(singYamlPath));
+      var state = new ContainerManager(shell).queryState(project);
+      return new LoadedProject(config, state);
+    } catch (ApiException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new ApiException(500, "project_load_failed", "Failed to load project.", null);
+    }
+  }
+
+  private void requireProjectExists(String project) {
+    var state = loadProject(project).state();
+    if (state instanceof ContainerState.NotCreated) {
+      throw new ApiException(
+          404, "project_not_created", "Project '" + project + "' does not exist.", null);
+    }
+    if (state instanceof ContainerState.Error e) {
+      throw new ApiException(500, "container_error", e.message(), null);
+    }
+  }
+
+  private SpecWorkspace workspace(LoadedProject loaded) {
+    if (loaded.config().agent() == null || loaded.config().agent().specsDir() == null) {
+      throw new ApiException(
+          422,
+          "specs_not_configured",
+          "No specs_dir configured in the project agent block.",
+          "Add specs_dir to sing.yaml.");
+    }
+    var specsDir =
+        "/home/" + loaded.config().sshUser() + "/workspace/" + loaded.config().agent().specsDir();
+    return new SpecWorkspace(shell, loaded.config().name(), specsDir);
+  }
+
+  private static Spec resolveSpec(List<Spec> specs, String specId) {
+    if (specId == null || specId.isBlank()) {
+      return SpecDirectory.nextReady(specs);
+    }
+    var spec = SpecDirectory.findById(specs, specId);
+    if (spec == null) {
+      throw new ApiException(404, "spec_not_found", "Spec '" + specId + "' was not found.", null);
+    }
+    if (!SpecDirectory.isReady(specs, spec)) {
+      throw new ApiException(
+          409,
+          "spec_not_ready",
+          "Spec '" + specId + "' is not ready for dispatch.",
+          "Resolve dependencies or choose a ready spec.");
+    }
+    return spec;
+  }
+
+  private static Map<String, Object> specMap(List<Spec> specs, Spec spec) {
+    var map = new LinkedHashMap<String, Object>(spec.toMap());
+    map.put("ready", SpecDirectory.isReady(specs, spec));
+    map.put("blocked", SpecDirectory.isBlocked(specs, spec));
+    var unmet = SpecDirectory.unmetDependencies(specs, spec);
+    if (!unmet.isEmpty()) {
+      map.put("unmet_dependencies", unmet);
+    }
+    return map;
+  }
+
+  private static Map<String, Object> dispatchedSpecMap(Spec spec, String branch) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("id", spec.id());
+    map.put("title", spec.title());
+    map.put("status", "in_progress");
+    if (branch != null && !branch.isBlank()) {
+      map.put("branch", branch);
+    }
+    return map;
+  }
+
+  private static String buildTaskPrompt(Spec spec, String description) {
+    return "Your current spec: \"" + spec.title() + "\" (id: " + spec.id() + ").\n\n" + description;
+  }
+
+  private static String branchName(SingYaml config, Spec spec) {
+    if (config.agent() == null || !config.agent().autoBranch()) {
+      return "";
+    }
+    var prefix = config.agent().branchPrefix() != null ? config.agent().branchPrefix() : "sing/";
+    return spec.branch() != null ? spec.branch() : prefix + spec.id();
+  }
+
+  private String createSnapshotIfNeeded(String project, SingYaml config) {
+    if (config.agent() == null || !config.agent().autoSnapshot()) {
+      return "";
+    }
+    var snapMgr = new SnapshotManager(shell);
+    if (!shouldSnapshot(snapMgr, project)) {
+      return "";
+    }
+    var label = SnapshotManager.defaultLabel();
+    try {
+      snapMgr.create(project, label);
+      return label;
+    } catch (Exception e) {
+      throw new ApiException(500, "snapshot_failed", "Failed to create dispatch snapshot.", null);
+    }
+  }
+
+  private boolean createBranchIfNeeded(String project, SingYaml config, String branch) {
+    if (branch == null
+        || branch.isBlank()
+        || config.repos() == null
+        || config.repos().size() != 1) {
+      return false;
+    }
+    var repoDir = "/home/" + config.sshUser() + "/workspace/" + config.repos().getFirst().path();
+    var repoExists =
+        exec(ContainerExec.asDevUser(project, List.of("test", "-d", repoDir + "/.git")));
+    if (!repoExists.ok()) {
+      return false;
+    }
+    var result =
+        exec(
+            ContainerExec.asDevUser(
+                project, List.of("git", "-C", repoDir, "checkout", "-b", branch)));
+    if (!result.ok()) {
+      throw new ApiException(
+          500, "branch_create_failed", "Failed to create branch '" + branch + "'.", null);
+    }
+    return true;
+  }
+
+  private void launchAgent(
+      String project, SingYaml config, String task, String branch, String mode) {
+    try {
+      var session = new AgentSession(shell);
+      session.ensureDirectory(project);
+      session.writeTaskFile(project, task);
+      session.writeSession(project, task, Objects.requireNonNullElse(branch, ""));
+      var agentCli = AgentCli.fromYamlName(config.agent().type());
+      var workDir = "/home/" + config.sshUser() + "/workspace";
+      var command =
+          mode.equals("background")
+              ? AgentSession.buildBackgroundLaunchCommand(
+                  project, config.sshUser(), workDir, true, agentCli)
+              : AgentSession.buildForegroundTaskCommand(
+                  project, config.sshUser(), workDir, true, agentCli);
+      var result = exec(command);
+      if (!result.ok()) {
+        throw new ApiException(500, "agent_launch_failed", "Failed to launch agent.", null);
+      }
+      launchWatcherIfGuardrails(project, config);
+    } catch (ApiException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new ApiException(500, "agent_launch_failed", "Failed to launch agent.", null);
+    }
+  }
+
+  private void launchWatcherIfGuardrails(String project, SingYaml config) throws IOException {
+    if (config.agent() == null || config.agent().guardrails() == null) {
+      return;
+    }
+    var cmd =
+        List.of(
+            "nohup",
+            SingPaths.binaryPath().toString(),
+            "agent",
+            "watch",
+            project,
+            "-f",
+            SingPaths.resolveSingYaml(project, file).toAbsolutePath().toString());
+    var watchLog = SingPaths.projectDir(project).resolve("watch.log");
+    Files.createDirectories(watchLog.getParent());
+    new ProcessBuilder(cmd)
+        .redirectOutput(ProcessBuilder.Redirect.to(watchLog.toFile()))
+        .redirectErrorStream(true)
+        .start();
+  }
+
+  private static boolean shouldSnapshot(SnapshotManager snapMgr, String project) {
+    try {
+      var snapshots = snapMgr.list(project);
+      if (snapshots.isEmpty()) {
+        return true;
+      }
+      var latestTime = OffsetDateTime.parse(snapshots.getLast().createdAt()).toInstant();
+      return Instant.now().isAfter(latestTime.plus(SNAPSHOT_INTERVAL));
+    } catch (Exception ignored) {
+      return true;
+    }
+  }
+
+  private AgentSession.SessionInfo querySession(AgentSession session, String project) {
+    try {
+      return session.queryStatus(project);
+    } catch (Exception e) {
+      throw new ApiException(500, "agent_status_failed", "Failed to query agent status.", null);
+    }
+  }
+
+  private Map<String, Object> agentMap(
+      SingYaml config, String mode, AgentSession.SessionInfo info) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("type", config.agent() != null ? config.agent().type() : "");
+    map.put("mode", mode);
+    map.put("running", info != null && info.running());
+    if (info != null) {
+      map.putAll(sessionMap(info));
+    }
+    return map;
+  }
+
+  private static Map<String, Object> sessionMap(AgentSession.SessionInfo info) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("pid", info.pid());
+    map.put("task", info.task());
+    map.put("started_at", info.startedAt());
+    map.put("branch", info.branch());
+    map.put("log_path", info.logPath());
+    return map;
+  }
+
+  private ShellExec.Result exec(List<String> command) {
+    try {
+      return shell.exec(command);
+    } catch (Exception e) {
+      throw new ApiException(500, "command_failed", "A sing system command failed.", null);
+    }
+  }
+
+  private static String optionalString(Map<String, Object> map, String key) {
+    var value = map.get(key);
+    return value == null ? null : value.toString();
+  }
+
+  private record LoadedProject(SingYaml config, ContainerState state) {}
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/api/SingApiOperations.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/SingApiOperations.java
@@ -27,10 +27,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 public final class SingApiOperations implements ApiOperations {
 
@@ -55,93 +54,105 @@ public final class SingApiOperations implements ApiOperations {
   }
 
   @Override
-  public Map<String, Object> health() {
-    var map = new LinkedHashMap<String, Object>();
-    map.put("status", "ok");
-    return map;
+  public Result<HealthResponse> health() {
+    return Result.success(new HealthResponse("ok"));
   }
 
   @Override
-  public Map<String, Object> project(String project) {
+  public Result<ProjectResponse> project(String project) {
+    return safe(() -> projectValue(project));
+  }
+
+  @Override
+  public Result<SpecsResponse> specs(String project) {
+    return safe(() -> specsValue(project));
+  }
+
+  @Override
+  public Result<SpecResponse> spec(String project, String specId) {
+    return safe(() -> specValue(project, specId));
+  }
+
+  @Override
+  public Result<DispatchResponse> dispatch(String project, DispatchRequest request) {
+    return safe(() -> dispatchValue(project, request));
+  }
+
+  @Override
+  public Result<AgentStatusResponse> agentStatus(String project) {
+    return safe(() -> agentStatusValue(project));
+  }
+
+  @Override
+  public Result<AgentLogResponse> agentLog(String project, int tail) {
+    return safe(() -> agentLogValue(project, tail));
+  }
+
+  @Override
+  public Result<StopAgentResponse> stopAgent(String project) {
+    return safe(() -> stopAgentValue(project));
+  }
+
+  @Override
+  public Result<AgentReportResponse> agentReport(String project) {
+    return safe(() -> agentReportValue(project));
+  }
+
+  private ProjectResponse projectValue(String project) {
     var loaded = loadProject(project);
-    var map = new LinkedHashMap<String, Object>();
-    map.put("name", project);
-    map.put("container_status", statusName(loaded.state()));
-    if (loaded.config().agent() != null) {
-      var agent = new LinkedHashMap<String, Object>();
-      agent.put("type", loaded.config().agent().type());
-      agent.put("auto_snapshot", loaded.config().agent().autoSnapshot());
-      agent.put("auto_branch", loaded.config().agent().autoBranch());
-      agent.put("specs_dir", loaded.config().agent().specsDir());
-      map.put("agent", agent);
-    }
-    return map;
+    var agent = loaded.config().agent() != null ? agentConfigView(loaded.config()) : null;
+    return new ProjectResponse(project, statusName(loaded.state()), agent);
   }
 
-  @Override
-  public Map<String, Object> specs(String project) {
+  private SpecsResponse specsValue(String project) {
     var loaded = loadRunningProject(project);
     var specs = readIndex(workspace(loaded));
     var summary = SpecDirectory.summarize(specs);
-    var map = new LinkedHashMap<String, Object>();
-    map.put("name", project);
-    map.put("specs", specs.stream().map(spec -> specMap(specs, spec)).toList());
-    map.put("counts", summary.counts());
-    map.put("summary", summary.toMap());
-    return map;
+    return new SpecsResponse(
+        project,
+        specs.stream().map(spec -> specView(specs, spec)).toList(),
+        summaryView(summary.counts()),
+        boardSummaryView(summary));
   }
 
-  @Override
-  public Map<String, Object> spec(String project, String specId) {
+  private SpecResponse specValue(String project, String specId) {
     var loaded = loadRunningProject(project);
     var workspace = workspace(loaded);
     var specs = readIndex(workspace);
     var spec = SpecDirectory.findById(specs, specId);
     if (spec == null) {
-      throw new ApiException(404, "spec_not_found", "Spec '" + specId + "' was not found.", null);
+      throw new ApiException(ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found.");
     }
     var content = readSpecBody(workspace, specId);
-    var map = new LinkedHashMap<String, Object>();
-    map.put("name", project);
-    map.put("spec", specMap(specs, spec));
-    map.put("spec_path", workspace.specMarkdownPath(specId));
-    map.put("content_available", content != null);
-    if (content != null) {
-      map.put("content", content);
-    }
-    return map;
+    return new SpecResponse(
+        project,
+        specView(specs, spec),
+        workspace.specMarkdownPath(specId),
+        content != null,
+        content);
   }
 
-  @Override
-  public Map<String, Object> dispatch(String project, Map<String, Object> request) {
+  private DispatchResponse dispatchValue(String project, DispatchRequest request) {
     var loaded = loadRunningProject(project);
-    var specId = optionalString(request, "spec_id");
-    var mode = Objects.toString(request.getOrDefault("mode", "background"));
-    var dryRun = Boolean.TRUE.equals(request.get("dry_run"));
-    if (!mode.equals("background") && !mode.equals("foreground")) {
+    if (!request.mode().equals("background") && !request.mode().equals("foreground")) {
       throw new ApiException(
-          422, "invalid_mode", "Dispatch mode must be background or foreground.", null);
+          ErrorCode.INVALID_MODE, "Dispatch mode must be background or foreground.");
     }
 
     var agentSession = new AgentSession(shell);
     var existing = querySession(agentSession, project);
     if (existing != null && existing.running()) {
       throw new ApiException(
-          409,
-          "agent_already_running",
+          ErrorCode.AGENT_ALREADY_RUNNING,
           "Agent is already running for project '" + project + "'.",
           "Stop the active agent before dispatching another spec.");
     }
 
     var workspace = workspace(loaded);
     var specs = readIndex(workspace);
-    var nextSpec = resolveSpec(specs, specId);
+    var nextSpec = resolveSpec(specs, request.specId());
     if (nextSpec == null) {
-      var map = new LinkedHashMap<String, Object>();
-      map.put("name", project);
-      map.put("dispatched", false);
-      map.put("reason", "no_pending_specs");
-      return map;
+      return new DispatchResponse(project, false, "no_pending_specs", null, null, "", false);
     }
 
     updateStatus(workspace, nextSpec.id(), "in_progress");
@@ -151,86 +162,71 @@ public final class SingApiOperations implements ApiOperations {
     var snapshot = createSnapshotIfNeeded(project, loaded.config());
     var branchCreated = createBranchIfNeeded(project, loaded.config(), branch);
 
-    if (!dryRun) {
-      launchAgent(project, loaded.config(), task, branch, mode);
+    if (!request.dryRun()) {
+      launchAgent(project, loaded.config(), task, branch, request.mode());
     }
 
-    var status = dryRun ? null : querySession(agentSession, project);
-    var map = new LinkedHashMap<String, Object>();
-    map.put("name", project);
-    map.put("dispatched", true);
-    map.put("spec", dispatchedSpecMap(nextSpec, branch));
-    map.put("agent", agentMap(loaded.config(), mode, status));
-    map.put("snapshot", snapshot);
-    map.put("branch_created", branchCreated);
-    return map;
+    var status = request.dryRun() ? null : querySession(agentSession, project);
+    return new DispatchResponse(
+        project,
+        true,
+        null,
+        dispatchedSpecView(nextSpec, branch),
+        agentStatusView(loaded.config(), request.mode(), status),
+        snapshot,
+        branchCreated);
   }
 
-  @Override
-  public Map<String, Object> agentStatus(String project) {
+  private AgentStatusResponse agentStatusValue(String project) {
     requireProjectExists(project);
     var info = querySession(new AgentSession(shell), project);
-    var map = new LinkedHashMap<String, Object>();
-    map.put("name", project);
-    map.put("agent_running", info != null && info.running());
-    if (info != null) {
-      map.putAll(sessionMap(info));
-    }
-    return map;
+    return new AgentStatusResponse(
+        project,
+        info != null && info.running(),
+        info != null ? info.pid() : null,
+        info != null ? info.task() : null,
+        info != null ? info.startedAt() : null,
+        info != null ? info.branch() : null,
+        info != null ? info.logPath() : null);
   }
 
-  @Override
-  public Map<String, Object> agentLog(String project, int tail) {
+  private AgentLogResponse agentLogValue(String project, int tail) {
     requireProjectExists(project);
     var cmd =
         ContainerExec.asDevUser(
             project, List.of("tail", "-n", String.valueOf(tail), AgentSession.logPath()));
     var result = exec(cmd);
-    var map = new LinkedHashMap<String, Object>();
-    map.put("name", project);
     if (!result.ok()) {
       if (result.stderr().contains("No such file")) {
-        map.put("lines", List.of());
-        map.put("error", "No agent log found");
-        return map;
+        return new AgentLogResponse(project, List.of(), "No agent log found");
       }
-      throw new ApiException(500, "agent_log_failed", "Failed to read agent log.", null);
+      throw new ApiException(ErrorCode.AGENT_LOG_FAILED, "Failed to read agent log.");
     }
-    map.put(
-        "lines",
-        Arrays.stream(result.stdout().split("\n")).filter(line -> !line.isEmpty()).toList());
-    return map;
+    var lines = Arrays.stream(result.stdout().split("\n")).filter(line -> !line.isEmpty()).toList();
+    return new AgentLogResponse(project, lines, null);
   }
 
-  @Override
-  public Map<String, Object> stopAgent(String project) {
+  private StopAgentResponse stopAgentValue(String project) {
     requireProjectExists(project);
     var agentSession = new AgentSession(shell);
     var info = querySession(agentSession, project);
-    var map = new LinkedHashMap<String, Object>();
-    map.put("name", project);
     if (info == null || !info.running()) {
-      map.put("stopped", false);
-      map.put("reason", "no_agent_running");
-      return map;
+      return new StopAgentResponse(project, false, "no_agent_running", null);
     }
     try {
       agentSession.killAgent(project);
     } catch (Exception e) {
-      throw new ApiException(500, "agent_stop_failed", "Failed to stop agent.", null);
+      throw new ApiException(ErrorCode.AGENT_STOP_FAILED, "Failed to stop agent.", e);
     }
-    map.put("stopped", true);
-    map.put("pid", info.pid());
-    return map;
+    return new StopAgentResponse(project, true, null, info.pid());
   }
 
-  @Override
-  public Map<String, Object> agentReport(String project) {
+  private AgentReportResponse agentReportValue(String project) {
     var loaded = loadProject(project);
     try {
-      return new AgentReporter(shell).generate(project, loaded.config()).toMap();
+      return agentReportView(new AgentReporter(shell).generate(project, loaded.config()));
     } catch (Exception e) {
-      throw new ApiException(500, "agent_report_failed", "Failed to generate agent report.", null);
+      throw new ApiException(ErrorCode.AGENT_REPORT_FAILED, "Failed to generate agent report.", e);
     }
   }
 
@@ -238,7 +234,7 @@ public final class SingApiOperations implements ApiOperations {
     try {
       return workspace.readIndex();
     } catch (Exception e) {
-      throw new ApiException(500, "specs_read_failed", "Failed to read specs index.", null);
+      throw new ApiException(ErrorCode.SPECS_READ_FAILED, "Failed to read specs index.", e);
     }
   }
 
@@ -246,7 +242,7 @@ public final class SingApiOperations implements ApiOperations {
     try {
       return workspace.readSpecBody(specId);
     } catch (Exception e) {
-      throw new ApiException(500, "spec_read_failed", "Failed to read spec content.", null);
+      throw new ApiException(ErrorCode.SPEC_READ_FAILED, "Failed to read spec content.", e);
     }
   }
 
@@ -255,7 +251,7 @@ public final class SingApiOperations implements ApiOperations {
       workspace.updateStatus(specId, status);
     } catch (Exception e) {
       throw new ApiException(
-          500, "spec_status_update_failed", "Failed to update spec status.", null);
+          ErrorCode.SPEC_STATUS_UPDATE_FAILED, "Failed to update spec status.", e);
     }
   }
 
@@ -276,15 +272,14 @@ public final class SingApiOperations implements ApiOperations {
       }
       case ContainerState.Stopped ignored ->
           throw new ApiException(
-              409,
-              "project_stopped",
+              ErrorCode.PROJECT_STOPPED,
               "Project '" + project + "' is stopped.",
               "Start it with sing up " + project + ".");
       case ContainerState.NotCreated ignored ->
           throw new ApiException(
-              404, "project_not_created", "Project '" + project + "' does not exist.", null);
-      case ContainerState.Error e ->
-          throw new ApiException(500, "container_error", e.message(), null);
+              ErrorCode.PROJECT_NOT_CREATED, "Project '" + project + "' does not exist.");
+      case ContainerState.Error error ->
+          throw new ApiException(ErrorCode.CONTAINER_ERROR, error.message());
     }
   }
 
@@ -292,17 +287,15 @@ public final class SingApiOperations implements ApiOperations {
     var singYamlPath = SingPaths.resolveSingYaml(project, file);
     if (!Files.exists(singYamlPath)) {
       throw new ApiException(
-          404,
-          "project_descriptor_not_found",
-          "Project descriptor was not found: " + singYamlPath.toAbsolutePath(),
-          null);
+          ErrorCode.PROJECT_DESCRIPTOR_NOT_FOUND,
+          "Project descriptor was not found: " + singYamlPath.toAbsolutePath());
     }
     try {
       var config = SingYaml.fromMap(YamlUtil.parseFile(singYamlPath));
       var state = new ContainerManager(shell).queryState(project);
       return new LoadedProject(config, state);
     } catch (Exception e) {
-      throw new ApiException(500, "project_load_failed", "Failed to load project.", null);
+      throw new ApiException(ErrorCode.PROJECT_LOAD_FAILED, "Failed to load project.", e);
     }
   }
 
@@ -310,18 +303,17 @@ public final class SingApiOperations implements ApiOperations {
     var state = loadProject(project).state();
     if (state instanceof ContainerState.NotCreated) {
       throw new ApiException(
-          404, "project_not_created", "Project '" + project + "' does not exist.", null);
+          ErrorCode.PROJECT_NOT_CREATED, "Project '" + project + "' does not exist.");
     }
-    if (state instanceof ContainerState.Error e) {
-      throw new ApiException(500, "container_error", e.message(), null);
+    if (state instanceof ContainerState.Error error) {
+      throw new ApiException(ErrorCode.CONTAINER_ERROR, error.message());
     }
   }
 
   private SpecWorkspace workspace(LoadedProject loaded) {
     if (loaded.config().agent() == null || loaded.config().agent().specsDir() == null) {
       throw new ApiException(
-          422,
-          "specs_not_configured",
+          ErrorCode.SPECS_NOT_CONFIGURED,
           "No specs_dir configured in the project agent block.",
           "Add specs_dir to sing.yaml.");
     }
@@ -336,38 +328,36 @@ public final class SingApiOperations implements ApiOperations {
     }
     var spec = SpecDirectory.findById(specs, specId);
     if (spec == null) {
-      throw new ApiException(404, "spec_not_found", "Spec '" + specId + "' was not found.", null);
+      throw new ApiException(ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found.");
     }
     if (!SpecDirectory.isReady(specs, spec)) {
       throw new ApiException(
-          409,
-          "spec_not_ready",
+          ErrorCode.SPEC_NOT_READY,
           "Spec '" + specId + "' is not ready for dispatch.",
           "Resolve dependencies or choose a ready spec.");
     }
     return spec;
   }
 
-  private static Map<String, Object> specMap(List<Spec> specs, Spec spec) {
-    var map = new LinkedHashMap<String, Object>(spec.toMap());
-    map.put("ready", SpecDirectory.isReady(specs, spec));
-    map.put("blocked", SpecDirectory.isBlocked(specs, spec));
-    var unmet = SpecDirectory.unmetDependencies(specs, spec);
-    if (!unmet.isEmpty()) {
-      map.put("unmet_dependencies", unmet);
-    }
-    return map;
+  private static SpecView specView(List<Spec> specs, Spec spec) {
+    return new SpecView(
+        spec.id(),
+        spec.title(),
+        spec.status(),
+        spec.assignee(),
+        spec.dependsOn(),
+        spec.branch(),
+        SpecDirectory.isReady(specs, spec),
+        SpecDirectory.isBlocked(specs, spec),
+        SpecDirectory.unmetDependencies(specs, spec));
   }
 
-  private static Map<String, Object> dispatchedSpecMap(Spec spec, String branch) {
-    var map = new LinkedHashMap<String, Object>();
-    map.put("id", spec.id());
-    map.put("title", spec.title());
-    map.put("status", "in_progress");
-    if (branch != null && !branch.isBlank()) {
-      map.put("branch", branch);
-    }
-    return map;
+  private static DispatchedSpecView dispatchedSpecView(Spec spec, String branch) {
+    return new DispatchedSpecView(
+        spec.id(),
+        spec.title(),
+        "in_progress",
+        branch != null && !branch.isBlank() ? branch : null);
   }
 
   private static String buildTaskPrompt(Spec spec, String description) {
@@ -395,7 +385,7 @@ public final class SingApiOperations implements ApiOperations {
       snapMgr.create(project, label);
       return label;
     } catch (Exception e) {
-      throw new ApiException(500, "snapshot_failed", "Failed to create dispatch snapshot.", null);
+      throw new ApiException(ErrorCode.SNAPSHOT_FAILED, "Failed to create dispatch snapshot.", e);
     }
   }
 
@@ -418,7 +408,7 @@ public final class SingApiOperations implements ApiOperations {
                 project, List.of("git", "-C", repoDir, "checkout", "-b", branch)));
     if (!result.ok()) {
       throw new ApiException(
-          500, "branch_create_failed", "Failed to create branch '" + branch + "'.", null);
+          ErrorCode.BRANCH_CREATE_FAILED, "Failed to create branch '" + branch + "'.");
     }
     return true;
   }
@@ -440,13 +430,11 @@ public final class SingApiOperations implements ApiOperations {
                   project, config.sshUser(), workDir, true, agentCli);
       var result = exec(command);
       if (!result.ok()) {
-        throw new ApiException(500, "agent_launch_failed", "Failed to launch agent.", null);
+        throw new ApiException(ErrorCode.AGENT_LAUNCH_FAILED, "Failed to launch agent.");
       }
       launchWatcherIfGuardrails(project, config);
-    } catch (ApiException e) {
-      throw e;
     } catch (Exception e) {
-      throw new ApiException(500, "agent_launch_failed", "Failed to launch agent.", null);
+      throw new ApiException(ErrorCode.AGENT_LAUNCH_FAILED, "Failed to launch agent.", e);
     }
   }
 
@@ -492,43 +480,79 @@ public final class SingApiOperations implements ApiOperations {
     try {
       return session.queryStatus(project);
     } catch (Exception e) {
-      throw new ApiException(500, "agent_status_failed", "Failed to query agent status.", null);
+      throw new ApiException(ErrorCode.AGENT_STATUS_FAILED, "Failed to query agent status.", e);
     }
   }
 
-  private Map<String, Object> agentMap(
+  private static AgentConfigView agentConfigView(SingYaml config) {
+    var agent = config.agent();
+    return new AgentConfigView(
+        agent.type(), agent.autoSnapshot(), agent.autoBranch(), agent.specsDir());
+  }
+
+  private static AgentStatusView agentStatusView(
       SingYaml config, String mode, AgentSession.SessionInfo info) {
-    var map = new LinkedHashMap<String, Object>();
-    map.put("type", config.agent() != null ? config.agent().type() : "");
-    map.put("mode", mode);
-    map.put("running", info != null && info.running());
-    if (info != null) {
-      map.putAll(sessionMap(info));
-    }
-    return map;
+    return new AgentStatusView(
+        config.agent() != null ? config.agent().type() : "",
+        mode,
+        info != null && info.running(),
+        info != null ? info.pid() : null,
+        info != null ? info.task() : null,
+        info != null ? info.startedAt() : null,
+        info != null ? info.branch() : null,
+        info != null ? info.logPath() : null);
   }
 
-  private static Map<String, Object> sessionMap(AgentSession.SessionInfo info) {
-    var map = new LinkedHashMap<String, Object>();
-    map.put("pid", info.pid());
-    map.put("task", info.task());
-    map.put("started_at", info.startedAt());
-    map.put("branch", info.branch());
-    map.put("log_path", info.logPath());
-    return map;
+  private static AgentReportResponse agentReportView(AgentReporter.Report report) {
+    return new AgentReportResponse(
+        report.name(),
+        report.sessionStatus(),
+        report.startedAt(),
+        report.endedAt(),
+        report.duration(),
+        report.branch(),
+        report.specs().stream().map(spec -> specView(report.specs(), spec)).toList(),
+        report.commitCount(),
+        report.lastCommitMinutesAgo() >= 0 ? report.lastCommitMinutesAgo() : null,
+        report.guardrailTriggered(),
+        report.guardrailReason(),
+        report.guardrailAction(),
+        report.rolledBack(),
+        report.rollbackSnapshot());
+  }
+
+  private static SpecSummaryView summaryView(java.util.Map<String, Integer> counts) {
+    return new SpecSummaryView(
+        counts.getOrDefault("pending", 0),
+        counts.getOrDefault("in_progress", 0),
+        counts.getOrDefault("review", 0),
+        counts.getOrDefault("done", 0));
+  }
+
+  private static BoardSummaryView boardSummaryView(SpecDirectory.Summary summary) {
+    return new BoardSummaryView(
+        summaryView(summary.counts()),
+        summary.readyCount(),
+        summary.blockedCount(),
+        summary.nextReadyId());
   }
 
   private ShellExec.Result exec(List<String> command) {
     try {
       return shell.exec(command);
     } catch (Exception e) {
-      throw new ApiException(500, "command_failed", "A sing system command failed.", null);
+      throw new ApiException(ErrorCode.COMMAND_FAILED, "A sing system command failed.", e);
     }
   }
 
-  private static String optionalString(Map<String, Object> map, String key) {
-    var value = map.get(key);
-    return value == null ? null : value.toString();
+  private static <T> Result<T> safe(Supplier<T> supplier) {
+    try {
+      return Result.success(supplier.get());
+    } catch (ApiException e) {
+      return e.failure().asFailure();
+    } catch (Exception e) {
+      return Result.failure(ErrorCode.INTERNAL, "sing API operation failed.", e);
+    }
   }
 
   private record LoadedProject(SingYaml config, ContainerState state) {}

--- a/sing-infra/src/main/java/ai/singlr/sing/api/SingApiServer.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/SingApiServer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public final class SingApiServer implements AutoCloseable {
+
+  private final HttpServer server;
+  private final ExecutorService executor;
+
+  public SingApiServer(String host, int port, ApiOperations operations, String token)
+      throws IOException {
+    server = HttpServer.create(new InetSocketAddress(host, port), 32);
+    executor = Executors.newVirtualThreadPerTaskExecutor();
+    server.createContext("/", new ApiRouter(operations, new BearerAuth(token)));
+    server.setExecutor(executor);
+  }
+
+  public void start() {
+    server.start();
+  }
+
+  public int port() {
+    return server.getAddress().getPort();
+  }
+
+  @Override
+  public void close() {
+    server.stop(0);
+    executor.close();
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ApiCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ApiCommand.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.commands;
+
+import ai.singlr.sing.api.ApiTokenStore;
+import ai.singlr.sing.api.SingApiOperations;
+import ai.singlr.sing.api.SingApiServer;
+import ai.singlr.sing.engine.Banner;
+import java.nio.file.Path;
+import java.security.SecureRandom;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Spec;
+
+@Command(
+    name = "api",
+    description = "Run the authenticated local sing API server.",
+    mixinStandardHelpOptions = true)
+public final class ApiCommand implements Runnable {
+
+  @Option(names = "--host", description = "Host to bind.", defaultValue = "127.0.0.1")
+  private String host;
+
+  @Option(names = "--port", description = "Port to bind.", defaultValue = "7070")
+  private int port;
+
+  @Option(names = "--token", description = "Bearer token. Defaults to token-file contents.")
+  private String token;
+
+  @Option(names = "--token-file", description = "Bearer token file.")
+  private Path tokenFile;
+
+  @Spec private CommandSpec spec;
+
+  @Override
+  public void run() {
+    try {
+      execute();
+    } catch (Exception e) {
+      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
+      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
+      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
+    }
+  }
+
+  private void execute() throws Exception {
+    var resolvedToken = token != null ? token : tokenStore().readOrCreate();
+    try (var server = new SingApiServer(host, port, new SingApiOperations(), resolvedToken)) {
+      server.start();
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|green ✓|@ sing API listening on http://" + host + ":" + server.port()));
+      new CountDownLatch(1).await();
+    }
+  }
+
+  private ApiTokenStore tokenStore() {
+    return tokenFile != null
+        ? new ApiTokenStore(tokenFile, new SecureRandom())
+        : ApiTokenStore.defaultStore();
+  }
+}

--- a/sing-infra/src/test/java/ai/singlr/sing/api/ApiJsonTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/api/ApiJsonTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ApiJsonTest {
+
+  @Test
+  void schemaWrapsScalarValuesAsData() {
+    var json = ApiJson.withSchema("ok");
+
+    assertEquals(1, json.get("schema_version"));
+    assertEquals("ok", json.get("data"));
+  }
+
+  @Test
+  void encodesPrimitiveNullEnumListAndMapValues() {
+    var value =
+        Map.of(
+            "text",
+            "ok",
+            "number",
+            7,
+            "flag",
+            true,
+            "error",
+            ErrorCode.NOT_FOUND,
+            "list",
+            List.of("one", ErrorCode.CONFLICT));
+
+    var encoded = ApiJson.encode(value);
+
+    assertTrue(encoded instanceof Map<?, ?>);
+    var map = (Map<?, ?>) encoded;
+    assertEquals("ok", map.get("text"));
+    assertEquals(7, map.get("number"));
+    assertEquals(true, map.get("flag"));
+    assertEquals("not_found", map.get("error"));
+    assertEquals(List.of("one", "conflict"), map.get("list"));
+    assertNull(ApiJson.encode(null));
+  }
+
+  @Test
+  void omitsNullMapAndRecordValues() {
+    var source = new java.util.LinkedHashMap<String, Object>();
+    source.put("keep", "yes");
+    source.put("skip", null);
+    var encodedMap = ApiJson.encode(source);
+    var record = new SampleRecord("hello", null, ErrorCode.INTERNAL);
+    var encodedRecord = ApiJson.encode(record);
+
+    assertEquals(Map.of("keep", "yes"), encodedMap);
+    assertTrue(encodedRecord instanceof Map<?, ?>);
+    var map = (Map<?, ?>) encodedRecord;
+    assertEquals("hello", map.get("camel_case"));
+    assertEquals("internal", map.get("error_code"));
+    assertFalse(map.containsKey("missing_value"));
+  }
+
+  @Test
+  void fallsBackToStringForPlainObjects() {
+    var value = new StringBuilder("plain");
+
+    assertEquals("plain", ApiJson.encode(value));
+  }
+
+  @Test
+  void wrapsRecordAccessorFailures() {
+    var record = new ExplodingRecord("value");
+
+    var thrown = assertThrows(IllegalStateException.class, () -> ApiJson.encode(record));
+
+    assertEquals("Failed to serialize API response", thrown.getMessage());
+  }
+
+  private record SampleRecord(String camelCase, String missingValue, ErrorCode errorCode) {}
+
+  private record ExplodingRecord(String value) {
+    @Override
+    public String value() {
+      throw new IllegalStateException("boom");
+    }
+  }
+}

--- a/sing-infra/src/test/java/ai/singlr/sing/api/ApiResultIntegrationTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/api/ApiResultIntegrationTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ApiResultIntegrationTest {
+
+  @Test
+  void exceptionExposesFailureStatusAndError() {
+    var exception = new ApiException(ErrorCode.PROJECT_STOPPED, "Stopped.", "Run sing up.");
+
+    assertEquals(409, exception.status());
+    assertEquals(ErrorCode.PROJECT_STOPPED, exception.failure().errorCode());
+    assertEquals("project_stopped", exception.error().code());
+    assertEquals("Run sing up.", exception.error().action());
+  }
+
+  @Test
+  void exceptionSupportsCauses() {
+    var cause = new IllegalStateException("root");
+    var exception = new ApiException(ErrorCode.COMMAND_FAILED, "Failed.", cause);
+
+    assertEquals(cause, exception.failure().cause());
+  }
+
+  @Test
+  void responseHelpersSerializeSuccessAndFailureResults() {
+    var success = ApiResponse.ok(Map.of("ok", true));
+    var failure = ApiResponse.from(Result.failure(ErrorCode.NOT_FOUND, "Missing."));
+
+    assertEquals(200, success.status());
+    assertEquals(true, success.body().get("ok"));
+    assertEquals(404, failure.status());
+    assertEquals("not_found", failure.body().toString().contains("not_found") ? "not_found" : null);
+  }
+}

--- a/sing-infra/src/test/java/ai/singlr/sing/api/ApiRouterTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/api/ApiRouterTest.java
@@ -194,6 +194,26 @@ class ApiRouterTest {
   }
 
   @Test
+  void missingTailValueReturnsUnprocessableEntity() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/projects/acme/agent/log?tail", "token");
+
+      assertEquals(422, response.statusCode());
+      assertTrue(response.body().contains("invalid_tail"));
+    }
+  }
+
+  @Test
+  void urlDecodedTailIsPassedToOperations() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/projects/acme/agent/log?tail=4%32", "token");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("42"));
+    }
+  }
+
+  @Test
   void missingTailQueryValueUsesDefault() throws Exception {
     try (var server = server()) {
       var response = get(server, "/v1/projects/acme/agent/log?foo=bar", "token");
@@ -206,6 +226,7 @@ class ApiRouterTest {
   @Test
   void shortUnknownRoutesReturnNotFound() throws Exception {
     try (var server = server()) {
+      assertEquals(404, get(server, "/", "token").statusCode());
       assertEquals(404, get(server, "/v1", "token").statusCode());
       assertEquals(404, get(server, "/bad/projects/acme", "token").statusCode());
       assertEquals(404, get(server, "/v1/project/acme", "token").statusCode());
@@ -213,10 +234,34 @@ class ApiRouterTest {
   }
 
   @Test
-  void unknownKnownFamiliesReturnMethodNotAllowed() throws Exception {
+  void knownResourcesWithWrongMethodsReturnMethodNotAllowed() throws Exception {
+    try (var server = server()) {
+      assertEquals(405, post(server, "/v1/projects/acme", "token", "{}").statusCode());
+      assertEquals(405, post(server, "/v1/projects/acme/specs", "token", "{}").statusCode());
+      assertEquals(405, get(server, "/v1/projects/acme/dispatch", "token").statusCode());
+      assertEquals(405, post(server, "/v1/projects/acme/agent", "token", "{}").statusCode());
+      assertEquals(405, post(server, "/v1/projects/acme/agent/log", "token", "{}").statusCode());
+      assertEquals(405, get(server, "/v1/projects/acme/agent/stop", "token").statusCode());
+      assertEquals(405, get(server, "/v1/projects/acme/agent/report", "token").statusCode());
+    }
+  }
+
+  @Test
+  void malformedKnownResourcesReturnMethodNotAllowed() throws Exception {
     try (var server = server()) {
       assertEquals(405, get(server, "/v1/projects/acme/specs/auth/extra", "token").statusCode());
-      assertEquals(405, get(server, "/v1/projects/acme/agent/report", "token").statusCode());
+      assertEquals(405, get(server, "/v1/projects/acme/dispatch/extra", "token").statusCode());
+      assertEquals(405, get(server, "/v1/projects/acme/agent/log/extra", "token").statusCode());
+    }
+  }
+
+  @Test
+  void unknownAgentSubResourcesReturnNotFound() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/projects/acme/agent/unknown", "token");
+
+      assertEquals(404, response.statusCode());
+      assertTrue(response.body().contains("not_found"));
     }
   }
 

--- a/sing-infra/src/test/java/ai/singlr/sing/api/ApiRouterTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/api/ApiRouterTest.java
@@ -12,7 +12,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -71,8 +70,8 @@ class ApiRouterTest {
       var response = post(server, "/v1/projects/acme/dispatch", "token", "{\"spec_id\": \"auth\"}");
 
       assertEquals(200, response.statusCode());
-      assertTrue(response.body().contains("\"spec_id\": \"auth\""));
-      assertTrue(response.body().contains("\"project\": \"acme\""));
+      assertTrue(response.body().contains("\"id\": \"auth\""));
+      assertTrue(response.body().contains("\"name\": \"acme\""));
     }
   }
 
@@ -180,7 +179,7 @@ class ApiRouterTest {
       var response = get(server, "/v1/projects/acme/agent/log?tail=42", "token");
 
       assertEquals(200, response.statusCode());
-      assertTrue(response.body().contains("\"tail\": 42"));
+      assertTrue(response.body().contains("42"));
     }
   }
 
@@ -200,7 +199,7 @@ class ApiRouterTest {
       var response = get(server, "/v1/projects/acme/agent/log?foo=bar", "token");
 
       assertEquals(200, response.statusCode());
-      assertTrue(response.body().contains("\"tail\": 200"));
+      assertTrue(response.body().contains("200"));
     }
   }
 
@@ -242,7 +241,7 @@ class ApiRouterTest {
       var response = get(server, "/v1/projects/acme/agent", "token");
 
       assertEquals(409, response.statusCode());
-      assertTrue(response.body().contains("agent_busy"));
+      assertTrue(response.body().contains("conflict"));
     }
   }
 
@@ -254,15 +253,17 @@ class ApiRouterTest {
       var response = get(server, "/v1/projects/acme/agent", "token");
 
       assertEquals(500, response.statusCode());
-      assertTrue(response.body().contains("internal_error"));
+      assertTrue(response.body().contains("internal"));
     }
   }
 
   @Test
   void responseHelpersAddSchema() {
     assertEquals(201, ApiResponse.created(Map.of("created", true)).status());
-    assertFalse(new ApiError("code", "message", "").toMap().containsKey("action"));
-    assertTrue(new ApiError("code", "message", "fix").toMap().containsKey("action"));
+    assertFalse(
+        ApiJson.withSchema(new ApiError("code", "message", "")).toString().contains("action"));
+    assertTrue(
+        ApiJson.withSchema(new ApiError("code", "message", "fix")).toString().contains("action"));
     assertThrows(IllegalArgumentException.class, () -> new BearerAuth(null));
     assertThrows(IllegalArgumentException.class, () -> new BearerAuth(""));
   }
@@ -300,64 +301,105 @@ class ApiRouterTest {
 
   private static class FakeOperations implements ApiOperations {
     @Override
-    public Map<String, Object> health() {
-      return Map.of("status", "ok");
+    public Result<HealthResponse> health() {
+      return Result.success(new HealthResponse("ok"));
     }
 
     @Override
-    public Map<String, Object> project(String project) {
-      return Map.of("project", project, "container_status", "running");
+    public Result<ProjectResponse> project(String project) {
+      return Result.success(new ProjectResponse(project, "running", null));
     }
 
     @Override
-    public Map<String, Object> specs(String project) {
-      return Map.of("project", project, "specs", java.util.List.of());
+    public Result<SpecsResponse> specs(String project) {
+      return Result.success(
+          new SpecsResponse(
+              project,
+              java.util.List.of(),
+              new SpecSummaryView(0, 0, 0, 0),
+              new BoardSummaryView(new SpecSummaryView(0, 0, 0, 0), 0, 0, null)));
     }
 
     @Override
-    public Map<String, Object> spec(String project, String specId) {
-      return Map.of("project", project, "spec_id", specId);
+    public Result<SpecResponse> spec(String project, String specId) {
+      return Result.success(
+          new SpecResponse(
+              project,
+              new SpecView(
+                  specId,
+                  "Spec",
+                  "pending",
+                  null,
+                  java.util.List.of(),
+                  null,
+                  true,
+                  false,
+                  java.util.List.of()),
+              "specs/" + specId + "/spec.md",
+              true,
+              "content"));
     }
 
     @Override
-    public Map<String, Object> dispatch(String project, Map<String, Object> request) {
-      var map = new LinkedHashMap<String, Object>();
-      map.put("project", project);
-      map.put("spec_id", request.get("spec_id"));
-      return map;
+    public Result<DispatchResponse> dispatch(String project, DispatchRequest request) {
+      return Result.success(
+          new DispatchResponse(
+              project,
+              true,
+              null,
+              new DispatchedSpecView(request.specId(), "Spec", "in_progress", null),
+              null,
+              "",
+              false));
     }
 
     @Override
-    public Map<String, Object> agentStatus(String project) {
-      return Map.of("project", project, "agent_running", false);
+    public Result<AgentStatusResponse> agentStatus(String project) {
+      return Result.success(new AgentStatusResponse(project, false, null, null, null, null, null));
     }
 
     @Override
-    public Map<String, Object> agentLog(String project, int tail) {
-      return Map.of("project", project, "tail", tail);
+    public Result<AgentLogResponse> agentLog(String project, int tail) {
+      return Result.success(
+          new AgentLogResponse(project, java.util.List.of(String.valueOf(tail)), null));
     }
 
     @Override
-    public Map<String, Object> stopAgent(String project) {
-      return Map.of("project", project, "stopped", false);
+    public Result<StopAgentResponse> stopAgent(String project) {
+      return Result.success(new StopAgentResponse(project, false, null, null));
     }
 
     @Override
-    public Map<String, Object> agentReport(String project) {
-      return Map.of("project", project, "session_status", "No session");
+    public Result<AgentReportResponse> agentReport(String project) {
+      return Result.success(
+          new AgentReportResponse(
+              project,
+              "No session",
+              null,
+              null,
+              null,
+              null,
+              java.util.List.of(),
+              0,
+              null,
+              false,
+              null,
+              null,
+              false,
+              null));
     }
   }
 
   private static final class FailingOperations extends FakeOperations {
     @Override
-    public Map<String, Object> agentStatus(String project) {
-      throw new ApiException(409, "agent_busy", "Agent is busy.", "Wait.");
+    public Result<AgentStatusResponse> agentStatus(String project) {
+      return Result.failure(ErrorCode.CONFLICT, "Agent is busy.", "Wait.");
     }
   }
 
   private static final class ExplodingOperations extends FakeOperations {
     @Override
-    public Map<String, Object> agentStatus(String project) {
+    public Result<AgentStatusResponse> agentStatus(String project) {
       throw new IllegalStateException("boom");
     }
   }

--- a/sing-infra/src/test/java/ai/singlr/sing/api/ApiRouterTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/api/ApiRouterTest.java
@@ -40,6 +40,22 @@ class ApiRouterTest {
   }
 
   @Test
+  void malformedBearerHeaderIsRejected() throws Exception {
+    try (var server = server()) {
+      var request =
+          HttpRequest.newBuilder(uri(server, "/v1/projects/acme/agent"))
+              .header("Authorization", "Token token")
+              .GET()
+              .build();
+
+      var response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+
+      assertEquals(401, response.statusCode());
+      assertTrue(response.body().contains("missing_bearer_token"));
+    }
+  }
+
+  @Test
   void protectedRoutesRejectWrongBearerToken() throws Exception {
     try (var server = server()) {
       var response = get(server, "/v1/projects/acme/agent", "wrong");
@@ -111,6 +127,16 @@ class ApiRouterTest {
   }
 
   @Test
+  void emptyJsonBodyDefaultsToEmptyRequest() throws Exception {
+    try (var server = server()) {
+      var response = post(server, "/v1/projects/acme/dispatch", "token", "");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("schema_version"));
+    }
+  }
+
+  @Test
   void unsupportedContentTypeReturnsUnsupportedMediaType() throws Exception {
     try (var server = server()) {
       var request =
@@ -149,6 +175,53 @@ class ApiRouterTest {
   }
 
   @Test
+  void validTailIsPassedToOperations() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/projects/acme/agent/log?tail=42", "token");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"tail\": 42"));
+    }
+  }
+
+  @Test
+  void invalidTailTextReturnsUnprocessableEntity() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/projects/acme/agent/log?tail=abc", "token");
+
+      assertEquals(422, response.statusCode());
+      assertTrue(response.body().contains("invalid_tail"));
+    }
+  }
+
+  @Test
+  void missingTailQueryValueUsesDefault() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/projects/acme/agent/log?foo=bar", "token");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"tail\": 200"));
+    }
+  }
+
+  @Test
+  void shortUnknownRoutesReturnNotFound() throws Exception {
+    try (var server = server()) {
+      assertEquals(404, get(server, "/v1", "token").statusCode());
+      assertEquals(404, get(server, "/bad/projects/acme", "token").statusCode());
+      assertEquals(404, get(server, "/v1/project/acme", "token").statusCode());
+    }
+  }
+
+  @Test
+  void unknownKnownFamiliesReturnMethodNotAllowed() throws Exception {
+    try (var server = server()) {
+      assertEquals(405, get(server, "/v1/projects/acme/specs/auth/extra", "token").statusCode());
+      assertEquals(405, get(server, "/v1/projects/acme/agent/report", "token").statusCode());
+    }
+  }
+
+  @Test
   void routesAgentAndSpecEndpoints() throws Exception {
     try (var server = server()) {
       assertEquals(200, get(server, "/v1/projects/acme", "token").statusCode());
@@ -171,6 +244,27 @@ class ApiRouterTest {
       assertEquals(409, response.statusCode());
       assertTrue(response.body().contains("agent_busy"));
     }
+  }
+
+  @Test
+  void unexpectedOperationExceptionsBecomeInternalErrors() throws Exception {
+    try (var server = new SingApiServer("127.0.0.1", 0, new ExplodingOperations(), "token")) {
+      server.start();
+
+      var response = get(server, "/v1/projects/acme/agent", "token");
+
+      assertEquals(500, response.statusCode());
+      assertTrue(response.body().contains("internal_error"));
+    }
+  }
+
+  @Test
+  void responseHelpersAddSchema() {
+    assertEquals(201, ApiResponse.created(Map.of("created", true)).status());
+    assertFalse(new ApiError("code", "message", "").toMap().containsKey("action"));
+    assertTrue(new ApiError("code", "message", "fix").toMap().containsKey("action"));
+    assertThrows(IllegalArgumentException.class, () -> new BearerAuth(null));
+    assertThrows(IllegalArgumentException.class, () -> new BearerAuth(""));
   }
 
   private static SingApiServer server() throws IOException {
@@ -258,6 +352,13 @@ class ApiRouterTest {
     @Override
     public Map<String, Object> agentStatus(String project) {
       throw new ApiException(409, "agent_busy", "Agent is busy.", "Wait.");
+    }
+  }
+
+  private static final class ExplodingOperations extends FakeOperations {
+    @Override
+    public Map<String, Object> agentStatus(String project) {
+      throw new IllegalStateException("boom");
     }
   }
 }

--- a/sing-infra/src/test/java/ai/singlr/sing/api/ApiRouterTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/api/ApiRouterTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ApiRouterTest {
+
+  @Test
+  void healthDoesNotRequireAuth() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/health", null);
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"status\": \"ok\""));
+      assertTrue(response.body().contains("\"schema_version\": 1"));
+    }
+  }
+
+  @Test
+  void protectedRoutesRequireBearerToken() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/projects/acme/agent", null);
+
+      assertEquals(401, response.statusCode());
+      assertTrue(response.body().contains("missing_bearer_token"));
+    }
+  }
+
+  @Test
+  void protectedRoutesRejectWrongBearerToken() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/projects/acme/agent", "wrong");
+
+      assertEquals(403, response.statusCode());
+      assertTrue(response.body().contains("invalid_bearer_token"));
+    }
+  }
+
+  @Test
+  void dispatchParsesJsonBody() throws Exception {
+    try (var server = server()) {
+      var response = post(server, "/v1/projects/acme/dispatch", "token", "{\"spec_id\": \"auth\"}");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"spec_id\": \"auth\""));
+      assertTrue(response.body().contains("\"project\": \"acme\""));
+    }
+  }
+
+  @Test
+  void methodMismatchReturnsMethodNotAllowed() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/projects/acme/dispatch", "token");
+
+      assertEquals(405, response.statusCode());
+      assertTrue(response.body().contains("method_not_allowed"));
+    }
+  }
+
+  @Test
+  void unknownRouteReturnsNotFound() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/projects/acme/unknown", "token");
+
+      assertEquals(404, response.statusCode());
+      assertTrue(response.body().contains("not_found"));
+    }
+  }
+
+  @Test
+  void invalidProjectNameReturnsUnprocessableEntity() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/projects/Bad_Name/agent", "token");
+
+      assertEquals(422, response.statusCode());
+      assertTrue(response.body().contains("invalid_request"));
+    }
+  }
+
+  @Test
+  void invalidSpecIdReturnsUnprocessableEntity() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/projects/acme/specs/Bad_Name", "token");
+
+      assertEquals(422, response.statusCode());
+      assertTrue(response.body().contains("invalid_request"));
+    }
+  }
+
+  @Test
+  void invalidJsonReturnsBadRequest() throws Exception {
+    try (var server = server()) {
+      var response = post(server, "/v1/projects/acme/dispatch", "token", "{");
+
+      assertEquals(400, response.statusCode());
+      assertTrue(response.body().contains("invalid_json"));
+    }
+  }
+
+  @Test
+  void unsupportedContentTypeReturnsUnsupportedMediaType() throws Exception {
+    try (var server = server()) {
+      var request =
+          HttpRequest.newBuilder(uri(server, "/v1/projects/acme/dispatch"))
+              .header("Authorization", "Bearer token")
+              .header("Content-Type", "text/plain")
+              .POST(HttpRequest.BodyPublishers.ofString("{}"))
+              .build();
+
+      var response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+
+      assertEquals(415, response.statusCode());
+      assertTrue(response.body().contains("unsupported_media_type"));
+    }
+  }
+
+  @Test
+  void oversizedBodyReturnsPayloadTooLarge() throws Exception {
+    try (var server = server()) {
+      var body = "{\"value\":\"" + "x".repeat(70_000) + "\"}";
+      var response = post(server, "/v1/projects/acme/dispatch", "token", body);
+
+      assertEquals(413, response.statusCode());
+      assertTrue(response.body().contains("request_too_large"));
+    }
+  }
+
+  @Test
+  void invalidTailReturnsUnprocessableEntity() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/projects/acme/agent/log?tail=0", "token");
+
+      assertEquals(422, response.statusCode());
+      assertTrue(response.body().contains("invalid_tail"));
+    }
+  }
+
+  @Test
+  void routesAgentAndSpecEndpoints() throws Exception {
+    try (var server = server()) {
+      assertEquals(200, get(server, "/v1/projects/acme", "token").statusCode());
+      assertEquals(200, get(server, "/v1/projects/acme/specs", "token").statusCode());
+      assertEquals(200, get(server, "/v1/projects/acme/specs/auth", "token").statusCode());
+      assertEquals(200, get(server, "/v1/projects/acme/agent", "token").statusCode());
+      assertEquals(200, get(server, "/v1/projects/acme/agent/log", "token").statusCode());
+      assertEquals(200, post(server, "/v1/projects/acme/agent/stop", "token", "{}").statusCode());
+      assertEquals(200, post(server, "/v1/projects/acme/agent/report", "token", "{}").statusCode());
+    }
+  }
+
+  @Test
+  void operationExceptionsBecomeStructuredErrors() throws Exception {
+    try (var server = new SingApiServer("127.0.0.1", 0, new FailingOperations(), "token")) {
+      server.start();
+
+      var response = get(server, "/v1/projects/acme/agent", "token");
+
+      assertEquals(409, response.statusCode());
+      assertTrue(response.body().contains("agent_busy"));
+    }
+  }
+
+  private static SingApiServer server() throws IOException {
+    var server = new SingApiServer("127.0.0.1", 0, new FakeOperations(), "token");
+    server.start();
+    return server;
+  }
+
+  private static HttpResponse<String> get(SingApiServer server, String path, String token)
+      throws Exception {
+    var builder = HttpRequest.newBuilder(uri(server, path)).GET();
+    if (token != null) {
+      builder.header("Authorization", "Bearer " + token);
+    }
+    return HttpClient.newHttpClient().send(builder.build(), HttpResponse.BodyHandlers.ofString());
+  }
+
+  private static HttpResponse<String> post(
+      SingApiServer server, String path, String token, String body) throws Exception {
+    var builder =
+        HttpRequest.newBuilder(uri(server, path))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body));
+    if (token != null) {
+      builder.header("Authorization", "Bearer " + token);
+    }
+    return HttpClient.newHttpClient().send(builder.build(), HttpResponse.BodyHandlers.ofString());
+  }
+
+  private static URI uri(SingApiServer server, String path) {
+    return URI.create("http://127.0.0.1:" + server.port() + path);
+  }
+
+  private static class FakeOperations implements ApiOperations {
+    @Override
+    public Map<String, Object> health() {
+      return Map.of("status", "ok");
+    }
+
+    @Override
+    public Map<String, Object> project(String project) {
+      return Map.of("project", project, "container_status", "running");
+    }
+
+    @Override
+    public Map<String, Object> specs(String project) {
+      return Map.of("project", project, "specs", java.util.List.of());
+    }
+
+    @Override
+    public Map<String, Object> spec(String project, String specId) {
+      return Map.of("project", project, "spec_id", specId);
+    }
+
+    @Override
+    public Map<String, Object> dispatch(String project, Map<String, Object> request) {
+      var map = new LinkedHashMap<String, Object>();
+      map.put("project", project);
+      map.put("spec_id", request.get("spec_id"));
+      return map;
+    }
+
+    @Override
+    public Map<String, Object> agentStatus(String project) {
+      return Map.of("project", project, "agent_running", false);
+    }
+
+    @Override
+    public Map<String, Object> agentLog(String project, int tail) {
+      return Map.of("project", project, "tail", tail);
+    }
+
+    @Override
+    public Map<String, Object> stopAgent(String project) {
+      return Map.of("project", project, "stopped", false);
+    }
+
+    @Override
+    public Map<String, Object> agentReport(String project) {
+      return Map.of("project", project, "session_status", "No session");
+    }
+  }
+
+  private static final class FailingOperations extends FakeOperations {
+    @Override
+    public Map<String, Object> agentStatus(String project) {
+      throw new ApiException(409, "agent_busy", "Agent is busy.", "Wait.");
+    }
+  }
+}

--- a/sing-infra/src/test/java/ai/singlr/sing/api/ApiTokenStoreTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/api/ApiTokenStoreTest.java
@@ -48,4 +48,25 @@ class ApiTokenStoreTest {
 
     assertTrue(error.getMessage().contains("empty"));
   }
+
+  @Test
+  void defaultStoreUsesSingDirectory() {
+    assertTrue(ApiTokenStore.defaultStore().path().toString().endsWith("api-token"));
+  }
+
+  @Test
+  void unsupportedPermissionsAreIgnored() throws Exception {
+    var path = tempDir.resolve("api-token");
+    var store =
+        new ApiTokenStore(
+            path,
+            new SecureRandom(new byte[] {1}),
+            ignored -> {
+              throw new UnsupportedOperationException("not posix");
+            });
+
+    var token = store.readOrCreate();
+
+    assertFalse(token.isBlank());
+  }
 }

--- a/sing-infra/src/test/java/ai/singlr/sing/api/ApiTokenStoreTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/api/ApiTokenStoreTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.SecureRandom;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ApiTokenStoreTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void createsTokenWhenMissing() throws Exception {
+    var path = tempDir.resolve("api-token");
+    var store = new ApiTokenStore(path, new SecureRandom(new byte[] {1, 2, 3}));
+
+    var token = store.readOrCreate();
+
+    assertFalse(token.isBlank());
+    assertEquals(token, Files.readString(path).strip());
+    assertEquals(path, store.path());
+  }
+
+  @Test
+  void reusesExistingToken() throws Exception {
+    var path = tempDir.resolve("api-token");
+    Files.writeString(path, "known-token\n");
+    var store = new ApiTokenStore(path, new SecureRandom());
+
+    assertEquals("known-token", store.readOrCreate());
+  }
+
+  @Test
+  void rejectsBlankExistingToken() throws Exception {
+    var path = tempDir.resolve("api-token");
+    Files.writeString(path, "\n");
+    var store = new ApiTokenStore(path, new SecureRandom());
+
+    var error = assertThrows(java.io.IOException.class, store::readOrCreate);
+
+    assertTrue(error.getMessage().contains("empty"));
+  }
+}

--- a/sing-infra/src/test/java/ai/singlr/sing/api/ResultTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/api/ResultTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ResultTest {
+
+  @Test
+  void successExposesValueAndStatus() {
+    var result = Result.success("ok", 201);
+
+    assertTrue(result.isSuccess());
+    assertFalse(result.isFailure());
+    assertEquals("ok", result.orThrow());
+    assertEquals("ok", result.value());
+    assertEquals(201, result.code());
+    assertNull(result.errorCode());
+    assertNull(result.errorMessage());
+    assertNull(result.action());
+    assertEquals(List.of(), result.fieldErrors());
+    assertNull(result.cause());
+    assertNull(result.fullError());
+  }
+
+  @Test
+  void defaultSuccessUsesOkStatus() {
+    var result = Result.success("ok");
+
+    assertEquals(200, result.code());
+  }
+
+  @Test
+  void failureExposesStructuredError() {
+    var fieldErrors =
+        List.of(FieldError.of("spec_id", "is required"), FieldError.of("mode", "is invalid"));
+    var result = Result.failure(ErrorCode.INVALID_REQUEST, "Invalid request.", fieldErrors);
+
+    assertFalse(result.isSuccess());
+    assertTrue(result.isFailure());
+    assertNull(result.value());
+    assertEquals(422, result.code());
+    assertEquals(ErrorCode.INVALID_REQUEST, result.errorCode());
+    assertEquals("Invalid request.", result.errorMessage());
+    assertNull(result.action());
+    assertEquals(fieldErrors, result.fieldErrors());
+    assertNull(result.cause());
+    assertEquals(
+        "Invalid request. - Field errors: [spec_id: is required, mode: is invalid]",
+        result.fullError());
+  }
+
+  @Test
+  void failureSupportsActionAndCause() {
+    var cause = new IllegalArgumentException("boom");
+    var withAction = Result.failure(ErrorCode.CONFLICT, "Busy.", "Wait.");
+    var withCause = Result.failure(ErrorCode.INTERNAL, "Failed.", cause);
+
+    assertEquals("Wait.", withAction.action());
+    assertEquals(cause, withCause.cause());
+    assertEquals("Busy.", withAction.fullError());
+  }
+
+  @Test
+  void failureCanBeReTyped() {
+    Result<String> result = Result.failure(ErrorCode.NOT_FOUND, "Missing.");
+
+    var failure = result.<Integer>asFailure();
+
+    assertEquals(ErrorCode.NOT_FOUND, failure.errorCode());
+    assertEquals("Missing.", failure.errorMessage());
+  }
+
+  @Test
+  void failureWithNullMessageHasNoFullError() {
+    var failure = new Result.Failure<String>(ErrorCode.INTERNAL, null, null, null, null);
+
+    assertNull(failure.fullError());
+    assertEquals(List.of(), failure.fieldErrors());
+  }
+
+  @Test
+  void failuresThrowWithFullErrorAndCause() {
+    var cause = new IllegalStateException("root");
+    Result<String> result = Result.failure(ErrorCode.INTERNAL, "Failed.", cause);
+
+    var thrown = assertThrows(IllegalStateException.class, result::orThrow);
+
+    assertEquals("Failed.", thrown.getMessage());
+    assertEquals(cause, thrown.getCause());
+  }
+
+  @Test
+  void successCannotBeConvertedToFailure() {
+    var result = Result.success("ok");
+
+    assertThrows(IllegalStateException.class, result::asFailure);
+  }
+}

--- a/sing-infra/src/test/java/ai/singlr/sing/api/SingApiOperationsTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/api/SingApiOperationsTest.java
@@ -8,9 +8,11 @@ package ai.singlr.sing.api;
 import static org.junit.jupiter.api.Assertions.*;
 
 import ai.singlr.sing.engine.ShellExec;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +63,15 @@ class SingApiOperationsTest {
           depends_on: [missing]
       """;
 
+  private static final String INDEX_WITH_BRANCH_YAML =
+      """
+      specs:
+        - id: auth
+          title: Add auth
+          status: pending
+          branch: feat/custom
+      """;
+
   @TempDir Path tempDir;
 
   @Test
@@ -68,6 +79,11 @@ class SingApiOperationsTest {
     var operations = new SingApiOperations(new FakeShell(), "sing.yaml");
 
     assertEquals("ok", operations.health().get("status"));
+  }
+
+  @Test
+  void defaultConstructorSupportsHealthChecks() {
+    assertEquals("ok", new SingApiOperations().health().get("status"));
   }
 
   @Test
@@ -79,6 +95,34 @@ class SingApiOperationsTest {
     assertEquals("acme", result.get("name"));
     assertEquals("running", result.get("container_status"));
     assertTrue(result.get("agent").toString().contains("claude-code"));
+  }
+
+  @Test
+  void projectMapsStoppedMissingAndErrorStates() throws Exception {
+    assertEquals(
+        "stopped",
+        operations(shell().on("incus list ^acme$", STOPPED_JSON))
+            .project("acme")
+            .get("container_status"));
+    assertEquals(
+        "not_created",
+        operations(shell().on("incus list ^acme$", EMPTY_JSON))
+            .project("acme")
+            .get("container_status"));
+    assertEquals(
+        "error",
+        operations(shell().on("incus list ^acme$", new ShellExec.Result(1, "", "boom")))
+            .project("acme")
+            .get("container_status"));
+  }
+
+  @Test
+  void projectOmitsAgentWhenUnconfigured() throws Exception {
+    var operations = operations(noAgentYaml(), shell().on("incus list ^acme$", RUNNING_JSON));
+
+    var result = operations.project("acme");
+
+    assertFalse(result.containsKey("agent"));
   }
 
   @Test
@@ -123,6 +167,23 @@ class SingApiOperationsTest {
 
     assertEquals(404, error.status());
     assertEquals("spec_not_found", error.error().code());
+  }
+
+  @Test
+  void specAllowsMissingContent() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .on(
+                    "cat /home/dev/workspace/specs/auth/spec.md",
+                    new ShellExec.Result(1, "", "No such file")));
+
+    var result = operations.spec("acme", "auth");
+
+    assertEquals(false, result.get("content_available"));
+    assertFalse(result.containsKey("content"));
   }
 
   @Test
@@ -189,6 +250,22 @@ class SingApiOperationsTest {
   }
 
   @Test
+  void dispatchRejectsUnknownSpec() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML));
+
+    var error =
+        assertThrows(
+            ApiException.class, () -> operations.dispatch("acme", Map.of("spec_id", "missing")));
+
+    assertEquals("spec_not_found", error.error().code());
+  }
+
+  @Test
   void dispatchRejectsRunningAgent() throws Exception {
     var operations =
         operations(
@@ -225,6 +302,44 @@ class SingApiOperationsTest {
   }
 
   @Test
+  void projectErrorMapsToContainerError() throws Exception {
+    var operations =
+        operations(shell().on("incus list ^acme$", new ShellExec.Result(1, "", "incus down")));
+
+    var error = assertThrows(ApiException.class, () -> operations.specs("acme"));
+
+    assertEquals("container_error", error.error().code());
+  }
+
+  @Test
+  void agentEndpointRejectsMissingProject() throws Exception {
+    var operations = operations(shell().on("incus list ^acme$", EMPTY_JSON));
+
+    var error = assertThrows(ApiException.class, () -> operations.agentStatus("acme"));
+
+    assertEquals("project_not_created", error.error().code());
+  }
+
+  @Test
+  void agentEndpointRejectsContainerErrors() throws Exception {
+    var operations =
+        operations(shell().on("incus list ^acme$", new ShellExec.Result(1, "", "incus down")));
+
+    var error = assertThrows(ApiException.class, () -> operations.agentStatus("acme"));
+
+    assertEquals("container_error", error.error().code());
+  }
+
+  @Test
+  void specsRequireConfiguredAgentDirectory() throws Exception {
+    var operations = operations(noAgentYaml(), shell().on("incus list ^acme$", RUNNING_JSON));
+
+    var error = assertThrows(ApiException.class, () -> operations.specs("acme"));
+
+    assertEquals("specs_not_configured", error.error().code());
+  }
+
+  @Test
   void agentStatusReturnsNotRunning() throws Exception {
     var operations =
         operations(
@@ -235,6 +350,38 @@ class SingApiOperationsTest {
     var result = operations.agentStatus("acme");
 
     assertEquals(false, result.get("agent_running"));
+  }
+
+  @Test
+  void agentStatusReturnsRunningSessionDetails() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", "123")
+                .on("kill -0 123", "")
+                .on(
+                    "cat /home/dev/.sing/agent-session.json",
+                    "{\"task\": \"work\", \"started_at\": \"2026-01-01T00:00:00Z\", \"branch\": \"sing/auth\"}"));
+
+    var result = operations.agentStatus("acme");
+
+    assertEquals(true, result.get("agent_running"));
+    assertEquals(123, result.get("pid"));
+    assertEquals("work", result.get("task"));
+  }
+
+  @Test
+  void agentStatusMapsQueryFailures() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .throwOn("cat /home/dev/.sing/agent.pid", new IOException("denied")));
+
+    var error = assertThrows(ApiException.class, () -> operations.agentStatus("acme"));
+
+    assertEquals("agent_status_failed", error.error().code());
   }
 
   @Test
@@ -263,6 +410,19 @@ class SingApiOperationsTest {
     var result = operations.agentLog("acme", 2);
 
     assertEquals(List.of("one", "two"), result.get("lines"));
+  }
+
+  @Test
+  void agentLogMapsThrownCommandsToApiError() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .throwOn("tail -n 200 /home/dev/.sing/agent.log", new IOException("no shell")));
+
+    var error = assertThrows(ApiException.class, () -> operations.agentLog("acme", 200));
+
+    assertEquals("command_failed", error.error().code());
   }
 
   @Test
@@ -300,6 +460,111 @@ class SingApiOperationsTest {
   }
 
   @Test
+  void dispatchLaunchesForegroundAgentAndReturnsSessionDetails() throws Exception {
+    var operations =
+        operations(
+            baseYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", "123")
+                .on("kill -0 123", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/.sing/agent-session.json", "{\"task\": \"work\"}")
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .on("cat /home/dev/workspace/specs/auth/spec.md", "")
+                .on("mkdir -p /home/dev/workspace/specs", "")
+                .on("printf '%s'", "")
+                .on("mkdir -p /home/dev/.sing", "")
+                .on("bash -l -c", ""));
+
+    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "mode", "foreground"));
+
+    assertTrue(result.get("agent").toString().contains("mode=foreground"));
+    assertTrue(result.get("agent").toString().contains("pid=123"));
+  }
+
+  @Test
+  void dispatchMapsLaunchFailure() throws Exception {
+    var operations =
+        operations(
+            baseYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
+                .on("mkdir -p /home/dev/workspace/specs", "")
+                .on("printf '%s'", "")
+                .on("-- mkdir -p /home/dev/.sing", "")
+                .on("claude", new ShellExec.Result(1, "", "missing cli")));
+
+    var error =
+        assertThrows(
+            ApiException.class, () -> operations.dispatch("acme", Map.of("spec_id", "auth")));
+
+    assertEquals("agent_launch_failed", error.error().code());
+  }
+
+  @Test
+  void dispatchLaunchesWatcherWhenGuardrailsAreConfigured() throws Exception {
+    var launched = new LinkedHashMap<String, Object>();
+    var operations =
+        operations(
+            guardrailsYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
+                .on("mkdir -p /home/dev/workspace/specs", "")
+                .on("printf '%s'", "")
+                .on("-- mkdir -p /home/dev/.sing", "")
+                .on("claude", ""),
+            (command, logPath) -> {
+              launched.put("command", command);
+              launched.put("log_path", logPath.toString());
+            });
+
+    operations.dispatch("acme", Map.of("spec_id", "auth"));
+
+    assertTrue(launched.get("command").toString().contains("agent, watch, acme"));
+    assertTrue(launched.get("log_path").toString().endsWith("watch.log"));
+  }
+
+  @Test
+  void dispatchMapsWatcherFailureToLaunchFailure() throws Exception {
+    var operations =
+        operations(
+            guardrailsYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
+                .on("mkdir -p /home/dev/workspace/specs", "")
+                .on("printf '%s'", "")
+                .on("-- mkdir -p /home/dev/.sing", "")
+                .on("claude", ""),
+            (command, logPath) -> {
+              throw new IOException("watch failed");
+            });
+
+    var error =
+        assertThrows(
+            ApiException.class, () -> operations.dispatch("acme", Map.of("spec_id", "auth")));
+
+    assertEquals("agent_launch_failed", error.error().code());
+  }
+
+  @Test
+  void watcherProcessLauncherStartsCommand() throws Exception {
+    var logPath = tempDir.resolve("watch.log");
+
+    SingApiOperations.launchWatcherProcess(List.of("/bin/true"), logPath);
+
+    assertTrue(Files.exists(logPath));
+  }
+
+  @Test
   void dispatchCreatesBranchWhenConfigured() throws Exception {
     var operations =
         operations(
@@ -318,6 +583,47 @@ class SingApiOperationsTest {
 
     assertEquals(true, result.get("branch_created"));
     assertTrue(result.get("spec").toString().contains("sing/auth"));
+  }
+
+  @Test
+  void dispatchUsesSpecBranchWhenProvided() throws Exception {
+    var operations =
+        operations(
+            branchYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_WITH_BRANCH_YAML)
+                .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
+                .on("mkdir -p /home/dev/workspace/specs", "")
+                .on("printf '%s'", "")
+                .on("test -d /home/dev/workspace/app/.git", "")
+                .on("git -C /home/dev/workspace/app checkout -b feat/custom", ""));
+
+    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true));
+
+    assertTrue(result.get("spec").toString().contains("feat/custom"));
+  }
+
+  @Test
+  void dispatchSkipsBranchWhenRepoIsMissing() throws Exception {
+    var operations =
+        operations(
+            branchYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
+                .on("mkdir -p /home/dev/workspace/specs", "")
+                .on("printf '%s'", "")
+                .on(
+                    "test -d /home/dev/workspace/app/.git",
+                    new ShellExec.Result(1, "", "missing")));
+
+    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true));
+
+    assertEquals(false, result.get("branch_created"));
   }
 
   @Test
@@ -358,6 +664,48 @@ class SingApiOperationsTest {
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", "")
                 .on("incus snapshot list acme --format json", "[]")
+                .on("incus snapshot create acme", ""));
+
+    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true));
+
+    assertFalse(result.get("snapshot").toString().isBlank());
+  }
+
+  @Test
+  void dispatchSkipsRecentSnapshot() throws Exception {
+    var snapshots = "[{\"name\": \"snap\", \"created_at\": \"" + Instant.now() + "\"}]";
+    var operations =
+        operations(
+            snapshotYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
+                .on("mkdir -p /home/dev/workspace/specs", "")
+                .on("printf '%s'", "")
+                .on("incus snapshot list acme --format json", snapshots));
+
+    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true));
+
+    assertEquals("", result.get("snapshot"));
+  }
+
+  @Test
+  void dispatchCreatesSnapshotWhenLatestTimestampIsInvalid() throws Exception {
+    var operations =
+        operations(
+            snapshotYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
+                .on("mkdir -p /home/dev/workspace/specs", "")
+                .on("printf '%s'", "")
+                .on(
+                    "incus snapshot list acme --format json",
+                    "[{\"name\": \"snap\", \"created_at\": \"bad\"}]")
                 .on("incus snapshot create acme", ""));
 
     var result = operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true));
@@ -409,6 +757,50 @@ class SingApiOperationsTest {
   }
 
   @Test
+  void stopAgentMapsKillFailure() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", "123")
+                .on("kill -0 123", "")
+                .on("cat /home/dev/.sing/agent-session.json", "{\"task\": \"work\"}")
+                .throwOn("kill 123", new IOException("permission denied")));
+
+    var error = assertThrows(ApiException.class, () -> operations.stopAgent("acme"));
+
+    assertEquals("agent_stop_failed", error.error().code());
+  }
+
+  @Test
+  void agentReportReturnsSummary() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML));
+
+    var result = operations.agentReport("acme");
+
+    assertEquals("acme", result.get("name"));
+    assertEquals("No session", result.get("session_status"));
+  }
+
+  @Test
+  void agentReportMapsReporterFailure() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .throwOn("cat /home/dev/.sing/agent.pid", new IOException("boom")));
+
+    var error = assertThrows(ApiException.class, () -> operations.agentReport("acme"));
+
+    assertEquals("agent_report_failed", error.error().code());
+  }
+
+  @Test
   void agentLogFailureMapsToApiError() throws Exception {
     var operations =
         operations(
@@ -432,10 +824,73 @@ class SingApiOperationsTest {
     assertEquals("project_descriptor_not_found", error.error().code());
   }
 
+  @Test
+  void malformedDescriptorMapsToProjectLoadFailure() throws Exception {
+    var operations = operations("name: [", shell().on("incus list ^acme$", RUNNING_JSON));
+
+    var error = assertThrows(ApiException.class, () -> operations.project("acme"));
+
+    assertEquals("project_load_failed", error.error().code());
+  }
+
+  @Test
+  void specIndexFailuresMapToApiErrors() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on(
+                    "cat /home/dev/workspace/specs/index.yaml",
+                    new ShellExec.Result(1, "", "denied")));
+
+    var error = assertThrows(ApiException.class, () -> operations.specs("acme"));
+
+    assertEquals("specs_read_failed", error.error().code());
+  }
+
+  @Test
+  void specBodyFailuresMapToApiErrors() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .throwOn("cat /home/dev/workspace/specs/auth/spec.md", new IOException("denied")));
+
+    var error = assertThrows(ApiException.class, () -> operations.spec("acme", "auth"));
+
+    assertEquals("spec_read_failed", error.error().code());
+  }
+
+  @Test
+  void statusUpdateFailuresMapToApiErrors() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .throwOn("mkdir -p /home/dev/workspace/specs", new IOException("denied")));
+
+    var error =
+        assertThrows(
+            ApiException.class, () -> operations.dispatch("acme", Map.of("spec_id", "auth")));
+
+    assertEquals("spec_status_update_failed", error.error().code());
+  }
+
   private SingApiOperations operations(String yamlContent, FakeShell shell) throws Exception {
     var yaml = tempDir.resolve("sing-" + System.nanoTime() + ".yaml");
     Files.writeString(yaml, yamlContent);
     return new SingApiOperations(shell, yaml.toString());
+  }
+
+  private SingApiOperations operations(
+      String yamlContent, FakeShell shell, SingApiOperations.WatcherLauncher watcherLauncher)
+      throws Exception {
+    var yaml = tempDir.resolve("sing-" + System.nanoTime() + ".yaml");
+    Files.writeString(yaml, yamlContent);
+    return new SingApiOperations(shell, yaml.toString(), watcherLauncher);
   }
 
   private static String baseYaml() {
@@ -446,6 +901,14 @@ class SingApiOperationsTest {
         agent:
           type: claude-code
           specs_dir: specs
+        """;
+  }
+
+  private static String noAgentYaml() {
+    return """
+        name: acme
+        ssh:
+          user: dev
         """;
   }
 
@@ -477,6 +940,20 @@ class SingApiOperationsTest {
         """;
   }
 
+  private static String guardrailsYaml() {
+    return """
+        name: acme
+        ssh:
+          user: dev
+        agent:
+          type: claude-code
+          specs_dir: specs
+          guardrails:
+            max_duration: 4h
+            action: stop
+        """;
+  }
+
   private SingApiOperations operations(FakeShell shell) throws Exception {
     var yaml = tempDir.resolve("sing.yaml");
     Files.writeString(yaml, baseYaml());
@@ -489,6 +966,7 @@ class SingApiOperationsTest {
 
   private static final class FakeShell implements ShellExec {
     private final Map<String, Result> scripts = new LinkedHashMap<>();
+    private final Map<String, Exception> failures = new LinkedHashMap<>();
 
     FakeShell on(String pattern, String stdout) {
       return on(pattern, new Result(0, stdout, ""));
@@ -499,9 +977,19 @@ class SingApiOperationsTest {
       return this;
     }
 
+    FakeShell throwOn(String pattern, Exception failure) {
+      failures.put(pattern, failure);
+      return this;
+    }
+
     @Override
-    public Result exec(List<String> command) {
+    public Result exec(List<String> command) throws IOException {
       var joined = String.join(" ", command);
+      for (var entry : failures.entrySet()) {
+        if (joined.contains(entry.getKey())) {
+          throw (IOException) entry.getValue();
+        }
+      }
       for (var entry : scripts.entrySet()) {
         if (joined.contains(entry.getKey())) {
           return entry.getValue();
@@ -511,7 +999,7 @@ class SingApiOperationsTest {
     }
 
     @Override
-    public Result exec(List<String> command, Path workDir, Duration timeout) {
+    public Result exec(List<String> command, Path workDir, Duration timeout) throws IOException {
       return exec(command);
     }
 

--- a/sing-infra/src/test/java/ai/singlr/sing/api/SingApiOperationsTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/api/SingApiOperationsTest.java
@@ -78,12 +78,12 @@ class SingApiOperationsTest {
   void healthReturnsOk() {
     var operations = new SingApiOperations(new FakeShell(), "sing.yaml");
 
-    assertEquals("ok", operations.health().get("status"));
+    assertEquals("ok", get(operations.health(), "status"));
   }
 
   @Test
   void defaultConstructorSupportsHealthChecks() {
-    assertEquals("ok", new SingApiOperations().health().get("status"));
+    assertEquals("ok", get(new SingApiOperations().health(), "status"));
   }
 
   @Test
@@ -92,28 +92,29 @@ class SingApiOperationsTest {
 
     var result = operations.project("acme");
 
-    assertEquals("acme", result.get("name"));
-    assertEquals("running", result.get("container_status"));
-    assertTrue(result.get("agent").toString().contains("claude-code"));
+    assertEquals("acme", get(result, "name"));
+    assertEquals("running", get(result, "container_status"));
+    assertTrue(get(result, "agent").toString().contains("claude-code"));
   }
 
   @Test
   void projectMapsStoppedMissingAndErrorStates() throws Exception {
     assertEquals(
         "stopped",
-        operations(shell().on("incus list ^acme$", STOPPED_JSON))
-            .project("acme")
-            .get("container_status"));
+        get(
+            operations(shell().on("incus list ^acme$", STOPPED_JSON)).project("acme"),
+            "container_status"));
     assertEquals(
         "not_created",
-        operations(shell().on("incus list ^acme$", EMPTY_JSON))
-            .project("acme")
-            .get("container_status"));
+        get(
+            operations(shell().on("incus list ^acme$", EMPTY_JSON)).project("acme"),
+            "container_status"));
     assertEquals(
         "error",
-        operations(shell().on("incus list ^acme$", new ShellExec.Result(1, "", "boom")))
-            .project("acme")
-            .get("container_status"));
+        get(
+            operations(shell().on("incus list ^acme$", new ShellExec.Result(1, "", "boom")))
+                .project("acme"),
+            "container_status"));
   }
 
   @Test
@@ -122,7 +123,7 @@ class SingApiOperationsTest {
 
     var result = operations.project("acme");
 
-    assertFalse(result.containsKey("agent"));
+    assertFalse(containsKey(result, "agent"));
   }
 
   @Test
@@ -135,9 +136,9 @@ class SingApiOperationsTest {
 
     var result = operations.specs("acme");
 
-    assertEquals("acme", result.get("name"));
-    assertTrue(result.get("specs") instanceof List<?>);
-    assertTrue(result.toString().contains("next_ready_id=auth"));
+    assertEquals("acme", get(result, "name"));
+    assertTrue(get(result, "specs") instanceof List<?>);
+    assertTrue(ApiJson.withSchema(result.orThrow()).toString().contains("next_ready_id=auth"));
   }
 
   @Test
@@ -151,8 +152,8 @@ class SingApiOperationsTest {
 
     var result = operations.spec("acme", "auth");
 
-    assertEquals(true, result.get("content_available"));
-    assertEquals("# Auth", result.get("content"));
+    assertEquals(true, get(result, "content_available"));
+    assertEquals("# Auth", get(result, "content"));
   }
 
   @Test
@@ -163,10 +164,9 @@ class SingApiOperationsTest {
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML));
 
-    var error = assertThrows(ApiException.class, () -> operations.spec("acme", "missing"));
+    var error = operations.spec("acme", "missing");
 
-    assertEquals(404, error.status());
-    assertEquals("spec_not_found", error.error().code());
+    assertError(ErrorCode.SPEC_NOT_FOUND, error);
   }
 
   @Test
@@ -182,8 +182,8 @@ class SingApiOperationsTest {
 
     var result = operations.spec("acme", "auth");
 
-    assertEquals(false, result.get("content_available"));
-    assertFalse(result.containsKey("content"));
+    assertEquals(false, get(result, "content_available"));
+    assertFalse(containsKey(result, "content"));
   }
 
   @Test
@@ -195,10 +195,10 @@ class SingApiOperationsTest {
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/workspace/specs/index.yaml", index));
 
-    var result = operations.dispatch("acme", Map.of());
+    var result = operations.dispatch("acme", request());
 
-    assertEquals(false, result.get("dispatched"));
-    assertEquals("no_pending_specs", result.get("reason"));
+    assertEquals(false, get(result, "dispatched"));
+    assertEquals("no_pending_specs", get(result, "reason"));
   }
 
   @Test
@@ -213,11 +213,11 @@ class SingApiOperationsTest {
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", ""));
 
-    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true));
+    var result = operations.dispatch("acme", request("auth", "background", true));
 
-    assertEquals(true, result.get("dispatched"));
-    assertTrue(result.get("spec").toString().contains("status=in_progress"));
-    assertTrue(result.get("agent").toString().contains("running=false"));
+    assertEquals(true, get(result, "dispatched"));
+    assertTrue(get(result, "spec").toString().contains("status=in_progress"));
+    assertTrue(get(result, "agent").toString().contains("running=false"));
   }
 
   @Test
@@ -229,24 +229,18 @@ class SingApiOperationsTest {
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
                 .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML));
 
-    var error =
-        assertThrows(
-            ApiException.class, () -> operations.dispatch("acme", Map.of("spec_id", "billing")));
+    var error = operations.dispatch("acme", request("billing"));
 
-    assertEquals(409, error.status());
-    assertEquals("spec_not_ready", error.error().code());
+    assertError(ErrorCode.SPEC_NOT_READY, error);
   }
 
   @Test
   void dispatchRejectsInvalidMode() throws Exception {
     var operations = operations(shell().on("incus list ^acme$", RUNNING_JSON));
 
-    var error =
-        assertThrows(
-            ApiException.class, () -> operations.dispatch("acme", Map.of("mode", "sideways")));
+    var error = operations.dispatch("acme", request(null, "sideways", false));
 
-    assertEquals(422, error.status());
-    assertEquals("invalid_mode", error.error().code());
+    assertError(ErrorCode.INVALID_MODE, error);
   }
 
   @Test
@@ -258,11 +252,9 @@ class SingApiOperationsTest {
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
                 .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML));
 
-    var error =
-        assertThrows(
-            ApiException.class, () -> operations.dispatch("acme", Map.of("spec_id", "missing")));
+    var error = operations.dispatch("acme", request("missing"));
 
-    assertEquals("spec_not_found", error.error().code());
+    assertError(ErrorCode.SPEC_NOT_FOUND, error);
   }
 
   @Test
@@ -275,30 +267,27 @@ class SingApiOperationsTest {
                 .on("kill -0 123", "")
                 .on("cat /home/dev/.sing/agent-session.json", "{\"task\": \"work\"}"));
 
-    var error = assertThrows(ApiException.class, () -> operations.dispatch("acme", Map.of()));
+    var error = operations.dispatch("acme", request());
 
-    assertEquals(409, error.status());
-    assertEquals("agent_already_running", error.error().code());
+    assertError(ErrorCode.AGENT_ALREADY_RUNNING, error);
   }
 
   @Test
   void projectStoppedMapsToConflict() throws Exception {
     var operations = operations(shell().on("incus list ^acme$", STOPPED_JSON));
 
-    var error = assertThrows(ApiException.class, () -> operations.specs("acme"));
+    var error = operations.specs("acme");
 
-    assertEquals(409, error.status());
-    assertEquals("project_stopped", error.error().code());
+    assertError(ErrorCode.PROJECT_STOPPED, error);
   }
 
   @Test
   void projectMissingMapsToNotFound() throws Exception {
     var operations = operations(shell().on("incus list ^acme$", EMPTY_JSON));
 
-    var error = assertThrows(ApiException.class, () -> operations.specs("acme"));
+    var error = operations.specs("acme");
 
-    assertEquals(404, error.status());
-    assertEquals("project_not_created", error.error().code());
+    assertError(ErrorCode.PROJECT_NOT_CREATED, error);
   }
 
   @Test
@@ -306,18 +295,18 @@ class SingApiOperationsTest {
     var operations =
         operations(shell().on("incus list ^acme$", new ShellExec.Result(1, "", "incus down")));
 
-    var error = assertThrows(ApiException.class, () -> operations.specs("acme"));
+    var error = operations.specs("acme");
 
-    assertEquals("container_error", error.error().code());
+    assertError(ErrorCode.CONTAINER_ERROR, error);
   }
 
   @Test
   void agentEndpointRejectsMissingProject() throws Exception {
     var operations = operations(shell().on("incus list ^acme$", EMPTY_JSON));
 
-    var error = assertThrows(ApiException.class, () -> operations.agentStatus("acme"));
+    var error = operations.agentStatus("acme");
 
-    assertEquals("project_not_created", error.error().code());
+    assertError(ErrorCode.PROJECT_NOT_CREATED, error);
   }
 
   @Test
@@ -325,18 +314,18 @@ class SingApiOperationsTest {
     var operations =
         operations(shell().on("incus list ^acme$", new ShellExec.Result(1, "", "incus down")));
 
-    var error = assertThrows(ApiException.class, () -> operations.agentStatus("acme"));
+    var error = operations.agentStatus("acme");
 
-    assertEquals("container_error", error.error().code());
+    assertError(ErrorCode.CONTAINER_ERROR, error);
   }
 
   @Test
   void specsRequireConfiguredAgentDirectory() throws Exception {
     var operations = operations(noAgentYaml(), shell().on("incus list ^acme$", RUNNING_JSON));
 
-    var error = assertThrows(ApiException.class, () -> operations.specs("acme"));
+    var error = operations.specs("acme");
 
-    assertEquals("specs_not_configured", error.error().code());
+    assertError(ErrorCode.SPECS_NOT_CONFIGURED, error);
   }
 
   @Test
@@ -349,7 +338,7 @@ class SingApiOperationsTest {
 
     var result = operations.agentStatus("acme");
 
-    assertEquals(false, result.get("agent_running"));
+    assertEquals(false, get(result, "agent_running"));
   }
 
   @Test
@@ -366,9 +355,9 @@ class SingApiOperationsTest {
 
     var result = operations.agentStatus("acme");
 
-    assertEquals(true, result.get("agent_running"));
-    assertEquals(123, result.get("pid"));
-    assertEquals("work", result.get("task"));
+    assertEquals(true, get(result, "agent_running"));
+    assertEquals(123, get(result, "pid"));
+    assertEquals("work", get(result, "task"));
   }
 
   @Test
@@ -379,9 +368,9 @@ class SingApiOperationsTest {
                 .on("incus list ^acme$", RUNNING_JSON)
                 .throwOn("cat /home/dev/.sing/agent.pid", new IOException("denied")));
 
-    var error = assertThrows(ApiException.class, () -> operations.agentStatus("acme"));
+    var error = operations.agentStatus("acme");
 
-    assertEquals("agent_status_failed", error.error().code());
+    assertError(ErrorCode.AGENT_STATUS_FAILED, error);
   }
 
   @Test
@@ -396,7 +385,7 @@ class SingApiOperationsTest {
 
     var result = operations.agentLog("acme", 200);
 
-    assertEquals("No agent log found", result.get("error"));
+    assertEquals("No agent log found", get(result, "error"));
   }
 
   @Test
@@ -409,7 +398,7 @@ class SingApiOperationsTest {
 
     var result = operations.agentLog("acme", 2);
 
-    assertEquals(List.of("one", "two"), result.get("lines"));
+    assertEquals(List.of("one", "two"), get(result, "lines"));
   }
 
   @Test
@@ -420,9 +409,9 @@ class SingApiOperationsTest {
                 .on("incus list ^acme$", RUNNING_JSON)
                 .throwOn("tail -n 200 /home/dev/.sing/agent.log", new IOException("no shell")));
 
-    var error = assertThrows(ApiException.class, () -> operations.agentLog("acme", 200));
+    var error = operations.agentLog("acme", 200);
 
-    assertEquals("command_failed", error.error().code());
+    assertError(ErrorCode.COMMAND_FAILED, error);
   }
 
   @Test
@@ -435,7 +424,7 @@ class SingApiOperationsTest {
 
     var result = operations.stopAgent("acme");
 
-    assertEquals(false, result.get("stopped"));
+    assertEquals(false, get(result, "stopped"));
   }
 
   @Test
@@ -453,10 +442,10 @@ class SingApiOperationsTest {
                 .on("mkdir -p /home/dev/.sing", "")
                 .on("claude", ""));
 
-    var result = operations.dispatch("acme", Map.of("spec_id", "auth"));
+    var result = operations.dispatch("acme", request("auth"));
 
-    assertEquals(true, result.get("dispatched"));
-    assertTrue(result.get("agent").toString().contains("mode=background"));
+    assertEquals(true, get(result, "dispatched"));
+    assertTrue(get(result, "agent").toString().contains("mode=background"));
   }
 
   @Test
@@ -476,10 +465,19 @@ class SingApiOperationsTest {
                 .on("mkdir -p /home/dev/.sing", "")
                 .on("bash -l -c", ""));
 
-    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "mode", "foreground"));
+    var result = operations.dispatch("acme", request("auth", "foreground", false));
 
-    assertTrue(result.get("agent").toString().contains("mode=foreground"));
-    assertTrue(result.get("agent").toString().contains("pid=123"));
+    assertTrue(get(result, "agent").toString().contains("mode=foreground"));
+    assertTrue(get(result, "agent").toString().contains("pid=123"));
+  }
+
+  @Test
+  void dispatchMapsUnexpectedFailures() throws Exception {
+    var operations = operations(baseYaml(), shell().on("incus list ^acme$", RUNNING_JSON));
+
+    var error = operations.dispatch("acme", null);
+
+    assertError(ErrorCode.INTERNAL, error);
   }
 
   @Test
@@ -497,11 +495,9 @@ class SingApiOperationsTest {
                 .on("-- mkdir -p /home/dev/.sing", "")
                 .on("claude", new ShellExec.Result(1, "", "missing cli")));
 
-    var error =
-        assertThrows(
-            ApiException.class, () -> operations.dispatch("acme", Map.of("spec_id", "auth")));
+    var error = operations.dispatch("acme", request("auth"));
 
-    assertEquals("agent_launch_failed", error.error().code());
+    assertError(ErrorCode.AGENT_LAUNCH_FAILED, error);
   }
 
   @Test
@@ -524,7 +520,7 @@ class SingApiOperationsTest {
               launched.put("log_path", logPath.toString());
             });
 
-    operations.dispatch("acme", Map.of("spec_id", "auth"));
+    operations.dispatch("acme", request("auth"));
 
     assertTrue(launched.get("command").toString().contains("agent, watch, acme"));
     assertTrue(launched.get("log_path").toString().endsWith("watch.log"));
@@ -548,11 +544,9 @@ class SingApiOperationsTest {
               throw new IOException("watch failed");
             });
 
-    var error =
-        assertThrows(
-            ApiException.class, () -> operations.dispatch("acme", Map.of("spec_id", "auth")));
+    var error = operations.dispatch("acme", request("auth"));
 
-    assertEquals("agent_launch_failed", error.error().code());
+    assertError(ErrorCode.AGENT_LAUNCH_FAILED, error);
   }
 
   @Test
@@ -579,10 +573,10 @@ class SingApiOperationsTest {
                 .on("test -d /home/dev/workspace/app/.git", "")
                 .on("git -C /home/dev/workspace/app checkout -b sing/auth", ""));
 
-    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true));
+    var result = operations.dispatch("acme", request("auth", "background", true));
 
-    assertEquals(true, result.get("branch_created"));
-    assertTrue(result.get("spec").toString().contains("sing/auth"));
+    assertEquals(true, get(result, "branch_created"));
+    assertTrue(get(result, "spec").toString().contains("sing/auth"));
   }
 
   @Test
@@ -600,9 +594,9 @@ class SingApiOperationsTest {
                 .on("test -d /home/dev/workspace/app/.git", "")
                 .on("git -C /home/dev/workspace/app checkout -b feat/custom", ""));
 
-    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true));
+    var result = operations.dispatch("acme", request("auth", "background", true));
 
-    assertTrue(result.get("spec").toString().contains("feat/custom"));
+    assertTrue(get(result, "spec").toString().contains("feat/custom"));
   }
 
   @Test
@@ -621,9 +615,9 @@ class SingApiOperationsTest {
                     "test -d /home/dev/workspace/app/.git",
                     new ShellExec.Result(1, "", "missing")));
 
-    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true));
+    var result = operations.dispatch("acme", request("auth", "background", true));
 
-    assertEquals(false, result.get("branch_created"));
+    assertEquals(false, get(result, "branch_created"));
   }
 
   @Test
@@ -643,12 +637,9 @@ class SingApiOperationsTest {
                     "git -C /home/dev/workspace/app checkout -b sing/auth",
                     new ShellExec.Result(1, "", "exists")));
 
-    var error =
-        assertThrows(
-            ApiException.class,
-            () -> operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true)));
+    var error = operations.dispatch("acme", request("auth", "background", true));
 
-    assertEquals("branch_create_failed", error.error().code());
+    assertError(ErrorCode.BRANCH_CREATE_FAILED, error);
   }
 
   @Test
@@ -666,9 +657,9 @@ class SingApiOperationsTest {
                 .on("incus snapshot list acme --format json", "[]")
                 .on("incus snapshot create acme", ""));
 
-    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true));
+    var result = operations.dispatch("acme", request("auth", "background", true));
 
-    assertFalse(result.get("snapshot").toString().isBlank());
+    assertFalse(get(result, "snapshot").toString().isBlank());
   }
 
   @Test
@@ -686,9 +677,9 @@ class SingApiOperationsTest {
                 .on("printf '%s'", "")
                 .on("incus snapshot list acme --format json", snapshots));
 
-    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true));
+    var result = operations.dispatch("acme", request("auth", "background", true));
 
-    assertEquals("", result.get("snapshot"));
+    assertEquals("", get(result, "snapshot"));
   }
 
   @Test
@@ -708,9 +699,9 @@ class SingApiOperationsTest {
                     "[{\"name\": \"snap\", \"created_at\": \"bad\"}]")
                 .on("incus snapshot create acme", ""));
 
-    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true));
+    var result = operations.dispatch("acme", request("auth", "background", true));
 
-    assertFalse(result.get("snapshot").toString().isBlank());
+    assertFalse(get(result, "snapshot").toString().isBlank());
   }
 
   @Test
@@ -728,12 +719,9 @@ class SingApiOperationsTest {
                 .on("incus snapshot list acme --format json", "[]")
                 .on("incus snapshot create acme", new ShellExec.Result(1, "", "no space")));
 
-    var error =
-        assertThrows(
-            ApiException.class,
-            () -> operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true)));
+    var error = operations.dispatch("acme", request("auth", "background", true));
 
-    assertEquals("snapshot_failed", error.error().code());
+    assertError(ErrorCode.SNAPSHOT_FAILED, error);
   }
 
   @Test
@@ -752,8 +740,8 @@ class SingApiOperationsTest {
 
     var result = operations.stopAgent("acme");
 
-    assertEquals(true, result.get("stopped"));
-    assertEquals(123, result.get("pid"));
+    assertEquals(true, get(result, "stopped"));
+    assertEquals(123, get(result, "pid"));
   }
 
   @Test
@@ -767,9 +755,9 @@ class SingApiOperationsTest {
                 .on("cat /home/dev/.sing/agent-session.json", "{\"task\": \"work\"}")
                 .throwOn("kill 123", new IOException("permission denied")));
 
-    var error = assertThrows(ApiException.class, () -> operations.stopAgent("acme"));
+    var error = operations.stopAgent("acme");
 
-    assertEquals("agent_stop_failed", error.error().code());
+    assertError(ErrorCode.AGENT_STOP_FAILED, error);
   }
 
   @Test
@@ -783,8 +771,8 @@ class SingApiOperationsTest {
 
     var result = operations.agentReport("acme");
 
-    assertEquals("acme", result.get("name"));
-    assertEquals("No session", result.get("session_status"));
+    assertEquals("acme", get(result, "name"));
+    assertEquals("No session", get(result, "session_status"));
   }
 
   @Test
@@ -795,9 +783,9 @@ class SingApiOperationsTest {
                 .on("incus list ^acme$", RUNNING_JSON)
                 .throwOn("cat /home/dev/.sing/agent.pid", new IOException("boom")));
 
-    var error = assertThrows(ApiException.class, () -> operations.agentReport("acme"));
+    var error = operations.agentReport("acme");
 
-    assertEquals("agent_report_failed", error.error().code());
+    assertError(ErrorCode.AGENT_REPORT_FAILED, error);
   }
 
   @Test
@@ -810,27 +798,27 @@ class SingApiOperationsTest {
                     "tail -n 200 /home/dev/.sing/agent.log",
                     new ShellExec.Result(1, "", "permission denied")));
 
-    var error = assertThrows(ApiException.class, () -> operations.agentLog("acme", 200));
+    var error = operations.agentLog("acme", 200);
 
-    assertEquals("agent_log_failed", error.error().code());
+    assertError(ErrorCode.AGENT_LOG_FAILED, error);
   }
 
   @Test
   void missingDescriptorMapsToNotFound() {
     var operations = new SingApiOperations(shell(), tempDir.resolve("missing.yaml").toString());
 
-    var error = assertThrows(ApiException.class, () -> operations.project("acme"));
+    var error = operations.project("acme");
 
-    assertEquals("project_descriptor_not_found", error.error().code());
+    assertError(ErrorCode.PROJECT_DESCRIPTOR_NOT_FOUND, error);
   }
 
   @Test
   void malformedDescriptorMapsToProjectLoadFailure() throws Exception {
     var operations = operations("name: [", shell().on("incus list ^acme$", RUNNING_JSON));
 
-    var error = assertThrows(ApiException.class, () -> operations.project("acme"));
+    var error = operations.project("acme");
 
-    assertEquals("project_load_failed", error.error().code());
+    assertError(ErrorCode.PROJECT_LOAD_FAILED, error);
   }
 
   @Test
@@ -843,9 +831,9 @@ class SingApiOperationsTest {
                     "cat /home/dev/workspace/specs/index.yaml",
                     new ShellExec.Result(1, "", "denied")));
 
-    var error = assertThrows(ApiException.class, () -> operations.specs("acme"));
+    var error = operations.specs("acme");
 
-    assertEquals("specs_read_failed", error.error().code());
+    assertError(ErrorCode.SPECS_READ_FAILED, error);
   }
 
   @Test
@@ -857,9 +845,9 @@ class SingApiOperationsTest {
                 .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
                 .throwOn("cat /home/dev/workspace/specs/auth/spec.md", new IOException("denied")));
 
-    var error = assertThrows(ApiException.class, () -> operations.spec("acme", "auth"));
+    var error = operations.spec("acme", "auth");
 
-    assertEquals("spec_read_failed", error.error().code());
+    assertError(ErrorCode.SPEC_READ_FAILED, error);
   }
 
   @Test
@@ -872,11 +860,34 @@ class SingApiOperationsTest {
                 .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
                 .throwOn("mkdir -p /home/dev/workspace/specs", new IOException("denied")));
 
-    var error =
-        assertThrows(
-            ApiException.class, () -> operations.dispatch("acme", Map.of("spec_id", "auth")));
+    var error = operations.dispatch("acme", request("auth"));
 
-    assertEquals("spec_status_update_failed", error.error().code());
+    assertError(ErrorCode.SPEC_STATUS_UPDATE_FAILED, error);
+  }
+
+  private static Object get(Result<?> result, String key) {
+    return ApiJson.withSchema(result.orThrow()).get(key);
+  }
+
+  private static boolean containsKey(Result<?> result, String key) {
+    return ApiJson.withSchema(result.orThrow()).containsKey(key);
+  }
+
+  private static void assertError(ErrorCode errorCode, Result<?> result) {
+    assertTrue(result.isFailure());
+    assertEquals(errorCode, result.errorCode());
+  }
+
+  private static DispatchRequest request() {
+    return request(null, "background", false);
+  }
+
+  private static DispatchRequest request(String specId) {
+    return request(specId, "background", false);
+  }
+
+  private static DispatchRequest request(String specId, String mode, boolean dryRun) {
+    return new DispatchRequest(specId, mode, dryRun);
   }
 
   private SingApiOperations operations(String yamlContent, FakeShell shell) throws Exception {

--- a/sing-infra/src/test/java/ai/singlr/sing/api/SingApiOperationsTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/api/SingApiOperationsTest.java
@@ -1,0 +1,523 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sing.engine.ShellExec;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SingApiOperationsTest {
+
+  private static final String RUNNING_JSON =
+      """
+      [
+        {
+          "name": "acme",
+          "status": "Running",
+          "state": {
+            "network": {
+              "eth0": {
+                "addresses": [
+                  {"family": "inet", "address": "10.0.0.42", "scope": "global"}
+                ]
+              }
+            }
+          }
+        }
+      ]
+      """;
+
+  private static final String STOPPED_JSON =
+      """
+      [{"name": "acme", "status": "Stopped", "state": {}}]
+      """;
+
+  private static final String EMPTY_JSON = "[]";
+
+  private static final String INDEX_YAML =
+      """
+      specs:
+        - id: setup
+          title: Setup project
+          status: done
+        - id: auth
+          title: Add auth
+          status: pending
+          depends_on: [setup]
+        - id: billing
+          title: Add billing
+          status: pending
+          depends_on: [missing]
+      """;
+
+  @TempDir Path tempDir;
+
+  @Test
+  void healthReturnsOk() {
+    var operations = new SingApiOperations(new FakeShell(), "sing.yaml");
+
+    assertEquals("ok", operations.health().get("status"));
+  }
+
+  @Test
+  void projectReturnsContainerAndAgentStatus() throws Exception {
+    var operations = operations(shell().on("incus list ^acme$", RUNNING_JSON));
+
+    var result = operations.project("acme");
+
+    assertEquals("acme", result.get("name"));
+    assertEquals("running", result.get("container_status"));
+    assertTrue(result.get("agent").toString().contains("claude-code"));
+  }
+
+  @Test
+  void specsReturnsBoardSummary() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML));
+
+    var result = operations.specs("acme");
+
+    assertEquals("acme", result.get("name"));
+    assertTrue(result.get("specs") instanceof List<?>);
+    assertTrue(result.toString().contains("next_ready_id=auth"));
+  }
+
+  @Test
+  void specReturnsContentWhenPresent() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .on("cat /home/dev/workspace/specs/auth/spec.md", "# Auth"));
+
+    var result = operations.spec("acme", "auth");
+
+    assertEquals(true, result.get("content_available"));
+    assertEquals("# Auth", result.get("content"));
+  }
+
+  @Test
+  void specReturnsNotFoundForUnknownSpec() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML));
+
+    var error = assertThrows(ApiException.class, () -> operations.spec("acme", "missing"));
+
+    assertEquals(404, error.status());
+    assertEquals("spec_not_found", error.error().code());
+  }
+
+  @Test
+  void dispatchReturnsNoPendingSpecs() throws Exception {
+    var index = "specs:\n  - id: done\n    title: Done\n    status: done\n";
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/workspace/specs/index.yaml", index));
+
+    var result = operations.dispatch("acme", Map.of());
+
+    assertEquals(false, result.get("dispatched"));
+    assertEquals("no_pending_specs", result.get("reason"));
+  }
+
+  @Test
+  void dispatchDryRunUpdatesSpecAndReturnsStructuredResult() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
+                .on("mkdir -p /home/dev/workspace/specs", "")
+                .on("printf '%s'", ""));
+
+    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true));
+
+    assertEquals(true, result.get("dispatched"));
+    assertTrue(result.get("spec").toString().contains("status=in_progress"));
+    assertTrue(result.get("agent").toString().contains("running=false"));
+  }
+
+  @Test
+  void dispatchRejectsBlockedSpec() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML));
+
+    var error =
+        assertThrows(
+            ApiException.class, () -> operations.dispatch("acme", Map.of("spec_id", "billing")));
+
+    assertEquals(409, error.status());
+    assertEquals("spec_not_ready", error.error().code());
+  }
+
+  @Test
+  void dispatchRejectsInvalidMode() throws Exception {
+    var operations = operations(shell().on("incus list ^acme$", RUNNING_JSON));
+
+    var error =
+        assertThrows(
+            ApiException.class, () -> operations.dispatch("acme", Map.of("mode", "sideways")));
+
+    assertEquals(422, error.status());
+    assertEquals("invalid_mode", error.error().code());
+  }
+
+  @Test
+  void dispatchRejectsRunningAgent() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", "123")
+                .on("kill -0 123", "")
+                .on("cat /home/dev/.sing/agent-session.json", "{\"task\": \"work\"}"));
+
+    var error = assertThrows(ApiException.class, () -> operations.dispatch("acme", Map.of()));
+
+    assertEquals(409, error.status());
+    assertEquals("agent_already_running", error.error().code());
+  }
+
+  @Test
+  void projectStoppedMapsToConflict() throws Exception {
+    var operations = operations(shell().on("incus list ^acme$", STOPPED_JSON));
+
+    var error = assertThrows(ApiException.class, () -> operations.specs("acme"));
+
+    assertEquals(409, error.status());
+    assertEquals("project_stopped", error.error().code());
+  }
+
+  @Test
+  void projectMissingMapsToNotFound() throws Exception {
+    var operations = operations(shell().on("incus list ^acme$", EMPTY_JSON));
+
+    var error = assertThrows(ApiException.class, () -> operations.specs("acme"));
+
+    assertEquals(404, error.status());
+    assertEquals("project_not_created", error.error().code());
+  }
+
+  @Test
+  void agentStatusReturnsNotRunning() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing")));
+
+    var result = operations.agentStatus("acme");
+
+    assertEquals(false, result.get("agent_running"));
+  }
+
+  @Test
+  void agentLogHandlesMissingLog() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on(
+                    "tail -n 200 /home/dev/.sing/agent.log",
+                    new ShellExec.Result(1, "", "No such file")));
+
+    var result = operations.agentLog("acme", 200);
+
+    assertEquals("No agent log found", result.get("error"));
+  }
+
+  @Test
+  void agentLogReturnsLines() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("tail -n 2 /home/dev/.sing/agent.log", "one\ntwo\n"));
+
+    var result = operations.agentLog("acme", 2);
+
+    assertEquals(List.of("one", "two"), result.get("lines"));
+  }
+
+  @Test
+  void stopAgentReturnsNoAgentRunning() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing")));
+
+    var result = operations.stopAgent("acme");
+
+    assertEquals(false, result.get("stopped"));
+  }
+
+  @Test
+  void dispatchLaunchesBackgroundAgent() throws Exception {
+    var operations =
+        operations(
+            baseYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
+                .on("mkdir -p /home/dev/workspace/specs", "")
+                .on("printf '%s'", "")
+                .on("mkdir -p /home/dev/.sing", "")
+                .on("claude", ""));
+
+    var result = operations.dispatch("acme", Map.of("spec_id", "auth"));
+
+    assertEquals(true, result.get("dispatched"));
+    assertTrue(result.get("agent").toString().contains("mode=background"));
+  }
+
+  @Test
+  void dispatchCreatesBranchWhenConfigured() throws Exception {
+    var operations =
+        operations(
+            branchYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
+                .on("mkdir -p /home/dev/workspace/specs", "")
+                .on("printf '%s'", "")
+                .on("test -d /home/dev/workspace/app/.git", "")
+                .on("git -C /home/dev/workspace/app checkout -b sing/auth", ""));
+
+    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true));
+
+    assertEquals(true, result.get("branch_created"));
+    assertTrue(result.get("spec").toString().contains("sing/auth"));
+  }
+
+  @Test
+  void dispatchMapsBranchFailure() throws Exception {
+    var operations =
+        operations(
+            branchYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
+                .on("mkdir -p /home/dev/workspace/specs", "")
+                .on("printf '%s'", "")
+                .on("test -d /home/dev/workspace/app/.git", "")
+                .on(
+                    "git -C /home/dev/workspace/app checkout -b sing/auth",
+                    new ShellExec.Result(1, "", "exists")));
+
+    var error =
+        assertThrows(
+            ApiException.class,
+            () -> operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true)));
+
+    assertEquals("branch_create_failed", error.error().code());
+  }
+
+  @Test
+  void dispatchCreatesSnapshotWhenConfigured() throws Exception {
+    var operations =
+        operations(
+            snapshotYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
+                .on("mkdir -p /home/dev/workspace/specs", "")
+                .on("printf '%s'", "")
+                .on("incus snapshot list acme --format json", "[]")
+                .on("incus snapshot create acme", ""));
+
+    var result = operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true));
+
+    assertFalse(result.get("snapshot").toString().isBlank());
+  }
+
+  @Test
+  void dispatchMapsSnapshotFailure() throws Exception {
+    var operations =
+        operations(
+            snapshotYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
+                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
+                .on("mkdir -p /home/dev/workspace/specs", "")
+                .on("printf '%s'", "")
+                .on("incus snapshot list acme --format json", "[]")
+                .on("incus snapshot create acme", new ShellExec.Result(1, "", "no space")));
+
+    var error =
+        assertThrows(
+            ApiException.class,
+            () -> operations.dispatch("acme", Map.of("spec_id", "auth", "dry_run", true)));
+
+    assertEquals("snapshot_failed", error.error().code());
+  }
+
+  @Test
+  void stopAgentKillsRunningAgent() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sing/agent.pid", "123")
+                .on("kill -0 123", "")
+                .on("cat /home/dev/.sing/agent-session.json", "{\"task\": \"work\"}")
+                .on("kill 123", "")
+                .on("sleep 3", "")
+                .on("kill -9 123", "")
+                .on("rm -f /home/dev/.sing/agent.pid", ""));
+
+    var result = operations.stopAgent("acme");
+
+    assertEquals(true, result.get("stopped"));
+    assertEquals(123, result.get("pid"));
+  }
+
+  @Test
+  void agentLogFailureMapsToApiError() throws Exception {
+    var operations =
+        operations(
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on(
+                    "tail -n 200 /home/dev/.sing/agent.log",
+                    new ShellExec.Result(1, "", "permission denied")));
+
+    var error = assertThrows(ApiException.class, () -> operations.agentLog("acme", 200));
+
+    assertEquals("agent_log_failed", error.error().code());
+  }
+
+  @Test
+  void missingDescriptorMapsToNotFound() {
+    var operations = new SingApiOperations(shell(), tempDir.resolve("missing.yaml").toString());
+
+    var error = assertThrows(ApiException.class, () -> operations.project("acme"));
+
+    assertEquals("project_descriptor_not_found", error.error().code());
+  }
+
+  private SingApiOperations operations(String yamlContent, FakeShell shell) throws Exception {
+    var yaml = tempDir.resolve("sing-" + System.nanoTime() + ".yaml");
+    Files.writeString(yaml, yamlContent);
+    return new SingApiOperations(shell, yaml.toString());
+  }
+
+  private static String baseYaml() {
+    return """
+        name: acme
+        ssh:
+          user: dev
+        agent:
+          type: claude-code
+          specs_dir: specs
+        """;
+  }
+
+  private static String branchYaml() {
+    return """
+        name: acme
+        ssh:
+          user: dev
+        repos:
+          - url: https://github.com/acme/app.git
+            path: app
+        agent:
+          type: claude-code
+          specs_dir: specs
+          auto_branch: true
+          branch_prefix: sing/
+        """;
+  }
+
+  private static String snapshotYaml() {
+    return """
+        name: acme
+        ssh:
+          user: dev
+        agent:
+          type: claude-code
+          specs_dir: specs
+          auto_snapshot: true
+        """;
+  }
+
+  private SingApiOperations operations(FakeShell shell) throws Exception {
+    var yaml = tempDir.resolve("sing.yaml");
+    Files.writeString(yaml, baseYaml());
+    return new SingApiOperations(shell, yaml.toString());
+  }
+
+  private static FakeShell shell() {
+    return new FakeShell();
+  }
+
+  private static final class FakeShell implements ShellExec {
+    private final Map<String, Result> scripts = new LinkedHashMap<>();
+
+    FakeShell on(String pattern, String stdout) {
+      return on(pattern, new Result(0, stdout, ""));
+    }
+
+    FakeShell on(String pattern, Result result) {
+      scripts.put(pattern, result);
+      return this;
+    }
+
+    @Override
+    public Result exec(List<String> command) {
+      var joined = String.join(" ", command);
+      for (var entry : scripts.entrySet()) {
+        if (joined.contains(entry.getKey())) {
+          return entry.getValue();
+        }
+      }
+      return new Result(1, "", "no script for " + joined);
+    }
+
+    @Override
+    public Result exec(List<String> command, Path workDir, Duration timeout) {
+      return exec(command);
+    }
+
+    @Override
+    public boolean isDryRun() {
+      return false;
+    }
+  }
+}

--- a/sing-infra/src/test/java/ai/singlr/sing/commands/ApiCommandTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/commands/ApiCommandTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.commands;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sing.Sing;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class ApiCommandTest {
+
+  @Test
+  void apiCommandIsRegistered() {
+    var command = new CommandLine(new Sing());
+    var output = new StringWriter();
+    command.setOut(new PrintWriter(output));
+
+    var exitCode = command.execute("--help");
+
+    assertEquals(0, exitCode);
+    assertTrue(output.toString().contains("api"));
+  }
+
+  @Test
+  void apiHelpShowsSecurityOptions() {
+    var command = new CommandLine(new Sing());
+    var output = new StringWriter();
+    command.setOut(new PrintWriter(output));
+
+    var exitCode = command.execute("api", "--help");
+
+    assertEquals(0, exitCode);
+    assertTrue(output.toString().contains("--token"));
+    assertTrue(output.toString().contains("--token-file"));
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `sing api`, an authenticated local HTTP API for Chorus/IDE integration.
- Exposes project/spec/dispatch/agent endpoints with structured JSON responses and bearer-token auth.
- Hardens API error handling, token-file behavior, guardrail watcher launch testability, and request validation.
- Adds comprehensive API tests and a JaCoCo `verify` gate requiring 100% line and method coverage for `ai.singlr.sing.api.*` classes.

## Validation
- `mvn -pl sing-infra spotless:apply`
- `mvn -pl sing-infra -am verify`
- Result: 786 tests passing; JaCoCo API coverage check met.

## Notes
- Branch: `feat/sing-local-api-server`
- Latest commits: `adc2cde Add authenticated local API server`, `4c3b11d test: enforce sing API coverage`
- `gh` was previously unauthenticated in this container, so create the PR from this pushed branch if CLI auth is still unavailable.
