### PR TITLE
Fix security scan CI reactor build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  verify:
+    name: Verify, security scan, and native build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,18 +34,22 @@ jobs:
       - name: Cache OWASP Dependency-Check data
         uses: actions/cache@v4
         with:
-          path: ~/.m2/repository/org/owasp/dependency-check-data
-          key: dependency-check-${{ runner.os }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/dependency-check-data
+          key: dependency-check-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}-${{ github.run_id }}
           restore-keys: |
+            dependency-check-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}-
             dependency-check-${{ runner.os }}-
 
       - name: Scan dependencies
         run: >
-          mvn org.owasp:dependency-check-maven:12.1.8:check
+          mvn install org.owasp:dependency-check-maven:12.1.8:aggregate
+          -DskipTests
+          -Djacoco.skip=true
           -Dformat=HTML
           -DfailBuildOnCVSS=7
           -DskipTestScope=true
           -DnvdApiKey=${{ secrets.NVD_API_KEY }}
+          -DdataDirectory=${{ runner.temp }}/dependency-check-data
 
       - name: Upload dependency check reports
         uses: actions/upload-artifact@v4

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -49,7 +49,7 @@ Background and foreground agent launch commands now pass work directories and ge
 Spec index and markdown writes now pass output paths as positional arguments instead of concatenating target paths into shell redirection scripts.
 
 ### Dependency vulnerability scanning added
-CI now runs OWASP Dependency-Check with the repository `NVD_API_KEY` secret, fails builds for CVSS 7+ findings, skips test-scope dependencies, caches NVD data, and uploads HTML reports.
+CI now runs OWASP Dependency-Check with the repository `NVD_API_KEY` secret, fails builds for CVSS 7+ findings, skips test-scope dependencies, installs reactor modules before the aggregate scan, caches NVD data, and uploads HTML reports.
 
 ## Accepted Risks
 
@@ -62,5 +62,5 @@ Spec markdown is intentionally passed to coding agents. The security boundary is
 ## Verification
 - Focused regression suite: `mvn -pl sing-infra,sing-harness -am -Dtest=ApiTokenStoreTest,ApiRouterTest,ApiCommandTest,SpecWorkspaceTest,AgentSessionTest -Dsurefire.failIfNoSpecifiedTests=false test`
 - Full verification: `mvn clean verify`
-- CI dependency scan: `mvn org.owasp:dependency-check-maven:12.1.8:check -Dformat=HTML -DfailBuildOnCVSS=7 -DskipTestScope=true -DnvdApiKey=${{ secrets.NVD_API_KEY }}`
+- CI dependency scan: `mvn install org.owasp:dependency-check-maven:12.1.8:aggregate -DskipTests -Djacoco.skip=true -Dformat=HTML -DfailBuildOnCVSS=7 -DskipTestScope=true -DnvdApiKey=${{ secrets.NVD_API_KEY }} -DdataDirectory=${{ runner.temp }}/dependency-check-data`
 - Native packaging attempted with `mvn package -Pnative -DskipTests`; local execution requires GraalVM and this container uses Temurin, so CI remains the authoritative native-image check.


### PR DESCRIPTION
## Summary
- Rename the CI job from `test` to `verify` with a clearer display name.
- Make OWASP Dependency-Check reactor-safe by installing local modules before running the aggregate scan.
- Skip tests and JaCoCo during the scan-only install phase so coverage gates remain owned by `mvn clean verify`.
- Use an explicit cached Dependency-Check data directory for NVD data reuse across runs.

## Validation
- Parsed `.github/workflows/ci.yml` with Python YAML.
- `mvn install org.owasp:dependency-check-maven:12.1.8:aggregate -DskipTests -Djacoco.skip=true -Ddependency-check.skip=true`

Release Notes:

- Fixed the Sing security scan CI job for multi-module Maven builds.
