### PR TITLE
Release 0.13.20: ContainerStateGuard — dedupe container-state preconditions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.19</version>
+    <version>0.13.20</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.19</version>
+        <version>0.13.20</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.19</version>
+        <version>0.13.20</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.19</version>
+        <version>0.13.20</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentAuditCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentAuditCommand.java
@@ -10,7 +10,7 @@ import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
@@ -68,17 +68,7 @@ public final class AgentAuditCommand implements Runnable {
     var mgr = new ContainerManager(shell);
     var state = mgr.queryState(name);
 
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     var sshUser = config.sshUser();
     var scriptPath = "/home/" + sshUser + "/.sail/security-audit.sh";

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentContextRegenCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentContextRegenCommand.java
@@ -10,7 +10,7 @@ import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
@@ -74,17 +74,7 @@ public final class AgentContextRegenCommand implements Runnable {
     var mgr = new ContainerManager(shell);
     var state = mgr.queryState(name);
 
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     var contextFiles = AgentContextGenerator.generateFiles(config);
     var auditFiles = AgentAuditFiles.assemble(config);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLaunchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLaunchCommand.java
@@ -13,7 +13,7 @@ import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.GuardrailWatcher;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
@@ -95,17 +95,7 @@ public final class AgentLaunchCommand implements Runnable {
     var mgr = new ContainerManager(shell);
 
     var state = mgr.queryState(name);
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     if (!path.isBlank()) {
       validateSafePath(path, "--path");

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLogCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLogCommand.java
@@ -9,7 +9,7 @@ import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ShellExecutor;
 import java.util.Arrays;
@@ -56,17 +56,7 @@ public final class AgentLogCommand implements Runnable {
     var mgr = new ContainerManager(shell);
 
     var state = mgr.queryState(name);
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     var logPath = AgentSession.logPath();
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentReviewCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentReviewCommand.java
@@ -10,7 +10,7 @@ import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
@@ -68,17 +68,7 @@ public final class AgentReviewCommand implements Runnable {
     var mgr = new ContainerManager(shell);
     var state = mgr.queryState(name);
 
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     var sshUser = config.sshUser();
     var scriptPath = "/home/" + sshUser + "/.sail/code-review.sh";

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStatusCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStatusCommand.java
@@ -12,6 +12,7 @@ import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.GuardrailChecker;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
@@ -166,17 +167,7 @@ public final class AgentStatusCommand implements Runnable {
     var mgr = new ContainerManager(shell);
 
     var state = mgr.queryState(name);
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     var agentSession = new AgentSession(shell);
     var info = agentSession.queryStatus(name);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStopCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStopCommand.java
@@ -8,7 +8,7 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ShellExecutor;
 import java.util.LinkedHashMap;
@@ -47,17 +47,7 @@ public final class AgentStopCommand implements Runnable {
     var mgr = new ContainerManager(shell);
 
     var state = mgr.queryState(name);
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     var agentSession = new AgentSession(shell);
     var info = agentSession.queryStatus(name);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentSweepCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentSweepCommand.java
@@ -11,7 +11,7 @@ import ai.singlr.sail.engine.AgentCli;
 import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
@@ -80,17 +80,7 @@ public final class AgentSweepCommand implements Runnable {
     var mgr = new ContainerManager(shell);
     var state = mgr.queryState(name);
 
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     var singYamlPath = SailPaths.resolveSailYaml(name, file);
     SailYaml config = null;

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
@@ -15,7 +15,7 @@ import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.GuardrailChecker;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
@@ -168,17 +168,7 @@ public final class AgentWatchCommand implements Runnable {
   private void requireRunning(ShellExecutor shell) throws Exception {
     var mgr = new ContainerManager(shell);
     var state = mgr.queryState(name);
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
   }
 
   private SailYaml loadConfig() throws Exception {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
@@ -21,7 +21,7 @@ import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerSailSetup;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.DispatchRepos;
 import ai.singlr.sail.engine.GuardrailWatcher;
 import ai.singlr.sail.engine.HostInfo;
@@ -122,17 +122,7 @@ public final class DispatchCommand implements Runnable {
     var mgr = new ContainerManager(shell);
 
     var state = mgr.queryState(name);
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     var singYamlPath = SailPaths.resolveSailYaml(name, file);
     if (!Files.exists(singYamlPath)) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ExecCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ExecCommand.java
@@ -8,7 +8,7 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ShellExecutor;
 import java.util.LinkedHashMap;
@@ -52,17 +52,7 @@ public final class ExecCommand implements Runnable {
     var mgr = new ContainerManager(shell);
 
     var state = mgr.queryState(name);
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     var fullCmd = ContainerExec.asDevUser(name, command);
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/LogsCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/LogsCommand.java
@@ -9,7 +9,7 @@ import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ShellExecutor;
 import java.io.IOException;
@@ -60,17 +60,7 @@ public final class LogsCommand implements Runnable {
     var mgr = new ContainerManager(shell);
 
     var state = mgr.queryState(name);
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     if (service == null) {
       listServices(shell);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddFileCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddFileCommand.java
@@ -10,7 +10,7 @@ import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExec;
@@ -101,17 +101,7 @@ public final class ProjectAddFileCommand implements Runnable {
     var mgr = new ContainerManager(shell);
     var state = mgr.queryState(name);
 
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     var sshUser = config.sshUser();
     var workspaceDir = "/home/" + sshUser + "/workspace";

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddRepoCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddRepoCommand.java
@@ -10,7 +10,7 @@ import ai.singlr.sail.config.SailYamlUpdater;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ProjectApplier;
 import ai.singlr.sail.engine.ProjectProvisioner;
@@ -88,17 +88,7 @@ public final class ProjectAddRepoCommand implements Runnable {
     var mgr = new ContainerManager(shell);
     var state = mgr.queryState(name);
 
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     SailYaml.Repo repo;
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddServiceCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddServiceCommand.java
@@ -10,7 +10,7 @@ import ai.singlr.sail.config.SailYamlUpdater;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ProjectApplier;
 import ai.singlr.sail.engine.SailPaths;
@@ -88,17 +88,7 @@ public final class ProjectAddServiceCommand implements Runnable {
     var mgr = new ContainerManager(shell);
     var state = mgr.queryState(name);
 
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     String svcName;
     SailYaml.Service service;

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectRemoveServiceCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectRemoveServiceCommand.java
@@ -9,7 +9,7 @@ import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.SailYamlUpdater;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ProjectApplier;
 import ai.singlr.sail.engine.SailPaths;
@@ -78,17 +78,7 @@ public final class ProjectRemoveServiceCommand implements Runnable {
     var mgr = new ContainerManager(shell);
     var state = mgr.queryState(name);
 
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     var applier = new ProjectApplier(shell, out);
     var result = applier.removeServices(name, List.of(serviceName));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PsCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PsCommand.java
@@ -9,7 +9,7 @@ import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ShellExecutor;
 import java.io.IOException;
@@ -47,17 +47,7 @@ public final class PsCommand implements Runnable {
     var mgr = new ContainerManager(shell);
 
     var state = mgr.queryState(name);
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     var cmd = ContainerExec.asDevUser(name, List.of("podman", "ps", "--format", "json"));
     var result = shell.exec(cmd);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/RestoreCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/RestoreCommand.java
@@ -10,6 +10,7 @@ import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SnapshotManager;
@@ -53,15 +54,7 @@ public final class RestoreCommand implements Runnable {
     var snapMgr = new SnapshotManager(shell);
 
     var state = mgr.queryState(name);
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored -> {}
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireCreated(state, name);
 
     if (label == null) {
       var snapshots = snapMgr.list(name);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
@@ -13,7 +13,7 @@ import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.GuardrailWatcher;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
@@ -119,17 +119,7 @@ public final class RunCommand implements Runnable {
     var mgr = new ContainerManager(shell);
     var state = mgr.queryState(name);
 
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireRunning(state, name);
 
     if (!path.isBlank()) {
       validateSafePath(path, "--path");

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SnapCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SnapCommand.java
@@ -8,7 +8,7 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SnapshotManager;
@@ -55,15 +55,7 @@ public final class SnapCommand implements Runnable {
     var snapMgr = new SnapshotManager(shell);
 
     var state = mgr.queryState(name);
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored -> {}
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireCreated(state, name);
 
     if (label == null) {
       label = SnapshotManager.defaultLabel();

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SnapDeleteCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SnapDeleteCommand.java
@@ -8,7 +8,7 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SnapshotManager;
@@ -55,15 +55,7 @@ public final class SnapDeleteCommand implements Runnable {
     var snapMgr = new SnapshotManager(shell);
 
     var state = mgr.queryState(name);
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored -> {}
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireCreated(state, name);
 
     if (!json) {
       Banner.printBranding(System.out, Ansi.AUTO);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SnapsCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SnapsCommand.java
@@ -8,7 +8,7 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SnapshotManager;
@@ -47,15 +47,7 @@ public final class SnapsCommand implements Runnable {
     var snapMgr = new SnapshotManager(shell);
 
     var state = mgr.queryState(name);
-    switch (state) {
-      case ContainerState.Running ignored -> {}
-      case ContainerState.Stopped ignored -> {}
-      case ContainerState.NotCreated ignored ->
-          throw new IllegalStateException(
-              "Project '" + name + "' does not exist. Run 'sail project create' first.");
-      case ContainerState.Error e ->
-          throw new IllegalStateException("Container error: " + e.message());
-    }
+    ContainerStateGuard.requireCreated(state, name);
 
     var snapshots = snapMgr.list(name);
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerStateGuard.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerStateGuard.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+/**
+ * Lifecycle preconditions shared by the commands that operate on a project container. Each guard
+ * inspects a live {@link ContainerState} and throws {@link IllegalStateException} with an
+ * actionable message when the container is not in an acceptable state.
+ */
+public final class ContainerStateGuard {
+
+  private ContainerStateGuard() {}
+
+  /** Requires the container to be running; throws otherwise. */
+  public static void requireRunning(ContainerState state, String name) {
+    switch (state) {
+      case ContainerState.Running ignored -> {}
+      case ContainerState.Stopped ignored ->
+          throw new IllegalStateException(
+              "Project '" + name + "' is stopped. Start it with: sail project start " + name);
+      case ContainerState.NotCreated ignored ->
+          throw new IllegalStateException(
+              "Project '" + name + "' does not exist. Run 'sail project create' first.");
+      case ContainerState.Error e ->
+          throw new IllegalStateException("Container error: " + e.message());
+    }
+  }
+
+  /** Requires the container to exist (running or stopped); throws otherwise. */
+  public static void requireCreated(ContainerState state, String name) {
+    switch (state) {
+      case ContainerState.Running ignored -> {}
+      case ContainerState.Stopped ignored -> {}
+      case ContainerState.NotCreated ignored ->
+          throw new IllegalStateException(
+              "Project '" + name + "' does not exist. Run 'sail project create' first.");
+      case ContainerState.Error e ->
+          throw new IllegalStateException("Container error: " + e.message());
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerStateGuardTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerStateGuardTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ContainerStateGuardTest {
+
+  @Test
+  void requireRunningPassesWhenRunning() {
+    assertDoesNotThrow(
+        () -> ContainerStateGuard.requireRunning(new ContainerState.Running("10.0.0.5"), "demo"));
+  }
+
+  @Test
+  void requireRunningRejectsStoppedWithStartHint() {
+    var ex =
+        assertThrows(
+            IllegalStateException.class,
+            () -> ContainerStateGuard.requireRunning(new ContainerState.Stopped(), "demo"));
+    assertEquals(
+        "Project 'demo' is stopped. Start it with: sail project start demo", ex.getMessage());
+  }
+
+  @Test
+  void requireRunningRejectsNotCreatedWithCreateHint() {
+    var ex =
+        assertThrows(
+            IllegalStateException.class,
+            () -> ContainerStateGuard.requireRunning(new ContainerState.NotCreated(), "demo"));
+    assertEquals(
+        "Project 'demo' does not exist. Run 'sail project create' first.", ex.getMessage());
+  }
+
+  @Test
+  void requireRunningRejectsErrorWithMessage() {
+    var ex =
+        assertThrows(
+            IllegalStateException.class,
+            () -> ContainerStateGuard.requireRunning(new ContainerState.Error("boom"), "demo"));
+    assertEquals("Container error: boom", ex.getMessage());
+  }
+
+  @Test
+  void requireCreatedPassesWhenRunning() {
+    assertDoesNotThrow(
+        () -> ContainerStateGuard.requireCreated(new ContainerState.Running(null), "demo"));
+  }
+
+  @Test
+  void requireCreatedPassesWhenStopped() {
+    assertDoesNotThrow(
+        () -> ContainerStateGuard.requireCreated(new ContainerState.Stopped(), "demo"));
+  }
+
+  @Test
+  void requireCreatedRejectsNotCreatedWithCreateHint() {
+    var ex =
+        assertThrows(
+            IllegalStateException.class,
+            () -> ContainerStateGuard.requireCreated(new ContainerState.NotCreated(), "demo"));
+    assertEquals(
+        "Project 'demo' does not exist. Run 'sail project create' first.", ex.getMessage());
+  }
+
+  @Test
+  void requireCreatedRejectsErrorWithMessage() {
+    var ex =
+        assertThrows(
+            IllegalStateException.class,
+            () -> ContainerStateGuard.requireCreated(new ContainerState.Error("boom"), "demo"));
+    assertEquals("Container error: boom", ex.getMessage());
+  }
+}


### PR DESCRIPTION
## Summary

Top DRY finding from the codebase audit: the container-state `switch (state)` precondition was copy-pasted across ~34 command classes. This extracts the canonical forms into a single `ContainerStateGuard` (in `ai.singlr.sail.engine`, beside `ContainerState`) with two intent-revealing guards, and migrates the 22 sites that used the canonical messages verbatim.

- **`requireRunning(state, name)`** — no-ops when `Running`, throws `IllegalStateException` with the canonical stopped / not-created / error messages otherwise. **18 sites:** Exec, Run, ProjectAddRepo, AgentSweep, ProjectRemoveService, ProjectAddFile, AgentLog, Ps, AgentStop, Dispatch, ProjectAddService, AgentWatch, AgentLaunch, AgentContextRegen, AgentReview, AgentAudit, Logs, AgentStatus.
- **`requireCreated(state, name)`** — also accepts `Stopped` (snapshot commands operate on stopped containers). **4 sites:** Snap, Snaps, Restore, SnapDelete.

## Deliberately left untouched (~12 variants)

These have intentional differences and would be the wrong thing to force through a shared guard:

- **Message variants:** `Shell` (`sudo` hint), `AgentAttach` (`sail project up` hint), `ProjectInstallAgent` / `ProjectApply` / `ProjectResourcesSet` (name-in-create-hint), `AgentReport` (short message).
- **Different shapes:** `Up` / `Down` / `ProjectMigrate` (full lifecycle handling), `ProjectList` / `ProjectConfig` (display-string mappers), `Connect` (switch expression returning the ipv4).

## Verification

- Behavior-preserving: migrated messages are byte-identical to the originals.
- New `ContainerStateGuardTest` covers all 8 state/guard combinations.
- Full suite green (1420 tests in sail-infra); JaCoCo gates met across all modules; spotless clean.
- Net **−87 lines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)