### PR TITLE
Standardize sing CLI command error handling

### DIFF
--- a/sing-infra/src/main/java/ai/singlr/sing/commands/AgentAuditCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/AgentAuditCommand.java
@@ -17,7 +17,6 @@ import ai.singlr.sing.engine.SingPaths;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -50,13 +49,7 @@ public final class AgentAuditCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/AgentContextRegenCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/AgentContextRegenCommand.java
@@ -24,7 +24,6 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
@@ -58,13 +57,7 @@ public final class AgentContextRegenCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/AgentLaunchCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/AgentLaunchCommand.java
@@ -70,13 +70,7 @@ public final class AgentLaunchCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/AgentLogCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/AgentLogCommand.java
@@ -7,7 +7,6 @@ package ai.singlr.sing.commands;
 
 import ai.singlr.sing.config.YamlUtil;
 import ai.singlr.sing.engine.AgentSession;
-import ai.singlr.sing.engine.Banner;
 import ai.singlr.sing.engine.ContainerExec;
 import ai.singlr.sing.engine.ContainerManager;
 import ai.singlr.sing.engine.ContainerState;
@@ -16,7 +15,6 @@ import ai.singlr.sing.engine.ShellExecutor;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -49,13 +47,7 @@ public final class AgentLogCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/AgentReportCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/AgentReportCommand.java
@@ -15,7 +15,6 @@ import ai.singlr.sing.engine.NameValidator;
 import ai.singlr.sing.engine.ShellExecutor;
 import ai.singlr.sing.engine.SingPaths;
 import java.nio.file.Files;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -45,13 +44,7 @@ public final class AgentReportCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/AgentReviewCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/AgentReviewCommand.java
@@ -17,7 +17,6 @@ import ai.singlr.sing.engine.SingPaths;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -50,13 +49,7 @@ public final class AgentReviewCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/AgentStatusCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/AgentStatusCommand.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -54,13 +53,7 @@ public final class AgentStatusCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/AgentStopCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/AgentStopCommand.java
@@ -7,13 +7,11 @@ package ai.singlr.sing.commands;
 
 import ai.singlr.sing.config.YamlUtil;
 import ai.singlr.sing.engine.AgentSession;
-import ai.singlr.sing.engine.Banner;
 import ai.singlr.sing.engine.ContainerManager;
 import ai.singlr.sing.engine.ContainerState;
 import ai.singlr.sing.engine.NameValidator;
 import ai.singlr.sing.engine.ShellExecutor;
 import java.util.LinkedHashMap;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -40,13 +38,7 @@ public final class AgentStopCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/AgentSweepCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/AgentSweepCommand.java
@@ -17,7 +17,6 @@ import ai.singlr.sing.engine.ShellExecutor;
 import ai.singlr.sing.engine.SingPaths;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -71,13 +70,7 @@ public final class AgentSweepCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/AgentWatchCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/AgentWatchCommand.java
@@ -10,7 +10,6 @@ import ai.singlr.sing.config.Notifications;
 import ai.singlr.sing.config.SingYaml;
 import ai.singlr.sing.config.YamlUtil;
 import ai.singlr.sing.engine.AgentSession;
-import ai.singlr.sing.engine.Banner;
 import ai.singlr.sing.engine.ContainerExec;
 import ai.singlr.sing.engine.ContainerManager;
 import ai.singlr.sing.engine.ContainerState;
@@ -60,13 +59,7 @@ public final class AgentWatchCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ApiCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ApiCommand.java
@@ -8,10 +8,8 @@ package ai.singlr.sing.commands;
 import ai.singlr.sing.api.ApiTokenStore;
 import ai.singlr.sing.api.SingApiOperations;
 import ai.singlr.sing.api.SingApiServer;
-import ai.singlr.sing.engine.Banner;
 import java.nio.file.Path;
 import java.security.SecureRandom;
