### PR TITLE
Harden SAIL security posture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: Verify, security scan, and native build

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -1,4 +1,12 @@
-# Sail Security Audit
+# SAIL Security Audit
+
+## Status
+Audit refreshed against current `main` after the SAIL rename. The previous findings still mostly
+apply, but the document needed to reflect the current `sail.yaml`-only posture and the current module
+names: `sail-core`, `sail-harness`, and `sail-infra`.
+
+No intentional backwards compatibility remains for `sing.yaml` or the `sing` CLI alias. Remaining
+`singlr-ai/sing` references are GitHub repository slugs, not runtime branding or config aliases.
 
 ## Scope
 This audit covers the current `sail` CLI and runtime trust boundaries:
@@ -7,7 +15,8 @@ This audit covers the current `sail` CLI and runtime trust boundaries:
 - Bare-metal Ubuntu host running Incus and project containers.
 - Project containers running developer tooling and agent CLIs as the `dev` user.
 - Local API server used by Chorus through an SSH tunnel.
-- Spec directories, generated project files, agent session files, logs, webhooks, GitHub tokens, and generated handoff/report artifacts.
+- Spec directories, generated project files, agent session files, logs, webhooks, GitHub tokens,
+  API bearer tokens, release assets, installer scripts, and generated handoff/report artifacts.
 
 ## Threat Model
 
@@ -18,49 +27,150 @@ This audit covers the current `sail` CLI and runtime trust boundaries:
 - The engineer's ability to approve and dispatch autonomous agents safely.
 
 ### Trust Boundaries
-- CLI arguments and YAML configuration cross from the engineer workstation into host and container command execution.
+- CLI arguments and `sail.yaml` configuration cross from the engineer workstation into host and
+  container command execution.
 - Spec content crosses from project data into agent prompts and dispatch flows.
-- Local API requests cross from Chorus into `sail` host operations through bearer-token authentication.
-- Agent output crosses from untrusted model/tool execution into PR, handoff, report, and review workflows.
+- Local API requests cross from Chorus into `sail` host operations through bearer-token
+  authentication.
+- Agent output crosses from untrusted model/tool execution into PR, handoff, report, and review
+  workflows.
+- Release artifacts cross from GitHub Releases into local binaries through `install.sh`,
+  `sail upgrade`, and the silent auto-upgrader.
 
 ### Primary Risks
-- Command injection through interpolated paths, branches, spec IDs, repo paths, or generated task content.
+- Command injection through interpolated paths, branches, spec IDs, repo paths, repo hosts, or
+  generated task content.
 - Exposing the local API beyond loopback without intentional operator opt-in.
-- Token disclosure through permissive token-file permissions, symlinks, logs, errors, or command output.
-- Cross-project access through path traversal, invalid container names, or unsafe generated SSH configuration.
-- Prompt injection in specs or generated handoff content causing unsafe automation or misleading reviewer agents.
-- Supply-chain drift in Maven dependencies, GitHub Actions, installer scripts, and agent CLI bootstrap commands.
+- Token disclosure through permissive token-file permissions, symlinks, logs, errors, process
+  arguments, git credential stores, or command output.
+- Cross-project access through path traversal, invalid container names, unsafe generated SSH
+  configuration, or ambiguous Incus matches.
+- Prompt injection in specs or generated handoff content causing unsafe automation or misleading
+  reviewer agents.
+- Supply-chain drift in Maven dependencies, GitHub Actions, installer scripts, release artifacts,
+  and agent CLI bootstrap commands.
 
