### PR TITLE
Import legacy project state during SAIL migration

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectMigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectMigrateCommand.java
@@ -16,6 +16,9 @@ import ai.singlr.sail.engine.SpecIndexMigrator;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -108,8 +111,10 @@ public final class ProjectMigrateCommand implements Runnable {
     }
     if (name != null && !name.isBlank()) {
       NameValidator.requireValidProjectName(name);
+      importLegacyState(List.of(name));
       return List.of(name);
     }
+    importLegacyState(List.of());
     var projects = managedProjects();
     if (projects.isEmpty()) {
       throw new IllegalStateException("No projects found.");
@@ -130,6 +135,103 @@ public final class ProjectMigrateCommand implements Runnable {
           .sorted(Comparator.naturalOrder())
           .toList();
     }
+  }
+
+  private static void importLegacyState(List<String> projects) throws Exception {
+    importLegacyHostConfig();
+    importLegacyProjects(
+        legacyProjectsDir(),
+        SailPaths.projectsDir(),
+        projects,
+        SailPaths.PROJECT_DESCRIPTOR,
+        "sing.yaml");
+  }
+
+  private static void importLegacyHostConfig() throws Exception {
+    var source = legacySailDir().resolve("host.yaml");
+    var target = SailPaths.hostConfigPath();
+    if (!Files.isRegularFile(source, LinkOption.NOFOLLOW_LINKS) || Files.exists(target)) {
+      return;
+    }
+    Files.createDirectories(target.getParent());
+    Files.copy(source, target, StandardCopyOption.COPY_ATTRIBUTES);
+  }
+
+  static List<String> importLegacyProjects(
+      Path legacyProjectsDir,
+      Path projectsDir,
+      List<String> requestedProjects,
+      String descriptor,
+      String legacyDescriptor)
+      throws Exception {
+    if (!Files.isDirectory(legacyProjectsDir, LinkOption.NOFOLLOW_LINKS)) {
+      return List.of();
+    }
+    var requested = requestedProjects == null ? List.<String>of() : requestedProjects;
+    var projects =
+        requested.isEmpty() ? legacyProjects(legacyProjectsDir, legacyDescriptor) : requested;
+    var imported = new ArrayList<String>();
+    for (var project : projects) {
+      NameValidator.requireValidProjectName(project);
+      var legacyProjectDir = legacyProjectsDir.resolve(project);
+      if (!Files.isDirectory(legacyProjectDir, LinkOption.NOFOLLOW_LINKS)
+          || !Files.isRegularFile(
+              legacyProjectDir.resolve(legacyDescriptor), LinkOption.NOFOLLOW_LINKS)) {
+        continue;
+      }
+      var projectDir = projectsDir.resolve(project);
+      if (Files.isRegularFile(projectDir.resolve(descriptor), LinkOption.NOFOLLOW_LINKS)) {
+        continue;
+      }
+      copyLegacyProject(legacyProjectDir, projectDir, descriptor, legacyDescriptor);
+      imported.add(project);
+    }
+    return imported.stream().sorted(Comparator.naturalOrder()).toList();
+  }
+
+  private static List<String> legacyProjects(Path legacyProjectsDir, String legacyDescriptor)
+      throws Exception {
+    try (var paths = Files.list(legacyProjectsDir)) {
+      return paths
+          .filter(path -> Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS))
+          .filter(
+              path ->
+                  Files.isRegularFile(path.resolve(legacyDescriptor), LinkOption.NOFOLLOW_LINKS))
+          .map(path -> path.getFileName().toString())
+          .sorted(Comparator.naturalOrder())
+          .toList();
+    }
+  }
+
+  private static void copyLegacyProject(
+      Path legacyProjectDir, Path projectDir, String descriptor, String legacyDescriptor)
+      throws Exception {
+    try (var paths = Files.walk(legacyProjectDir)) {
+      for (var source : paths.sorted(Comparator.naturalOrder()).toList()) {
+        var relative = legacyProjectDir.relativize(source);
+        var target =
+            relative.toString().equals(legacyDescriptor)
+                ? projectDir.resolve(descriptor)
+                : projectDir.resolve(relative);
+        if (Files.isSymbolicLink(source) || Files.exists(target)) {
+          continue;
+        }
+        if (Files.isDirectory(source, LinkOption.NOFOLLOW_LINKS)) {
+          Files.createDirectories(target);
+        } else if (Files.isRegularFile(source, LinkOption.NOFOLLOW_LINKS)) {
+          Files.createDirectories(target.getParent());
+          Files.copy(source, target, StandardCopyOption.COPY_ATTRIBUTES);
+        }
+      }
+    }
+  }
+
+  private static Path legacySailDir() {
+    return Path.of(System.getProperty("user.home"), ".sing");
+  }
+
+  private static Path legacyProjectsDir() {
+    return legacySailDir().resolve("projects");
   }
 
   private String descriptorFile(String project) {

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectMigrateCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectMigrateCommandTest.java
@@ -5,7 +5,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import ai.singlr.sail.Sail;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
 
 class ProjectMigrateCommandTest {
@@ -44,5 +48,42 @@ class ProjectMigrateCommandTest {
 
     assertNotEquals(0, command.execute("project", "migrate"));
     assertNotEquals(0, command.execute("project", "migrate", "acme", "--all"));
+  }
+
+  @Test
+  void importsLegacySingProjectDescriptors(@TempDir Path tempDir) throws Exception {
+    var legacyProjects = tempDir.resolve(".sing/projects");
+    var sailProjects = tempDir.resolve(".sail/projects");
+    var legacyProject = legacyProjects.resolve("manatee");
+    Files.createDirectories(legacyProject);
+    Files.writeString(legacyProject.resolve("sing.yaml"), "name: manatee\n");
+    Files.writeString(legacyProject.resolve("provision-state.yaml"), "ok: true\n");
+
+    var imported =
+        ProjectMigrateCommand.importLegacyProjects(
+            legacyProjects, sailProjects, List.of(), "sail.yaml", "sing.yaml");
+
+    assertEquals(List.of("manatee"), imported);
+    assertEquals("name: manatee\n", Files.readString(sailProjects.resolve("manatee/sail.yaml")));
+    assertEquals(
+        "ok: true\n", Files.readString(sailProjects.resolve("manatee/provision-state.yaml")));
+    assertFalse(Files.exists(sailProjects.resolve("manatee/sing.yaml")));
+  }
+
+  @Test
+  void legacyImportDoesNotOverwriteCanonicalProject(@TempDir Path tempDir) throws Exception {
+    var legacyProjects = tempDir.resolve(".sing/projects");
+    var sailProjects = tempDir.resolve(".sail/projects");
+    Files.createDirectories(legacyProjects.resolve("manatee"));
+    Files.createDirectories(sailProjects.resolve("manatee"));
+    Files.writeString(legacyProjects.resolve("manatee/sing.yaml"), "name: old\n");
+    Files.writeString(sailProjects.resolve("manatee/sail.yaml"), "name: new\n");
+
+    var imported =
+        ProjectMigrateCommand.importLegacyProjects(
+            legacyProjects, sailProjects, List.of("manatee"), "sail.yaml", "sing.yaml");
+
+    assertEquals(List.of(), imported);
+    assertEquals("name: new\n", Files.readString(sailProjects.resolve("manatee/sail.yaml")));
   }
 }


### PR DESCRIPTION
## Summary
- import legacy ~/.sing/projects entries into ~/.sail/projects during sail project migrate
- rename legacy sing.yaml descriptors to sail.yaml without overwriting canonical state
- carry over legacy host.yaml when the new host config is missing

## Test
- mvn -pl sail-infra -am -Dtest=ProjectMigrateCommandTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn clean verify