### PR TITLE
Add sing coverage quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,17 @@ jobs:
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run tests
-        run: mvn clean test
+      - name: Verify quality gates
+        run: mvn clean verify
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: jacoco-reports
+          path: |
+            **/target/site/jacoco
+            **/target/site/jacoco.xml
 
       - name: Build native image
         run: mvn package -Pnative -DskipTests

--- a/QUALITY.md
+++ b/QUALITY.md
@@ -1,0 +1,31 @@
+# Quality Gates
+
+`sing` treats quality gates as ratchets: each gate protects the best current baseline while pure logic is extracted from process-heavy boundaries and raised toward 100% coverage.
+
+## Local Validation
+
+Run the same command CI runs before opening a PR:
+
+```bash
+mvn clean verify
+```
+
+For a focused test loop, run the affected module and test classes first, then finish with full verification:
+
+```bash
+mvn -pl sing-infra -am -Dtest=CliJsonTest,CliCommandTest -Dsurefire.failIfNoSpecifiedTests=false test
+mvn clean verify
+```
+
+## Coverage Policy
+
+- API contract classes under `ai.singlr.sing.api.*` require 100% line and method coverage.
+- Pure CLI runtime utilities have explicit class gates. `CliCommand` requires 100% line, method, and branch coverage. `CliJson` requires 100% method coverage and high line/branch coverage, with only defensive reflection failure paths outside the current threshold.
+- Every module has bundle-level line, method, branch, and class gates set to the current verified baseline so coverage cannot silently regress.
+- Generated code, unreachable defensive paths, and external process boundaries may use staged thresholds only when full coverage would encourage brittle tests.
+
+## Ratchet Rules
+
+- New pure domain services, validators, DTO mappers, renderers, and command metadata should target 100% line and method coverage in the same PR that introduces them.
+- Infrastructure gateways should be covered through fakes before raising their gates.
+- Do not lower a gate without documenting the reason in the PR.

--- a/pom.xml
+++ b/pom.xml
@@ -123,13 +123,38 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>api-coverage-check</id>
+                        <id>coverage-check</id>
                         <phase>verify</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>
                         <configuration>
                             <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.44</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>METHOD</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.67</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.36</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>CLASS</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.86</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
                                 <rule>
                                     <element>CLASS</element>
                                     <includes>
@@ -145,6 +170,52 @@
                                             <counter>METHOD</counter>
                                             <value>COVEREDRATIO</value>
                                             <minimum>1.0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                                <rule>
+                                    <element>CLASS</element>
+                                    <includes>
+                                        <include>ai.singlr.sing.commands.CliCommand</include>
+                                    </includes>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>METHOD</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                                <rule>
+                                    <element>CLASS</element>
+                                    <includes>
+                                        <include>ai.singlr.sing.commands.CliJson</include>
+                                    </includes>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.96</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>METHOD</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.97</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/sing-infra/src/test/java/ai/singlr/sing/commands/CliCommandTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/commands/CliCommandTest.java
@@ -88,6 +88,53 @@ class CliCommandTest {
     assertTrue(capturedErr.toString(StandardCharsets.UTF_8).contains("try --dry-run"));
   }
 
+  @Test
+  void returnsWhenCommandSucceeds() {
+    var command = new CommandLine(new TestCommand());
+    var spec = command.getCommandSpec();
+
+    assertDoesNotThrow(() -> CliCommand.run(spec, () -> {}));
+    assertEquals("", capturedErr.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void writesToCustomErrorStream() {
+    var command = new CommandLine(new TestCommand());
+    var spec = command.getCommandSpec();
+    var err = new ByteArrayOutputStream();
+
+    assertThrows(
+        CommandLine.ExecutionException.class,
+        () ->
+            CliCommand.run(
+                spec,
+                new PrintStream(err),
+                () -> {
+                  throw new IllegalStateException("custom");
+                }));
+
+    assertEquals("", capturedErr.toString(StandardCharsets.UTF_8));
+    assertTrue(err.toString(StandardCharsets.UTF_8).contains("custom"));
+  }
+
+  @Test
+  void ignoresBlankFailureHints() {
+    var command = new CommandLine(new TestCommand());
+    var spec = command.getCommandSpec();
+
+    assertThrows(
+        CommandLine.ExecutionException.class,
+        () ->
+            CliCommand.run(
+                spec,
+                " ",
+                () -> {
+                  throw new IllegalStateException("boom");
+                }));
+
+    assertEquals(1, capturedErr.toString(StandardCharsets.UTF_8).lines().count());
+  }
+
   @Command(name = "test")
   private static final class TestCommand implements Runnable {
     @Override

--- a/sing-infra/src/test/java/ai/singlr/sing/commands/CliJsonTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/commands/CliJsonTest.java
@@ -7,6 +7,7 @@ package ai.singlr.sing.commands;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +34,54 @@ class CliJsonTest {
     var json = CliJson.stringify(new OptionalResponse("demo\n\"quoted\"", "tab\tvalue"));
 
     assertEquals("{\"name\": \"demo\\n\\\"quoted\\\"\", \"value\": \"tab\\tvalue\"}", json);
+  }
+
+  @Test
+  void serializesPrimitiveTopLevelValues() {
+    assertEquals("null", CliJson.stringify(null));
+    assertEquals("42", CliJson.stringify(42));
+    assertEquals("false", CliJson.stringify(false));
+    assertEquals("\"ready\"", CliJson.stringify(State.READY));
+  }
+
+  @Test
+  void serializesMapsAndSkipsNullValues() {
+    var values = new LinkedHashMap<String, Object>();
+    values.put("name", "demo");
+    values.put("missing", null);
+    values.put("count", 2);
+
+    assertEquals("{\"name\": \"demo\", \"count\": 2}", CliJson.stringify(values));
+  }
+
+  @Test
+  void serializesEmptyListsAndMaps() {
+    assertEquals("[]", CliJson.stringify(List.of()));
+    assertEquals("{}", CliJson.stringify(new LinkedHashMap<>()));
+  }
+
+  @Test
+  void fallsBackToStringForUnknownObjects() {
+    var value =
+        new Object() {
+          @Override
+          public String toString() {
+            return "custom";
+          }
+        };
+
+    assertEquals("\"custom\"", CliJson.stringify(value));
+  }
+
+  @Test
+  void escapesAllJsonControlCharacters() {
+    var json = CliJson.stringify("backspace\b formfeed\f carriage\r control\u0001 slash\\");
+
+    assertEquals("\"backspace\\b formfeed\\f carriage\\r control\\u0001 slash\\\\\"", json);
+  }
+
+  private enum State {
+    READY
   }
 
   private record ExampleResponse(


### PR DESCRIPTION
## Summary
- add staged JaCoCo bundle baselines so module coverage cannot silently regress
- keep API contract classes at 100% line/method coverage and add explicit gates for `CliCommand` and `CliJson`
- expand `CliCommand` and `CliJson` edge-case tests
- make CI run `mvn clean verify` and upload JaCoCo reports
- document the local validation workflow and coverage ratchet policy in `QUALITY.md`

## Validation
- `git diff --check`
- `mvn -pl sing-infra -am -Dtest=CliJsonTest,CliCommandTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn verify`
- `mvn clean verify`

## Coverage Snapshot
- `sing-core`: 94.86% line, 94.40% method, 82.91% branch
- `sing-harness`: 61.99% line, 67.80% method, 52.00% branch
- `sing-infra`: 44.45% line, 69.86% method, 37.12% branch

## Release Notes
- Improved CI quality gates and coverage reporting for sing.
