### PR TITLE
Add project fleet migration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,26 @@ Specs live in a shared private repo (e.g., `your-org/projects/acme-health/specs/
 
 No project board needed. The spec directory *is* the board. Git history is the audit trail.
 
+### Fleet Migration
+
+After upgrading `sing`, bring existing project containers up to the current spec layout and agent
+instructions with one command:
+
+```bash
+sing project migrate --all --pull-specs
+```
+
+For a single project:
+
+```bash
+sing project migrate acme-health --pull-specs
+```
+
+The migration starts stopped projects, regenerates agent context files, converts legacy
+`specs/index.yaml` entries into `specs/<id>/spec.yaml`, removes the legacy index after a safe
+conversion, and reports spec Git sync state. Use `--json` for automation or `--keep-index` if you
+want to retain the old index file during manual review.
+
 ## Context Generation
 
 `sing agent run` (or `sing agent context regen`) generates a complete agent environment from `sing.yaml`. Context files are agent-agnostic — Claude Code gets `CLAUDE.md`, Codex gets `AGENTS.md`, Gemini gets `GEMINI.md`. Same content, different format.

--- a/sing-core/src/main/java/ai/singlr/sing/engine/SpecIndexMigrator.java
+++ b/sing-core/src/main/java/ai/singlr/sing/engine/SpecIndexMigrator.java
@@ -1,0 +1,159 @@
+package ai.singlr.sing.engine;
+
+import ai.singlr.sing.config.Spec;
+import ai.singlr.sing.config.SpecDirectory;
+import ai.singlr.sing.config.YamlUtil;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeoutException;
+
+public final class SpecIndexMigrator {
+
+  private final ShellExec shell;
+
+  public SpecIndexMigrator(ShellExec shell) {
+    this.shell = Objects.requireNonNull(shell);
+  }
+
+  public Result migrate(String project, String specsDir, boolean keepIndex)
+      throws IOException, InterruptedException, TimeoutException {
+    NameValidator.requireValidProjectName(project);
+    requireSafeSpecsDir(specsDir);
+    if (shell.isDryRun()) {
+      return new Result(false, 0, 0, false, List.of("Dry run: spec index migration not executed."));
+    }
+
+    var indexPath = specsDir + "/index.yaml";
+    var indexCheck = exec(project, "test", "-f", indexPath);
+    if (!indexCheck.ok()) {
+      return new Result(false, 0, 0, false, List.of());
+    }
+
+    var index = exec(project, "cat", indexPath);
+    if (!index.ok()) {
+      throw new IOException("Failed to read legacy spec index: " + index.stderr());
+    }
+
+    var specs = parseSpecs(index.stdout());
+    var converted = 0;
+    var skipped = 0;
+    var warnings = new ArrayList<String>();
+
+    for (var spec : specs) {
+      var specDir = specsDir + "/" + spec.id();
+      var metadataPath = specDir + "/spec.yaml";
+      var existing = exec(project, "test", "-f", metadataPath);
+      if (existing.ok()) {
+        var existingSpec = readExistingSpec(project, metadataPath);
+        if (sameMetadata(existingSpec, spec)) {
+          skipped++;
+          continue;
+        }
+        skipped++;
+        warnings.add(
+            "Skipped " + spec.id() + ": spec.yaml already exists with different metadata.");
+        continue;
+      }
+      var mkdir = exec(project, "mkdir", "-p", specDir);
+      if (!mkdir.ok()) {
+        throw new IOException(
+            "Failed to create spec directory '" + spec.id() + "': " + mkdir.stderr());
+      }
+      writeMetadata(project, metadataPath, spec);
+      converted++;
+    }
+
+    var removed = false;
+    if (!keepIndex && warnings.isEmpty()) {
+      var remove = exec(project, "rm", "-f", indexPath);
+      if (!remove.ok()) {
+        throw new IOException("Failed to remove legacy spec index: " + remove.stderr());
+      }
+      removed = true;
+    }
+
+    return new Result(true, converted, skipped, removed, List.copyOf(warnings));
+  }
+
+  private static List<Spec> parseSpecs(String yaml) {
+    var map = YamlUtil.parseMap(yaml);
+    var rawSpecs = map.get("specs");
+    if (!(rawSpecs instanceof List<?> specs)) {
+      return List.of();
+    }
+    var parsed = new ArrayList<Spec>();
+    for (var rawSpec : specs) {
+      if (!(rawSpec instanceof Map<?, ?> rawMap)) {
+        throw new IllegalArgumentException("Each legacy spec index entry must be a map.");
+      }
+      parsed.add(Spec.fromMap(copyStringMap(rawMap)));
+    }
+    return List.copyOf(parsed);
+  }
+
+  private Spec readExistingSpec(String project, String metadataPath)
+      throws IOException, InterruptedException, TimeoutException {
+    var existing = exec(project, "cat", metadataPath);
+    if (!existing.ok()) {
+      throw new IOException("Failed to read existing spec metadata: " + existing.stderr());
+    }
+    return SpecDirectory.parseMetadata(YamlUtil.parseMap(existing.stdout()));
+  }
+
+  private void writeMetadata(String project, String metadataPath, Spec spec)
+      throws IOException, InterruptedException, TimeoutException {
+    var yaml = YamlUtil.dumpToString(SpecDirectory.generateMetadata(spec));
+    var write =
+        shell.exec(
+            ContainerExec.asDevUser(
+                project,
+                List.of("bash", "-c", "printf '%s' \"$1\" > \"$2\"", "bash", yaml, metadataPath)));
+    if (!write.ok()) {
+      throw new IOException("Failed to write spec metadata: " + write.stderr());
+    }
+  }
+
+  private ShellExec.Result exec(String project, String... args)
+      throws IOException, InterruptedException, TimeoutException {
+    return shell.exec(ContainerExec.asDevUser(project, List.of(args)));
+  }
+
+  private static void requireSafeSpecsDir(String specsDir) {
+    if (specsDir == null
+        || specsDir.isBlank()
+        || specsDir.contains("..")
+        || specsDir.chars().anyMatch(character -> character < 0x20 || character == 0x7f)) {
+      throw new IllegalArgumentException("Invalid specsDir: " + specsDir);
+    }
+  }
+
+  private static boolean sameMetadata(Spec left, Spec right) {
+    return Objects.equals(normalized(left), normalized(right));
+  }
+
+  private static Map<String, Object> normalized(Spec spec) {
+    return SpecDirectory.generateMetadata(spec);
+  }
+
+  private static Map<String, Object> copyStringMap(Map<?, ?> rawMap) {
+    var map = new LinkedHashMap<String, Object>();
+    for (var entry : rawMap.entrySet()) {
+      if (!(entry.getKey() instanceof String key)) {
+        throw new IllegalArgumentException("Spec metadata keys must be strings.");
+      }
+      map.put(key, entry.getValue());
+    }
+    return map;
+  }
+
+  public record Result(
+      boolean indexFound, int converted, int skipped, boolean indexRemoved, List<String> warnings) {
+    public Result {
+      warnings = warnings == null ? List.of() : List.copyOf(warnings);
+    }
+  }
+}

--- a/sing-core/src/test/java/ai/singlr/sing/engine/SpecIndexMigratorTest.java
+++ b/sing-core/src/test/java/ai/singlr/sing/engine/SpecIndexMigratorTest.java
@@ -1,0 +1,162 @@
+package ai.singlr.sing.engine;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SpecIndexMigratorTest {
+
+  private static final String SPECS_DIR = "/home/dev/workspace/specs";
+
+  @Test
+  void convertsLegacyIndexToPerSpecMetadataAndRemovesIndex() throws Exception {
+    var shell =
+        new FakeShell()
+            .on("test -f " + SPECS_DIR + "/index.yaml", ok())
+            .on("cat " + SPECS_DIR + "/index.yaml", ok(indexYaml()))
+            .on("test -f " + SPECS_DIR + "/auth/spec.yaml", missing())
+            .on("mkdir -p " + SPECS_DIR + "/auth", ok())
+            .on("test -f " + SPECS_DIR + "/payments/spec.yaml", missing())
+            .on("mkdir -p " + SPECS_DIR + "/payments", ok())
+            .on("printf '%s'", ok())
+            .on("rm -f " + SPECS_DIR + "/index.yaml", ok());
+
+    var result = new SpecIndexMigrator(shell).migrate("acme", SPECS_DIR, false);
+
+    assertTrue(result.indexFound());
+    assertEquals(2, result.converted());
+    assertEquals(0, result.skipped());
+    assertTrue(result.indexRemoved());
+    assertTrue(shell.invoked("rm -f " + SPECS_DIR + "/index.yaml"));
+  }
+
+  @Test
+  void keepsIndexWhenExistingMetadataDiffers() throws Exception {
+    var shell =
+        new FakeShell()
+            .on("test -f " + SPECS_DIR + "/index.yaml", ok())
+            .on("cat " + SPECS_DIR + "/index.yaml", ok(indexYaml()))
+            .on("test -f " + SPECS_DIR + "/auth/spec.yaml", ok())
+            .on(
+                "cat " + SPECS_DIR + "/auth/spec.yaml",
+                ok(
+                    """
+                    id: auth
+                    title: Different
+                    status: pending
+                    """))
+            .on("test -f " + SPECS_DIR + "/payments/spec.yaml", missing())
+            .on("mkdir -p " + SPECS_DIR + "/payments", ok())
+            .on("printf '%s'", ok());
+
+    var result = new SpecIndexMigrator(shell).migrate("acme", SPECS_DIR, false);
+
+    assertEquals(1, result.converted());
+    assertEquals(1, result.skipped());
+    assertFalse(result.indexRemoved());
+    assertFalse(shell.invoked("rm -f " + SPECS_DIR + "/index.yaml"));
+    assertEquals(1, result.warnings().size());
+  }
+
+  @Test
+  void noOpsWhenLegacyIndexIsAbsent() throws Exception {
+    var shell = new FakeShell().on("test -f " + SPECS_DIR + "/index.yaml", missing());
+
+    var result = new SpecIndexMigrator(shell).migrate("acme", SPECS_DIR, false);
+
+    assertFalse(result.indexFound());
+    assertEquals(0, result.converted());
+    assertFalse(result.indexRemoved());
+  }
+
+  @Test
+  void dryRunDoesNotTouchContainer() throws Exception {
+    var shell = new FakeShell().withDryRun(true);
+
+    var result = new SpecIndexMigrator(shell).migrate("acme", SPECS_DIR, false);
+
+    assertFalse(result.indexFound());
+    assertEquals(1, result.warnings().size());
+    assertTrue(shell.invocations().isEmpty());
+  }
+
+  private static ShellExec.Result ok() {
+    return ok("");
+  }
+
+  private static ShellExec.Result ok(String stdout) {
+    return new ShellExec.Result(0, stdout, "");
+  }
+
+  private static ShellExec.Result missing() {
+    return new ShellExec.Result(1, "", "No such file");
+  }
+
+  private static String indexYaml() {
+    return """
+        specs:
+          - id: auth
+            title: Auth flow
+            status: pending
+            assignee: codex
+            depends_on:
+              - base
+            branch: feat/auth
+          - id: payments
+            title: Payments
+            status: review
+        """;
+  }
+
+  private static final class FakeShell implements ShellExec {
+    private final Map<String, Result> scripts = new LinkedHashMap<>();
+    private final List<String> invocations = new ArrayList<>();
+    private boolean dryRun;
+
+    private FakeShell on(String pattern, Result result) {
+      scripts.put(pattern, result);
+      return this;
+    }
+
+    private FakeShell withDryRun(boolean dryRun) {
+      this.dryRun = dryRun;
+      return this;
+    }
+
+    private boolean invoked(String pattern) {
+      return invocations.stream().anyMatch(command -> command.contains(pattern));
+    }
+
+    private List<String> invocations() {
+      return List.copyOf(invocations);
+    }
+
+    @Override
+    public Result exec(List<String> command) {
+      var joined = String.join(" ", command);
+      invocations.add(joined);
+      for (var entry : scripts.entrySet()) {
+        if (joined.contains(entry.getKey())) {
+          return entry.getValue();
+        }
+      }
+      return new Result(1, "", "no script for " + joined);
+    }
+
+    @Override
+    public Result exec(List<String> command, Path workDir, Duration timeout) {
+      return exec(command);
+    }
+
+    @Override
+    public boolean isDryRun() {
+      return dryRun;
+    }
+  }
+}

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectCommand.java
@@ -15,6 +15,7 @@ import picocli.CommandLine.Command;
       ProjectInitCommand.class,
       ProjectCreateCommand.class,
       ProjectApplyCommand.class,
+      ProjectMigrateCommand.class,
       UpCommand.class,
       DownCommand.class,
       SwitchCommand.class,

--- a/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectMigrateCommand.java
+++ b/sing-infra/src/main/java/ai/singlr/sing/commands/ProjectMigrateCommand.java
@@ -1,0 +1,351 @@
+package ai.singlr.sing.commands;
+
+import ai.singlr.sing.config.SingYaml;
+import ai.singlr.sing.config.YamlUtil;
+import ai.singlr.sing.engine.Banner;
+import ai.singlr.sing.engine.ContainerExec;
+import ai.singlr.sing.engine.ContainerManager;
+import ai.singlr.sing.engine.ContainerState;
+import ai.singlr.sing.engine.GitSpecSync;
+import ai.singlr.sing.engine.NameValidator;
+import ai.singlr.sing.engine.ProjectApplier;
+import ai.singlr.sing.engine.ShellExec;
+import ai.singlr.sing.engine.ShellExecutor;
+import ai.singlr.sing.engine.SingPaths;
+import ai.singlr.sing.engine.SpecIndexMigrator;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.function.Function;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+@Command(
+    name = "migrate",
+    description = "Bring existing project containers up to the current sing layout.",
+    mixinStandardHelpOptions = true)
+public final class ProjectMigrateCommand implements Runnable {
+
+  private final Function<Boolean, ShellExec> shellFactory;
+
+  public ProjectMigrateCommand() {
+    this(ShellExecutor::new);
+  }
+
+  ProjectMigrateCommand(Function<Boolean, ShellExec> shellFactory) {
+    this.shellFactory = shellFactory;
+  }
+
+  @Parameters(index = "0", arity = "0..1", description = "Project name.")
+  private String name;
+
+  @Option(names = "--all", description = "Migrate all managed sing projects.")
+  private boolean all;
+
+  @Option(
+      names = {"-f", "--file"},
+      description = "Path to sing.yaml project descriptor for single-project migration.",
+      defaultValue = "sing.yaml")
+  private String file;
+
+  @Option(names = "--no-start", description = "Do not start stopped projects automatically.")
+  private boolean noStart;
+
+  @Option(names = "--keep-index", description = "Keep specs/index.yaml after successful migration.")
+  private boolean keepIndex;
+
+  @Option(names = "--pull-specs", description = "Pull Git-backed specs before migration when safe.")
+  private boolean pullSpecs;
+
+  @Option(names = "--dry-run", description = "Print commands instead of executing them.")
+  private boolean dryRun;
+
+  @Option(names = "--json", description = "Output in JSON format.")
+  private boolean json;
+
+  @Spec private CommandSpec spec;
+
+  @Override
+  public void run() {
+    CliCommand.run(spec, this::execute);
+  }
+
+  private void execute() throws Exception {
+    var selectedProjects = selectedProjects();
+    var shell = shellFactory.apply(dryRun);
+    var migrator = new Migrator(shell, noStart, keepIndex, pullSpecs, json);
+    var results = new ArrayList<ProjectResult>();
+    for (var project : selectedProjects) {
+      results.add(migrator.migrate(project, descriptorFile(project)));
+    }
+
+    if (json) {
+      var map = new LinkedHashMap<String, Object>();
+      map.put("action", "project_migrate");
+      map.put("results", results.stream().map(ProjectResult::toMap).toList());
+      map.put("summary", summary(results));
+      System.out.println(YamlUtil.dumpJson(map));
+      return;
+    }
+
+    printHuman(results);
+    if (results.stream().anyMatch(result -> "failed".equals(result.status()))) {
+      throw new IllegalStateException("One or more project migrations failed.");
+    }
+  }
+
+  private List<String> selectedProjects() throws Exception {
+    if (all == (name != null && !name.isBlank())) {
+      throw new IllegalArgumentException("Specify exactly one project name or --all.");
+    }
+    if (name != null && !name.isBlank()) {
+      NameValidator.requireValidProjectName(name);
+      return List.of(name);
+    }
+    var projects = managedProjects();
+    if (projects.isEmpty()) {
+      throw new IllegalStateException("No projects found.");
+    }
+    return projects;
+  }
+
+  private static List<String> managedProjects() throws Exception {
+    var projectsDir = SingPaths.projectsDir();
+    if (!Files.isDirectory(projectsDir)) {
+      return List.of();
+    }
+    try (var paths = Files.list(projectsDir)) {
+      return paths
+          .filter(Files::isDirectory)
+          .filter(path -> Files.isRegularFile(path.resolve("sing.yaml")))
+          .map(path -> path.getFileName().toString())
+          .sorted(Comparator.naturalOrder())
+          .toList();
+    }
+  }
+
+  private String descriptorFile(String project) {
+    return all ? SingPaths.projectDir(project).resolve("sing.yaml").toString() : file;
+  }
+
+  private static java.util.Map<String, Object> summary(List<ProjectResult> results) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("total", results.size());
+    map.put("ok", results.stream().filter(result -> "ok".equals(result.status())).count());
+    map.put("failed", results.stream().filter(result -> "failed".equals(result.status())).count());
+    map.put("started", results.stream().filter(ProjectResult::started).count());
+    map.put("specs_converted", results.stream().mapToInt(ProjectResult::specsConverted).sum());
+    return map;
+  }
+
+  private static void printHuman(List<ProjectResult> results) {
+    Banner.printBranding(System.out, Ansi.AUTO);
+    System.out.println();
+    for (var result : results) {
+      var marker = "ok".equals(result.status()) ? "@|green \u2713|@" : "@|red \u2717|@";
+      System.out.println(
+          Ansi.AUTO.string("  " + marker + " @|bold " + result.name() + "|@ " + result.status()));
+      if (result.error() != null) {
+        System.out.println("    " + result.error());
+      } else {
+        System.out.println(
+            "    context: "
+                + result.contextFiles()
+                + ", specs converted: "
+                + result.specsConverted()
+                + ", sync: "
+                + result.specSyncState());
+        if (result.indexRemoved()) {
+          System.out.println("    removed legacy specs/index.yaml");
+        }
+      }
+      for (var warning : result.warnings()) {
+        System.out.println(Ansi.AUTO.string("    @|yellow \u26a0|@ " + warning));
+      }
+    }
+  }
+
+  private static final class Migrator {
+    private final ShellExec shell;
+    private final boolean noStart;
+    private final boolean keepIndex;
+    private final boolean pullSpecs;
+    private final boolean json;
+
+    private Migrator(
+        ShellExec shell, boolean noStart, boolean keepIndex, boolean pullSpecs, boolean json) {
+      this.shell = shell;
+      this.noStart = noStart;
+      this.keepIndex = keepIndex;
+      this.pullSpecs = pullSpecs;
+      this.json = json;
+    }
+
+    private ProjectResult migrate(String project, String file) {
+      try {
+        NameValidator.requireValidProjectName(project);
+        var warnings = new ArrayList<String>();
+        var manager = new ContainerManager(shell);
+        var started = ensureRunning(project, manager);
+        var singYamlPath = SingPaths.resolveSingYaml(project, file);
+        if (!Files.exists(singYamlPath)) {
+          throw new IllegalStateException("Project descriptor not found: " + singYamlPath);
+        }
+        var config = SingYaml.fromMap(YamlUtil.parseFile(singYamlPath));
+        if (config.agent() == null || config.agent().specsDir() == null) {
+          throw new IllegalStateException(
+              "No specs_dir configured in agent block. Add 'specs_dir: specs' to sing.yaml.");
+        }
+
+        var specsDir = "/home/" + config.sshUser() + "/workspace/" + config.agent().specsDir();
+        var syncState = syncBeforeMigration(project, specsDir, warnings);
+        var output = json ? new PrintStream(OutputStream.nullOutputStream()) : System.out;
+        var applier = new ProjectApplier(shell, output);
+        var context = applier.applyAgentContext(project, config);
+        applier.applySpecsScaffold(project, config);
+        var index = new SpecIndexMigrator(shell).migrate(project, specsDir, keepIndex);
+        warnings.addAll(index.warnings());
+        syncState = syncState(project, specsDir, warnings);
+        return ProjectResult.ok(
+            project,
+            started,
+            context.added(),
+            index.converted(),
+            index.skipped(),
+            index.indexRemoved(),
+            syncState,
+            warnings);
+      } catch (Exception e) {
+        return ProjectResult.failed(project, e.getMessage());
+      }
+    }
+
+    private boolean ensureRunning(String project, ContainerManager manager) throws Exception {
+      return switch (manager.queryState(project)) {
+        case ContainerState.Running ignored -> false;
+        case ContainerState.Stopped ignored -> {
+          if (noStart) {
+            throw new IllegalStateException(
+                "Project is stopped. Start it with: sing project start " + project);
+          }
+          manager.start(project);
+          yield true;
+        }
+        case ContainerState.NotCreated ignored ->
+            throw new IllegalStateException(
+                "Project does not exist. Run 'sing project create' first.");
+        case ContainerState.Error error ->
+            throw new IllegalStateException("Container error: " + error.message());
+      };
+    }
+
+    private String syncBeforeMigration(String project, String specsDir, List<String> warnings) {
+      if (!pullSpecs) {
+        return syncState(project, specsDir, warnings);
+      }
+      try {
+        var sync = sync(project, specsDir);
+        var status = sync.status();
+        if (!status.repository()) {
+          return status.state().name().toLowerCase();
+        }
+        switch (status.state()) {
+          case CLEAN, BEHIND, AHEAD -> {
+            sync.pull();
+            return sync.status().state().name().toLowerCase();
+          }
+          case DIRTY, DIVERGED, CONFLICTED, NO_UPSTREAM, NOT_A_REPOSITORY, ERROR ->
+              warnings.add("Skipped spec pull: " + status.message());
+        }
+        return status.state().name().toLowerCase();
+      } catch (Exception e) {
+        warnings.add("Spec pull failed: " + e.getMessage());
+        return "error";
+      }
+    }
+
+    private String syncState(String project, String specsDir, List<String> warnings) {
+      try {
+        return sync(project, specsDir).status().state().name().toLowerCase();
+      } catch (Exception e) {
+        warnings.add("Spec sync status failed: " + e.getMessage());
+        return "error";
+      }
+    }
+
+    private GitSpecSync sync(String project, String specsDir) {
+      return new GitSpecSync(
+          shell, ContainerExec.asDevUser(project, List.of("git", "-C", specsDir)));
+    }
+  }
+
+  private record ProjectResult(
+      String name,
+      String status,
+      boolean started,
+      int contextFiles,
+      int specsConverted,
+      int specsSkipped,
+      boolean indexRemoved,
+      String specSyncState,
+      List<String> warnings,
+      String error) {
+
+    private ProjectResult {
+      warnings = warnings == null ? List.of() : List.copyOf(warnings);
+    }
+
+    private static ProjectResult ok(
+        String name,
+        boolean started,
+        int contextFiles,
+        int specsConverted,
+        int specsSkipped,
+        boolean indexRemoved,
+        String syncState,
+        List<String> warnings) {
+      return new ProjectResult(
+          name,
+          "ok",
+          started,
+          contextFiles,
+          specsConverted,
+          specsSkipped,
+          indexRemoved,
+          syncState,
+          warnings,
+          null);
+    }
+
+    private static ProjectResult failed(String name, String error) {
+      return new ProjectResult(name, "failed", false, 0, 0, 0, false, "unknown", List.of(), error);
+    }
+
+    private java.util.Map<String, Object> toMap() {
+      var map = new LinkedHashMap<String, Object>();
+      map.put("name", name);
+      map.put("status", status);
+      map.put("started", started);
+      map.put("context_files", contextFiles);
+      map.put("specs_converted", specsConverted);
+      map.put("specs_skipped", specsSkipped);
+      map.put("index_removed", indexRemoved);
+      map.put("spec_sync_state", specSyncState);
+      if (!warnings.isEmpty()) {
+        map.put("warnings", warnings);
+      }
+      if (error != null) {
+        map.put("error", error);
+      }
+      return map;
+    }
+  }
+}

--- a/sing-infra/src/test/java/ai/singlr/sing/commands/ProjectMigrateCommandTest.java
+++ b/sing-infra/src/test/java/ai/singlr/sing/commands/ProjectMigrateCommandTest.java
@@ -1,0 +1,48 @@
+package ai.singlr.sing.commands;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sing.Sing;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class ProjectMigrateCommandTest {
+
+  @Test
+  void projectHelpListsMigrate() {
+    var command = new CommandLine(new Sing());
+    var out = new StringWriter();
+    command.setOut(new PrintWriter(out));
+
+    var exitCode = command.execute("project", "--help");
+
+    assertEquals(0, exitCode);
+    assertTrue(out.toString().contains("migrate"));
+  }
+
+  @Test
+  void migrateHelpShowsFleetOptions() {
+    var command = new CommandLine(new Sing());
+    var out = new StringWriter();
+    command.setOut(new PrintWriter(out));
+
+    var exitCode = command.execute("project", "migrate", "--help");
+
+    assertEquals(0, exitCode);
+    var help = out.toString();
+    assertTrue(help.contains("--all"));
+    assertTrue(help.contains("--pull-specs"));
+    assertTrue(help.contains("--keep-index"));
+    assertTrue(help.contains("--json"));
+  }
+
+  @Test
+  void migrateRequiresSingleProjectOrAll() {
+    var command = new CommandLine(new Sing());
+
+    assertNotEquals(0, command.execute("project", "migrate"));
+    assertNotEquals(0, command.execute("project", "migrate", "acme", "--all"));
+  }
+}


### PR DESCRIPTION
## Summary
- Add `sing project migrate` for single-project and fleet migration
- Convert legacy `specs/index.yaml` into per-spec `spec.yaml` metadata with conflict-safe behavior
- Regenerate agent context/spec scaffolding and report spec Git sync state
- Document the production fleet command for existing servers

## Validation
- `mvn -C -f /home/dev/workspace/sing/pom.xml clean verify`

## Fleet command after merge + release
```bash
sing project migrate --all --pull-specs
```

For first production run where you want to inspect before deleting legacy indexes:
```bash
sing project migrate --all --pull-specs --keep-index
```