### PR TITLE
Target spec dispatch by repository

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/config/Spec.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/Spec.java
@@ -21,6 +21,7 @@ import java.util.Objects;
  * @param status lifecycle state: pending, in_progress, review, done
  * @param assignee engineer responsible (nullable, matches git identity)
  * @param dependsOn IDs of specs that must be done first
+ * @param repos repository paths this spec should branch and work in
  * @param branch git branch for this spec's work (nullable)
  */
 public record Spec(
@@ -29,7 +30,18 @@ public record Spec(
     String status,
     String assignee,
     List<String> dependsOn,
+    List<String> repos,
     String branch) {
+
+  public Spec(
+      String id,
+      String title,
+      String status,
+      String assignee,
+      List<String> dependsOn,
+      String branch) {
+    this(id, title, status, assignee, dependsOn, List.of(), branch);
+  }
 
   @SuppressWarnings("unchecked")
   public static Spec fromMap(Map<String, Object> map) {
@@ -42,6 +54,7 @@ public record Spec(
     var status = Objects.requireNonNullElse((String) map.get("status"), "pending");
     var assignee = (String) map.get("assignee");
     var dependsOn = (List<String>) map.get("depends_on");
+    var repos = reposFromMap(map);
     var branch = (String) map.get("branch");
     return new Spec(
         id,
@@ -49,6 +62,7 @@ public record Spec(
         status,
         assignee,
         dependsOn != null ? List.copyOf(dependsOn) : List.of(),
+        repos,
         branch);
   }
 
@@ -65,9 +79,34 @@ public record Spec(
     if (!dependsOn.isEmpty()) {
       map.put("depends_on", dependsOn);
     }
+    if (repos.size() == 1) {
+      map.put("repo", repos.getFirst());
+    } else if (!repos.isEmpty()) {
+      map.put("repos", repos);
+    }
     if (branch != null) {
       map.put("branch", branch);
     }
     return map;
+  }
+
+  private static List<String> reposFromMap(Map<String, Object> map) {
+    var repo = (String) map.get("repo");
+    var repos = (List<String>) map.get("repos");
+    if (repo != null && repos != null) {
+      throw new IllegalArgumentException("spec may define repo or repos, not both");
+    }
+    if (repo != null) {
+      return validatedRepos(List.of(repo));
+    }
+    if (repos != null) {
+      return validatedRepos(repos);
+    }
+    return List.of();
+  }
+
+  private static List<String> validatedRepos(List<String> repos) {
+    repos.forEach(repo -> NameValidator.requireSafePath(repo, "spec.repo"));
+    return List.copyOf(repos);
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/config/SpecDirectory.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/SpecDirectory.java
@@ -106,6 +106,7 @@ public final class SpecDirectory {
                         newStatus,
                         spec.assignee(),
                         spec.dependsOn(),
+                        spec.repos(),
                         spec.branch())
                     : spec)
         .toList();

--- a/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
@@ -455,7 +455,7 @@ public final class AgentContextGenerator {
         ```
         %s/
         ├── oauth-flow/
-        │   ├── spec.yaml        # Metadata: id, title, status, assignee, depends_on, branch
+        │   ├── spec.yaml        # Metadata: id, title, status, assignee, depends_on, repo/repos, branch
         │   ├── spec.md          # Detailed specification
         │   └── plan.md          # Optional implementation plan
         └── search-api/
@@ -473,8 +473,13 @@ public final class AgentContextGenerator {
         status: in_progress
         assignee: claude-code
         depends_on: []
+        repo: app
         branch: feat/oauth-flow
         ```
+
+        Use `repo: <path>` for a single target repository and `repos: [api, web]` for cross-repo
+        work. The values must match `repos[].path` in `sail.yaml`. If a multi-repository
+        project omits repo targeting, `sail spec dispatch` will not auto-create a branch.
 
         ### Status Lifecycle
         `pending` → `in_progress` → `review` → `done`
@@ -483,7 +488,7 @@ public final class AgentContextGenerator {
         ### Interactive Mode
         When the engineer asks you to brainstorm or write a spec:
         1. Create a directory under `%1$s/` named after the spec id
-        2. Write `%1$s/<id>/spec.yaml` with metadata and status `pending`
+        2. Write `%1$s/<id>/spec.yaml` with metadata, repo targeting, and status `pending`
         3. Write `%1$s/<id>/spec.md` with the detailed specification
 
         ### Dependencies
@@ -569,7 +574,8 @@ public final class AgentContextGenerator {
 
           ### Multi-Repository Work
           This project has multiple repositories. When working on a task:
-          - Determine which repos the task touches from the task description
+          - Use the spec's `repo` or `repos` metadata as the source of truth for affected repos
+          - If repo metadata is missing, infer the affected repos from the task and update the spec before dispatch
           - Create a feature branch with the same name in each affected repo
           - Commit and push changes in all affected repos
           - Create a pull request in each affected repo, linking them in the descriptions

--- a/sail-core/src/main/java/ai/singlr/sail/gen/SpecSkillGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/SpecSkillGenerator.java
@@ -242,6 +242,7 @@ public final class SpecSkillGenerator {
            title: "<title>"
            status: pending
            depends_on: []
+           repo: <repo-path>
            ```
         4. Write `%1$s/<id>/spec.md` using the spec template
         5. Confirm: "Created spec `<id>` — fill in the details in `%1$s/<id>/spec.md`"
@@ -251,6 +252,10 @@ public final class SpecSkillGenerator {
 
         Ask the engineer if this spec depends on any existing specs, and set `depends_on` \
         accordingly.
+
+        Ask which repository the spec targets when the project has multiple repos. Use \
+        `repo: <path>` for one repo and `repos: [repo-a, repo-b]` for cross-repo work. \
+        Values must match `repos[].path` in `sail.yaml`.
         """
         .formatted(specsDir);
   }
@@ -302,6 +307,7 @@ public final class SpecSkillGenerator {
         status: in_progress
         assignee: claude-code
         depends_on: []
+        repo: app
         branch: feat/oauth-flow
         ```
 
@@ -323,7 +329,13 @@ public final class SpecSkillGenerator {
         - **status** (required): one of pending, in_progress, review, done
         - **assignee** (optional): agent type or engineer name
         - **depends_on** (optional): list of spec ids that must be done first
+        - **repo** (optional): single target repository path from `sail.yaml` `repos[].path`
+        - **repos** (optional): list of target repository paths for cross-repo work
         - **branch** (optional): git branch name for this spec's work
+
+        In multi-repo projects, always include `repo` or `repos` before dispatch so Sail can \
+        create the branch in the right repository. If omitted, dispatch only auto-branches when \
+        the project has exactly one configured repo.
 
         ### Directory Structure
         ```

--- a/sail-core/src/test/java/ai/singlr/sail/config/SpecTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/SpecTest.java
@@ -23,6 +23,7 @@ class SpecTest {
             "status", "in_progress",
             "assignee", "alice",
             "depends_on", List.of("setup-db"),
+            "repo", "chorus",
             "branch", "feat/oauth");
 
     var spec = Spec.fromMap(map);
@@ -32,6 +33,7 @@ class SpecTest {
     assertEquals("in_progress", spec.status());
     assertEquals("alice", spec.assignee());
     assertEquals(List.of("setup-db"), spec.dependsOn());
+    assertEquals(List.of("chorus"), spec.repos());
     assertEquals("feat/oauth", spec.branch());
   }
 
@@ -54,6 +56,13 @@ class SpecTest {
     var spec = Spec.fromMap(Map.of("id", "task1"));
 
     assertTrue(spec.dependsOn().isEmpty());
+  }
+
+  @Test
+  void defaultsReposToEmptyList() {
+    var spec = Spec.fromMap(Map.of("id", "task1"));
+
+    assertTrue(spec.repos().isEmpty());
   }
 
   @Test
@@ -97,6 +106,38 @@ class SpecTest {
   }
 
   @Test
+  void toMapWritesSingleRepoAsRepo() {
+    var spec =
+        new Spec(
+            "auth",
+            "Implement Auth",
+            "done",
+            "bob",
+            List.of("setup"),
+            List.of("chorus"),
+            "feat/auth");
+
+    var map = spec.toMap();
+
+    assertEquals("chorus", map.get("repo"));
+    assertFalse(map.containsKey("repos"));
+  }
+
+  @Test
+  void parsesMultipleRepos() {
+    var spec = Spec.fromMap(Map.of("id", "auth", "repos", List.of("sing", "chorus")));
+
+    assertEquals(List.of("sing", "chorus"), spec.repos());
+  }
+
+  @Test
+  void rejectsRepoAndReposTogether() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Spec.fromMap(Map.of("id", "auth", "repo", "sing", "repos", List.of("chorus"))));
+  }
+
+  @Test
   void toMapOmitsNullAndEmptyFields() {
     var spec = new Spec("auth", "", "pending", null, List.of(), null);
 
@@ -122,6 +163,7 @@ class SpecTest {
     assertEquals(spec.status(), parsed.status());
     assertEquals(spec.assignee(), parsed.assignee());
     assertEquals(spec.dependsOn(), parsed.dependsOn());
+    assertEquals(spec.repos(), parsed.repos());
     assertEquals(spec.branch(), parsed.branch());
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -46,9 +46,14 @@ record SpecSyncStatusView(
     boolean repository,
     String message) {}
 
-record DispatchRequest(String specId, String mode, boolean dryRun) {
+record DispatchRequest(String specId, String mode, boolean dryRun, List<String> repos) {
+  DispatchRequest(String specId, String mode, boolean dryRun) {
+    this(specId, mode, dryRun, List.of());
+  }
+
   DispatchRequest {
     mode = mode == null || mode.isBlank() ? "background" : mode;
+    repos = repos == null ? List.of() : List.copyOf(repos);
   }
 }
 
@@ -96,17 +101,24 @@ record SpecView(
     String status,
     String assignee,
     List<String> dependsOn,
+    List<String> repos,
     String branch,
     boolean ready,
     boolean blocked,
     List<String> unmetDependencies) {
   public SpecView {
     dependsOn = dependsOn == null ? List.of() : List.copyOf(dependsOn);
+    repos = repos == null ? List.of() : List.copyOf(repos);
     unmetDependencies = unmetDependencies == null ? List.of() : List.copyOf(unmetDependencies);
   }
 }
 
-record DispatchedSpecView(String id, String title, String status, String branch) {}
+record DispatchedSpecView(
+    String id, String title, String status, List<String> repos, String branch) {
+  public DispatchedSpecView {
+    repos = repos == null ? List.of() : List.copyOf(repos);
+  }
+}
 
 record AgentStatusView(
     String type,

--- a/sail-infra/src/main/java/ai/singlr/sail/api/JsonBody.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/JsonBody.java
@@ -9,6 +9,7 @@ import ai.singlr.sail.config.YamlUtil;
 import com.sun.net.httpserver.HttpExchange;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -23,7 +24,8 @@ public final class JsonBody {
     return new DispatchRequest(
         optionalString(map, "spec_id"),
         optionalString(map, "mode"),
-        Boolean.TRUE.equals(map.get("dry_run")));
+        Boolean.TRUE.equals(map.get("dry_run")),
+        optionalStringList(map, "repo", "repos"));
   }
 
   public static SpecSyncRequest readSpecSyncRequest(HttpExchange exchange) throws IOException {
@@ -62,5 +64,26 @@ public final class JsonBody {
   private static String optionalString(Map<String, Object> map, String key) {
     var value = map.get(key);
     return value == null ? null : Objects.toString(value);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<String> optionalStringList(
+      Map<String, Object> map, String single, String many) {
+    var one = map.get(single);
+    var list = map.get(many);
+    if (one != null && list != null) {
+      throw new ApiException(
+          ErrorCode.INVALID_JSON, "Request body may define repo or repos, not both.");
+    }
+    if (one != null) {
+      return List.of(Objects.toString(one));
+    }
+    if (list == null) {
+      return List.of();
+    }
+    if (list instanceof List<?> values) {
+      return values.stream().map(Objects::toString).toList();
+    }
+    return List.of(Objects.toString(list));
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -15,6 +15,7 @@ import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.DispatchRepos;
 import ai.singlr.sail.engine.GitSpecSync;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
@@ -199,12 +200,14 @@ public final class SailApiOperations implements ApiOperations {
       return new DispatchResponse(project, false, "no_pending_specs", null, null, "", false);
     }
 
+    var targetRepos = DispatchRepos.resolve(loaded.config(), nextSpec, request.repos());
+    var taskSpec = withTargetRepos(nextSpec, targetRepos);
     updateStatus(workspace, nextSpec.id(), "in_progress");
     var specBody = Objects.requireNonNullElse(readSpecBody(workspace, nextSpec.id()), "");
-    var task = buildTaskPrompt(nextSpec, specBody.isBlank() ? nextSpec.title() : specBody);
+    var task = buildTaskPrompt(taskSpec, specBody.isBlank() ? nextSpec.title() : specBody);
     var branch = branchName(loaded.config(), nextSpec);
     var snapshot = createSnapshotIfNeeded(project, loaded.config());
-    var branchCreated = createBranchIfNeeded(project, loaded.config(), branch);
+    var branchCreated = createBranchIfNeeded(project, loaded.config(), targetRepos, branch);
 
     if (!request.dryRun()) {
       launchAgent(project, loaded.config(), task, branch, request.mode());
@@ -215,7 +218,7 @@ public final class SailApiOperations implements ApiOperations {
         project,
         true,
         null,
-        dispatchedSpecView(nextSpec, branch),
+        dispatchedSpecView(taskSpec, branch),
         agentStatusView(loaded.config(), request.mode(), status),
         snapshot,
         branchCreated);
@@ -400,6 +403,7 @@ public final class SailApiOperations implements ApiOperations {
         spec.status(),
         spec.assignee(),
         spec.dependsOn(),
+        spec.repos(),
         spec.branch(),
         SpecDirectory.isReady(specs, spec),
         SpecDirectory.isBlocked(specs, spec),
@@ -440,11 +444,38 @@ public final class SailApiOperations implements ApiOperations {
         spec.id(),
         spec.title(),
         "in_progress",
+        spec.repos(),
         branch != null && !branch.isBlank() ? branch : null);
   }
 
+  private static Spec withTargetRepos(Spec spec, List<SailYaml.Repo> targetRepos) {
+    return new Spec(
+        spec.id(),
+        spec.title(),
+        spec.status(),
+        spec.assignee(),
+        spec.dependsOn(),
+        targetRepos.stream().map(SailYaml.Repo::path).toList(),
+        spec.branch());
+  }
+
   private static String buildTaskPrompt(Spec spec, String description) {
-    return "Your current spec: \"" + spec.title() + "\" (id: " + spec.id() + ").\n\n" + description;
+    var targetRepos =
+        spec.repos().isEmpty()
+            ? ""
+            : "\nTarget repo"
+                + (spec.repos().size() == 1 ? "" : "s")
+                + ": "
+                + String.join(", ", spec.repos())
+                + "\n";
+    return "Your current spec: \""
+        + spec.title()
+        + "\" (id: "
+        + spec.id()
+        + ")."
+        + targetRepos
+        + "\n"
+        + description;
   }
 
   private static String branchName(SailYaml config, Spec spec) {
@@ -472,28 +503,31 @@ public final class SailApiOperations implements ApiOperations {
     }
   }
 
-  private boolean createBranchIfNeeded(String project, SailYaml config, String branch) {
-    if (branch == null
-        || branch.isBlank()
-        || config.repos() == null
-        || config.repos().size() != 1) {
+  private boolean createBranchIfNeeded(
+      String project, SailYaml config, List<SailYaml.Repo> targetRepos, String branch) {
+    if (branch == null || branch.isBlank() || targetRepos.isEmpty()) {
       return false;
     }
-    var repoDir = "/home/" + config.sshUser() + "/workspace/" + config.repos().getFirst().path();
-    var repoExists =
-        exec(ContainerExec.asDevUser(project, List.of("test", "-d", repoDir + "/.git")));
-    if (!repoExists.ok()) {
-      return false;
+    var created = false;
+    for (var repo : targetRepos) {
+      var repoDir = "/home/" + config.sshUser() + "/workspace/" + repo.path();
+      var repoExists =
+          exec(ContainerExec.asDevUser(project, List.of("test", "-d", repoDir + "/.git")));
+      if (!repoExists.ok()) {
+        continue;
+      }
+      var result =
+          exec(
+              ContainerExec.asDevUser(
+                  project, List.of("git", "-C", repoDir, "checkout", "-b", branch)));
+      if (!result.ok()) {
+        throw new ApiException(
+            ErrorCode.BRANCH_CREATE_FAILED,
+            "Failed to create branch '" + branch + "' in repo '" + repo.path() + "'.");
+      }
+      created = true;
     }
-    var result =
-        exec(
-            ContainerExec.asDevUser(
-                project, List.of("git", "-C", repoDir, "checkout", "-b", branch)));
-    if (!result.ok()) {
-      throw new ApiException(
-          ErrorCode.BRANCH_CREATE_FAILED, "Failed to create branch '" + branch + "'.");
-    }
-    return true;
+    return created;
   }
 
   private void launchAgent(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
@@ -15,6 +15,7 @@ import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.DispatchRepos;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
@@ -54,6 +55,12 @@ public final class DispatchCommand implements Runnable {
 
   @Option(names = "--background", description = "Run agent in background.", defaultValue = "true")
   private boolean background;
+
+  @Option(
+      names = "--repo",
+      split = ",",
+      description = "Repository path(s) to branch for this spec.")
+  private List<String> repoOverrides;
 
   @Option(names = "--dry-run", description = "Print commands instead of executing them.")
   private boolean dryRun;
@@ -137,11 +144,13 @@ public final class DispatchCommand implements Runnable {
       return;
     }
 
+    var targetRepos = DispatchRepos.resolve(config, nextSpec, repoOverrides);
+    var taskSpec = withTargetRepos(nextSpec, targetRepos);
     specWorkspace.updateStatus(nextSpec.id(), "in_progress");
 
     var specBody = Objects.requireNonNullElse(specWorkspace.readSpecBody(nextSpec.id()), "");
     var description = !specBody.isBlank() ? specBody : nextSpec.title();
-    var task = buildTaskPrompt(nextSpec, description, config.agent().specsDir());
+    var task = buildTaskPrompt(taskSpec, description, config.agent().specsDir());
 
     if (json) {
       System.out.println(
@@ -192,15 +201,16 @@ public final class DispatchCommand implements Runnable {
     if (config.agent().autoBranch()) {
       var prefix = config.agent().branchPrefix() != null ? config.agent().branchPrefix() : "sail/";
       branchName = nextSpec.branch() != null ? nextSpec.branch() : prefix + nextSpec.id();
-      var created = false;
-      if (config.repos() != null && config.repos().size() == 1) {
-        var repoDir = workDir + "/" + config.repos().getFirst().path();
+      var created = 0;
+      for (var repo : targetRepos) {
+        var repoDir = workDir + "/" + repo.path();
         var repoExists =
             shell.exec(ContainerExec.asDevUser(name, List.of("test", "-d", repoDir + "/.git")));
         if (repoExists.ok()) {
           if (!json) {
             System.out.println(
-                Ansi.AUTO.string("  @|bold Creating branch:|@ " + branchName + "..."));
+                Ansi.AUTO.string(
+                    "  @|bold Creating branch:|@ " + branchName + " in " + repo.path() + "..."));
           }
           var branchCmd =
               ContainerExec.asDevUser(
@@ -211,13 +221,14 @@ public final class DispatchCommand implements Runnable {
                 "Failed to create branch '" + branchName + "': " + result.stderr());
           }
           if (!json) {
-            System.out.println(Ansi.AUTO.string("  @|green \u2713|@ Branch " + branchName));
+            System.out.println(
+                Ansi.AUTO.string("  @|green \u2713|@ Branch " + branchName + " in " + repo.path()));
             System.out.println();
           }
-          created = true;
+          created++;
         }
       }
-      if (!created && !json) {
+      if (created == 0 && !json) {
         System.out.println(
             Ansi.AUTO.string("  @|faint Branch:|@ " + branchName + " (create manually in repo)"));
         System.out.println();
@@ -280,7 +291,33 @@ public final class DispatchCommand implements Runnable {
   }
 
   static String buildTaskPrompt(Spec spec, String description, String specsDir) {
-    return "Your current spec: \"" + spec.title() + "\" (id: " + spec.id() + ").\n\n" + description;
+    var targetRepos =
+        spec.repos().isEmpty()
+            ? ""
+            : "\nTarget repo"
+                + (spec.repos().size() == 1 ? "" : "s")
+                + ": "
+                + String.join(", ", spec.repos())
+                + "\n";
+    return "Your current spec: \""
+        + spec.title()
+        + "\" (id: "
+        + spec.id()
+        + ")."
+        + targetRepos
+        + "\n"
+        + description;
+  }
+
+  private static Spec withTargetRepos(Spec spec, List<SailYaml.Repo> targetRepos) {
+    return new Spec(
+        spec.id(),
+        spec.title(),
+        spec.status(),
+        spec.assignee(),
+        spec.dependsOn(),
+        targetRepos.stream().map(SailYaml.Repo::path).toList(),
+        spec.branch());
   }
 
   private void printNoSpecs() {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SpecCreateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SpecCreateCommand.java
@@ -50,6 +50,9 @@ public final class SpecCreateCommand implements Runnable {
   @Option(names = "--branch", description = "Branch name.")
   private String branch;
 
+  @Option(names = "--repo", split = ",", description = "Repository path(s) this spec targets.")
+  private List<String> repos;
+
   @Option(names = "--depends-on", split = ",", description = "Comma-separated dependency ids.")
   private List<String> dependsOn;
 
@@ -80,6 +83,8 @@ public final class SpecCreateCommand implements Runnable {
     NameValidator.requireValidSpecId(resolvedSpecId);
     var resolvedDependsOn = dependsOn != null ? List.copyOf(dependsOn) : List.<String>of();
     resolvedDependsOn.forEach(NameValidator::requireValidSpecId);
+    var resolvedRepos = repos != null ? List.copyOf(repos) : List.<String>of();
+    resolvedRepos.forEach(repo -> NameValidator.requireSafePath(repo, "spec.repo"));
 
     var shell = new ShellExecutor(false);
     var mgr = new ContainerManager(shell);
@@ -110,7 +115,15 @@ public final class SpecCreateCommand implements Runnable {
     var workspace =
         new SpecWorkspace(
             shell, name, "/home/" + config.sshUser() + "/workspace/" + config.agent().specsDir());
-    var spec = new Spec(resolvedSpecId, title.strip(), status, assignee, resolvedDependsOn, branch);
+    var spec =
+        new Spec(
+            resolvedSpecId,
+            title.strip(),
+            status,
+            assignee,
+            resolvedDependsOn,
+            resolvedRepos,
+            branch);
     workspace.createSpec(spec, SpecScaffold.markdownTemplate(title));
 
     if (json) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SpecListCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SpecListCommand.java
@@ -168,8 +168,11 @@ public final class SpecListCommand implements Runnable {
           spec.dependsOn().isEmpty()
               ? ""
               : " @|faint \u2190 " + String.join(", ", spec.dependsOn()) + "|@";
+      var repos =
+          spec.repos().isEmpty() ? "" : " @|faint [" + String.join(", ", spec.repos()) + "]|@";
       System.out.println(
-          ansi.string(prefix + "@|bold " + spec.id() + "|@  " + spec.title() + deps + suffix));
+          ansi.string(
+              prefix + "@|bold " + spec.id() + "|@  " + spec.title() + repos + deps + suffix));
     }
     System.out.println();
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/DispatchRepos.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/DispatchRepos.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.config.Spec;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+public final class DispatchRepos {
+
+  private DispatchRepos() {}
+
+  public static List<SailYaml.Repo> resolve(SailYaml config, Spec spec, List<String> overrides) {
+    var configured = configuredRepos(config);
+    var requested = requestedRepos(spec, overrides);
+    if (requested.isEmpty()) {
+      return configured.size() == 1 ? List.of(configured.values().iterator().next()) : List.of();
+    }
+    return requested.stream().map(path -> requireConfigured(configured, path)).toList();
+  }
+
+  private static LinkedHashMap<String, SailYaml.Repo> configuredRepos(SailYaml config) {
+    var repos = new LinkedHashMap<String, SailYaml.Repo>();
+    if (config.repos() == null) {
+      return repos;
+    }
+    for (var repo : config.repos()) {
+      repos.put(repo.path(), repo);
+    }
+    return repos;
+  }
+
+  private static List<String> requestedRepos(Spec spec, List<String> overrides) {
+    var requested = overrides != null && !overrides.isEmpty() ? overrides : spec.repos();
+    return requested.stream().map(DispatchRepos::validatedPath).distinct().toList();
+  }
+
+  private static String validatedPath(String path) {
+    NameValidator.requireSafePath(path, "spec.repo");
+    return path;
+  }
+
+  private static SailYaml.Repo requireConfigured(
+      LinkedHashMap<String, SailYaml.Repo> configured, String path) {
+    var repo = configured.get(path);
+    if (repo == null) {
+      throw new IllegalArgumentException(
+          "Spec targets repo '" + path + "', but that repo is not configured in sail.yaml.");
+    }
+    return repo;
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/SpecWorkspace.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/SpecWorkspace.java
@@ -79,7 +79,13 @@ public final class SpecWorkspace {
     }
     var updated =
         new Spec(
-            spec.id(), spec.title(), newStatus, spec.assignee(), spec.dependsOn(), spec.branch());
+            spec.id(),
+            spec.title(),
+            newStatus,
+            spec.assignee(),
+            spec.dependsOn(),
+            spec.repos(),
+            spec.branch());
     writeMetadata(updated);
     return updated;
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -94,6 +94,66 @@ class ApiRouterTest {
   }
 
   @Test
+  void dispatchParsesSingleRepoTarget() throws Exception {
+    try (var server = server()) {
+      var response =
+          post(
+              server,
+              "/v1/projects/acme/dispatch",
+              "token",
+              "{\"spec_id\": \"auth\", \"repo\": \"chorus\"}");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"repos\": [\"chorus\"]"));
+    }
+  }
+
+  @Test
+  void dispatchParsesMultipleRepoTargets() throws Exception {
+    try (var server = server()) {
+      var response =
+          post(
+              server,
+              "/v1/projects/acme/dispatch",
+              "token",
+              "{\"spec_id\": \"auth\", \"repos\": [\"sing\", \"chorus\"]}");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"repos\": [\"sing\", \"chorus\"]"));
+    }
+  }
+
+  @Test
+  void dispatchParsesScalarReposTarget() throws Exception {
+    try (var server = server()) {
+      var response =
+          post(
+              server,
+              "/v1/projects/acme/dispatch",
+              "token",
+              "{\"spec_id\": \"auth\", \"repos\": \"chorus\"}");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"repos\": [\"chorus\"]"));
+    }
+  }
+
+  @Test
+  void dispatchRejectsRepoAndReposTogether() throws Exception {
+    try (var server = server()) {
+      var response =
+          post(
+              server,
+              "/v1/projects/acme/dispatch",
+              "token",
+              "{\"spec_id\": \"auth\", \"repo\": \"sing\", \"repos\": [\"chorus\"]}");
+
+      assertEquals(400, response.statusCode());
+      assertTrue(response.body().contains("invalid_json"));
+    }
+  }
+
+  @Test
   void specSyncRejectsExtraPathSegments() throws Exception {
     try (var server = server()) {
       var response = get(server, "/v1/projects/acme/spec-sync/extra", "token");
@@ -406,6 +466,7 @@ class ApiRouterTest {
                   "pending",
                   null,
                   java.util.List.of(),
+                  java.util.List.of(),
                   null,
                   true,
                   false,
@@ -448,7 +509,8 @@ class ApiRouterTest {
               project,
               true,
               null,
-              new DispatchedSpecView(request.specId(), "Spec", "in_progress", null),
+              new DispatchedSpecView(
+                  request.specId(), "Spec", "in_progress", request.repos(), null),
               null,
               "",
               false));

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
@@ -160,6 +160,7 @@ class DispatchCommandTest {
     var help = sw.toString();
     assertTrue(help.contains("--spec"));
     assertTrue(help.contains("--background"));
+    assertTrue(help.contains("--repo"));
     assertTrue(help.contains("--dry-run"));
     assertTrue(help.contains("--json"));
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/DispatchReposTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/DispatchReposTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.config.Spec;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DispatchReposTest {
+
+  @Test
+  void usesSpecRepoWhenProjectHasMultipleRepos() {
+    var targets =
+        DispatchRepos.resolve(
+            config("sing", "chorus"),
+            new Spec("ui", "UI", "pending", null, List.of(), List.of("chorus"), "feat/ui"),
+            List.of());
+
+    assertEquals(List.of("chorus"), targets.stream().map(SailYaml.Repo::path).toList());
+  }
+
+  @Test
+  void overrideWinsOverSpecRepo() {
+    var targets =
+        DispatchRepos.resolve(
+            config("sing", "chorus"),
+            new Spec("ui", "UI", "pending", null, List.of(), List.of("sing"), "feat/ui"),
+            List.of("chorus"));
+
+    assertEquals(List.of("chorus"), targets.stream().map(SailYaml.Repo::path).toList());
+  }
+
+  @Test
+  void fallsBackToSingleConfiguredRepo() {
+    var targets =
+        DispatchRepos.resolve(
+            config("sing"),
+            new Spec("ui", "UI", "pending", null, List.of(), List.of(), "feat/ui"),
+            List.of());
+
+    assertEquals(List.of("sing"), targets.stream().map(SailYaml.Repo::path).toList());
+  }
+
+  @Test
+  void leavesMultiRepoDispatchUntargetedWhenSpecOmitsRepo() {
+    var targets =
+        DispatchRepos.resolve(
+            config("sing", "chorus"),
+            new Spec("ui", "UI", "pending", null, List.of(), List.of(), "feat/ui"),
+            List.of());
+
+    assertTrue(targets.isEmpty());
+  }
+
+  @Test
+  void rejectsUnknownRepo() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            DispatchRepos.resolve(
+                config("sing"),
+                new Spec("ui", "UI", "pending", null, List.of(), List.of("chorus"), "feat/ui"),
+                List.of()));
+  }
+
+  private static SailYaml config(String... paths) {
+    return SailYaml.fromMap(
+        Map.of(
+            "name",
+            "workspace",
+            "repos",
+            Arrays.stream(paths)
+                .map(
+                    path ->
+                        Map.<String, Object>of("url", "https://example.com/" + path, "path", path))
+                .toList()));
+  }
+}


### PR DESCRIPTION
## Summary
- Add spec metadata support for repo/repos targets
- Branch targeted repositories during dispatch instead of guessing from the first configured repo
- Update API dispatch, spec creation/listing, and generated agent/spec guidance for multi-repo projects

## Verification
- mvn clean verify