-import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
@@ -41,13 +39,7 @@ public final class ApiCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/CliCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/CliCommand.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.commands;
+
+import ai.singlr.sing.engine.Banner;
+import java.io.PrintStream;
+import java.util.Objects;
+import picocli.CommandLine;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Model.CommandSpec;
+
+final class CliCommand {
+
+  private CliCommand() {}
+
+  static void run(CommandSpec commandSpec, CheckedRunnable runnable) {
+    run(commandSpec, System.err, null, runnable);
+  }
+
+  static void run(CommandSpec commandSpec, String failureHint, CheckedRunnable runnable) {
+    run(commandSpec, System.err, failureHint, runnable);
+  }
+
+  static void run(CommandSpec commandSpec, PrintStream err, CheckedRunnable runnable) {
+    run(commandSpec, err, null, runnable);
+  }
+
+  private static void run(
+      CommandSpec commandSpec, PrintStream err, String failureHint, CheckedRunnable runnable) {
+    try {
+      runnable.run();
+    } catch (Exception e) {
+      var message = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
+      err.println(Banner.errorLine(message, Ansi.AUTO));
+      if (failureHint != null && !failureHint.isBlank()) {
+        err.println(failureHint);
+      }
+      throw new CommandLine.ExecutionException(commandSpec.commandLine(), message, e);
+    }
+  }
+
+  @FunctionalInterface
+  interface CheckedRunnable {
+    void run() throws Exception;
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/CliJson.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/CliJson.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.commands;
+
+import java.lang.reflect.RecordComponent;
+import java.util.List;
+import java.util.Map;
+
+final class CliJson {
+
+  private CliJson() {}
+
+  static String stringify(Object value) {
+    var builder = new StringBuilder();
+    append(builder, value);
+    return builder.toString();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void append(StringBuilder builder, Object value) {
+    switch (value) {
+      case null -> builder.append("null");
+      case String string -> appendString(builder, string);
+      case Number number -> builder.append(number);
+      case Boolean bool -> builder.append(bool);
+      case Enum<?> enumValue -> appendString(builder, enumValue.name().toLowerCase());
+      case List<?> list -> appendList(builder, list);
+      case Map<?, ?> map -> appendMap(builder, (Map<Object, Object>) map);
+      default -> {
+        if (value.getClass().isRecord()) {
+          appendRecord(builder, value);
+        } else {
+          appendString(builder, value.toString());
+        }
+      }
+    }
+  }
+
+  private static void appendList(StringBuilder builder, List<?> values) {
+    builder.append('[');
+    for (var index = 0; index < values.size(); index++) {
+      if (index > 0) {
+        builder.append(", ");
+      }
+      append(builder, values.get(index));
+    }
+    builder.append(']');
+  }
+
+  private static void appendMap(StringBuilder builder, Map<Object, Object> values) {
+    builder.append('{');
+    var first = true;
+    for (var entry : values.entrySet()) {
+      if (entry.getValue() == null) {
+        continue;
+      }
+      if (!first) {
+        builder.append(", ");
+      }
+      appendString(builder, entry.getKey().toString());
+      builder.append(": ");
+      append(builder, entry.getValue());
+      first = false;
+    }
+    builder.append('}');
+  }
+
+  private static void appendRecord(StringBuilder builder, Object record) {
+    builder.append('{');
+    var first = true;
+    for (var component : record.getClass().getRecordComponents()) {
+      var value = componentValue(record, component);
+      if (value == null) {
+        continue;
+      }
+      if (!first) {
+        builder.append(", ");
+      }
+      appendString(builder, toSnakeCase(component.getName()));
+      builder.append(": ");
+      append(builder, value);
+      first = false;
+    }
+    builder.append('}');
+  }
+
+  private static Object componentValue(Object record, RecordComponent component) {
+    try {
+      return component.getAccessor().invoke(record);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Failed to serialize CLI JSON response", e);
+    }
+  }
+
+  private static void appendString(StringBuilder builder, String value) {
+    builder.append('"');
+    for (var index = 0; index < value.length(); index++) {
+      var ch = value.charAt(index);
+      switch (ch) {
+        case '\\' -> builder.append("\\\\");
+        case '"' -> builder.append("\\\"");
+        case '\b' -> builder.append("\\b");
+        case '\f' -> builder.append("\\f");
+        case '\n' -> builder.append("\\n");
+        case '\r' -> builder.append("\\r");
+        case '\t' -> builder.append("\\t");
+        default -> {
+          if (ch < 0x20) {
+            builder.append(String.format("\\u%04x", (int) ch));
+          } else {
+            builder.append(ch);
+          }
+        }
+      }
+    }
+    builder.append('"');
+  }
+
+  private static String toSnakeCase(String name) {
+    var builder = new StringBuilder();
+    for (var index = 0; index < name.length(); index++) {
+      var ch = name.charAt(index);
+      if (Character.isUpperCase(ch)) {
+        builder.append('_').append(Character.toLowerCase(ch));
+      } else {
+        builder.append(ch);
+      }
+    }
+    return builder.toString();
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ClientInitCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ClientInitCommand.java
@@ -10,7 +10,6 @@ import ai.singlr.sing.config.YamlUtil;
 import ai.singlr.sing.engine.Banner;
 import ai.singlr.sing.engine.SingPaths;
 import java.nio.file.Files;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -34,13 +33,7 @@ public final class ClientInitCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ConnectCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ConnectCommand.java
@@ -7,7 +7,6 @@ package ai.singlr.sing.commands;
 
 import ai.singlr.sing.config.HostYaml;
 import ai.singlr.sing.config.YamlUtil;
-import ai.singlr.sing.engine.Banner;
 import ai.singlr.sing.engine.ContainerManager;
 import ai.singlr.sing.engine.ContainerState;
 import ai.singlr.sing.engine.NameValidator;
@@ -16,7 +15,6 @@ import ai.singlr.sing.engine.SingPaths;
 import java.util.LinkedHashMap;
 import java.util.Objects;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -46,13 +44,7 @@ public final class ConnectCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/DispatchCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/DispatchCommand.java
@@ -25,7 +25,6 @@ import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 import picocli.CommandLine.Command;
@@ -72,13 +71,7 @@ public final class DispatchCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(commandSpec.commandLine(), msg, e);
-    }
+    CliCommand.run(commandSpec, this::execute);
   }
 
   private void execute() throws Exception {
@@ -151,13 +144,14 @@ public final class DispatchCommand implements Runnable {
     var task = buildTaskPrompt(nextSpec, description, config.agent().specsDir());
 
     if (json) {
-      var map = new LinkedHashMap<String, Object>();
-      map.put("name", name);
-      map.put("spec_id", nextSpec.id());
-      map.put("spec_title", nextSpec.title());
-      map.put("mode", background ? "background" : "foreground");
-      map.put("task", task);
-      System.out.println(YamlUtil.dumpJson(map));
+      System.out.println(
+          CliJson.stringify(
+              new DispatchPreview(
+                  name,
+                  nextSpec.id(),
+                  nextSpec.title(),
+                  background ? "background" : "foreground",
+                  task)));
       if (dryRun) {
         return;
       }
@@ -292,11 +286,7 @@ public final class DispatchCommand implements Runnable {
 
   private void printNoSpecs() {
     if (json) {
-      var map = new LinkedHashMap<String, Object>();
-      map.put("name", name);
-      map.put("dispatched", false);
-      map.put("reason", "no_pending_specs");
-      System.out.println(YamlUtil.dumpJson(map));
+      System.out.println(CliJson.stringify(new NoDispatch(name, false, "no_pending_specs")));
     } else {
       System.out.println(Ansi.AUTO.string("  @|faint No pending specs found for " + name + ".|@"));
     }
@@ -336,6 +326,10 @@ public final class DispatchCommand implements Runnable {
               Ansi.AUTO));
     }
   }
+
+  record DispatchPreview(String name, String specId, String specTitle, String mode, String task) {}
+
+  record NoDispatch(String name, boolean dispatched, String reason) {}
 
   private static final Duration SNAPSHOT_INTERVAL = Duration.ofHours(24);
 

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/DownCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/DownCommand.java
@@ -13,7 +13,6 @@ import ai.singlr.sing.engine.NameValidator;
 import ai.singlr.sing.engine.ShellExecutor;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -40,13 +39,7 @@ public final class DownCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ExecCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ExecCommand.java
@@ -6,7 +6,6 @@
 package ai.singlr.sing.commands;
 
 import ai.singlr.sing.config.YamlUtil;
-import ai.singlr.sing.engine.Banner;
 import ai.singlr.sing.engine.ContainerExec;
 import ai.singlr.sing.engine.ContainerManager;
 import ai.singlr.sing.engine.ContainerState;
@@ -14,9 +13,7 @@ import ai.singlr.sing.engine.NameValidator;
 import ai.singlr.sing.engine.ShellExecutor;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -46,13 +43,7 @@ public final class ExecCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/HostConfigSetCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/HostConfigSetCommand.java
@@ -7,12 +7,10 @@ package ai.singlr.sing.commands;
 
 import ai.singlr.sing.config.HostYaml;
 import ai.singlr.sing.config.YamlUtil;
-import ai.singlr.sing.engine.Banner;
 import ai.singlr.sing.engine.NetworkDetector;
 import ai.singlr.sing.engine.SingPaths;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
-import java.util.Objects;
 import java.util.Set;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
@@ -45,13 +43,7 @@ public final class HostConfigSetCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/HostInitCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/HostInitCommand.java
@@ -69,15 +69,10 @@ public final class HostInitCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      System.err.println(
-          "  If this is unexpected, re-run with --dry-run to see what would execute.");
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(
+        spec,
+        "  If this is unexpected, re-run with --dry-run to see what would execute.",
+        this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/HostStatusCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/HostStatusCommand.java
@@ -17,7 +17,6 @@ import ai.singlr.sing.engine.SingPaths;
 import ai.singlr.sing.engine.ZfsQuery;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -37,13 +36,7 @@ public final class HostStatusCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/HostUpdateCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/HostUpdateCommand.java
@@ -14,7 +14,6 @@ import java.nio.file.Files;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -39,13 +38,7 @@ public final class HostUpdateCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/LogsCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/LogsCommand.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -52,13 +51,7 @@ public final class LogsCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectAddFileCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectAddFileCommand.java
@@ -80,13 +80,7 @@ public final class ProjectAddFileCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectAddRepoCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectAddRepoCommand.java
@@ -67,13 +67,7 @@ public final class ProjectAddRepoCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectAddServiceCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectAddServiceCommand.java
@@ -68,13 +68,7 @@ public final class ProjectAddServiceCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectApplyCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectApplyCommand.java
@@ -58,13 +58,7 @@ public final class ProjectApplyCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectConfigCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectConfigCommand.java
@@ -20,7 +20,6 @@ import ai.singlr.sing.engine.SpecWorkspace;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -50,13 +49,7 @@ public final class ProjectConfigCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectCreateCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectCreateCommand.java
@@ -23,7 +23,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -64,15 +63,10 @@ public final class ProjectCreateCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      System.err.println(
-          "  If this is unexpected, re-run with --dry-run to see what would execute.");
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(
+        spec,
+        "  If this is unexpected, re-run with --dry-run to see what would execute.",
+        this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectDemoCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectDemoCommand.java
@@ -26,7 +26,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -56,13 +55,7 @@ public final class ProjectDemoCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectDestroyCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectDestroyCommand.java
@@ -17,7 +17,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -47,15 +46,10 @@ public final class ProjectDestroyCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      System.err.println(
-          "  If this is unexpected, re-run with --dry-run to see what would execute.");
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(
+        spec,
+        "  If this is unexpected, re-run with --dry-run to see what would execute.",
+        this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectInitCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectInitCommand.java
@@ -42,13 +42,7 @@ public final class ProjectInitCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectInstallAgentCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectInstallAgentCommand.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -49,13 +48,7 @@ public final class ProjectInstallAgentCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectListCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectListCommand.java
@@ -13,7 +13,6 @@ import ai.singlr.sing.engine.ShellExecutor;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -33,13 +32,7 @@ public final class ProjectListCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectPullCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectPullCommand.java
@@ -20,7 +20,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -73,13 +72,7 @@ public final class ProjectPullCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectPushCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectPushCommand.java
@@ -75,13 +75,7 @@ public final class ProjectPushCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectRemoveServiceCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectRemoveServiceCommand.java
@@ -8,7 +8,6 @@ package ai.singlr.sing.commands;
 import ai.singlr.sing.config.SingYaml;
 import ai.singlr.sing.config.SingYamlUpdater;
 import ai.singlr.sing.config.YamlUtil;
-import ai.singlr.sing.engine.Banner;
 import ai.singlr.sing.engine.ContainerManager;
 import ai.singlr.sing.engine.ContainerState;
 import ai.singlr.sing.engine.NameValidator;
@@ -18,7 +17,6 @@ import ai.singlr.sing.engine.SingPaths;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -54,13 +52,7 @@ public final class ProjectRemoveServiceCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectResourcesSetCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectResourcesSetCommand.java
@@ -81,13 +81,7 @@ public final class ProjectResourcesSetCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, err, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/PsCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/PsCommand.java
@@ -14,7 +14,6 @@ import ai.singlr.sing.engine.NameValidator;
 import ai.singlr.sing.engine.ShellExecutor;
 import java.io.IOException;
 import java.util.List;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -39,13 +38,7 @@ public final class PsCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/RestoreCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/RestoreCommand.java
@@ -14,7 +14,6 @@ import ai.singlr.sing.engine.NameValidator;
 import ai.singlr.sing.engine.ShellExecutor;
 import ai.singlr.sing.engine.SnapshotManager;
 import java.util.LinkedHashMap;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -44,13 +43,7 @@ public final class RestoreCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/RunCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/RunCommand.java
@@ -87,13 +87,7 @@ public final class RunCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ShellCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ShellCommand.java
@@ -5,15 +5,12 @@
 
 package ai.singlr.sing.commands;
 
-import ai.singlr.sing.engine.Banner;
 import ai.singlr.sing.engine.ContainerManager;
 import ai.singlr.sing.engine.ContainerState;
 import ai.singlr.sing.engine.NameValidator;
 import ai.singlr.sing.engine.ShellExecutor;
 import java.util.List;
-import java.util.Objects;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Spec;
@@ -31,13 +28,7 @@ public final class ShellCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/SnapCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/SnapCommand.java
@@ -13,7 +13,6 @@ import ai.singlr.sing.engine.NameValidator;
 import ai.singlr.sing.engine.ShellExecutor;
 import ai.singlr.sing.engine.SnapshotManager;
 import java.util.LinkedHashMap;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -46,13 +45,7 @@ public final class SnapCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/SnapsCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/SnapsCommand.java
@@ -14,7 +14,6 @@ import ai.singlr.sing.engine.ShellExecutor;
 import ai.singlr.sing.engine.SnapshotManager;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -38,13 +37,7 @@ public final class SnapsCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/SnapsPruneCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/SnapsPruneCommand.java
@@ -17,7 +17,6 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import java.util.regex.Pattern;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
@@ -59,13 +58,7 @@ public final class SnapsPruneCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(commandSpec.commandLine(), msg, e);
-    }
+    CliCommand.run(commandSpec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/SpecCreateCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/SpecCreateCommand.java
@@ -20,7 +20,6 @@ import ai.singlr.sing.engine.SpecWorkspace;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -67,13 +66,7 @@ public final class SpecCreateCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(commandSpec.commandLine(), msg, e);
-    }
+    CliCommand.run(commandSpec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/SpecListCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/SpecListCommand.java
@@ -20,7 +20,6 @@ import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import picocli.CommandLine.Command;
@@ -55,13 +54,7 @@ public final class SpecListCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(commandSpec.commandLine(), msg, e);
-    }
+    CliCommand.run(commandSpec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/SpecShowCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/SpecShowCommand.java
@@ -18,7 +18,6 @@ import ai.singlr.sing.engine.SpecWorkspace;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -50,13 +49,7 @@ public final class SpecShowCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(commandSpec.commandLine(), msg, e);
-    }
+    CliCommand.run(commandSpec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/SpecStatusCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/SpecStatusCommand.java
@@ -17,7 +17,6 @@ import ai.singlr.sing.engine.SingPaths;
 import ai.singlr.sing.engine.SpecWorkspace;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -52,13 +51,7 @@ public final class SpecStatusCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(commandSpec.commandLine(), msg, e);
-    }
+    CliCommand.run(commandSpec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/SwitchCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/SwitchCommand.java
@@ -15,7 +15,6 @@ import ai.singlr.sing.engine.NameValidator;
 import ai.singlr.sing.engine.ResourceChecker;
 import ai.singlr.sing.engine.ShellExecutor;
 import java.util.LinkedHashMap;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -42,13 +41,7 @@ public final class SwitchCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/UpCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/UpCommand.java
@@ -15,7 +15,6 @@ import ai.singlr.sing.engine.NameValidator;
 import ai.singlr.sing.engine.ResourceChecker;
 import ai.singlr.sing.engine.ShellExecutor;
 import java.util.LinkedHashMap;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -42,13 +41,7 @@ public final class UpCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/UpgradeCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/UpgradeCommand.java
@@ -17,7 +17,6 @@ import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
-import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -46,13 +45,7 @@ public final class UpgradeCommand implements Runnable {
 
   @Override
   public void run() {
-    try {
-      execute();
-    } catch (Exception e) {
-      var msg = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
-      System.err.println(Banner.errorLine(msg, Ansi.AUTO));
-      throw new picocli.CommandLine.ExecutionException(spec.commandLine(), msg, e);
-    }
+    CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {

--- a/sing-infra/src/test/java/ai/singlr/sing/commands/CliCommandTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/commands/CliCommandTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.commands;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+class CliCommandTest {
+
+  private PrintStream originalErr;
+  private ByteArrayOutputStream capturedErr;
+
+  @BeforeEach
+  void captureErr() {
+    originalErr = System.err;
+    capturedErr = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(capturedErr));
+  }
+
+  @AfterEach
+  void restoreErr() {
+    System.setErr(originalErr);
+  }
+
+  @Test
+  void wrapsFailuresAsExecutionExceptions() {
+    var command = new CommandLine(new TestCommand());
+    var spec = command.getCommandSpec();
+
+    var error =
+        assertThrows(
+            CommandLine.ExecutionException.class,
+            () ->
+                CliCommand.run(
+                    spec,
+                    () -> {
+                      throw new IllegalStateException("boom");
+                    }));
+
+    assertEquals("boom", error.getMessage());
+    assertTrue(capturedErr.toString(StandardCharsets.UTF_8).contains("boom"));
+  }
+
+  @Test
+  void usesExceptionTypeWhenMessageIsMissing() {
+    var command = new CommandLine(new TestCommand());
+    var spec = command.getCommandSpec();
+
+    var error =
+        assertThrows(
+            CommandLine.ExecutionException.class,
+            () ->
+                CliCommand.run(
+                    spec,
+                    () -> {
+                      throw new IllegalStateException();
+                    }));
+
+    assertEquals("IllegalStateException", error.getMessage());
+  }
+
+  @Test
+  void printsFailureHintsWhenProvided() {
+    var command = new CommandLine(new TestCommand());
+    var spec = command.getCommandSpec();
+
+    assertThrows(
+        CommandLine.ExecutionException.class,
+        () ->
+            CliCommand.run(
+                spec,
+                "try --dry-run",
+                () -> {
+                  throw new IllegalStateException("boom");
+                }));
+
+    assertTrue(capturedErr.toString(StandardCharsets.UTF_8).contains("try --dry-run"));
+  }
+
+  @Command(name = "test")
+  private static final class TestCommand implements Runnable {
+    @Override
+    public void run() {}
+  }
+}

--- a/sing-infra/src/test/java/ai/singlr/sing/commands/CliJsonTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/commands/CliJsonTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Singular
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sing.commands;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CliJsonTest {
+
+  @Test
+  void serializesRecordFieldsAsSnakeCase() {
+    var json = CliJson.stringify(new ExampleResponse("demo", "spec-a", true, List.of("one")));
+
+    assertEquals(
+        "{\"project_name\": \"demo\", \"spec_id\": \"spec-a\", \"dry_run\": true, \"lines\": [\"one\"]}",
+        json);
+  }
+
+  @Test
+  void omitsNullRecordFields() {
+    var json = CliJson.stringify(new OptionalResponse("demo", null));
+
+    assertEquals("{\"name\": \"demo\"}", json);
+  }
+
+  @Test
+  void escapesStrings() {
+    var json = CliJson.stringify(new OptionalResponse("demo\n\"quoted\"", "tab\tvalue"));
+
+    assertEquals("{\"name\": \"demo\\n\\\"quoted\\\"\", \"value\": \"tab\\tvalue\"}", json);
+  }
+
+  private record ExampleResponse(
+      String projectName, String specId, boolean dryRun, List<String> lines) {}
+
+  private record OptionalResponse(String name, String value) {}
+}


### PR DESCRIPTION
## Summary

- Add a shared `CliCommand` execution boundary for command error handling, custom error streams, and failure hints.
- Migrate command classes off duplicated try/catch wrappers while preserving existing messages and causes.
- Add a record-aware `CliJson` renderer for command JSON output with snake_case fields and null omission.
- Move `spec dispatch` JSON output from ad-hoc maps to typed records rendered through `CliJson`.

## Tests

- `mvn verify`

Release Notes:

- Improved sing CLI error handling consistency and JSON output internals.
