### PR TITLE
Fix systemd agent dispatch for single-repo specs

### DIFF
--- a/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
@@ -26,6 +26,7 @@ public final class AgentSession {
   private static final String LOG_FILE = SAIL_DIR + "/agent.log";
   private static final String SESSION_FILE = SAIL_DIR + "/agent-session.json";
   private static final String TASK_FILE = SAIL_DIR + "/agent-task.txt";
+  private static final String SYSTEMD_UNIT = "sail-agent.service";
 
   private final ShellExec shell;
 
@@ -88,16 +89,15 @@ public final class AgentSession {
       throws IOException, InterruptedException, TimeoutException {
     var pidCmd = ContainerExec.asDevUser(containerName, List.of("cat", PID_FILE));
     var pidResult = shell.exec(pidCmd);
-    if (!pidResult.ok() || pidResult.stdout().isBlank()) {
+    var parsedPid = pidResult.ok() ? parsePid(pidResult.stdout()) : null;
+    if (parsedPid == null) {
+      parsedPid = querySystemdPid(containerName);
+    }
+    if (parsedPid == null) {
       return null;
     }
 
-    var pid = 0;
-    try {
-      pid = Integer.parseInt(pidResult.stdout().trim());
-    } catch (NumberFormatException e) {
-      return null;
-    }
+    var pid = parsedPid;
 
     var aliveCmd =
         ContainerExec.asDevUser(containerName, List.of("kill", "-0", String.valueOf(pid)));
@@ -179,19 +179,24 @@ public final class AgentSession {
       String model,
       String reasoningEffort) {
     var cli = Objects.requireNonNullElse(agentCli, AgentCli.CLAUDE_CODE);
-    var agentCmd =
-        "exec " + cli.headlessCommand(TASK_FILE, fullPermissions, model, reasoningEffort);
+    var agentCmd = cli.headlessCommand(TASK_FILE, fullPermissions, model, reasoningEffort);
     var script =
         """
         mkdir -p "$1"
         rm -f "$5"
         : > "$4"
         systemctl --user reset-failed sail-agent.service >/dev/null 2>&1 || true
-        systemd-run --user --unit sail-agent bash -lc 'cd "$1" && echo $$ > "$4" && exec bash -l -c "$2" > "$3" 2>&1' bash "$2" "$3" "$4" "$5"
+        systemd-run --user --unit sail-agent bash -lc 'printf "%s\\n" "$$" > "$4"; cd "$1" && exec bash -l -c "$2" > "$3" 2>&1' bash "$2" "$3" "$4" "$5"
         for i in $(seq 1 25); do
           test -s "$5" && exit 0
+          pid="$(systemctl --user show sail-agent.service --property=MainPID --value 2>/dev/null || true)"
+          case "$pid" in
+            ''|0|*[!0-9]*) ;;
+            *) printf '%s\\n' "$pid" > "$5"; exit 0 ;;
+          esac
           sleep 0.2
         done
+        systemctl --user status sail-agent.service --no-pager || true
         exit 1
         """;
     return ContainerExec.asDevUser(
@@ -233,5 +238,24 @@ public final class AgentSession {
   /** Returns the path to the agent log file inside the container. */
   public static String logPath() {
     return LOG_FILE;
+  }
+
+  private Integer querySystemdPid(String containerName)
+      throws IOException, InterruptedException, TimeoutException {
+    var cmd =
+        ContainerExec.asDevUser(
+            containerName,
+            List.of("systemctl", "--user", "show", SYSTEMD_UNIT, "--property=MainPID", "--value"));
+    var result = shell.exec(cmd);
+    return result.ok() ? parsePid(result.stdout()) : null;
+  }
+
+  private static Integer parsePid(String value) {
+    try {
+      var pid = Integer.parseInt(value.trim());
+      return pid > 0 ? pid : null;
+    } catch (NumberFormatException e) {
+      return null;
+    }
   }
 }

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
@@ -72,12 +72,37 @@ class AgentSessionTest {
 
   @Test
   void queryStatusWhenNoPidFile() throws Exception {
-    var shell = new ScriptedShellExecutor().onFail("cat /home/dev/.sail/agent.pid", "No such file");
+    var shell =
+        new ScriptedShellExecutor()
+            .onFail("cat /home/dev/.sail/agent.pid", "No such file")
+            .onOk("systemctl --user show sail-agent.service --property=MainPID --value", "0\n");
     var session = new AgentSession(shell);
 
     var info = session.queryStatus("acme-health");
 
     assertNull(info);
+  }
+
+  @Test
+  void queryStatusFallsBackToSystemdMainPid() throws Exception {
+    var shell =
+        new ScriptedShellExecutor()
+            .onFail("cat /home/dev/.sail/agent.pid", "No such file")
+            .onOk("systemctl --user show sail-agent.service --property=MainPID --value", "54321\n")
+            .onOk("kill -0 54321", "")
+            .onOk(
+                "cat /home/dev/.sail/agent-session.json",
+                """
+                {"task":"polish ui","started_at":"2026-05-07T03:00:00Z","branch":"feat/ui","log_path":"/home/dev/.sail/agent.log"}
+                """);
+    var session = new AgentSession(shell);
+
+    var info = session.queryStatus("acme-health");
+
+    assertNotNull(info);
+    assertTrue(info.running());
+    assertEquals(54321, info.pid());
+    assertEquals("polish ui", info.task());
   }
 
   @Test
@@ -180,7 +205,7 @@ class AgentSessionTest {
             "acme", "dev", "/home/dev/workspace", true, AgentCli.CLAUDE_CODE);
 
     var joined = String.join(" ", cmd);
-    assertTrue(joined.contains("exec claude --print --dangerously-skip-permissions"));
+    assertTrue(joined.contains("claude --print --dangerously-skip-permissions"));
   }
 
   @Test
@@ -215,6 +240,7 @@ class AgentSessionTest {
     assertTrue(
         joined.contains("codex exec --dangerously-bypass-approvals-and-sandbox --model gpt-5.5"));
     assertTrue(joined.contains("model_reasoning_effort='\"high\"'"));
+    assertFalse(joined.contains("exec codex exec"));
   }
 
   @Test
@@ -263,6 +289,7 @@ class AgentSessionTest {
 
     var script = cmd.get(cmd.indexOf("-lc") + 1);
     assertTrue(script.contains("systemd-run --user --unit sail-agent"));
+    assertTrue(script.contains("systemctl --user show sail-agent.service"));
     assertTrue(script.contains("cd \"$1\""));
     assertFalse(script.contains(workDir));
     assertTrue(cmd.contains(workDir));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
@@ -203,7 +203,7 @@ public final class DispatchCommand implements Runnable {
       branchName = nextSpec.branch() != null ? nextSpec.branch() : prefix + nextSpec.id();
       var created = 0;
       for (var repo : targetRepos) {
-        var repoDir = workDir + "/" + repo.path();
+        var repoDir = branchRepoDir(workDir, targetRepos, repo);
         var repoExists =
             shell.exec(ContainerExec.asDevUser(name, List.of("test", "-d", repoDir + "/.git")));
         if (repoExists.ok()) {
@@ -258,7 +258,10 @@ public final class DispatchCommand implements Runnable {
         var pb = new ProcessBuilder(sshCmd);
         pb.inheritIO();
         var process = pb.start();
-        process.waitFor();
+        var exitCode = process.waitFor();
+        if (exitCode != 0) {
+          throw new IOException("Failed to launch background agent; see output above.");
+        }
       }
       Banner.printAgentLaunched(name, task, branchName, System.out, Ansi.AUTO);
       if (!dryRun) {
@@ -350,6 +353,10 @@ public final class DispatchCommand implements Runnable {
     } else {
       System.out.println(Ansi.AUTO.string("  @|faint No pending specs found for " + name + ".|@"));
     }
+  }
+
+  static String branchRepoDir(String workDir, List<SailYaml.Repo> targetRepos, SailYaml.Repo repo) {
+    return targetRepos.size() == 1 ? workDir : workDir + "/" + repo.path();
   }
 
   private void launchWatcherIfGuardrails(SailYaml config) {

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.commands;
 import static org.junit.jupiter.api.Assertions.*;
 
 import ai.singlr.sail.Sail;
+import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -186,5 +187,25 @@ class DispatchCommandTest {
     assertTrue(help.contains("--repo"));
     assertTrue(help.contains("--dry-run"));
     assertTrue(help.contains("--json"));
+  }
+
+  @Test
+  void branchRepoDirUsesSingleTargetWorkDirDirectly() {
+    var repo = new SailYaml.Repo("https://github.com/org/chorus.git", "chorus", null);
+
+    var repoDir = DispatchCommand.branchRepoDir("/home/dev/workspace/chorus", List.of(repo), repo);
+
+    assertEquals("/home/dev/workspace/chorus", repoDir);
+  }
+
+  @Test
+  void branchRepoDirAppendsRepoPathForMultiRepoDispatch() {
+    var sing = new SailYaml.Repo("https://github.com/org/sing.git", "sing", null);
+    var chorus = new SailYaml.Repo("https://github.com/org/chorus.git", "chorus", null);
+
+    var repoDir =
+        DispatchCommand.branchRepoDir("/home/dev/workspace", List.of(sing, chorus), chorus);
+
+    assertEquals("/home/dev/workspace/chorus", repoDir);
   }
 }


### PR DESCRIPTION
## Summary
- create auto-branches at the single target repo root instead of appending the repo path twice
- make background agent launch fail loudly when the transient user systemd unit does not produce a PID
- let agent status recover the running PID from the user systemd unit if the PID file is missing

## Verification
- mvn -pl sail-harness,sail-infra -am -Dtest=AgentSessionTest,DispatchCommandTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn clean verify