-## Findings Fixed
+## Findings Fixed In This Audit
+
+### Process timeouts now apply while stdout is open
+`ShellExecutor` previously read stdout to EOF before waiting for the process timeout. A process that
+kept stdout open could bypass the timeout and hang the caller. Stdout and stderr are now drained
+asynchronously while the process timeout is enforced first.
+
+### Webhook URLs are redacted from warning logs
+Webhook failure paths no longer print the full webhook URL. Slack and Discord webhook paths are
+secret-bearing, so logs now include only the scheme and host.
+
+### Incus container names are validated at the command builder
+`ContainerExec.asDevUser` now validates container names before constructing `incus exec` commands.
+This makes the shared command builder defensive even when a future caller forgets to validate input.
+
+### Repo hosts are validated before SSH known-host scanning
+The provisioning path no longer interpolates repository hosts into a `bash -c` `ssh-keyscan`
+command. Hosts are validated and passed as positional arguments.
+
+### Installer checksum verification is mandatory
+`install.sh` now refuses to install a release asset when the matching `.sha256` asset is missing.
+The previous behavior skipped verification if the checksum could not be fetched.
+
+### CI workflow permissions are read-only
+The CI workflow now declares `contents: read`, reducing default GitHub token permissions for normal
+verification and dependency scanning.
+
+## Existing Controls Still Valid
 
 ### API bind address requires explicit remote opt-in
-`sail api` now refuses to bind to non-loopback addresses unless `--allow-remote` is supplied. This keeps the default local API posture local-first even when an operator mistypes `--host 0.0.0.0`.
+`sail api` refuses to bind to non-loopback addresses unless `--allow-remote` is supplied. This keeps
+the default local API posture local-first even when an operator mistypes `--host 0.0.0.0`.
 
 ### API token file hardening
-The API token store now rejects non-regular token paths, reapplies owner-only permissions before reusing existing tokens, and creates new token files with restrictive POSIX permissions when the filesystem supports them.
+The API token store rejects non-regular token paths, reapplies owner-only permissions before reusing
+existing tokens, and creates new token files with restrictive POSIX permissions when the filesystem
+supports them.
 
-### Duplicate bearer headers rejected
-The API authenticator now rejects requests with multiple `Authorization` headers instead of relying on the first header value.
+### Duplicate bearer headers are rejected
+The API authenticator rejects requests with multiple `Authorization` headers instead of relying on
+the first header value.
 
-### Agent launch shell interpolation reduced
-Background and foreground agent launch commands now pass work directories and generated agent commands as positional arguments to `bash -c` rather than interpolating the working directory into the shell script.
+### API request bodies are bounded
+JSON request bodies are capped at 64 KiB and must use `application/json` when a content type is
+present.
 
-### Spec write shell interpolation reduced
-Spec index and markdown writes now pass output paths as positional arguments instead of concatenating target paths into shell redirection scripts.
+### Project, spec, repo path, branch, service, snapshot, runtime, and SSH-user inputs are validated
+The shared validators reject traversal, absolute paths, invalid names, and unsafe branch/path
+characters before values reach Incus, Git, or filesystem operations.
 
-### Dependency vulnerability scanning added
-CI now runs OWASP Dependency-Check with the repository `NVD_API_KEY` secret, fails builds for CVSS 7+ findings, skips test-scope dependencies, installs reactor modules before the aggregate scan, caches NVD data, and uploads HTML reports.
+### Shell interpolation has been reduced in write and launch paths
+Spec writes, task writes, session writes, and agent launch commands pass dynamic values as
+positional arguments to `bash -c` instead of concatenating paths or content into shell scripts.
+
+### Git credentials are not embedded in clone command arguments
+Project provisioning writes `.git-credentials` inside the container with `0600` mode and configures
+Git's credential helper, avoiding token-bearing clone URLs in process arguments.
+
+### Webhook configuration blocks private network targets
+Notification URLs parsed from `sail.yaml` are restricted to HTTP(S) and reject private, loopback,
+link-local, and unresolvable hosts.
+
+### Dependency vulnerability scanning runs in CI
+CI runs OWASP Dependency-Check with the repository `NVD_API_KEY` secret, fails builds for CVSS 7+
+findings, skips test-scope dependencies, installs reactor modules before the aggregate scan, caches
+NVD data, and uploads HTML reports.
 
 ## Accepted Risks
 
 ### Agent install commands remain enum-controlled shell snippets
