### PR TITLE
Release 0.13.22: Re-check webhook host at send time (DNS-rebinding defense)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.21</version>
+    <version>0.13.22</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.21</version>
+        <version>0.13.22</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/config/Notifications.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/Notifications.java
@@ -5,8 +5,6 @@
 
 package ai.singlr.sail.config;
 
-import java.net.InetAddress;
-import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +55,7 @@ public record Notifications(String url, List<String> events) {
     if (url == null || url.isBlank()) {
       throw new IllegalArgumentException("notifications.url is required.");
     }
-    requireSafeWebhookUrl(url);
+    WebhookUrlSafety.requireSafe(url);
 
     var eventsRaw = (List<String>) map.get("events");
     if (eventsRaw != null) {
@@ -98,86 +96,5 @@ public record Notifications(String url, List<String> events) {
     }
     var legacy = LEGACY_ALIAS_OF.get(event);
     return legacy != null && events.contains(legacy);
-  }
-
-  /**
-   * Validates a webhook URL: must be http(s) and must not target private/internal networks. Package
-   * private for testing.
-   */
-  static void requireSafeWebhookUrl(String url) {
-    URI uri;
-    try {
-      uri = URI.create(url);
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException(
-          "Invalid notifications.url: '" + url + "'. Must be a valid URL.");
-    }
-
-    var scheme = uri.getScheme();
-    if (scheme == null || (!scheme.equals("https") && !scheme.equals("http"))) {
-      throw new IllegalArgumentException(
-          "Invalid notifications.url scheme: '"
-              + scheme
-              + "'. Only https:// and http:// are allowed.");
-    }
-
-    var host = uri.getHost();
-    if (host == null || host.isBlank()) {
-      throw new IllegalArgumentException(
-          "Invalid notifications.url: '" + url + "'. No hostname found.");
-    }
-
-    if (isPrivateHost(host)) {
-      throw new IllegalArgumentException(
-          "Invalid notifications.url: '"
-              + url
-              + "'. Private/internal network addresses are not allowed.");
-    }
-  }
-
-  /** Checks if a hostname resolves to a private or loopback address. */
-  private static boolean isPrivateHost(String host) {
-    var lower = host.toLowerCase();
-    if (lower.equals("localhost") || lower.equals("[::1]")) {
-      return true;
-    }
-
-    var bare =
-        lower.startsWith("[") && lower.endsWith("]")
-            ? lower.substring(1, lower.length() - 1)
-            : lower;
-
-    if (bare.startsWith("127.")
-        || bare.startsWith("10.")
-        || bare.startsWith("192.168.")
-        || bare.equals("169.254.169.254")
-        || bare.equals("0.0.0.0")
-        || bare.equals("::1")) {
-      return true;
-    }
-
-    if (bare.startsWith("172.")) {
-      try {
-        var parts = bare.split("\\.");
-        if (parts.length >= 2) {
-          var secondOctet = Integer.parseInt(parts[1]);
-          if (secondOctet >= 16 && secondOctet <= 31) {
-            return true;
-          }
-        }
-      } catch (NumberFormatException ignored) {
-      }
-    }
-
-    if (bare.startsWith("fd") || bare.startsWith("fc") || bare.startsWith("fe80")) {
-      return true;
-    }
-
-    try {
-      var addr = InetAddress.getByName(bare);
-      return addr.isLoopbackAddress() || addr.isSiteLocalAddress() || addr.isLinkLocalAddress();
-    } catch (Exception e) {
-      return true;
-    }
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/config/WebhookUrlSafety.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/WebhookUrlSafety.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.config;
+
+import java.net.InetAddress;
+import java.net.URI;
+
+/**
+ * SSRF policy for outbound webhook URLs. Validation runs at config parse time (via {@link
+ * Notifications}); the host check is also re-run at send time as defense-in-depth against
+ * DNS-rebinding, since a name that resolved to a public address when the config was parsed may
+ * resolve to a private one by the time the request is made.
+ */
+public final class WebhookUrlSafety {
+
+  private WebhookUrlSafety() {}
+
+  /**
+   * Validates that {@code url} is an http(s) URL whose host does not target a private/internal
+   * network. Throws {@link IllegalArgumentException} on any violation.
+   */
+  public static void requireSafe(String url) {
+    URI uri;
+    try {
+      uri = URI.create(url);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Invalid notifications.url: '" + url + "'. Must be a valid URL.");
+    }
+
+    var scheme = uri.getScheme();
+    if (scheme == null || (!scheme.equals("https") && !scheme.equals("http"))) {
+      throw new IllegalArgumentException(
+          "Invalid notifications.url scheme: '"
+              + scheme
+              + "'. Only https:// and http:// are allowed.");
+    }
+
+    var host = uri.getHost();
+    if (host == null || host.isBlank()) {
+      throw new IllegalArgumentException(
+          "Invalid notifications.url: '" + url + "'. No hostname found.");
+    }
+
+    if (isPrivateHost(host)) {
+      throw new IllegalArgumentException(
+          "Invalid notifications.url: '"
+              + url
+              + "'. Private/internal network addresses are not allowed.");
+    }
+  }
+
+  /** Returns true if the hostname is, or resolves to, a private/loopback/link-local address. */
+  public static boolean isPrivateHost(String host) {
+    var lower = host.toLowerCase();
+    if (lower.equals("localhost") || lower.equals("[::1]")) {
+      return true;
+    }
+
+    var bare =
+        lower.startsWith("[") && lower.endsWith("]")
+            ? lower.substring(1, lower.length() - 1)
+            : lower;
+
+    if (bare.startsWith("127.")
+        || bare.startsWith("10.")
+        || bare.startsWith("192.168.")
+        || bare.equals("169.254.169.254")
+        || bare.equals("0.0.0.0")
+        || bare.equals("::1")) {
+      return true;
+    }
+
+    if (bare.startsWith("172.")) {
+      try {
+        var parts = bare.split("\\.");
+        if (parts.length >= 2) {
+          var secondOctet = Integer.parseInt(parts[1]);
+          if (secondOctet >= 16 && secondOctet <= 31) {
+            return true;
+          }
+        }
+      } catch (NumberFormatException ignored) {
+      }
+    }
+
+    if (bare.startsWith("fd") || bare.startsWith("fc") || bare.startsWith("fe80")) {
+      return true;
+    }
+
+    try {
+      var addr = InetAddress.getByName(bare);
+      return addr.isLoopbackAddress() || addr.isSiteLocalAddress() || addr.isLinkLocalAddress();
+    } catch (Exception e) {
+      return true;
+    }
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/config/WebhookUrlSafetyTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/WebhookUrlSafetyTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class WebhookUrlSafetyTest {
+
+  @Test
+  void requireSafeAcceptsPublicHttps() {
+    assertDoesNotThrow(() -> WebhookUrlSafety.requireSafe("https://ntfy.sh/topic"));
+  }
+
+  @Test
+  void requireSafeRejectsNonHttpScheme() {
+    var ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WebhookUrlSafety.requireSafe("file:///etc/passwd"));
+    assertTrue(ex.getMessage().contains("scheme"));
+  }
+
+  @Test
+  void requireSafeRejectsMissingHost() {
+    assertThrows(
+        IllegalArgumentException.class, () -> WebhookUrlSafety.requireSafe("https:///nohost"));
+  }
+
+  @Test
+  void requireSafeRejectsPrivateHost() {
+    var ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WebhookUrlSafety.requireSafe("http://10.1.2.3/hook"));
+    assertTrue(ex.getMessage().contains("Private"));
+  }
+
+  @Test
+  void isPrivateHostFlagsLoopbackAndLocalNames() {
+    assertTrue(WebhookUrlSafety.isPrivateHost("localhost"));
+    assertTrue(WebhookUrlSafety.isPrivateHost("127.0.0.1"));
+    assertTrue(WebhookUrlSafety.isPrivateHost("[::1]"));
+    assertTrue(WebhookUrlSafety.isPrivateHost("::1"));
+  }
+
+  @Test
+  void isPrivateHostFlagsRfc1918Ranges() {
+    assertTrue(WebhookUrlSafety.isPrivateHost("10.0.0.1"));
+    assertTrue(WebhookUrlSafety.isPrivateHost("192.168.1.1"));
+    assertTrue(WebhookUrlSafety.isPrivateHost("172.16.0.1"));
+    assertTrue(WebhookUrlSafety.isPrivateHost("172.31.255.255"));
+  }
+
+  @Test
+  void isPrivateHostAllowsPublic172Octet() {
+    assertFalse(WebhookUrlSafety.isPrivateHost("172.32.0.1"));
+    assertFalse(WebhookUrlSafety.isPrivateHost("172.15.0.1"));
+  }
+
+  @Test
+  void isPrivateHostFlagsCloudMetadataAndUnspecified() {
+    assertTrue(WebhookUrlSafety.isPrivateHost("169.254.169.254"));
+    assertTrue(WebhookUrlSafety.isPrivateHost("0.0.0.0"));
+  }
+
+  @Test
+  void isPrivateHostFlagsIpv6UniqueLocalAndLinkLocal() {
+    assertTrue(WebhookUrlSafety.isPrivateHost("fd00::1"));
+    assertTrue(WebhookUrlSafety.isPrivateHost("fe80::1"));
+  }
+
+  @Test
+  void isPrivateHostTreatsUnresolvableAsPrivate() {
+    assertTrue(WebhookUrlSafety.isPrivateHost("no-such-host.invalid"));
+  }
+}

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.21</version>
+        <version>0.13.22</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/WebhookNotifier.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/WebhookNotifier.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.config.WebhookUrlSafety;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -41,6 +42,15 @@ public final class WebhookNotifier {
   /** Sends a notification. Best-effort — never throws. */
   public void notify(String event, String project, String title, String message) {
     try {
+      var host = URI.create(url).getHost();
+      if (host == null || WebhookUrlSafety.isPrivateHost(host)) {
+        System.err.println(
+            "  [webhook] Warning: refusing to send to "
+                + redactedUrl(url)
+                + " - host resolves to a private/internal address");
+        return;
+      }
+
       var payload = buildPayload(provider, event, project, title, message);
       var request =
           HttpRequest.newBuilder()

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/WebhookNotifierTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/WebhookNotifierTest.java
@@ -7,6 +7,9 @@ package ai.singlr.sail.engine;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 class WebhookNotifierTest {
@@ -163,5 +166,21 @@ class WebhookNotifierTest {
 
     assertTrue(payload.contains("\\\"quotes\\\""));
     assertTrue(payload.contains("Line1\\nLine2"));
+  }
+
+  @Test
+  void notifyRefusesToSendWhenHostResolvesPrivateAtSendTime() {
+    var notifier = new WebhookNotifier("http://127.0.0.1:9/hook");
+    var captured = new ByteArrayOutputStream();
+    var originalErr = System.err;
+    System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+    try {
+      notifier.notify("guardrail_triggered", "acme", "Title", "Message");
+    } finally {
+      System.setErr(originalErr);
+    }
+    var logged = captured.toString(StandardCharsets.UTF_8);
+    assertTrue(logged.contains("refusing to send"), logged);
+    assertFalse(logged.contains("127.0.0.1:9/hook"), "Must not log the unredacted URL");
   }
 }

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.21</version>
+        <version>0.13.22</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>


### PR DESCRIPTION
## Summary

The SSRF guard on `notifications.url` ran **only at config parse time** (`Notifications.fromMap`). A hostname that resolved to a public address when `sail.yaml` was parsed could be rebound to a private/internal address (e.g. cloud metadata `169.254.169.254`) before the webhook was actually sent. This adds a send-time re-check.

> **Stacked on #26 → #25.** Review/merge those first; this PR's diff is against #26's branch.

## Changes

- **`WebhookUrlSafety` (new, sail-core/config)** — single source of truth for the SSRF policy: `requireSafe(url)` (scheme + host + private-network rejection) and `isPrivateHost(host)`. Parse-time and send-time checks now share identical logic and can never drift apart.
- **`Notifications.fromMap`** delegates to `WebhookUrlSafety.requireSafe` — behavior byte-identical (all existing `NotificationsTest` SSRF cases still pass unchanged).
- **`WebhookNotifier.notify`** re-resolves and re-checks the host immediately before sending. On a private/internal resolution it logs a **redacted** warning and skips the request — preserving the best-effort, never-throw contract. This is the single chokepoint for both the `agent watch` and `WebhookReactor` send paths.

## Scope / honesty

Defense-in-depth, not a hard guarantee: it's bounded by the operator-trusted single-trust model and still has a small check-then-connect TOCTOU window (the recheck resolves, then `HttpClient` resolves again). Fully closing that would require pinning the connection to the validated IP, which breaks TLS SNI / provider detection — out of scope and unjustified under single-trust. What this PR removes is the parse-time-**only** gap.

## Verification

- `WebhookUrlSafetyTest` (10) covers the policy directly (loopback, RFC1918, the 172.16–31 boundary, metadata IP, IPv6 ULA/link-local, unresolvable → treated private).
- `WebhookNotifierTest` gains a send-time-refusal case asserting the request is skipped and the URL is not logged unredacted.
- Full suite green (core 872, harness 121, infra 1424); JaCoCo gates met across all modules; spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)