### PR TITLE
Replace spec index with per-spec metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Write specs during the day. Walk away. The agent works through them overnight.
 sing spec dispatch acme-health   # pick next ready spec, launch agent
 ```
 
-`dispatch` reads `specs/index.yaml` from the container, finds the next pending spec (respecting dependencies and assignee), reads the detailed `spec.md`, and launches the agent with full context. Guardrails enforce time limits. Auto-snapshot provides rollback safety.
+`dispatch` scans `specs/*/spec.yaml` from the container, finds the next pending spec (respecting dependencies and assignee), reads the detailed `spec.md`, and launches the agent with full context. Guardrails enforce time limits. Auto-snapshot provides rollback safety.
 
 ## Spec-Driven Workflow
 
@@ -77,37 +77,29 @@ Specs are the unit of work. Each spec lives in its own directory inside `specs/`
 
 ```
 specs/
-├── index.yaml                # Ordered list: id, title, status, assignee, depends_on
 ├── oauth-flow/
+│   ├── spec.yaml             # Metadata: id, title, status, assignee, depends_on
 │   ├── spec.md               # What to build and why (brainstormed with agent in Zed)
 │   └── plan.md               # How to build it (optional, for complex specs)
 ├── payment-integration/
+│   ├── spec.yaml
 │   ├── spec.md
 │   └── plan.md
 └── fix-footer-typo/
+    ├── spec.yaml
     └── spec.md               # Simple spec, no plan needed
 ```
 
-### index.yaml
+### spec.yaml
 
 ```yaml
-specs:
-  - id: oauth-flow
-    title: "Implement OAuth flow with Google"
-    status: pending
-    assignee: alice
-    depends_on: []
-
-  - id: payment-integration
-    title: "Stripe payment webhook"
-    status: pending
-    assignee: bob
-    depends_on:
-      - oauth-flow
-
-  - id: fix-footer-typo
-    title: "Fix typo in footer"
-    status: done
+id: payment-integration
+title: "Stripe payment webhook"
+status: pending
+assignee: bob
+depends_on:
+  - oauth-flow
+branch: feat/payment-integration
 ```
 
 ### Lifecycle

--- a/sing-core/src/main/java/ai/singlr/sing/config/SpecDirectory.java
+++ b/sing-core/src/main/java/ai/singlr/sing/config/SpecDirectory.java
@@ -12,9 +12,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Reads and writes the {@code specs/} directory structure used for spec-driven agent work. The
- * directory contains an {@code index.yaml} listing spec IDs in order, and one subdirectory per spec
- * with {@code spec.yaml} (metadata) and optionally {@code spec.md} (detailed description).
+ * Reads and writes the {@code specs/} directory structure used for spec-driven agent work. Each
+ * spec lives in its own directory with {@code spec.yaml} metadata and {@code spec.md} details.
  *
  * <p>This class is pure parsing/generation logic with no I/O — callers pass content strings in and
  * receive content strings back.
@@ -41,34 +40,19 @@ public final class SpecDirectory {
 
   private SpecDirectory() {}
 
-  /**
-   * Parses the {@code index.yaml} content into an ordered list of specs. Each entry in the {@code
-   * specs} list must have at least an {@code id} field.
-   */
-  @SuppressWarnings("unchecked")
-  public static List<Spec> parseIndex(Map<String, Object> indexMap) {
-    var rawSpecs = (List<Map<String, Object>>) indexMap.get("specs");
-    if (rawSpecs == null || rawSpecs.isEmpty()) {
-      return List.of();
-    }
-    return rawSpecs.stream().map(Spec::fromMap).toList();
+  public static Spec parseMetadata(Map<String, Object> metadata) {
+    return Spec.fromMap(metadata);
   }
 
-  /**
-   * Generates the {@code index.yaml} content from an ordered list of specs. Only writes the fields
-   * relevant to the index (id, title, status, assignee, depends_on, branch).
-   */
-  public static Map<String, Object> generateIndex(List<Spec> specs) {
-    var map = new LinkedHashMap<String, Object>();
-    map.put("specs", specs.stream().map(Spec::toMap).toList());
-    return map;
+  public static Map<String, Object> generateMetadata(Spec spec) {
+    return spec.toMap();
   }
 
   /**
    * Returns the first pending spec whose dependencies are all done and whose assignee matches the
    * given identity (or is unassigned). Returns {@code null} if no spec is ready.
    *
-   * @param specs ordered list of specs (from index)
+   * @param specs ordered list of specs
    * @param assignee the engineer's identity to match (nullable for any assignee)
    */
   public static Spec nextReady(List<Spec> specs, String assignee) {
@@ -110,7 +94,7 @@ public final class SpecDirectory {
   public static List<Spec> updateStatus(List<Spec> specs, String specId, String newStatus) {
     requireValidStatus(newStatus);
     if (findById(specs, specId) == null) {
-      throw new IllegalArgumentException("Spec '" + specId + "' not found in index.yaml");
+      throw new IllegalArgumentException("Spec '" + specId + "' not found");
     }
     return specs.stream()
         .map(

--- a/sing-core/src/main/java/ai/singlr/sing/gen/AgentContextGenerator.java
+++ b/sing-core/src/main/java/ai/singlr/sing/gen/AgentContextGenerator.java
@@ -454,44 +454,37 @@ public final class AgentContextGenerator {
         ### Directory Structure
         ```
         %s/
-        \u251c\u2500\u2500 index.yaml          # Ordered list of all specs with status
-        \u251c\u2500\u2500 oauth-flow/
-        \u2502   \u251c\u2500\u2500 spec.md           # Detailed specification
-        \u2502   \u2514\u2500\u2500 plan.md           # Optional implementation plan
-        \u251c\u2500\u2500 search-api/
-        \u2502   \u2514\u2500\u2500 spec.md
-        \u2514\u2500\u2500 archive/            # Completed specs moved here
+        ├── oauth-flow/
+        │   ├── spec.yaml        # Metadata: id, title, status, assignee, depends_on, branch
+        │   ├── spec.md          # Detailed specification
+        │   └── plan.md          # Optional implementation plan
+        └── search-api/
+            ├── spec.yaml
+            └── spec.md
         ```
 
         **Important:** Specs are managed separately from source repos. Never create a `specs/`
         directory inside a repo. Always use the absolute path `%1$s/` for all spec operations.
 
-        ### index.yaml Format
+        ### spec.yaml Format
         ```yaml
-        specs:
-          - id: oauth-flow
-            title: "OAuth 2.0 authorization code flow"
-            status: in_progress
-            assignee: claude-code
-            depends_on: []
-            branch: feat/oauth-flow
-          - id: search-api
-            title: "Full-text search API with Meilisearch"
-            status: pending
-            assignee: claude-code
-            depends_on: [oauth-flow]
-            branch: feat/search-api
+        id: oauth-flow
+        title: OAuth 2.0 authorization code flow
+        status: in_progress
+        assignee: claude-code
+        depends_on: []
+        branch: feat/oauth-flow
         ```
 
         ### Status Lifecycle
-        `pending` \u2192 `in_progress` \u2192 `review` \u2192 `done`
-        Spec status is managed by `sing`, not by you. Do not modify spec status in index.yaml.
+        `pending` → `in_progress` → `review` → `done`
+        Spec status is managed by `sing`, not by you. Do not modify spec status directly during autonomous execution.
 
         ### Interactive Mode
         When the engineer asks you to brainstorm or write a spec:
         1. Create a directory under `%1$s/` named after the spec id
-        2. Write `spec.md` with the detailed specification
-        3. Add the spec entry to `%1$s/index.yaml` with status `pending`
+        2. Write `%1$s/<id>/spec.yaml` with metadata and status `pending`
+        3. Write `%1$s/<id>/spec.md` with the detailed specification
 
         ### Dependencies
         The `depends_on` field lists spec ids that must be `done` before this spec can start.

--- a/sing-core/src/main/java/ai/singlr/sing/gen/SpecSkillGenerator.java
+++ b/sing-core/src/main/java/ai/singlr/sing/gen/SpecSkillGenerator.java
@@ -206,13 +206,13 @@ public final class SpecSkillGenerator {
         description = "Show the spec board — list all specs grouped by status"
 
         [command.prompt]
-        text = "Read specs/index.yaml and display all specs grouped by status as a kanban board. Show columns: Pending, In Progress, Review, Done. For each spec show id, title, and dependencies."
+        text = "Scan specs/*/spec.yaml and display all specs grouped by status as a kanban board. Show columns: Pending, In Progress, Review, Done. For each spec show id, title, and dependencies."
         """;
   }
 
   private static String listInstructions(String specsDir) {
     return """
-        Read `%s/index.yaml` and display specs grouped by status columns:
+        Scan `%s/*/spec.yaml` and display specs grouped by status columns:
 
         ```
         ┌─────────────┬─────────────────┬──────────────┬──────────────┐
@@ -236,16 +236,15 @@ public final class SpecSkillGenerator {
     return """
         1. Derive an id from the title (lowercase, hyphens, e.g., "OAuth Flow" → `oauth-flow`)
         2. Create directory `%1$s/<id>/`
-        3. Write `%1$s/<id>/spec.md` using the spec template
-        4. Read current `%1$s/index.yaml`
-        5. Append the new spec entry:
+        3. Write `%1$s/<id>/spec.yaml`:
            ```yaml
-           - id: <id>
-             title: "<title>"
-             status: pending
+           id: <id>
+           title: "<title>"
+           status: pending
+           depends_on: []
            ```
-        6. Write the updated `%1$s/index.yaml`
-        7. Confirm: "Created spec `<id>` — fill in the details in `%1$s/<id>/spec.md`"
+        4. Write `%1$s/<id>/spec.md` using the spec template
+        5. Confirm: "Created spec `<id>` — fill in the details in `%1$s/<id>/spec.md`"
 
         If the engineer provided detailed requirements during the conversation, fill in the \
         spec.md with those details instead of leaving placeholders.
@@ -258,25 +257,21 @@ public final class SpecSkillGenerator {
 
   private static String showInstructions(String specsDir) {
     return """
-        1. Read `%s/<id>/spec.md`
-        2. Display the full content
-        3. Also show the spec's status, assignee, and dependencies from index.yaml
+        1. Read `%s/<id>/spec.yaml`
+        2. Read `%s/<id>/spec.md`
+        3. Display metadata, dependencies, and the full markdown content
         """
-        .formatted(specsDir);
+        .formatted(specsDir, specsDir);
   }
 
   private static String updateInstructions(String specsDir) {
     return """
         Valid statuses: `pending`, `in_progress`, `review`, `done`
 
-        1. Read `%1$s/index.yaml`
-        2. Find the spec entry by id
-        3. Update the `status` field
-        4. Write the updated `%1$s/index.yaml`
-        5. Confirm: "Updated `<id>` → `<new-status>`"
-
-        When moving to `done`, ask the engineer if they want the spec directory moved to \
-        `%1$s/archive/<id>/`.
+        1. Read `%1$s/<id>/spec.yaml`
+        2. Update the `status` field
+        3. Write the updated `%1$s/<id>/spec.yaml`
+        4. Confirm: "Updated `<id>` → `<new-status>`"
         """
         .formatted(specsDir);
   }
@@ -289,31 +284,25 @@ public final class SpecSkillGenerator {
         1. Extract each distinct unit of work from the conversation
         2. For each, derive an id and title
         3. Infer dependencies from the natural ordering and relationships discussed
-        4. Create all spec directories and spec.md files
-        5. Update `%s/index.yaml` with all new entries in dependency order
-        6. Show the resulting board view
+        4. Create each `%s/<id>/spec.yaml` and `%s/<id>/spec.md`
+        5. Show the resulting board view
 
         This is the primary daytime workflow: brainstorm with the engineer, then materialize \
         the plan into specs with one confirmation.
         """
-        .formatted(specsDir);
+        .formatted(specsDir, specsDir);
   }
 
   private static String coreReference(String specsDir) {
     return """
-        ### index.yaml Format
+        ### spec.yaml Format
         ```yaml
-        specs:
-          - id: oauth-flow
-            title: "OAuth 2.0 authorization code flow"
-            status: in_progress
-            assignee: claude-code
-            depends_on: []
-            branch: feat/oauth-flow
-          - id: search-api
-            title: "Full-text search API"
-            status: pending
-            depends_on: [oauth-flow]
+        id: oauth-flow
+        title: OAuth 2.0 authorization code flow
+        status: in_progress
+        assignee: claude-code
+        depends_on: []
+        branch: feat/oauth-flow
         ```
 
         ### Status Lifecycle
@@ -322,8 +311,7 @@ public final class SpecSkillGenerator {
         - **in_progress**: agent is actively working on it (set by `sing spec dispatch`)
         - **review**: PR created, waiting for human review (set by `sing`)
         - **done**: PR merged, work complete (set by engineer via `sing`)
-        Status is managed by `sing`, not by the agent. Do not modify status in index.yaml
-        during autonomous execution.
+        Status is managed by `sing`, not by the agent. Do not modify status directly during autonomous execution.
 
         ### Important
         Specs live at `%1$s/` — an absolute path in the workspace root, NOT inside any repo.
@@ -340,18 +328,17 @@ public final class SpecSkillGenerator {
         ### Directory Structure
         ```
         %s/
-        ├── index.yaml
-        ├── <spec-id>/
-        │   ├── spec.md        # Detailed specification
-        │   └── plan.md        # Optional implementation plan
-        └── archive/           # Completed specs moved here
+        └── <spec-id>/
+            ├── spec.yaml     # Metadata
+            ├── spec.md       # Detailed specification
+            └── plan.md       # Optional implementation plan
         ```
 
         ### Dependency Rules
         A spec cannot be started if any of its `depends_on` specs are not `done`.
         When listing specs, visually indicate which pending specs are blocked.
         """
-        .formatted(specsDir);
+        .formatted(specsDir, specsDir);
   }
 
   private static String specTemplate() {

--- a/sing-core/src/test/java/ai/singlr/sing/config/SpecDirectoryTest.java
+++ b/sing-core/src/test/java/ai/singlr/sing/config/SpecDirectoryTest.java
@@ -14,53 +14,37 @@ import org.junit.jupiter.api.Test;
 class SpecDirectoryTest {
 
   @Test
-  void parseIndexReturnsOrderedSpecs() {
-    var indexMap =
+  void parseMetadataReturnsSpec() {
+    var metadata =
         Map.<String, Object>of(
-            "specs",
-            List.of(
-                Map.<String, Object>of("id", "auth", "title", "Implement auth", "status", "done"),
-                Map.<String, Object>of(
-                    "id", "search",
-                    "title", "Add search",
-                    "status", "pending",
-                    "depends_on", List.of("auth"))));
+            "id",
+            "search",
+            "title",
+            "Add search",
+            "status",
+            "pending",
+            "depends_on",
+            List.of("auth"));
 
-    var specs = SpecDirectory.parseIndex(indexMap);
+    var spec = SpecDirectory.parseMetadata(metadata);
 
-    assertEquals(2, specs.size());
-    assertEquals("auth", specs.getFirst().id());
-    assertEquals("search", specs.get(1).id());
-    assertEquals(List.of("auth"), specs.get(1).dependsOn());
+    assertEquals("search", spec.id());
+    assertEquals("Add search", spec.title());
+    assertEquals("pending", spec.status());
+    assertEquals(List.of("auth"), spec.dependsOn());
   }
 
   @Test
-  void parseIndexReturnsEmptyForMissingKey() {
-    assertTrue(SpecDirectory.parseIndex(Map.of()).isEmpty());
-  }
+  void generateMetadataRoundTrips() {
+    var spec = new Spec("search", "Search", "pending", "alice", List.of("auth"), "feat/search");
 
-  @Test
-  void parseIndexReturnsEmptyForEmptyList() {
-    assertTrue(SpecDirectory.parseIndex(Map.of("specs", List.of())).isEmpty());
-  }
+    var metadata = SpecDirectory.generateMetadata(spec);
+    var parsed = SpecDirectory.parseMetadata(metadata);
 
-  @Test
-  @SuppressWarnings("unchecked")
-  void generateIndexRoundTrips() {
-    var specs =
-        List.of(
-            new Spec("auth", "Auth", "done", null, List.of(), null),
-            new Spec("search", "Search", "pending", "alice", List.of("auth"), "feat/search"));
-
-    var indexMap = SpecDirectory.generateIndex(specs);
-    var parsed = SpecDirectory.parseIndex(indexMap);
-
-    assertEquals(2, parsed.size());
-    assertEquals("auth", parsed.getFirst().id());
-    assertEquals("done", parsed.getFirst().status());
-    assertEquals("search", parsed.get(1).id());
-    assertEquals("alice", parsed.get(1).assignee());
-    assertEquals(List.of("auth"), parsed.get(1).dependsOn());
+    assertEquals("search", parsed.id());
+    assertEquals("alice", parsed.assignee());
+    assertEquals(List.of("auth"), parsed.dependsOn());
+    assertEquals("feat/search", parsed.branch());
   }
 
   @Test
@@ -250,20 +234,6 @@ class SpecDirectoryTest {
 
     assertEquals(1, counts.get("blocked"));
     assertEquals(0, counts.get("pending"));
-  }
-
-  @Test
-  void generateIndexPreservesOrder() {
-    var specs =
-        List.of(
-            new Spec("z-last", "Z", "pending", null, List.of(), null),
-            new Spec("a-first", "A", "done", null, List.of(), null));
-
-    var indexMap = SpecDirectory.generateIndex(specs);
-    var parsed = SpecDirectory.parseIndex(indexMap);
-
-    assertEquals("z-last", parsed.getFirst().id());
-    assertEquals("a-first", parsed.get(1).id());
   }
 
   @Test

--- a/sing-core/src/test/java/ai/singlr/sing/engine/GitSpecSyncTest.java
+++ b/sing-core/src/test/java/ai/singlr/sing/engine/GitSpecSyncTest.java
@@ -47,7 +47,7 @@ class GitSpecSyncTest {
 
   @Test
   void dirtyStatusHandlesNonConflictEntries() throws Exception {
-    var status = sync(repositoryShell("## main...origin/main\n?? index.yaml\n")).status();
+    var status = sync(repositoryShell("## main...origin/main\n?? spec.yaml\n")).status();
 
     assertEquals(GitSpecSync.State.DIRTY, status.state());
     assertFalse(status.conflicted());
@@ -81,7 +81,7 @@ class GitSpecSyncTest {
 
   @Test
   void reportsDirtyBeforeAheadBehind() throws Exception {
-    var shell = repositoryShell("## main...origin/main [ahead 1, behind 2]\n M index.yaml\n");
+    var shell = repositoryShell("## main...origin/main [ahead 1, behind 2]\n M spec.yaml\n");
     var sync = sync(shell);
 
     var status = sync.status();
@@ -94,7 +94,7 @@ class GitSpecSyncTest {
 
   @Test
   void reportsConflictedBeforeDirty() throws Exception {
-    var shell = repositoryShell("## main...origin/main\nUU index.yaml\n");
+    var shell = repositoryShell("## main...origin/main\nUU spec.yaml\n");
     var sync = sync(shell);
 
     var status = sync.status();
@@ -150,7 +150,7 @@ class GitSpecSyncTest {
 
   @Test
   void pullFailsWhenDirty() throws Exception {
-    var shell = repositoryShell("## main...origin/main\n M index.yaml\n");
+    var shell = repositoryShell("## main...origin/main\n M spec.yaml\n");
     var sync = sync(shell);
 
     var thrown = assertThrows(IllegalStateException.class, sync::pull);
@@ -247,7 +247,7 @@ class GitSpecSyncTest {
   @Test
   void pullRejectsUnsafeStates() {
     assertPullRejected(repositoryShell("## main...origin/main [ahead 1, behind 1]\n"));
-    assertPullRejected(repositoryShell("## main...origin/main\nUU index.yaml\n"));
+    assertPullRejected(repositoryShell("## main...origin/main\nUU spec.yaml\n"));
     assertPullRejected(noUpstreamShell());
     assertPullRejected(
         new ScriptedShellExecutor().onFail("rev-parse --is-inside-work-tree", "fatal"));
@@ -278,9 +278,9 @@ class GitSpecSyncTest {
 
   @Test
   void pushRejectsUnsafeStates() {
-    assertPushRejected(repositoryShell("## main...origin/main\n M index.yaml\n"));
+    assertPushRejected(repositoryShell("## main...origin/main\n M spec.yaml\n"));
     assertPushRejected(repositoryShell("## main...origin/main [ahead 1, behind 1]\n"));
-    assertPushRejected(repositoryShell("## main...origin/main\nUU index.yaml\n"));
+    assertPushRejected(repositoryShell("## main...origin/main\nUU spec.yaml\n"));
     assertPushRejected(noUpstreamShell());
     assertPushRejected(
         new ScriptedShellExecutor().onFail("rev-parse --is-inside-work-tree", "fatal"));

--- a/sing-core/src/test/java/ai/singlr/sing/gen/AgentContextGeneratorTest.java
+++ b/sing-core/src/test/java/ai/singlr/sing/gen/AgentContextGeneratorTest.java
@@ -1233,7 +1233,7 @@ class AgentContextGeneratorTest {
 
     assertTrue(md.contains("## Spec-Driven Development"));
     assertTrue(md.contains("specs/"));
-    assertTrue(md.contains("index.yaml"));
+    assertTrue(md.contains("spec.yaml"));
     assertTrue(md.contains("spec.md"));
     assertTrue(md.contains("Status Lifecycle"));
     assertTrue(md.contains("pending"));

--- a/sing-core/src/test/java/ai/singlr/sing/gen/SpecSkillGeneratorTest.java
+++ b/sing-core/src/test/java/ai/singlr/sing/gen/SpecSkillGeneratorTest.java
@@ -46,7 +46,7 @@ class SpecSkillGeneratorTest {
     var files = SpecSkillGenerator.generateFiles(AgentCli.CLAUDE_CODE, "my-specs", BASE);
     var content = files.get(0).content();
 
-    assertTrue(content.contains("my-specs/index.yaml"));
+    assertTrue(content.contains("my-specs/<id>/spec.yaml"));
     assertTrue(content.contains("my-specs/<id>/spec.md"));
   }
 
@@ -137,7 +137,7 @@ class SpecSkillGeneratorTest {
 
     assertFalse(instructions.isEmpty());
     assertTrue(instructions.contains("Spec Management"));
-    assertTrue(instructions.contains("specs/index.yaml"));
+    assertTrue(instructions.contains("specs/<id>/spec.yaml"));
     assertTrue(instructions.contains("spec.md"));
   }
 
@@ -177,13 +177,13 @@ class SpecSkillGeneratorTest {
     var customDir = "work-items";
 
     var claude = SpecSkillGenerator.generateFiles(AgentCli.CLAUDE_CODE, customDir, BASE);
-    assertTrue(claude.get(0).content().contains("work-items/index.yaml"));
+    assertTrue(claude.get(0).content().contains("work-items/<id>/spec.yaml"));
 
     var gemini = SpecSkillGenerator.generateFiles(AgentCli.GEMINI, customDir, BASE);
-    assertTrue(gemini.get(0).content().contains("work-items/index.yaml"));
+    assertTrue(gemini.get(0).content().contains("work-items/<id>/spec.yaml"));
 
     var codex = SpecSkillGenerator.codexInstructions(customDir);
-    assertTrue(codex.contains("work-items/index.yaml"));
+    assertTrue(codex.contains("work-items/<id>/spec.yaml"));
   }
 
   @Test

--- a/sing-harness/src/main/java/ai/singlr/sing/engine/AgentReporter.java
+++ b/sing-harness/src/main/java/ai/singlr/sing/engine/AgentReporter.java
@@ -136,13 +136,7 @@ public final class AgentReporter {
     var specs = List.<Spec>of();
     if (config.agent() != null && config.agent().specsDir() != null) {
       try {
-        var indexPath =
-            "/home/" + config.sshUser() + "/workspace/" + config.agent().specsDir() + "/index.yaml";
-        var catCmd = ContainerExec.asDevUser(containerName, List.of("cat", indexPath));
-        var catResult = shell.exec(catCmd);
-        if (catResult.ok() && !catResult.stdout().isBlank()) {
-          specs = SpecDirectory.parseIndex(YamlUtil.parseMap(catResult.stdout()));
-        }
+        specs = readSpecs(containerName, config);
       } catch (Exception ignored) {
       }
     }
@@ -241,6 +235,38 @@ public final class AgentReporter {
         guardrailAction,
         rolledBack,
         rollbackSnapshot);
+  }
+
+  private List<Spec> readSpecs(String containerName, SingYaml config)
+      throws IOException, InterruptedException, TimeoutException {
+    var specsDir = "/home/" + config.sshUser() + "/workspace/" + config.agent().specsDir();
+    var findResult =
+        shell.exec(
+            ContainerExec.asDevUser(
+                containerName,
+                List.of(
+                    "find",
+                    specsDir,
+                    "-mindepth",
+                    "2",
+                    "-maxdepth",
+                    "2",
+                    "-name",
+                    "spec.yaml",
+                    "-print")));
+    if (!findResult.ok() || findResult.stdout().isBlank()) {
+      return List.of();
+    }
+    var specs = new java.util.ArrayList<Spec>();
+    var paths = findResult.stdout().lines().filter(line -> !line.isBlank()).sorted().toList();
+    for (var path : paths) {
+      var catResult = shell.exec(ContainerExec.asDevUser(containerName, List.of("cat", path)));
+      if (!catResult.ok()) {
+        throw new IOException("Failed to read spec metadata: " + catResult.stderr());
+      }
+      specs.add(SpecDirectory.parseMetadata(YamlUtil.parseMap(catResult.stdout())));
+    }
+    return List.copyOf(specs);
   }
 
   private static Instant parseInstantSafe(String value) {

--- a/sing-harness/src/test/java/ai/singlr/sing/engine/AgentReporterTest.java
+++ b/sing-harness/src/test/java/ai/singlr/sing/engine/AgentReporterTest.java
@@ -22,15 +22,17 @@ class AgentReporterTest {
   void completedSessionWithSpecs(@TempDir java.nio.file.Path stateDir) throws Exception {
     var startedAt = Instant.now().minusSeconds(3600 * 4).toString();
     var lastCommit = String.valueOf(Instant.now().minusSeconds(300).getEpochSecond());
-    var indexYaml =
+    var authSpecYaml =
         """
-        specs:
-          - id: auth
-            title: Build auth module
-            status: done
-          - id: tests
-            title: Write tests
-            status: done
+        id: auth
+        title: Build auth module
+        status: done
+        """;
+    var testsSpecYaml =
+        """
+        id: tests
+        title: Write tests
+        status: done
         """;
     var shell =
         new ScriptedShellExecutor()
@@ -41,7 +43,11 @@ class AgentReporterTest {
                 "{\"task\":\"build auth\",\"started_at\":\""
                     + startedAt
                     + "\",\"branch\":\"sing/snap-20260302\",\"log_path\":\"/home/dev/.sing/agent.log\"}")
-            .onOk("cat /home/dev/workspace/specs/index.yaml", indexYaml)
+            .onOk(
+                "find /home/dev/workspace/specs -mindepth 2 -maxdepth 2 -name spec.yaml -print",
+                "/home/dev/workspace/specs/auth/spec.yaml\n/home/dev/workspace/specs/tests/spec.yaml\n")
+            .onOk("cat /home/dev/workspace/specs/auth/spec.yaml", authSpecYaml)
+            .onOk("cat /home/dev/workspace/specs/tests/spec.yaml", testsSpecYaml)
             .onOk("git -C /home/dev/workspace log -1 --format=%ct", lastCommit + "\n")
             .onOk("git -C /home/dev/workspace rev-list --count", "18\n")
             .onFail("cat /home/dev/guardrail-triggered.yaml", "No such file");
@@ -79,7 +85,9 @@ class AgentReporterTest {
             .onOk("git -C /home/dev/workspace log -1 --format=%ct", lastCommit + "\n")
             .onOk("git -C /home/dev/workspace rev-list --count", "5\n")
             .onFail("cat /home/dev/guardrail-triggered.yaml", "No such file")
-            .onFail("cat /home/dev/workspace/specs/index.yaml", "No such file");
+            .onFail(
+                "find /home/dev/workspace/specs -mindepth 2 -maxdepth 2 -name spec.yaml -print",
+                "No such file");
 
     var config = buildConfig("specs");
     var reporter = new AgentReporter(shell);
@@ -107,7 +115,9 @@ class AgentReporterTest {
                 "reason: max_duration\naction: snapshot-and-stop\n")
             .onOk("git -C /home/dev/workspace log -1 --format=%ct", "0\n")
             .onOk("git -C /home/dev/workspace rev-list --count", "45\n")
-            .onFail("cat /home/dev/workspace/specs/index.yaml", "No such file");
+            .onFail(
+                "find /home/dev/workspace/specs -mindepth 2 -maxdepth 2 -name spec.yaml -print",
+                "No such file");
 
     var config = buildConfig("specs");
     var reporter = new AgentReporter(shell);
@@ -126,7 +136,9 @@ class AgentReporterTest {
         new ScriptedShellExecutor()
             .onFail("cat /home/dev/.sing/agent.pid", "No such file")
             .onFail("cat /home/dev/guardrail-triggered.yaml", "No such file")
-            .onFail("cat /home/dev/workspace/specs/index.yaml", "No such file")
+            .onFail(
+                "find /home/dev/workspace/specs -mindepth 2 -maxdepth 2 -name spec.yaml -print",
+                "No such file")
             .onOk("git -C /home/dev/workspace log -1 --format=%ct", "\n")
             .onOk("git -C /home/dev/workspace rev-list --count", "0\n");
 
@@ -188,7 +200,9 @@ class AgentReporterTest {
             .onFail("cat /home/dev/guardrail-triggered.yaml", "No such file")
             .onOk("git -C /home/dev/workspace log -1 --format=%ct", "\n")
             .onOk("git -C /home/dev/workspace rev-list --count", "10\n")
-            .onFail("cat /home/dev/workspace/specs/index.yaml", "No such file");
+            .onFail(
+                "find /home/dev/workspace/specs -mindepth 2 -maxdepth 2 -name spec.yaml -print",
+                "No such file");
 
     var config = buildConfig("specs");
     var reporter = new AgentReporter(shell);
@@ -203,17 +217,19 @@ class AgentReporterTest {
   @Test
   void specsWithDependenciesIncluded(@TempDir java.nio.file.Path stateDir) throws Exception {
     var startedAt = Instant.now().minusSeconds(3600).toString();
-    var indexYaml =
+    var authSpecYaml =
         """
-        specs:
-          - id: auth
-            title: Build auth
-            status: done
-          - id: docs
-            title: Update docs
-            status: pending
-            depends_on:
-              - auth
+        id: auth
+        title: Build auth
+        status: done
+        """;
+    var docsSpecYaml =
+        """
+        id: docs
+        title: Update docs
+        status: pending
+        depends_on:
+          - auth
         """;
     var shell =
         new ScriptedShellExecutor()
@@ -224,7 +240,11 @@ class AgentReporterTest {
                 "{\"task\":\"build auth\",\"started_at\":\""
                     + startedAt
                     + "\",\"branch\":\"\",\"log_path\":\"/home/dev/.sing/agent.log\"}")
-            .onOk("cat /home/dev/workspace/specs/index.yaml", indexYaml)
+            .onOk(
+                "find /home/dev/workspace/specs -mindepth 2 -maxdepth 2 -name spec.yaml -print",
+                "/home/dev/workspace/specs/auth/spec.yaml\n/home/dev/workspace/specs/docs/spec.yaml\n")
+            .onOk("cat /home/dev/workspace/specs/auth/spec.yaml", authSpecYaml)
+            .onOk("cat /home/dev/workspace/specs/docs/spec.yaml", docsSpecYaml)
             .onOk("git -C /home/dev/workspace log -1 --format=%ct", "\n")
             .onOk("git -C /home/dev/workspace rev-list --count", "8\n")
             .onFail("cat /home/dev/guardrail-triggered.yaml", "No such file");

--- a/sing-infra/src/main/java/ai/singlr/sing/api/SingApiOperations.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/api/SingApiOperations.java
@@ -118,7 +118,7 @@ public final class SingApiOperations implements ApiOperations {
 
   private SpecsResponse specsValue(String project) {
     var loaded = loadRunningProject(project);
-    var specs = readIndex(workspace(loaded));
+    var specs = readSpecs(workspace(loaded));
     var summary = SpecDirectory.summarize(specs);
     return new SpecsResponse(
         project,
@@ -130,7 +130,7 @@ public final class SingApiOperations implements ApiOperations {
   private SpecResponse specValue(String project, String specId) {
     var loaded = loadRunningProject(project);
     var workspace = workspace(loaded);
-    var specs = readIndex(workspace);
+    var specs = readSpecs(workspace);
     var spec = SpecDirectory.findById(specs, specId);
     if (spec == null) {
       throw new ApiException(ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found.");
@@ -193,7 +193,7 @@ public final class SingApiOperations implements ApiOperations {
     }
 
     var workspace = workspace(loaded);
-    var specs = readIndex(workspace);
+    var specs = readSpecs(workspace);
     var nextSpec = resolveSpec(specs, request.specId());
     if (nextSpec == null) {
       return new DispatchResponse(project, false, "no_pending_specs", null, null, "", false);
@@ -274,11 +274,11 @@ public final class SingApiOperations implements ApiOperations {
     }
   }
 
-  private static List<Spec> readIndex(SpecWorkspace workspace) {
+  private static List<Spec> readSpecs(SpecWorkspace workspace) {
     try {
-      return workspace.readIndex();
+      return workspace.readSpecs();
     } catch (Exception e) {
-      throw new ApiException(ErrorCode.SPECS_READ_FAILED, "Failed to read specs index.", e);
+      throw new ApiException(ErrorCode.SPECS_READ_FAILED, "Failed to read spec metadata.", e);
     }
   }
 

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/AgentLaunchCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/AgentLaunchCommand.java
@@ -6,6 +6,7 @@
 package ai.singlr.sing.commands;
 
 import ai.singlr.sing.config.SingYaml;
+import ai.singlr.sing.config.SpecDirectory;
 import ai.singlr.sing.config.YamlUtil;
 import ai.singlr.sing.engine.AgentCli;
 import ai.singlr.sing.engine.AgentSession;
@@ -17,6 +18,7 @@ import ai.singlr.sing.engine.NameValidator;
 import ai.singlr.sing.engine.ShellExecutor;
 import ai.singlr.sing.engine.SingPaths;
 import ai.singlr.sing.engine.SnapshotManager;
+import ai.singlr.sing.engine.SpecWorkspace;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
@@ -111,35 +113,28 @@ public final class AgentLaunchCommand implements Runnable {
         && config.agent() != null
         && config.agent().specsDir() != null) {
       var specsDir = "/home/" + config.sshUser() + "/workspace/" + config.agent().specsDir();
-      var catCmd = ContainerExec.asDevUser(name, List.of("cat", specsDir + "/index.yaml"));
-      var catResult = shell.exec(catCmd);
-      if (catResult.ok() && !catResult.stdout().isBlank()) {
-        var specs =
-            ai.singlr.sing.config.SpecDirectory.parseIndex(YamlUtil.parseMap(catResult.stdout()));
-        var nextSpec = ai.singlr.sing.config.SpecDirectory.nextReady(specs);
-        if (nextSpec != null) {
-          var specMdCmd =
-              ContainerExec.asDevUser(
-                  name, List.of("cat", specsDir + "/" + nextSpec.id() + "/spec.md"));
-          var specMdResult = shell.exec(specMdCmd);
-          var specBody = specMdResult.ok() ? specMdResult.stdout().strip() : "";
-          var description = !specBody.isBlank() ? specBody : nextSpec.title();
-          task =
-              "Your current spec: \""
-                  + nextSpec.title()
-                  + "\" (id: "
-                  + nextSpec.id()
-                  + ").\n\n"
-                  + description
-                  + "\n\nWhen complete, update "
-                  + config.agent().specsDir()
-                  + "/index.yaml and set this spec's status to \"done\"."
-                  + " Then pick up the next pending spec and continue working.";
-          if (!json) {
-            System.out.println(Ansi.AUTO.string("  @|bold Spec:|@ " + nextSpec.id()));
-            System.out.println(Ansi.AUTO.string("  @|faint " + nextSpec.title() + "|@"));
-            System.out.println();
-          }
+      var workspace = new SpecWorkspace(shell, name, specsDir);
+      var specs = workspace.readSpecs();
+      var nextSpec = SpecDirectory.nextReady(specs);
+      if (nextSpec != null) {
+        var specBody = Objects.requireNonNullElse(workspace.readSpecBody(nextSpec.id()), "");
+        var description = !specBody.isBlank() ? specBody : nextSpec.title();
+        task =
+            "Your current spec: \""
+                + nextSpec.title()
+                + "\" (id: "
+                + nextSpec.id()
+                + ").\n\n"
+                + description
+                + "\n\nWhen complete, run `sing spec status "
+                + name
+                + " "
+                + nextSpec.id()
+                + " done`. Then pick up the next pending spec and continue working.";
+        if (!json) {
+          System.out.println(Ansi.AUTO.string("  @|bold Spec:|@ " + nextSpec.id()));
+          System.out.println(Ansi.AUTO.string("  @|faint " + nextSpec.title() + "|@"));
+          System.out.println();
         }
       }
     }

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/AgentStatusCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/AgentStatusCommand.java
@@ -10,13 +10,13 @@ import ai.singlr.sing.config.SpecDirectory;
 import ai.singlr.sing.config.YamlUtil;
 import ai.singlr.sing.engine.AgentSession;
 import ai.singlr.sing.engine.Banner;
-import ai.singlr.sing.engine.ContainerExec;
 import ai.singlr.sing.engine.ContainerManager;
 import ai.singlr.sing.engine.ContainerState;
 import ai.singlr.sing.engine.GuardrailChecker;
 import ai.singlr.sing.engine.NameValidator;
 import ai.singlr.sing.engine.ShellExecutor;
 import ai.singlr.sing.engine.SingPaths;
+import ai.singlr.sing.engine.SpecWorkspace;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
@@ -214,14 +214,9 @@ public final class AgentStatusCommand implements Runnable {
         && config.agent().specsDir() != null
         && info != null) {
       try {
-        var indexPath =
-            "/home/" + config.sshUser() + "/workspace/" + config.agent().specsDir() + "/index.yaml";
-        var catCmd = ContainerExec.asDevUser(name, List.of("cat", indexPath));
-        var catResult = shell.exec(catCmd);
-        if (catResult.ok() && !catResult.stdout().isBlank()) {
-          var specs = SpecDirectory.parseIndex(YamlUtil.parseMap(catResult.stdout()));
-          taskCounts = SpecDirectory.statusCounts(specs);
-        }
+        var specsDir = "/home/" + config.sshUser() + "/workspace/" + config.agent().specsDir();
+        var specs = new SpecWorkspace(shell, name, specsDir).readSpecs();
+        taskCounts = SpecDirectory.statusCounts(specs);
       } catch (Exception ignored) {
       }
     }

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/DispatchCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/DispatchCommand.java
@@ -34,9 +34,9 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 /**
- * Dispatches the next ready spec to an agent for autonomous execution. Reads {@code
- * specs/index.yaml} from the container, finds the next pending spec (respecting dependencies and
- * assignee), reads its {@code spec.md}, and launches the configured agent.
+ * Dispatches the next ready spec to an agent for autonomous execution. Reads per-spec metadata from
+ * the container, finds the next pending spec, reads its {@code spec.md}, and launches the
+ * configured agent.
  */
 @Command(
     name = "dispatch",
@@ -113,7 +113,7 @@ public final class DispatchCommand implements Runnable {
     var specsDir = "/home/" + sshUser + "/workspace/" + config.agent().specsDir();
     var specWorkspace = new SpecWorkspace(shell, name, specsDir);
 
-    var specs = specWorkspace.readIndex();
+    var specs = specWorkspace.readSpecs();
     if (specs.isEmpty()) {
       printNoSpecs();
       return;
@@ -274,8 +274,7 @@ public final class DispatchCommand implements Runnable {
       return specs.stream()
           .filter(s -> s.id().equals(specId))
           .findFirst()
-          .orElseThrow(
-              () -> new IllegalArgumentException("Spec '" + specId + "' not found in index.yaml"));
+          .orElseThrow(() -> new IllegalArgumentException("Spec '" + specId + "' not found"));
     }
     return SpecDirectory.nextReady(specs);
   }

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectConfigCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectConfigCommand.java
@@ -177,7 +177,7 @@ public final class ProjectConfigCommand implements Runnable {
     }
     var specsDir = "/home/" + config.sshUser() + "/workspace/" + config.agent().specsDir();
     try {
-      var summary = SpecDirectory.summarize(new SpecWorkspace(shell, name, specsDir).readIndex());
+      var summary = SpecDirectory.summarize(new SpecWorkspace(shell, name, specsDir).readSpecs());
       return SpecSnapshot.available(summary);
     } catch (Exception e) {
       return SpecSnapshot.unavailable("specs_unavailable");

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/RunCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/RunCommand.java
@@ -6,6 +6,7 @@
 package ai.singlr.sing.commands;
 
 import ai.singlr.sing.config.SingYaml;
+import ai.singlr.sing.config.SpecDirectory;
 import ai.singlr.sing.config.YamlUtil;
 import ai.singlr.sing.engine.AgentCli;
 import ai.singlr.sing.engine.AgentSession;
@@ -17,6 +18,7 @@ import ai.singlr.sing.engine.NameValidator;
 import ai.singlr.sing.engine.ShellExecutor;
 import ai.singlr.sing.engine.SingPaths;
 import ai.singlr.sing.engine.SnapshotManager;
+import ai.singlr.sing.engine.SpecWorkspace;
 import ai.singlr.sing.gen.AgentContextGenerator;
 import ai.singlr.sing.gen.CodeReviewGenerator;
 import ai.singlr.sing.gen.GeneratedFile;
@@ -203,35 +205,28 @@ public final class RunCommand implements Runnable {
   private void launchAgent(ShellExecutor shell, SingYaml config) throws Exception {
     if (task == null && config.agent() != null && config.agent().specsDir() != null) {
       var specsDir = "/home/" + config.sshUser() + "/workspace/" + config.agent().specsDir();
-      var catCmd = ContainerExec.asDevUser(name, List.of("cat", specsDir + "/index.yaml"));
-      var catResult = shell.exec(catCmd);
-      if (catResult.ok() && !catResult.stdout().isBlank()) {
-        var specs =
-            ai.singlr.sing.config.SpecDirectory.parseIndex(YamlUtil.parseMap(catResult.stdout()));
-        var nextSpec = ai.singlr.sing.config.SpecDirectory.nextReady(specs);
-        if (nextSpec != null) {
-          var specMdCmd =
-              ContainerExec.asDevUser(
-                  name, List.of("cat", specsDir + "/" + nextSpec.id() + "/spec.md"));
-          var specMdResult = shell.exec(specMdCmd);
-          var specBody = specMdResult.ok() ? specMdResult.stdout().strip() : "";
-          var description = !specBody.isBlank() ? specBody : nextSpec.title();
-          task =
-              "Your current spec: \""
-                  + nextSpec.title()
-                  + "\" (id: "
-                  + nextSpec.id()
-                  + ").\n\n"
-                  + description
-                  + "\n\nWhen complete, update "
-                  + config.agent().specsDir()
-                  + "/index.yaml and set this spec's status to \"done\"."
-                  + " Then pick up the next pending spec and continue working.";
-          if (!json) {
-            System.out.println(Ansi.AUTO.string("  @|bold Spec:|@ " + nextSpec.id()));
-            System.out.println(Ansi.AUTO.string("  @|faint " + nextSpec.title() + "|@"));
-            System.out.println();
-          }
+      var workspace = new SpecWorkspace(shell, name, specsDir);
+      var specs = workspace.readSpecs();
+      var nextSpec = SpecDirectory.nextReady(specs);
+      if (nextSpec != null) {
+        var specBody = Objects.requireNonNullElse(workspace.readSpecBody(nextSpec.id()), "");
+        var description = !specBody.isBlank() ? specBody : nextSpec.title();
+        task =
+            "Your current spec: \""
+                + nextSpec.title()
+                + "\" (id: "
+                + nextSpec.id()
+                + ").\n\n"
+                + description
+                + "\n\nWhen complete, run `sing spec status "
+                + name
+                + " "
+                + nextSpec.id()
+                + " done`. Then pick up the next pending spec and continue working.";
+        if (!json) {
+          System.out.println(Ansi.AUTO.string("  @|bold Spec:|@ " + nextSpec.id()));
+          System.out.println(Ansi.AUTO.string("  @|faint " + nextSpec.title() + "|@"));
+          System.out.println();
         }
       }
     }

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/SpecCreateCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/SpecCreateCommand.java
@@ -28,7 +28,7 @@ import picocli.CommandLine.Parameters;
 
 @Command(
     name = "create",
-    description = "Create a spec scaffold and add it to index.yaml.",
+    description = "Create a spec scaffold with per-spec metadata.",
     mixinStandardHelpOptions = true)
 public final class SpecCreateCommand implements Runnable {
 

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/SpecListCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/SpecListCommand.java
@@ -29,8 +29,8 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 /**
- * Lists specs from a project's {@code specs/index.yaml} as a kanban board grouped by status. Reads
- * the index from inside the Incus container via {@code incus exec}.
+ * Lists specs from project per-spec metadata as a kanban board grouped by status. Reads the index
+ * from inside the Incus container via {@code incus exec}.
  */
 @Command(
     name = "list",
@@ -91,7 +91,7 @@ public final class SpecListCommand implements Runnable {
     var sshUser = config.sshUser();
     var specsDir = "/home/" + sshUser + "/workspace/" + config.agent().specsDir();
     var workspace = new SpecWorkspace(shell, name, specsDir);
-    var specs = workspace.readIndex();
+    var specs = workspace.readSpecs();
     if (specs.isEmpty()) {
       if (json) {
         var map = new LinkedHashMap<String, Object>();

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/SpecShowCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/SpecShowCommand.java
@@ -84,10 +84,10 @@ public final class SpecShowCommand implements Runnable {
 
     var specsDir = "/home/" + config.sshUser() + "/workspace/" + config.agent().specsDir();
     var workspace = new SpecWorkspace(shell, name, specsDir);
-    var specs = workspace.readIndex();
+    var specs = workspace.readSpecs();
     var spec = SpecDirectory.findById(specs, specId);
     if (spec == null) {
-      throw new IllegalArgumentException("Spec '" + specId + "' not found in index.yaml");
+      throw new IllegalArgumentException("Spec '" + specId + "' not found");
     }
 
     var content = workspace.readSpecBody(specId);

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/SpecStatusCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/SpecStatusCommand.java
@@ -89,7 +89,7 @@ public final class SpecStatusCommand implements Runnable {
         new SpecWorkspace(
             shell, name, "/home/" + config.sshUser() + "/workspace/" + config.agent().specsDir());
     var updated = workspace.updateStatus(specId, status);
-    var summary = SpecDirectory.summarize(workspace.readIndex());
+    var summary = SpecDirectory.summarize(workspace.readSpecs());
 
     if (json) {
       var map = new LinkedHashMap<String, Object>();

--- a/sing-infra/src/main/java/ai/singlr/sing/engine/ProjectApplier.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/engine/ProjectApplier.java
@@ -434,8 +434,7 @@ public final class ProjectApplier {
       return new ApplyResult(0, 0, 1, List.of());
     }
     out.println("  [add] Creating specs scaffold at " + config.agent().specsDir() + "/...");
-    shell.exec(ContainerExec.asDevUser(name, List.of("mkdir", "-p", specsPath + "/archive")));
-    pushFile(name, specsPath + "/index.yaml", "specs: []\n", sshUser);
+    shell.exec(ContainerExec.asDevUser(name, List.of("mkdir", "-p", specsPath)));
     return new ApplyResult(1, 0, 0, List.of());
   }
 

--- a/sing-infra/src/main/java/ai/singlr/sing/engine/ProjectProvisioner.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/engine/ProjectProvisioner.java
@@ -1108,8 +1108,7 @@ public final class ProjectProvisioner {
     }
 
     step(19, "Creating specs scaffold...");
-    execInContainer(config.name(), List.of("mkdir", "-p", specsPath + "/archive"));
-    pushFileToContainer(config.name(), specsPath + "/index.yaml", "specs: []\n");
+    execInContainer(config.name(), List.of("mkdir", "-p", specsPath));
     execInContainer(config.name(), List.of("chown", "-R", user + ":" + user, specsPath));
     tracker.advance(currentPhase);
     stepDone(19, "specs scaffold created at " + config.agent().specsDir() + "/");

--- a/sing-infra/src/main/java/ai/singlr/sing/engine/SpecWorkspace.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/engine/SpecWorkspace.java
@@ -1,14 +1,11 @@
-/*
- * Copyright (c) 2026 Singular
- * SPDX-License-Identifier: MIT
- */
-
 package ai.singlr.sing.engine;
 
 import ai.singlr.sing.config.Spec;
 import ai.singlr.sing.config.SpecDirectory;
 import ai.singlr.sing.config.YamlUtil;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
@@ -29,23 +26,33 @@ public final class SpecWorkspace {
     this.specsDir = specsDir;
   }
 
-  public List<Spec> readIndex() throws IOException, InterruptedException, TimeoutException {
-    var result = shell.exec(ContainerExec.asDevUser(containerName, List.of("cat", indexPath())));
-    if (!result.ok()) {
-      if (isMissingFile(result)) {
-        return List.of();
-      }
-      throw new IOException("Failed to read spec index: " + result.stderr());
-    }
-    if (result.stdout().isBlank()) {
+  public List<Spec> readSpecs() throws IOException, InterruptedException, TimeoutException {
+    var metadataPaths = specMetadataPaths();
+    if (metadataPaths.isEmpty()) {
       return List.of();
     }
-    return SpecDirectory.parseIndex(YamlUtil.parseMap(result.stdout()));
+    var specs = new ArrayList<Spec>();
+    for (var metadataPath : metadataPaths) {
+      specs.add(readMetadataPath(metadataPath));
+    }
+    requireUniqueSpecIds(specs);
+    return List.copyOf(specs);
   }
 
   public Spec readSpec(String specId) throws IOException, InterruptedException, TimeoutException {
     NameValidator.requireValidSpecId(specId);
-    return SpecDirectory.findById(readIndex(), specId);
+    var result =
+        shell.exec(
+            ContainerExec.asDevUser(containerName, List.of("cat", specMetadataPath(specId))));
+    if (result.ok()) {
+      var spec = SpecDirectory.parseMetadata(YamlUtil.parseMap(result.stdout()));
+      requireMatchingSpecId(specId, spec);
+      return spec;
+    }
+    if (isMissingFile(result)) {
+      return null;
+    }
+    throw new IOException("Failed to read spec metadata: " + result.stderr());
   }
 
   public String readSpecBody(String specId)
@@ -63,38 +70,29 @@ public final class SpecWorkspace {
     throw new IOException("Failed to read spec markdown: " + result.stderr());
   }
 
-  public void writeIndex(List<Spec> specs)
-      throws IOException, InterruptedException, TimeoutException {
-    ensureSpecsRoot();
-    var yaml = YamlUtil.dumpToString(SpecDirectory.generateIndex(specs));
-    var result =
-        shell.exec(
-            ContainerExec.asDevUser(
-                containerName,
-                List.of("bash", "-c", "printf '%s' \"$1\" > \"$2\"", "bash", yaml, indexPath())));
-    if (!result.ok()) {
-      throw new IOException("Failed to write spec index: " + result.stderr());
-    }
-  }
-
   public Spec updateStatus(String specId, String newStatus)
       throws IOException, InterruptedException, TimeoutException {
-    var specs = readIndex();
-    var updated = SpecDirectory.updateStatus(specs, specId, newStatus);
-    writeIndex(updated);
-    return SpecDirectory.findById(updated, specId);
+    SpecDirectory.requireValidStatus(newStatus);
+    var spec = readSpec(specId);
+    if (spec == null) {
+      throw new IllegalArgumentException("Spec '" + specId + "' not found");
+    }
+    var updated =
+        new Spec(
+            spec.id(), spec.title(), newStatus, spec.assignee(), spec.dependsOn(), spec.branch());
+    writeMetadata(updated);
+    return updated;
   }
 
   public void createSpec(Spec spec, String markdown)
       throws IOException, InterruptedException, TimeoutException {
     NameValidator.requireValidSpecId(spec.id());
-    var specs = readIndex();
-    if (SpecDirectory.findById(specs, spec.id()) != null || specDirectoryExists(spec.id())) {
+    if (specDirectoryExists(spec.id())) {
       throw new IllegalArgumentException("Spec '" + spec.id() + "' already exists.");
     }
     ensureSpecDirectory(spec.id());
+    writeMetadata(spec);
     writeSpecBody(spec.id(), markdown);
-    writeIndex(append(specs, spec));
   }
 
   public String specMarkdownPath(String specId) {
@@ -102,11 +100,61 @@ public final class SpecWorkspace {
     return specsDir + "/" + specId + "/spec.md";
   }
 
-  private void ensureSpecsRoot() throws IOException, InterruptedException, TimeoutException {
+  public String specMetadataPath(String specId) {
+    NameValidator.requireValidSpecId(specId);
+    return specsDir + "/" + specId + "/spec.yaml";
+  }
+
+  private List<String> specMetadataPaths()
+      throws IOException, InterruptedException, TimeoutException {
     var result =
-        shell.exec(ContainerExec.asDevUser(containerName, List.of("mkdir", "-p", specsDir)));
+        shell.exec(
+            ContainerExec.asDevUser(
+                containerName,
+                List.of(
+                    "find",
+                    specsDir,
+                    "-mindepth",
+                    "2",
+                    "-maxdepth",
+                    "2",
+                    "-name",
+                    "spec.yaml",
+                    "-print")));
     if (!result.ok()) {
-      throw new IOException("Failed to create specs directory: " + result.stderr());
+      if (isMissingFile(result)) {
+        return List.of();
+      }
+      throw new IOException("Failed to list spec metadata: " + result.stderr());
+    }
+    if (result.stdout().isBlank()) {
+      return List.of();
+    }
+    return result.stdout().lines().filter(line -> !line.isBlank()).sorted().toList();
+  }
+
+  private static void requireMatchingSpecId(String expectedId, Spec spec) throws IOException {
+    if (!expectedId.equals(spec.id())) {
+      throw new IOException(
+          "Spec metadata id mismatch for '" + expectedId + "': found '" + spec.id() + "'");
+    }
+  }
+
+  private Spec readMetadataPath(String path)
+      throws IOException, InterruptedException, TimeoutException {
+    var result = shell.exec(ContainerExec.asDevUser(containerName, List.of("cat", path)));
+    if (!result.ok()) {
+      throw new IOException("Failed to read spec metadata: " + result.stderr());
+    }
+    return SpecDirectory.parseMetadata(YamlUtil.parseMap(result.stdout()));
+  }
+
+  private static void requireUniqueSpecIds(List<Spec> specs) {
+    var ids = new HashSet<String>();
+    for (var spec : specs) {
+      if (!ids.add(spec.id())) {
+        throw new IllegalArgumentException("Duplicate spec id: " + spec.id());
+      }
     }
   }
 
@@ -118,6 +166,24 @@ public final class SpecWorkspace {
                 containerName, List.of("mkdir", "-p", specsDir + "/" + specId)));
     if (!result.ok()) {
       throw new IOException("Failed to create spec directory: " + result.stderr());
+    }
+  }
+
+  private void writeMetadata(Spec spec) throws IOException, InterruptedException, TimeoutException {
+    var yaml = YamlUtil.dumpToString(SpecDirectory.generateMetadata(spec));
+    var result =
+        shell.exec(
+            ContainerExec.asDevUser(
+                containerName,
+                List.of(
+                    "bash",
+                    "-c",
+                    "printf '%s' \"$1\" > \"$2\"",
+                    "bash",
+                    yaml,
+                    specMetadataPath(spec.id()))));
+    if (!result.ok()) {
+      throw new IOException("Failed to write spec metadata: " + result.stderr());
     }
   }
 
@@ -145,15 +211,6 @@ public final class SpecWorkspace {
         shell.exec(
             ContainerExec.asDevUser(containerName, List.of("test", "-e", specsDir + "/" + specId)));
     return result.ok();
-  }
-
-  private String indexPath() {
-    return specsDir + "/index.yaml";
-  }
-
-  private static List<Spec> append(List<Spec> specs, Spec spec) {
-    return java.util.stream.Stream.concat(specs.stream(), java.util.stream.Stream.of(spec))
-        .toList();
   }
 
   private static boolean isMissingFile(ShellExec.Result result) {

--- a/sing-infra/src/test/java/ai/singlr/sing/api/SingApiOperationsTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/api/SingApiOperationsTest.java
@@ -47,29 +47,49 @@ class SingApiOperationsTest {
 
   private static final String EMPTY_JSON = "[]";
 
-  private static final String INDEX_YAML =
+  private static final String SPEC_PATHS =
       """
-      specs:
-        - id: setup
-          title: Setup project
-          status: done
-        - id: auth
-          title: Add auth
-          status: pending
-          depends_on: [setup]
-        - id: billing
-          title: Add billing
-          status: pending
-          depends_on: [missing]
+      /home/dev/workspace/specs/auth/spec.yaml
+      /home/dev/workspace/specs/billing/spec.yaml
+      /home/dev/workspace/specs/setup/spec.yaml
       """;
 
-  private static final String INDEX_WITH_BRANCH_YAML =
+  private static final String SETUP_SPEC_YAML =
       """
-      specs:
-        - id: auth
-          title: Add auth
-          status: pending
-          branch: feat/custom
+      id: setup
+      title: Setup project
+      status: done
+      """;
+
+  private static final String AUTH_SPEC_YAML =
+      """
+      id: auth
+      title: Add auth
+      status: pending
+      depends_on: [setup]
+      """;
+
+  private static final String BILLING_SPEC_YAML =
+      """
+      id: billing
+      title: Add billing
+      status: pending
+      depends_on: [missing]
+      """;
+
+  private static final String AUTH_BRANCH_SPEC_YAML =
+      """
+      id: auth
+      title: Add auth
+      status: pending
+      branch: feat/custom
+      """;
+
+  private static final String DONE_SPEC_YAML =
+      """
+      id: done
+      title: Done
+      status: done
       """;
 
   @TempDir Path tempDir;
@@ -128,11 +148,7 @@ class SingApiOperationsTest {
 
   @Test
   void specsReturnsBoardSummary() throws Exception {
-    var operations =
-        operations(
-            shell()
-                .on("incus list ^acme$", RUNNING_JSON)
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML));
+    var operations = operations(shell().on("incus list ^acme$", RUNNING_JSON).withSpecs());
 
     var result = operations.specs("acme");
 
@@ -147,7 +163,7 @@ class SingApiOperationsTest {
         operations(
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .on("cat /home/dev/workspace/specs/auth/spec.md", "# Auth"));
 
     var result = operations.spec("acme", "auth");
@@ -158,11 +174,7 @@ class SingApiOperationsTest {
 
   @Test
   void specReturnsNotFoundForUnknownSpec() throws Exception {
-    var operations =
-        operations(
-            shell()
-                .on("incus list ^acme$", RUNNING_JSON)
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML));
+    var operations = operations(shell().on("incus list ^acme$", RUNNING_JSON).withSpecs());
 
     var error = operations.spec("acme", "missing");
 
@@ -175,7 +187,7 @@ class SingApiOperationsTest {
         operations(
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .on(
                     "cat /home/dev/workspace/specs/auth/spec.md",
                     new ShellExec.Result(1, "", "No such file")));
@@ -297,12 +309,7 @@ class SingApiOperationsTest {
 
   @Test
   void dispatchReturnsNoPendingSpecs() throws Exception {
-    var index = "specs:\n  - id: done\n    title: Done\n    status: done\n";
-    var operations =
-        operations(
-            shell()
-                .on("incus list ^acme$", RUNNING_JSON)
-                .on("cat /home/dev/workspace/specs/index.yaml", index));
+    var operations = operations(shell().on("incus list ^acme$", RUNNING_JSON).withDoneSpec());
 
     var result = operations.dispatch("acme", request());
 
@@ -317,7 +324,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", ""));
@@ -336,7 +343,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML));
+                .withSpecs());
 
     var error = operations.dispatch("acme", request("billing"));
 
@@ -359,7 +366,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML));
+                .withSpecs());
 
     var error = operations.dispatch("acme", request("missing"));
 
@@ -544,7 +551,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", "")
@@ -567,7 +574,7 @@ class SingApiOperationsTest {
                 .on("cat /home/dev/.sing/agent.pid", "123")
                 .on("kill -0 123", new ShellExec.Result(1, "", "missing"))
                 .on("cat /home/dev/.sing/agent-session.json", "{\"task\": \"work\"}")
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .on("cat /home/dev/workspace/specs/auth/spec.md", "")
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", "")
@@ -597,7 +604,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", "")
@@ -618,7 +625,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", "")
@@ -643,7 +650,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", "")
@@ -675,7 +682,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", "")
@@ -696,7 +703,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_WITH_BRANCH_YAML)
+                .withAuthBranchSpec()
                 .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", "")
@@ -716,7 +723,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", "")
@@ -737,7 +744,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", "")
@@ -759,7 +766,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", "")
@@ -780,7 +787,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", "")
@@ -799,7 +806,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", "")
@@ -821,7 +828,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .on("cat /home/dev/workspace/specs/auth/spec.md", "Do auth")
                 .on("mkdir -p /home/dev/workspace/specs", "")
                 .on("printf '%s'", "")
@@ -876,7 +883,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML));
+                .withSpecs());
 
     var result = operations.agentReport("acme");
 
@@ -937,7 +944,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on(
-                    "cat /home/dev/workspace/specs/index.yaml",
+                    "find /home/dev/workspace/specs -mindepth 2 -maxdepth 2 -name spec.yaml -print",
                     new ShellExec.Result(1, "", "denied")));
 
     var error = operations.specs("acme");
@@ -951,7 +958,7 @@ class SingApiOperationsTest {
         operations(
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .throwOn("cat /home/dev/workspace/specs/auth/spec.md", new IOException("denied")));
 
     var error = operations.spec("acme", "auth");
@@ -966,7 +973,7 @@ class SingApiOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sing/agent.pid", new ShellExec.Result(1, "", "missing"))
-                .on("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML)
+                .withSpecs()
                 .throwOn("mkdir -p /home/dev/workspace/specs", new IOException("denied")));
 
     var error = operations.dispatch("acme", request("auth"));
@@ -1109,6 +1116,29 @@ class SingApiOperationsTest {
     FakeShell throwOn(String pattern, Exception failure) {
       failures.put(pattern, failure);
       return this;
+    }
+
+    FakeShell withSpecs() {
+      return on(
+              "find /home/dev/workspace/specs -mindepth 2 -maxdepth 2 -name spec.yaml -print",
+              SPEC_PATHS)
+          .on("cat /home/dev/workspace/specs/auth/spec.yaml", AUTH_SPEC_YAML)
+          .on("cat /home/dev/workspace/specs/billing/spec.yaml", BILLING_SPEC_YAML)
+          .on("cat /home/dev/workspace/specs/setup/spec.yaml", SETUP_SPEC_YAML);
+    }
+
+    FakeShell withAuthBranchSpec() {
+      return on(
+              "find /home/dev/workspace/specs -mindepth 2 -maxdepth 2 -name spec.yaml -print",
+              "/home/dev/workspace/specs/auth/spec.yaml\n")
+          .on("cat /home/dev/workspace/specs/auth/spec.yaml", AUTH_BRANCH_SPEC_YAML);
+    }
+
+    FakeShell withDoneSpec() {
+      return on(
+              "find /home/dev/workspace/specs -mindepth 2 -maxdepth 2 -name spec.yaml -print",
+              "/home/dev/workspace/specs/done/spec.yaml\n")
+          .on("cat /home/dev/workspace/specs/done/spec.yaml", DONE_SPEC_YAML);
     }
 
     @Override

--- a/sing-infra/src/test/java/ai/singlr/sing/commands/DispatchCommandTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/commands/DispatchCommandTest.java
@@ -106,7 +106,7 @@ class DispatchCommandTest {
     assertTrue(prompt.contains("oauth-flow"));
     assertTrue(prompt.contains("Implement OAuth"));
     assertTrue(prompt.contains("Build Google OAuth integration"));
-    assertFalse(prompt.contains("index.yaml"), "Prompt should not contain lifecycle instructions");
+    assertFalse(prompt.contains("spec.yaml"), "Prompt should not contain lifecycle instructions");
   }
 
   @Test

--- a/sing-infra/src/test/java/ai/singlr/sing/commands/SpecSyncCommandTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/commands/SpecSyncCommandTest.java
@@ -43,7 +43,7 @@ class SpecSyncCommandTest {
   @Test
   void humanStatusUsesRedForDirtyRepository() throws Exception {
     var shell =
-        cleanShell().on("status --porcelain=v1 -b", "## main...origin/main\n M index.yaml\n");
+        cleanShell().on("status --porcelain=v1 -b", "## main...origin/main\n M spec.yaml\n");
 
     var result = execute(shell, "acme", "status", "-f", yaml());
 

--- a/sing-infra/src/test/java/ai/singlr/sing/engine/ProjectApplierTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/engine/ProjectApplierTest.java
@@ -835,11 +835,8 @@ class ProjectApplierTest {
     assertEquals(1, result.added());
     assertEquals(0, result.skipped());
     assertTrue(
-        shell.invocations().stream()
-            .anyMatch(c -> c.contains("mkdir") && c.contains("specs/archive")));
-    assertTrue(
-        shell.invocations().stream()
-            .anyMatch(c -> c.contains("incus file push") && c.contains("index.yaml")));
+        shell.invocations().stream().anyMatch(c -> c.contains("mkdir") && c.contains("specs")));
+    assertFalse(shell.invocations().stream().anyMatch(c -> c.contains("incus file push")));
   }
 
   @Test

--- a/sing-infra/src/test/java/ai/singlr/sing/engine/SpecWorkspaceTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/engine/SpecWorkspaceTest.java
@@ -1,8 +1,3 @@
-/*
- * Copyright (c) 2026 Singular
- * SPDX-License-Identifier: MIT
- */
-
 package ai.singlr.sing.engine;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -13,30 +8,127 @@ import org.junit.jupiter.api.Test;
 
 class SpecWorkspaceTest {
 
-  private static final String INDEX_YAML =
+  private static final String OAUTH_METADATA =
       """
-      specs:
-        - id: oauth-flow
-          title: OAuth Flow
-          status: pending
-        - id: search-api
-          title: Search API
-          status: review
-          depends_on:
-            - oauth-flow
+      id: oauth-flow
+      title: OAuth Flow
+      status: pending
+      """;
+
+  private static final String SEARCH_METADATA =
+      """
+      id: search-api
+      title: Search API
+      status: review
+      depends_on:
+        - oauth-flow
       """;
 
   @Test
-  void readIndexParsesOrderedSpecs() throws Exception {
+  void readSpecsScansMetadataFilesInSortedOrder() throws Exception {
     var shell =
-        new ScriptedShellExecutor().onOk("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML);
+        new ScriptedShellExecutor()
+            .onOk(
+                "find /home/dev/workspace/specs -mindepth 2 -maxdepth 2 -name spec.yaml -print",
+                "/home/dev/workspace/specs/search-api/spec.yaml\n/home/dev/workspace/specs/oauth-flow/spec.yaml\n")
+            .onOk("cat /home/dev/workspace/specs/oauth-flow/spec.yaml", OAUTH_METADATA)
+            .onOk("cat /home/dev/workspace/specs/search-api/spec.yaml", SEARCH_METADATA);
     var workspace = new SpecWorkspace(shell, "acme-health", "/home/dev/workspace/specs");
 
-    var specs = workspace.readIndex();
+    var specs = workspace.readSpecs();
 
     assertEquals(2, specs.size());
     assertEquals("oauth-flow", specs.getFirst().id());
     assertEquals("search-api", specs.get(1).id());
+    assertEquals(List.of("oauth-flow"), specs.get(1).dependsOn());
+  }
+
+  @Test
+  void readSpecsRejectsDuplicateIds() {
+    var duplicate =
+        """
+        id: oauth-flow
+        title: Duplicate OAuth Flow
+        status: pending
+        """;
+    var shell =
+        new ScriptedShellExecutor()
+            .onOk(
+                "find /home/dev/workspace/specs -mindepth 2 -maxdepth 2 -name spec.yaml -print",
+                "/home/dev/workspace/specs/oauth-flow/spec.yaml\n/home/dev/workspace/specs/duplicate/spec.yaml\n")
+            .onOk("cat /home/dev/workspace/specs/oauth-flow/spec.yaml", OAUTH_METADATA)
+            .onOk("cat /home/dev/workspace/specs/duplicate/spec.yaml", duplicate);
+    var workspace = new SpecWorkspace(shell, "acme-health", "/home/dev/workspace/specs");
+
+    var error = assertThrows(IllegalArgumentException.class, workspace::readSpecs);
+
+    assertTrue(error.getMessage().contains("Duplicate spec id"));
+  }
+
+  @Test
+  void readSpecsReturnsEmptyWhenDirectoryIsMissing() throws Exception {
+    var shell =
+        new ScriptedShellExecutor()
+            .onFail(
+                "find /home/dev/workspace/specs -mindepth 2 -maxdepth 2 -name spec.yaml -print",
+                "No such file");
+    var workspace = new SpecWorkspace(shell, "acme-health", "/home/dev/workspace/specs");
+
+    assertTrue(workspace.readSpecs().isEmpty());
+  }
+
+  @Test
+  void readSpecsThrowsOnUnexpectedListFailure() {
+    var shell =
+        new ScriptedShellExecutor()
+            .onFail(
+                "find /home/dev/workspace/specs -mindepth 2 -maxdepth 2 -name spec.yaml -print",
+                "permission denied");
+    var workspace = new SpecWorkspace(shell, "acme-health", "/home/dev/workspace/specs");
+
+    var error = assertThrows(java.io.IOException.class, workspace::readSpecs);
+
+    assertTrue(error.getMessage().contains("Failed to list spec metadata"));
+  }
+
+  @Test
+  void readSpecReadsSingleMetadataFile() throws Exception {
+    var shell =
+        new ScriptedShellExecutor()
+            .onOk("cat /home/dev/workspace/specs/oauth-flow/spec.yaml", OAUTH_METADATA);
+    var workspace = new SpecWorkspace(shell, "acme-health", "/home/dev/workspace/specs");
+
+    var spec = workspace.readSpec("oauth-flow");
+
+    assertEquals("OAuth Flow", spec.title());
+  }
+
+  @Test
+  void readSpecRejectsMismatchedMetadataId() {
+    var mismatch =
+        """
+        id: wrong-id
+        title: Wrong ID
+        status: pending
+        """;
+    var shell =
+        new ScriptedShellExecutor()
+            .onOk("cat /home/dev/workspace/specs/oauth-flow/spec.yaml", mismatch);
+    var workspace = new SpecWorkspace(shell, "acme-health", "/home/dev/workspace/specs");
+
+    var error = assertThrows(java.io.IOException.class, () -> workspace.readSpec("oauth-flow"));
+
+    assertTrue(error.getMessage().contains("Spec metadata id mismatch"));
+  }
+
+  @Test
+  void readSpecReturnsNullWhenMissing() throws Exception {
+    var shell =
+        new ScriptedShellExecutor()
+            .onFail("cat /home/dev/workspace/specs/oauth-flow/spec.yaml", "No such file");
+    var workspace = new SpecWorkspace(shell, "acme-health", "/home/dev/workspace/specs");
+
+    assertNull(workspace.readSpec("oauth-flow"));
   }
 
   @Test
@@ -52,18 +144,6 @@ class SpecWorkspaceTest {
   }
 
   @Test
-  void readIndexThrowsOnUnexpectedFailure() {
-    var shell =
-        new ScriptedShellExecutor()
-            .onFail("cat /home/dev/workspace/specs/index.yaml", "permission denied");
-    var workspace = new SpecWorkspace(shell, "acme-health", "/home/dev/workspace/specs");
-
-    var error = assertThrows(java.io.IOException.class, workspace::readIndex);
-
-    assertTrue(error.getMessage().contains("Failed to read spec index"));
-  }
-
-  @Test
   void readSpecBodyThrowsOnUnexpectedFailure() {
     var shell =
         new ScriptedShellExecutor()
@@ -76,7 +156,7 @@ class SpecWorkspaceTest {
   }
 
   @Test
-  void createSpecWritesMarkdownAndIndex() throws Exception {
+  void createSpecWritesMetadataAndMarkdown() throws Exception {
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
             .onceOnFail("test -e /home/dev/workspace/specs/oauth-flow", "No such file");
@@ -91,17 +171,15 @@ class SpecWorkspaceTest {
             .anyMatch(cmd -> cmd.contains("mkdir -p /home/dev/workspace/specs/oauth-flow")));
     assertTrue(
         commands.stream()
-            .anyMatch(cmd -> cmd.contains("/home/dev/workspace/specs/oauth-flow/spec.md")));
+            .anyMatch(cmd -> cmd.contains("/home/dev/workspace/specs/oauth-flow/spec.yaml")));
     assertTrue(
-        commands.stream().anyMatch(cmd -> cmd.contains("/home/dev/workspace/specs/index.yaml")));
-    assertTrue(commands.stream().anyMatch(cmd -> cmd.contains("oauth-flow")));
+        commands.stream()
+            .anyMatch(cmd -> cmd.contains("/home/dev/workspace/specs/oauth-flow/spec.md")));
   }
 
   @Test
-  void createSpecRejectsDuplicateIndexEntry() {
-    var shell =
-        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
-            .onOk("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML);
+  void createSpecRejectsDuplicateDirectory() {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
     var workspace = new SpecWorkspace(shell, "acme-health", "/home/dev/workspace/specs");
     var spec = new Spec("oauth-flow", "OAuth Flow", "pending", null, List.of(), null);
 
@@ -113,26 +191,32 @@ class SpecWorkspaceTest {
   }
 
   @Test
-  void writeIndexKeepsPathOutOfShellScript() throws Exception {
-    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
-    var workspace = new SpecWorkspace(shell, "acme-health", "/home/dev/specs; touch /tmp/pwned");
-    var spec = new Spec("oauth-flow", "OAuth Flow", "pending", null, List.of(), null);
-
-    workspace.writeIndex(List.of(spec));
-
-    assertTrue(shell.invocations().getLast().contains("printf '%s' \"$1\" > \"$2\""));
-  }
-
-  @Test
-  void updateStatusWritesUpdatedIndex() throws Exception {
+  void updateStatusWritesOnlyMetadata() throws Exception {
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
-            .onOk("cat /home/dev/workspace/specs/index.yaml", INDEX_YAML);
+            .onOk("cat /home/dev/workspace/specs/oauth-flow/spec.yaml", OAUTH_METADATA);
     var workspace = new SpecWorkspace(shell, "acme-health", "/home/dev/workspace/specs");
 
     var updated = workspace.updateStatus("oauth-flow", "review");
 
     assertEquals("review", updated.status());
     assertTrue(shell.invocations().stream().anyMatch(cmd -> cmd.contains("status: review")));
+    assertTrue(
+        shell.invocations().stream()
+            .anyMatch(cmd -> cmd.contains("/home/dev/workspace/specs/oauth-flow/spec.yaml")));
+  }
+
+  @Test
+  void writeMetadataKeepsPathOutOfShellScript() throws Exception {
+    var shell =
+        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+            .onceOnFail("test -e /home/dev/specs; touch /tmp/pwned/oauth-flow", "No such file");
+    var workspace = new SpecWorkspace(shell, "acme-health", "/home/dev/specs; touch /tmp/pwned");
+    var spec = new Spec("oauth-flow", "OAuth Flow", "pending", null, List.of(), null);
+
+    workspace.createSpec(spec, "# OAuth Flow");
+
+    assertTrue(
+        shell.invocations().stream().anyMatch(cmd -> cmd.contains("printf '%s' \"$1\" > \"$2\"")));
   }
 }


### PR DESCRIPTION
## Summary\n- remove the central specs/index.yaml model in favor of specs/<id>/spec.yaml metadata\n- update dispatch, status, API, reports, generated agent context, and docs to scan per-spec metadata\n- add validation for duplicate spec ids and mismatched spec metadata ids\n\n## Verification\n- mvn verify