-Agent CLI install commands still run through shell because npm-based global installs are shell-oriented. The command strings are enum-controlled, not user-provided. If agent installation becomes user-extensible, move to typed installers before accepting arbitrary commands.
+Agent CLI install commands still run through shell because npm-based global installs and vendor
+install scripts are shell-oriented. The command strings are enum-controlled, not user-provided. If
+agent installation becomes user-extensible, move to typed installers before accepting arbitrary
+commands.
+
+### Agent dispatch intentionally gives coding agents broad power
+Foreground/background launch paths can grant full agent permissions. This is an operational trust
+decision, not a parser boundary. Dispatch must remain an explicit engineer action, and model output
+must be treated as untrusted.
 
 ### Spec content remains untrusted prompt input
-Spec markdown is intentionally passed to coding agents. The security boundary is operational: agent dispatch requires explicit user action, tool permissions still apply in Chorus, and reviewer/handoff workflows must treat model output as untrusted.
+Spec markdown is intentionally passed to coding agents. Reviewer, audit, handoff, and report flows
+must not treat spec text or agent output as authoritative instructions.
+
+### API transport is local/tunnel-only by design
+The API uses bearer-token authentication but does not provide TLS itself. The intended deployment is
+loopback plus SSH tunnel. Remote binding requires explicit `--allow-remote` and should sit behind a
+trusted transport.
+
+### Some secrets can still be supplied as process arguments
+Flags such as `--git-token`, `--github-token`, and `sail api --token` are explicit operator
+escape hatches. Prefer environment variables, interactive prompts with echo disabled, or token files
+for sensitive values.
+
+### Release assets are checksum-verified but not signed
+`install.sh`, `sail upgrade`, and the auto-upgrader verify SHA-256 checksums, but the checksum is
+fetched from the same GitHub release channel as the binary. This protects against corruption and
+partial tampering, not a compromised release account or workflow.
+
+### GitHub Actions are version-pinned by major tag, not commit SHA
+Actions currently use major-version tags such as `actions/checkout@v4`. This is conventional, but
+not a maximum supply-chain posture.
+
+## Recommended Follow-Ups
+- Add release signing with cosign or minisign and verify signatures in `install.sh`, `sail upgrade`,
+  and the auto-upgrader.
+- Pin GitHub Actions by commit SHA once the release process stabilizes.
+- Add a small API request-rate guard if the API is expected to stay open for long-lived Chorus
+  sessions.
+- Consider replacing npm/global shell install snippets with typed installer implementations.
+- Add a periodic secret-scan job for generated examples, scripts, and release artifacts.
 
 ## Verification
-- Focused regression suite: `mvn -pl sail-infra,sail-harness -am -Dtest=ApiTokenStoreTest,ApiRouterTest,ApiCommandTest,SpecWorkspaceTest,AgentSessionTest -Dsurefire.failIfNoSpecifiedTests=false test`
-- Full verification: `mvn clean verify`
-- CI dependency scan: `mvn install org.owasp:dependency-check-maven:12.1.8:aggregate -DskipTests -Djacoco.skip=true -Dformat=HTML -DfailBuildOnCVSS=7 -DskipTestScope=true -DnvdApiKey=${{ secrets.NVD_API_KEY }} -DdataDirectory=${{ runner.temp }}/dependency-check-data`
-- Native packaging attempted with `mvn package -Pnative -DskipTests`; local execution requires GraalVM and this container uses Temurin, so CI remains the authoritative native-image check.
+- Focused regression suite:
+  `mvn -pl sail-core,sail-infra,sail-harness -am -Dtest=ShellExecutorTest,ContainerExecTest,WebhookNotifierTest,ProjectProvisionerTest -Dsurefire.failIfNoSpecifiedTests=false test`
+- Existing focused API/session suite:
+  `mvn -pl sail-infra,sail-harness -am -Dtest=ApiTokenStoreTest,ApiRouterTest,ApiCommandTest,SpecWorkspaceTest,AgentSessionTest -Dsurefire.failIfNoSpecifiedTests=false test`
+- Full verification:
+  `mvn clean verify`
+- CI dependency scan:
+  `mvn install org.owasp:dependency-check-maven:12.1.8:aggregate -DskipTests -Djacoco.skip=true -Dformat=HTML -DfailBuildOnCVSS=7 -DskipTestScope=true -DnvdApiKey=${{ secrets.NVD_API_KEY }} -DdataDirectory=${{ runner.temp }}/dependency-check-data`
+- Native packaging:
+  `mvn package -Pnative -DskipTests` requires GraalVM locally; CI remains the authoritative
+  native-image check when the local shell uses Temurin.

