### PR TITLE
Add SAIL banner brand mark

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
@@ -29,20 +29,20 @@ public final class Banner {
 
   private Banner() {}
 
-  private static final String AMBER = "\033[1;38;5;214m";
+  private static final String BRAND = "\033[1;38;2;252;73;38m";
   private static final String CYAN_BOLD = "\033[1;36m";
   private static final String DIM = "\033[2m";
   private static final String RESET = "\033[0m";
   private static final int ANIMATION_WIDTH = 64;
 
   /**
-   * Replaces picocli's bold-cyan ANSI escape with 256-color amber for brand-consistent borders.
+   * Replaces picocli's bold-cyan ANSI escape with the SAIL brand color for consistent borders.
    * Picocli only supports named colors, so we post-process its output.
    */
   static String amber(Ansi ansi, String markup) {
     var result = ansi.string(markup);
     if (ansi != Ansi.OFF) {
-      result = result.replace(CYAN_BOLD, AMBER);
+      result = result.replace(CYAN_BOLD, BRAND);
     }
     return result;
   }
@@ -51,16 +51,16 @@ public final class Banner {
   public static void printBranding(PrintStream out, Ansi ansi) {
     printIntroAnimation(out, ansi);
     var useColor = ansi != Ansi.OFF;
-    var a = useColor ? AMBER : "";
+    var a = useColor ? BRAND : "";
     var d = useColor ? DIM : "";
     var r = useColor ? RESET : "";
     out.println();
-    out.println("  " + a + "███████╗  █████╗  ██╗ ██╗" + r);
-    out.println("  " + a + "██╔════╝ ██╔══██╗ ██║ ██║" + r);
-    out.println("  " + a + "███████╗ ███████║ ██║ ██║" + r);
-    out.println("  " + a + "╚════██║ ██╔══██║ ██║ ██║" + r);
-    out.println("  " + a + "███████║ ██║  ██║ ██║ ███████╗" + r);
-    out.println("  " + a + "╚══════╝ ╚═╝  ╚═╝ ╚═╝ ╚══════╝" + r);
+    out.println("  " + a + "     /\\      ███████╗  █████╗  ██╗ ██╗" + r);
+    out.println("  " + a + "    /##\\     ██╔════╝ ██╔══██╗ ██║ ██║" + r);
+    out.println("  " + a + "   /####\\    ███████╗ ███████║ ██║ ██║" + r);
+    out.println("  " + a + "  /##/\\##\\   ╚════██║ ██╔══██║ ██║ ██║" + r);
+    out.println("  " + a + " /##/  \\##\\  ███████║ ██║  ██║ ██║ ███████╗" + r);
+    out.println("  " + a + "/__/    \\__\\ ╚══════╝ ╚═╝  ╚═╝ ╚═╝ ╚══════╝" + r);
     out.println();
     out.println(
         "  " + d + "Isolated dev environments for AI agents  ·  v" + SailVersion.version() + r);
@@ -89,7 +89,7 @@ public final class Banner {
             "    /__|   catching wind",
             "   /___|   SAIL ready");
     var useColor = ansi != Ansi.OFF;
-    var color = useColor ? AMBER : "";
+    var color = useColor ? BRAND : "";
     var reset = useColor ? RESET : "";
     for (var frame : frames) {
       out.print("\r  " + color + frame + reset);

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/BannerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/BannerTest.java
@@ -99,11 +99,12 @@ class BannerTest {
   }
 
   @Test
-  void brandingContainsSingAsciiArt() {
+  void brandingContainsSailAsciiArt() {
     var out = new ByteArrayOutputStream();
     Banner.printBranding(new PrintStream(out), Ansi.OFF);
     var output = out.toString(StandardCharsets.UTF_8);
 
+    assertTrue(output.contains("/##\\"));
     assertTrue(output.contains("███████"));
     assertTrue(output.contains("singlr-ai/sing"));
   }


### PR DESCRIPTION
## Summary
- add a pure-ASCII inverted-V brand mark before the SAIL wordmark
- switch the banner brand color to the current #fc4926 tone
- cover the icon in BannerTest

## Verification
- mvn -pl sail-infra -am -Dtest=BannerTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn clean verify