--- a/install.sh
+++ b/install.sh
@@ -80,15 +80,14 @@ HTTP_CODE=$(curl -fsSL -w '%{http_code}' "$DOWNLOAD_URL" -o "$TMPFILE" 2>/dev/nu
 info "Verifying checksum..."
 CHECKSUM_URL="https://github.com/${GITHUB_REPO}/releases/download/${TAG}/${BINARY_NAME}.sha256"
 EXPECTED=$(curl -fsSL "$CHECKSUM_URL" 2>/dev/null | awk '{print $1}' || true)
-if [ -n "$EXPECTED" ]; then
-  ACTUAL=$($CHECKSUM_CMD "$TMPFILE" | awk '{print $1}')
-  if [ "$EXPECTED" != "$ACTUAL" ]; then
-    fail "Checksum mismatch!\n  Expected: $EXPECTED\n  Actual:   $ACTUAL"
-  fi
-  ok "  Checksum verified."
-else
-  info "  Checksum not available — skipping verification."
+if [ -z "$EXPECTED" ]; then
+  fail "Checksum not available for $BINARY_NAME. Refusing to install unverifiable release asset."
 fi
+ACTUAL=$($CHECKSUM_CMD "$TMPFILE" | awk '{print $1}')
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+  fail "Checksum mismatch!\n  Expected: $EXPECTED\n  Actual:   $ACTUAL"
+fi
+ok "  Checksum verified."
 
 # --- Validate binary format ---
 if [ "$ELF_CHECK" = true ]; then

--- a/sail-core/src/main/java/ai/singlr/sail/engine/ContainerExec.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/ContainerExec.java
@@ -42,6 +42,7 @@ public final class ContainerExec {
    * @return an unmodifiable command list ready for {@link ShellExec#exec}
    */
   public static List<String> asDevUser(String containerName, List<String> args) {
+    NameValidator.requireValidProjectName(containerName);
     var prefix =
         List.of(
             "incus",

--- a/sail-core/src/main/java/ai/singlr/sail/engine/ShellExecutor.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/ShellExecutor.java
@@ -55,13 +55,8 @@ public final class ShellExecutor implements ShellExec {
     var process = pb.start();
     process.getOutputStream().close();
 
+    var stdoutFuture = CompletableFuture.supplyAsync(() -> readFully(process.getInputStream()));
     var stderrFuture = CompletableFuture.supplyAsync(() -> readFully(process.getErrorStream()));
-    String stdout;
-    String stderr;
-    try (var stdoutStream = process.getInputStream()) {
-      stdout = new String(stdoutStream.readAllBytes(), StandardCharsets.UTF_8);
-    }
-    stderr = stderrFuture.join();
 
     var finished = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
     if (!finished) {
@@ -70,6 +65,8 @@ public final class ShellExecutor implements ShellExec {
           "Command timed out after " + timeout.toSeconds() + "s: " + String.join(" ", command));
     }
 
+    var stdout = stdoutFuture.join();
+    var stderr = stderrFuture.join();
     return new Result(process.exitValue(), stdout, stderr);
   }
 

--- a/sail-core/src/test/java/ai/singlr/sail/engine/ContainerExecTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/ContainerExecTest.java
@@ -54,6 +54,13 @@ class ContainerExecTest {
   }
 
   @Test
+  void asDevUserRejectsInvalidContainerName() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ContainerExec.asDevUser("proj;touch-owned", List.of("echo", "hi")));
+  }
+
+  @Test
   void asDevUserReturnsUnmodifiableList() {
     var cmd = ContainerExec.asDevUser("proj", List.of("echo", "hi"));
 

--- a/sail-core/src/test/java/ai/singlr/sail/engine/ShellExecutorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/ShellExecutorTest.java
@@ -78,6 +78,19 @@ class ShellExecutorTest {
   }
 
   @Test
+  void timesOutWhenProcessKeepsStdoutOpen() {
+    var executor = new ShellExecutor(false);
+
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(2),
+        () ->
+            assertThrows(
+                TimeoutException.class,
+                () ->
+                    executor.exec(List.of("sh", "-c", "sleep 30"), null, Duration.ofMillis(200))));
+  }
+
+  @Test
   void customDefaultTimeout() throws Exception {
     var executor = new ShellExecutor(false, Duration.ofSeconds(30));
     var result = executor.exec(List.of("echo", "fast"));

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/WebhookNotifier.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/WebhookNotifier.java
@@ -53,10 +53,12 @@ public final class WebhookNotifier {
       var client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NEVER).build();
       var response = client.send(request, HttpResponse.BodyHandlers.ofString());
       if (response.statusCode() >= 400) {
-        System.err.println("  [webhook] Warning: HTTP " + response.statusCode() + " from " + url);
+        System.err.println(
+            "  [webhook] Warning: HTTP " + response.statusCode() + " from " + redactedUrl(url));
       }
     } catch (Exception e) {
-      System.err.println("  [webhook] Warning: failed to notify " + url + " — " + e.getMessage());
+      System.err.println(
+          "  [webhook] Warning: failed to notify " + redactedUrl(url) + " - " + e.getMessage());
     }
   }
 
@@ -131,6 +133,19 @@ public final class WebhookNotifier {
     var lower = url.toLowerCase();
     if (!lower.startsWith("https://") && !lower.startsWith("http://")) {
       throw new IllegalArgumentException("Webhook URL must use http or https scheme, got: " + url);
+    }
+  }
+
+  static String redactedUrl(String url) {
+    try {
+      var uri = URI.create(url);
+      var host = uri.getHost();
+      if (host == null || host.isBlank()) {
+        return "<webhook>";
+      }
+      return uri.getScheme() + "://" + host + "/...";
+    } catch (Exception e) {
+      return "<webhook>";
     }
   }
 

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/WebhookNotifierTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/WebhookNotifierTest.java
@@ -142,6 +142,16 @@ class WebhookNotifierTest {
   }
 
   @Test
+  void redactedUrlKeepsSecretPathOutOfLogs() {
+    var redacted =
+        WebhookNotifier.redactedUrl("https://hooks.slack.com/services/T123/B456/secret-token");
+
+    assertEquals("https://hooks.slack.com/...", redacted);
+    assertFalse(redacted.contains("secret-token"));
+    assertFalse(redacted.contains("T123"));
+  }
+
+  @Test
   void payloadEscapesSpecialCharacters() {
     var payload =
         WebhookNotifier.buildPayload(

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectProvisioner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectProvisioner.java
@@ -41,6 +41,8 @@ public final class ProjectProvisioner {
   private static final Duration INSTALL_TIMEOUT = Duration.ofMinutes(10);
 
   private static final Pattern VERSION_PATTERN = Pattern.compile("[0-9][0-9.]*");
+  private static final Pattern HOST_PATTERN =
+      Pattern.compile("^[A-Za-z0-9][A-Za-z0-9.-]*(?::[0-9]{1,5})?$");
   private static final String MAVEN_PRIMARY_BASE_URL = "https://dlcdn.apache.org/maven/maven-3/";
   private static final String MAVEN_ARCHIVE_BASE_URL =
       "https://archive.apache.org/dist/maven/maven-3/";
@@ -600,14 +602,16 @@ public final class ProjectProvisioner {
     var knownHostsPath = "/etc/ssh/ssh_known_hosts";
     var sshHosts = extractSshHosts(config.repos());
     if (!sshHosts.isEmpty()) {
-      var hostList = String.join(" ", sshHosts);
-      execInContainer(
-          name,
-          List.of(
-              "bash",
-              "-c",
-              "ssh-keyscan -H " + hostList + " >> " + knownHostsPath + " 2>/dev/null"),
-          INSTALL_TIMEOUT);
+      var command =
+          new ArrayList<>(
+              List.of(
+                  "bash",
+                  "-c",
+                  "out=$1; shift; ssh-keyscan -H \"$@\" >> \"$out\" 2>/dev/null",
+                  "ssh-keyscan",
+                  knownHostsPath));
+      command.addAll(sshHosts);
+      execInContainer(name, command, INSTALL_TIMEOUT);
     }
 
     if ("token".equals(config.git().auth()) && gitTokens != null && !gitTokens.isEmpty()) {
@@ -1254,7 +1258,7 @@ public final class ProjectProvisioner {
         }
       }
     }
-    return List.copyOf(hosts);
+    return hosts.stream().map(ProjectProvisioner::requireSafeHost).toList();
   }
 
   /**
@@ -1320,7 +1324,32 @@ public final class ProjectProvisioner {
         }
       }
     }
-    return List.copyOf(hosts);
+    return hosts.stream().map(ProjectProvisioner::requireSafeHost).toList();
+  }
+
+  private static String requireSafeHost(String host) {
+    if (host == null
+        || host.length() > 253
+        || !HOST_PATTERN.matcher(host).matches()
+        || host.contains("..")
+        || host.endsWith(".")
+        || invalidPort(host)) {
+      throw new IllegalArgumentException("Invalid repository host: '" + host + "'.");
+    }
+    return host;
+  }
+
+  private static boolean invalidPort(String host) {
+    var colon = host.lastIndexOf(':');
+    if (colon < 0) {
+      return false;
+    }
+    try {
+      var port = Integer.parseInt(host.substring(colon + 1));
+      return port < 1 || port > 65535;
+    } catch (NumberFormatException e) {
+      return true;
+    }
   }
 
   /** Returns the SSH user from config, defaulting to {@code "dev"}. */

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectProvisionerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectProvisionerTest.java
@@ -1046,6 +1046,9 @@ class ProjectProvisionerTest {
         cmds.stream()
             .anyMatch(c -> c.contains("ssh-keyscan") && c.contains("github.com gitlab.com")),
         "Should scan default hosts (github.com, gitlab.com) via ssh-keyscan");
+    assertFalse(
+        cmds.stream().anyMatch(c -> c.contains("ssh-keyscan -H github.com gitlab.com")),
+        "ssh-keyscan hosts must be passed as positional arguments, not interpolated into shell");
   }
 
   @Test
@@ -1254,6 +1257,20 @@ class ProjectProvisionerTest {
     assertTrue(hosts.contains("gitlab.com"), "Default gitlab.com");
     assertTrue(hosts.contains("bitbucket.org"), "SSH URL host");
     assertTrue(hosts.contains("gitlab.example.com"), "HTTPS URL host");
+  }
+
+  @Test
+  void extractSshHostsRejectsUnsafeHost() {
+    var repos = List.of(new SailYaml.Repo("https://github.com;touch/tmp/pwned", "app", null));
+
+    assertThrows(IllegalArgumentException.class, () -> ProjectProvisioner.extractSshHosts(repos));
+  }
+
+  @Test
+  void extractHttpsHostsRejectsUnsafeHost() {
+    var repos = List.of(new SailYaml.Repo("https://github.com;touch/tmp/pwned", "app", null));
+
+    assertThrows(IllegalArgumentException.class, () -> ProjectProvisioner.extractHttpsHosts(repos));
   }
 
   private static SailYaml configWithGitSshKey(String keyPath) {


### PR DESCRIPTION
## Summary
- refresh SECURITY_AUDIT.md for current SAIL-only posture and residual risks
- enforce command timeouts while stdout remains open
- redact webhook URLs, validate container/repo host inputs, and avoid interpolated ssh-keyscan hosts
- require installer checksums and set CI token permissions to read-only

## Verification
- bash -n install.sh
- mvn -pl sail-core,sail-infra,sail-harness -am -Dtest=ShellExecutorTest,ContainerExecTest,WebhookNotifierTest,ProjectProvisionerTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl sail-infra,sail-harness -am -Dtest=ApiTokenStoreTest,ApiRouterTest,ApiCommandTest,SpecWorkspaceTest,AgentSessionTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn clean verify