### PR TITLE
Passkey enrollment tickets + bootstrap (brick 7d) — 0.13.41

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.40</version>
+    <version>0.13.41</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.40</version>
+        <version>0.13.41</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/auth/EnrollmentService.java
+++ b/sail-core/src/main/java/ai/singlr/sail/auth/EnrollmentService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.auth;
+
+import ai.singlr.sail.store.EnrollmentTicketStore;
+import ai.singlr.sail.store.FdeStore;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Default {@link EnrollmentTickets} over the {@link EnrollmentTicketStore}, resolving FDE handles
+ * to the surrogate ids the store records. Tickets live for {@link #TTL} — long enough to complete a
+ * browser enrollment, short enough to limit exposure of an unused ticket.
+ */
+public final class EnrollmentService implements EnrollmentTickets {
+
+  static final Duration TTL = Duration.ofMinutes(15);
+
+  private final EnrollmentTicketStore tickets;
+  private final FdeStore fdes;
+
+  public EnrollmentService(EnrollmentTicketStore tickets, FdeStore fdes) {
+    this.tickets = Objects.requireNonNull(tickets, "tickets");
+    this.fdes = Objects.requireNonNull(fdes, "fdes");
+  }
+
+  @Override
+  public Ticket issue(String fdeHandle) {
+    var fde =
+        fdes.byHandle(fdeHandle)
+            .orElseThrow(
+                () ->
+                    new PasskeyException(
+                        PasskeyException.Kind.NOT_FOUND, "Unknown FDE: " + fdeHandle));
+    var created = tickets.issue(fde.id(), TTL);
+    return new Ticket(created.ticket(), fde.handle(), created.expiresAt());
+  }
+
+  @Override
+  public Optional<String> authorize(String ticket) {
+    return tickets.validate(ticket).map(EnrollmentTicketStore.TicketInfo::fdeHandle);
+  }
+
+  @Override
+  public boolean consume(String ticket) {
+    return tickets.consume(ticket);
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/auth/EnrollmentTickets.java
+++ b/sail-core/src/main/java/ai/singlr/sail/auth/EnrollmentTickets.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.auth;
+
+import java.util.Optional;
+
+/**
+ * Mints and resolves one-time passkey enrollment tickets. An admin issues a ticket for an FDE; the
+ * enrollment page presents it to the register endpoints in place of an operator credential, since a
+ * browser cannot carry one. The API handler depends on this abstraction rather than the store so
+ * its authorization path can be tested without a database.
+ */
+public interface EnrollmentTickets {
+
+  /** A minted ticket: the plaintext value (shown once), the FDE it enrolls, and its expiry. */
+  record Ticket(String ticket, String fdeHandle, String expiresAt) {}
+
+  /**
+   * Issues a ticket authorizing one enrollment for the FDE with {@code fdeHandle}. Throws {@link
+   * PasskeyException.Kind#NOT_FOUND} when no such FDE exists.
+   */
+  Ticket issue(String fdeHandle);
+
+  /** Resolves a live ticket to the handle of the FDE it enrolls, or empty if invalid/expired. */
+  Optional<String> authorize(String ticket);
+
+  /** Marks a ticket used; returns true only if it was still live (single-shot). */
+  boolean consume(String ticket);
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/EnrollmentTicketStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/EnrollmentTicketStore.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import ai.singlr.sail.webauthn.Hashes;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.Optional;
+
+/**
+ * One-time tickets that authorize a single passkey enrollment for one FDE. A browser running {@code
+ * navigator.credentials.create()} cannot carry an operator's API token, so an admin (or the host
+ * operator) mints a short-lived ticket and hands it to the enrollment page; the page presents it to
+ * the register endpoints in place of an admin credential. Like API tokens and sessions, the ticket
+ * is returned in plaintext once and stored only as its SHA-256 hash. It is {@link #validate live}
+ * until used or expired, and {@link #consume consumed} exactly once on a successful registration.
+ */
+public final class EnrollmentTicketStore {
+
+  private final Sqlite db;
+
+  public EnrollmentTicketStore(Sqlite db) {
+    this.db = db;
+  }
+
+  /** A freshly minted ticket; {@code ticket} is shown once and never stored in the clear. */
+  public record CreatedTicket(String ticket, String fdeId, String expiresAt) {}
+
+  /** A live ticket resolved to the FDE it enrolls. */
+  public record TicketInfo(String fdeId, String fdeHandle, String expiresAt) {}
+
+  public CreatedTicket issue(String fdeId, Duration ttl) {
+    var ticket = generateTicket();
+    var now = Instant.now();
+    var expiresAt = now.plus(ttl).toString();
+    db.execute(
+        "INSERT INTO enrollment_tickets (token_hash, fde_id, created_at, expires_at)"
+            + " VALUES (?, ?, ?, ?)",
+        sha256(ticket),
+        fdeId,
+        now.toString(),
+        expiresAt);
+    return new CreatedTicket(ticket, fdeId, expiresAt);
+  }
+
+  /** Resolves a live (unconsumed, unexpired) ticket to its FDE, pruning it if expired. */
+  public Optional<TicketInfo> validate(String ticket) {
+    var hash = sha256(ticket);
+    var info =
+        db.queryOne(
+            "SELECT t.fde_id, f.handle, t.expires_at FROM enrollment_tickets t"
+                + " JOIN fdes f ON f.id = t.fde_id"
+                + " WHERE t.token_hash = ? AND t.consumed_at IS NULL",
+            row -> new TicketInfo(row.text(0), row.text(1), row.text(2)),
+            hash);
+    if (info.isEmpty()) {
+      return Optional.empty();
+    }
+    if (Instant.parse(info.get().expiresAt()).isBefore(Instant.now())) {
+      db.execute("DELETE FROM enrollment_tickets WHERE token_hash = ?", hash);
+      return Optional.empty();
+    }
+    return info;
+  }
+
+  /** Marks a ticket used. Returns true only if it was still live, so consumption is single-shot. */
+  public boolean consume(String ticket) {
+    db.execute(
+        "UPDATE enrollment_tickets SET consumed_at = ? WHERE token_hash = ? AND consumed_at IS NULL",
+        Instant.now().toString(),
+        sha256(ticket));
+    return db.changes() > 0;
+  }
+
+  private static String generateTicket() {
+    var bytes = new byte[32];
+    new SecureRandom().nextBytes(bytes);
+    return "enr_" + HexFormat.of().formatHex(bytes);
+  }
+
+  private static String sha256(String input) {
+    return HexFormat.of().formatHex(Hashes.sha256(input.getBytes(StandardCharsets.UTF_8)));
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -217,6 +217,14 @@ public final class SchemaManager {
               fde_id TEXT REFERENCES fdes(id) ON DELETE CASCADE,
               created_at TEXT NOT NULL,
               expires_at TEXT NOT NULL
+          )""",
+          """
+          CREATE TABLE IF NOT EXISTS enrollment_tickets (
+              token_hash TEXT PRIMARY KEY,
+              fde_id TEXT NOT NULL REFERENCES fdes(id) ON DELETE CASCADE,
+              created_at TEXT NOT NULL,
+              expires_at TEXT NOT NULL,
+              consumed_at TEXT
           )""");
 
   private final Sqlite db;

--- a/sail-core/src/test/java/ai/singlr/sail/auth/EnrollmentServiceTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/auth/EnrollmentServiceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sail.store.EnrollmentTicketStore;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class EnrollmentServiceTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private EnrollmentService service;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    new FdeStore(db).add("uday", null, null);
+    service = new EnrollmentService(new EnrollmentTicketStore(db), new FdeStore(db));
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  @Test
+  void issueResolvesHandleAndAuthorizeReturnsIt() {
+    var ticket = service.issue("uday");
+    assertTrue(ticket.ticket().startsWith("enr_"));
+    assertEquals("uday", ticket.fdeHandle());
+    assertEquals("uday", service.authorize(ticket.ticket()).orElseThrow());
+  }
+
+  @Test
+  void issueRejectsUnknownFde() {
+    var e = assertThrows(PasskeyException.class, () -> service.issue("ghost"));
+    assertEquals(PasskeyException.Kind.NOT_FOUND, e.kind());
+  }
+
+  @Test
+  void authorizeIsEmptyForUnknownTicket() {
+    assertTrue(service.authorize("enr_nope").isEmpty());
+  }
+
+  @Test
+  void consumeIsSingleShotThenUnauthorized() {
+    var ticket = service.issue("uday").ticket();
+    assertTrue(service.consume(ticket));
+    assertFalse(service.consume(ticket));
+    assertTrue(service.authorize(ticket).isEmpty());
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/EnrollmentTicketStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/EnrollmentTicketStoreTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class EnrollmentTicketStoreTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private EnrollmentTicketStore store;
+  private String fdeId;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    fdeId = new FdeStore(db).add("uday", "Uday", null).id();
+    store = new EnrollmentTicketStore(db);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  @Test
+  void issuesAndValidatesResolvingHandle() {
+    var created = store.issue(fdeId, Duration.ofMinutes(15));
+    assertTrue(created.ticket().startsWith("enr_"));
+    assertEquals(fdeId, created.fdeId());
+
+    var info = store.validate(created.ticket()).orElseThrow();
+    assertEquals(fdeId, info.fdeId());
+    assertEquals("uday", info.fdeHandle());
+    assertEquals(created.expiresAt(), info.expiresAt());
+  }
+
+  @Test
+  void validateReturnsEmptyForUnknownTicket() {
+    assertTrue(store.validate("enr_bogus").isEmpty());
+  }
+
+  @Test
+  void expiredTicketIsRejectedAndPruned() {
+    var created = store.issue(fdeId, Duration.ofSeconds(-1));
+    assertTrue(store.validate(created.ticket()).isEmpty());
+    assertFalse(store.consume(created.ticket()));
+  }
+
+  @Test
+  void consumeIsSingleShot() {
+    var created = store.issue(fdeId, Duration.ofMinutes(15));
+    assertTrue(store.consume(created.ticket()));
+    assertFalse(store.consume(created.ticket()));
+    assertTrue(store.validate(created.ticket()).isEmpty());
+  }
+
+  @Test
+  void consumeUnknownTicketIsFalse() {
+    assertFalse(store.consume("enr_missing"));
+  }
+}

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.40</version>
+        <version>0.13.41</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.40</version>
+        <version>0.13.41</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/api/WebauthnAuthHandler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/WebauthnAuthHandler.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.auth.EnrollmentTickets;
 import ai.singlr.sail.auth.PasskeyCeremonies;
 import ai.singlr.sail.auth.PasskeyException;
 import ai.singlr.sail.config.YamlUtil;
@@ -18,10 +19,12 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Serves the passkey ceremony endpoints under {@code /v1/auth}. Registration ({@code
- * /register/start|finish}) enrolls a passkey for an FDE and requires an authenticated {@link
- * Capability#ADMIN} caller — it is credential management. Login ({@code /login/start|finish}) is
- * unauthenticated by design (the caller has no credential yet) and, on success, mints a session.
+ * Serves the passkey ceremony endpoints under {@code /v1/auth}. An admin mints an enrollment ticket
+ * ({@code POST /register/ticket}); registration ({@code /register/start|finish}) then enrolls a
+ * passkey for an FDE, authorized by either that ticket (so a browser, which cannot carry an
+ * operator token, can enroll) or an authenticated {@link Capability#ADMIN} caller. Login ({@code
+ * /login/start|finish}) is unauthenticated by design (the caller has no credential yet) and, on
+ * success, mints a session.
  *
  * <p>This handler is a thin adapter: it parses the JSON body, base64url-decodes the binary WebAuthn
  * fields, delegates to {@link PasskeyCeremonies}, and maps {@link PasskeyException} to an HTTP
@@ -32,13 +35,22 @@ public final class WebauthnAuthHandler implements HttpHandler {
 
   private static final Base64.Decoder B64URL = Base64.getUrlDecoder();
   private static final Base64.Encoder B64URL_ENC = Base64.getUrlEncoder().withoutPadding();
+  private static final String TICKET_HEADER = "X-Enrollment-Ticket";
 
   private final PasskeyCeremonies ceremonies;
+  private final EnrollmentTickets enrollment;
   private final ApiAuth auth;
+  private final String enrollOrigin;
 
-  public WebauthnAuthHandler(PasskeyCeremonies ceremonies, ApiAuth auth) {
+  public WebauthnAuthHandler(
+      PasskeyCeremonies ceremonies,
+      EnrollmentTickets enrollment,
+      ApiAuth auth,
+      String enrollOrigin) {
     this.ceremonies = ceremonies;
+    this.enrollment = enrollment;
     this.auth = Objects.requireNonNull(auth, "auth");
+    this.enrollOrigin = enrollOrigin;
   }
 
   @Override
@@ -76,6 +88,7 @@ public final class WebauthnAuthHandler implements HttpHandler {
     var path = exchange.getRequestURI().getPath();
     try {
       return switch (path) {
+        case "/v1/auth/register/ticket" -> registerTicket(exchange);
         case "/v1/auth/register/start" -> registerStart(exchange);
         case "/v1/auth/register/finish" -> registerFinish(exchange);
         case "/v1/auth/login/start" -> loginStart(exchange);
@@ -87,27 +100,76 @@ public final class WebauthnAuthHandler implements HttpHandler {
     }
   }
 
-  private ApiResponse registerStart(HttpExchange exchange) throws IOException {
+  private ApiResponse registerTicket(HttpExchange exchange) throws IOException {
     requireAdmin(exchange);
+    var ticket = enrollment.issue(requireString(JsonBody.readMap(exchange), "fde"));
+    var result = new LinkedHashMap<String, Object>();
+    result.put("ticket", ticket.ticket());
+    result.put("fde", ticket.fdeHandle());
+    result.put("expires_at", ticket.expiresAt());
+    if (enrollOrigin != null) {
+      result.put("enroll_url", enrollOrigin + "/enroll?ticket=" + ticket.ticket());
+    }
+    return ApiResponse.ok(result);
+  }
+
+  private ApiResponse registerStart(HttpExchange exchange) throws IOException {
     var body = JsonBody.readMap(exchange);
-    var ceremony = ceremonies.startRegistration(requireString(body, "fde"));
-    return ApiResponse.ok(ceremonyBody(ceremony));
+    var fdeHandle = authorizeEnrollmentStart(exchange, body);
+    return ApiResponse.ok(ceremonyBody(ceremonies.startRegistration(fdeHandle)));
   }
 
   private ApiResponse registerFinish(HttpExchange exchange) throws IOException {
-    requireAdmin(exchange);
     var body = JsonBody.readMap(exchange);
+    var ticket = enrollmentTicket(exchange);
+    if (ticket != null) {
+      requireLiveTicket(ticket);
+    } else {
+      requireAdmin(exchange);
+    }
     var registration =
         ceremonies.finishRegistration(
             requireString(body, "challenge_id"),
             decode(body, "client_data_json"),
             decode(body, "attestation_object"),
             optionalString(body, "label"));
+    if (ticket != null) {
+      enrollment.consume(ticket);
+    }
     var result = new LinkedHashMap<String, Object>();
     result.put("status", "registered");
     result.put("fde", registration.fdeHandle());
     result.put("credential_id", B64URL_ENC.encodeToString(registration.credentialId()));
     return ApiResponse.ok(result);
+  }
+
+  /**
+   * Authorizes a registration start: a valid {@code X-Enrollment-Ticket} binds the ceremony to the
+   * ticket's FDE; otherwise an authenticated {@link Capability#ADMIN} caller registers the FDE
+   * named in the body.
+   */
+  private String authorizeEnrollmentStart(HttpExchange exchange, Map<String, Object> body) {
+    var ticket = enrollmentTicket(exchange);
+    if (ticket != null) {
+      return enrollment.authorize(ticket).orElseThrow(WebauthnAuthHandler::ticketDenied);
+    }
+    requireAdmin(exchange);
+    return requireString(body, "fde");
+  }
+
+  private void requireLiveTicket(String ticket) {
+    if (enrollment.authorize(ticket).isEmpty()) {
+      throw ticketDenied();
+    }
+  }
+
+  private static String enrollmentTicket(HttpExchange exchange) {
+    var value = exchange.getRequestHeaders().getFirst(TICKET_HEADER);
+    return value == null || value.isBlank() ? null : value;
+  }
+
+  private static ApiException ticketDenied() {
+    return new ApiException(ErrorCode.FORBIDDEN, "Enrollment ticket is invalid or expired.");
   }
 
   private ApiResponse loginStart(HttpExchange exchange) throws IOException {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
@@ -5,9 +5,14 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.auth.EnrollmentService;
+import ai.singlr.sail.config.HostYaml;
+import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.store.EnrollmentTicketStore;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Files;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -23,7 +28,7 @@ import picocli.CommandLine.Spec;
     name = "fde",
     description = "Manage Forward Deployed Engineers (FDEs).",
     mixinStandardHelpOptions = true,
-    subcommands = {FdeCommand.Add.class, FdeCommand.ListFdes.class})
+    subcommands = {FdeCommand.Add.class, FdeCommand.ListFdes.class, FdeCommand.Enroll.class})
 public final class FdeCommand implements Runnable {
 
   @Override
@@ -85,6 +90,61 @@ public final class FdeCommand implements Runnable {
               }
             }
           });
+    }
+  }
+
+  @Command(
+      name = "enroll",
+      description = "Mint a one-time passkey enrollment ticket for an FDE.",
+      mixinStandardHelpOptions = true)
+  static final class Enroll implements Runnable {
+
+    @Parameters(index = "0", description = "FDE handle to enroll (must already exist).")
+    private String handle;
+
+    @Spec private CommandSpec spec;
+
+    @Override
+    public void run() {
+      CliCommand.run(
+          spec,
+          () -> {
+            try (var db = Sqlite.open(dbPath())) {
+              var ticket =
+                  new EnrollmentService(new EnrollmentTicketStore(db), new FdeStore(db))
+                      .issue(handle);
+              System.out.println(
+                  Ansi.AUTO.string(
+                      "  @|green ✓|@ Enrollment ticket for "
+                          + ticket.fdeHandle()
+                          + " (expires "
+                          + ticket.expiresAt()
+                          + "):"));
+              System.out.println("    " + ticket.ticket());
+              System.out.println();
+              var origin = enrollOrigin();
+              if (origin != null) {
+                System.out.println("  Open in a browser to enroll a passkey:");
+                System.out.println(
+                    Ansi.AUTO.string(
+                        "    @|cyan " + origin + "/enroll?ticket=" + ticket.ticket() + "|@"));
+              } else {
+                System.out.println(
+                    Ansi.AUTO.string(
+                        "  @|faint No webauthn origin configured; browse to"
+                            + " <origin>/enroll?ticket=<ticket>.|@"));
+              }
+            }
+          });
+    }
+
+    private static String enrollOrigin() throws Exception {
+      var path = SailPaths.hostConfigPath();
+      if (!Files.exists(path)) {
+        return null;
+      }
+      var webauthn = HostYaml.fromMap(YamlUtil.parseFile(path)).webauthn();
+      return webauthn.isConfigured() ? webauthn.origins().getFirst() : null;
     }
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -12,6 +12,7 @@ import ai.singlr.sail.api.ServerConnectionConfig;
 import ai.singlr.sail.api.SpecStoreAuditPersister;
 import ai.singlr.sail.api.TokenAuth;
 import ai.singlr.sail.api.WebauthnAuthHandler;
+import ai.singlr.sail.auth.EnrollmentService;
 import ai.singlr.sail.auth.PasskeyService;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.WebauthnConfig;
@@ -20,6 +21,7 @@ import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.store.AuthSessionStore;
 import ai.singlr.sail.store.DataMigration;
+import ai.singlr.sail.store.EnrollmentTicketStore;
 import ai.singlr.sail.store.EventStore;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.MigrationRunner;
@@ -140,8 +142,14 @@ public final class ServerStartCommand implements Runnable {
             new ShellExecutor(false), SailPaths.PROJECT_DESCRIPTOR, bus, persister, specStore);
 
     var webauthn = resolveWebauthn();
-    var passkeyService = webauthn.isConfigured() ? buildPasskeyService(db, webauthn) : null;
-    var passkeyHandler = new WebauthnAuthHandler(passkeyService, new TokenAuth(tokenStore));
+    var configured = webauthn.isConfigured();
+    var passkeyService = configured ? buildPasskeyService(db, webauthn) : null;
+    var enrollment =
+        configured ? new EnrollmentService(new EnrollmentTicketStore(db), new FdeStore(db)) : null;
+    var enrollOrigin = configured ? webauthn.origins().getFirst() : null;
+    var passkeyHandler =
+        new WebauthnAuthHandler(
+            passkeyService, enrollment, new TokenAuth(tokenStore), enrollOrigin);
 
     try (var server =
         new SailApiServer(host, port, operations, tokenStore, bus, persister, passkeyHandler)) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WebauthnAuthHandlerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WebauthnAuthHandlerTest.java
@@ -7,11 +7,14 @@ package ai.singlr.sail.api;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import ai.singlr.sail.auth.EnrollmentService;
+import ai.singlr.sail.auth.EnrollmentTickets;
 import ai.singlr.sail.auth.PasskeyCeremonies;
 import ai.singlr.sail.auth.PasskeyException;
 import ai.singlr.sail.auth.PasskeyService;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.store.AuthSessionStore;
+import ai.singlr.sail.store.EnrollmentTicketStore;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.PendingChallengeStore;
 import ai.singlr.sail.store.SchemaManager;
@@ -27,6 +30,7 @@ import java.net.http.HttpResponse;
 import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,6 +66,15 @@ class WebauthnAuthHandlerTest {
   }
 
   private void startWith(PasskeyCeremonies ceremonies) throws Exception {
+    startWith(
+        ceremonies,
+        ceremonies == null ? null : new FakeEnrollment(),
+        ceremonies == null ? null : ORIGIN);
+  }
+
+  private void startWith(
+      PasskeyCeremonies ceremonies, EnrollmentTickets enrollment, String enrollOrigin)
+      throws Exception {
     server =
         new SailApiServer(
             "127.0.0.1",
@@ -70,7 +83,8 @@ class WebauthnAuthHandlerTest {
             tokenStore,
             new EventBus(),
             null,
-            new WebauthnAuthHandler(ceremonies, new TokenAuth(tokenStore)));
+            new WebauthnAuthHandler(
+                ceremonies, enrollment, new TokenAuth(tokenStore), enrollOrigin));
     server.start();
   }
 
@@ -229,6 +243,77 @@ class WebauthnAuthHandlerTest {
   }
 
   @Test
+  void mintTicketRequiresAdmin() throws Exception {
+    startWith(new FakeCeremonies());
+    assertEquals(401, post("/v1/auth/register/ticket", null, "{\"fde\":\"uday\"}").statusCode());
+    assertEquals(
+        403, post("/v1/auth/register/ticket", viewerToken, "{\"fde\":\"uday\"}").statusCode());
+  }
+
+  @Test
+  void mintTicketReturnsTicketAndEnrollUrl() throws Exception {
+    startWith(new FakeCeremonies());
+    var response = post("/v1/auth/register/ticket", adminToken, "{\"fde\":\"uday\"}");
+    assertEquals(200, response.statusCode());
+    var body = YamlUtil.parseMap(response.body());
+    assertEquals("enr_fake", body.get("ticket"));
+    assertEquals("uday", body.get("fde"));
+    assertEquals(ORIGIN + "/enroll?ticket=enr_fake", body.get("enroll_url"));
+  }
+
+  @Test
+  void mintTicketMissingFdeIsRejected() throws Exception {
+    startWith(new FakeCeremonies());
+    assertEquals(422, post("/v1/auth/register/ticket", adminToken, "{}").statusCode());
+  }
+
+  @Test
+  void mintTicketUnknownFdeIsNotFound() throws Exception {
+    startWith(new FakeCeremonies());
+    assertEquals(
+        404, post("/v1/auth/register/ticket", adminToken, "{\"fde\":\"ghost\"}").statusCode());
+  }
+
+  @Test
+  void mintTicketOmitsUrlWhenOriginUnset() throws Exception {
+    startWith(new FakeCeremonies(), new FakeEnrollment(), null);
+    var body =
+        YamlUtil.parseMap(
+            post("/v1/auth/register/ticket", adminToken, "{\"fde\":\"uday\"}").body());
+    assertFalse(body.containsKey("enroll_url"));
+  }
+
+  @Test
+  void registerStartWithValidTicketNeedsNoToken() throws Exception {
+    startWith(new FakeCeremonies());
+    var response = postWithTicket("/v1/auth/register/start", "enr_valid", "{}");
+    assertEquals(200, response.statusCode());
+    assertEquals("wac_reg", YamlUtil.parseMap(response.body()).get("challenge_id"));
+  }
+
+  @Test
+  void registerStartWithInvalidTicketIsForbidden() throws Exception {
+    startWith(new FakeCeremonies());
+    assertEquals(403, postWithTicket("/v1/auth/register/start", "enr_bad", "{}").statusCode());
+  }
+
+  @Test
+  void registerFinishWithValidTicketSucceeds() throws Exception {
+    startWith(new FakeCeremonies());
+    var body =
+        "{\"challenge_id\":\"wac_reg\",\"client_data_json\":\"AAAA\",\"attestation_object\":\"AAAA\"}";
+    assertEquals(200, postWithTicket("/v1/auth/register/finish", "enr_valid", body).statusCode());
+  }
+
+  @Test
+  void registerFinishWithInvalidTicketIsForbidden() throws Exception {
+    startWith(new FakeCeremonies());
+    var body =
+        "{\"challenge_id\":\"wac_reg\",\"client_data_json\":\"AAAA\",\"attestation_object\":\"AAAA\"}";
+    assertEquals(403, postWithTicket("/v1/auth/register/finish", "enr_bad", body).statusCode());
+  }
+
+  @Test
   void realRoundTripEnrollsAndLogsIn() throws Exception {
     new FdeStore(db).add("uday", null, null);
     var service =
@@ -282,9 +367,102 @@ class WebauthnAuthHandlerTest {
         new AuthSessionStore(db).validate((String) session.get("session_token")).isPresent());
   }
 
+  @Test
+  void realTicketEnrollmentRoundTrip() throws Exception {
+    new FdeStore(db).add("uday", null, null);
+    var service =
+        new PasskeyService(
+            new RelyingParty(RP_ID, "Sail", Set.of(ORIGIN)),
+            new FdeStore(db),
+            new WebauthnCredentialStore(db),
+            new AuthSessionStore(db),
+            new PendingChallengeStore(db));
+    startWith(
+        service, new EnrollmentService(new EnrollmentTicketStore(db), new FdeStore(db)), ORIGIN);
+    var authenticator = new TestAuthenticator(RP_ID);
+
+    var mint =
+        YamlUtil.parseMap(
+            post("/v1/auth/register/ticket", adminToken, "{\"fde\":\"uday\"}").body());
+    var ticket = (String) mint.get("ticket");
+    assertEquals(ORIGIN + "/enroll?ticket=" + ticket, mint.get("enroll_url"));
+
+    var regStart =
+        YamlUtil.parseMap(postWithTicket("/v1/auth/register/start", ticket, "{}").body());
+    var registration = authenticator.register(challengeOf(regStart), ORIGIN);
+    var regFinish =
+        postWithTicket(
+            "/v1/auth/register/finish", ticket, registerFinishBody(regStart, registration));
+    assertEquals(200, regFinish.statusCode(), regFinish.body());
+
+    assertEquals(403, postWithTicket("/v1/auth/register/start", ticket, "{}").statusCode());
+
+    var loginStart = YamlUtil.parseMap(post("/v1/auth/login/start", null, "{}").body());
+    var assertion = authenticator.assertResponse(challengeOf(loginStart), ORIGIN);
+    var loginFinish = post("/v1/auth/login/finish", null, loginFinishBody(loginStart, assertion));
+    assertEquals(200, loginFinish.statusCode(), loginFinish.body());
+    assertEquals("uday", YamlUtil.parseMap(loginFinish.body()).get("fde"));
+  }
+
+  private HttpResponse<String> postWithTicket(String path, String ticket, String body)
+      throws Exception {
+    var builder = HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + server.port() + path));
+    builder.header("X-Enrollment-Ticket", ticket);
+    builder.header("Content-Type", "application/json");
+    builder.method("POST", HttpRequest.BodyPublishers.ofString(body));
+    return HttpClient.newHttpClient().send(builder.build(), HttpResponse.BodyHandlers.ofString());
+  }
+
+  private static String registerFinishBody(
+      Map<String, Object> regStart, TestAuthenticator.Registration registration) {
+    return "{\"challenge_id\":\""
+        + regStart.get("challenge_id")
+        + "\",\"client_data_json\":\""
+        + B64URL.encodeToString(registration.clientDataJson())
+        + "\",\"attestation_object\":\""
+        + B64URL.encodeToString(registration.attestationObject())
+        + "\"}";
+  }
+
+  private static String loginFinishBody(
+      Map<String, Object> loginStart, TestAuthenticator.Assertion assertion) {
+    return "{\"challenge_id\":\""
+        + loginStart.get("challenge_id")
+        + "\",\"credential_id\":\""
+        + B64URL.encodeToString(assertion.credentialId())
+        + "\",\"client_data_json\":\""
+        + B64URL.encodeToString(assertion.clientDataJson())
+        + "\",\"authenticator_data\":\""
+        + B64URL.encodeToString(assertion.authenticatorData())
+        + "\",\"signature\":\""
+        + B64URL.encodeToString(assertion.signature())
+        + "\"}";
+  }
+
   private static byte[] challengeOf(Map<String, Object> ceremony) {
     var publicKey = (Map<?, ?>) ceremony.get("public_key");
     return Base64.getUrlDecoder().decode((String) publicKey.get("challenge"));
+  }
+
+  private static final class FakeEnrollment implements EnrollmentTickets {
+
+    @Override
+    public Ticket issue(String fdeHandle) {
+      if ("ghost".equals(fdeHandle)) {
+        throw new PasskeyException(PasskeyException.Kind.NOT_FOUND, "no such fde");
+      }
+      return new Ticket("enr_fake", fdeHandle, "2026-06-01T00:00:00Z");
+    }
+
+    @Override
+    public Optional<String> authorize(String ticket) {
+      return "enr_valid".equals(ticket) ? Optional.of("uday") : Optional.empty();
+    }
+
+    @Override
+    public boolean consume(String ticket) {
+      return "enr_valid".equals(ticket);
+    }
   }
 
   private static final class FakeCeremonies implements PasskeyCeremonies {


### PR DESCRIPTION
## Brick 7d — enrollment tickets (and the bootstrap path)

A browser running `navigator.credentials.create()` cannot carry an operator API token, so passkey **registration** needs a credential a browser *can* hold. This adds **enrollment tickets**: one-time, FDE-bound, short-lived (15 min), SHA-256-hashed at rest (like API tokens and sessions).

### What's new
- **`EnrollmentTicketStore`** (`enrollment_tickets` table, append-only migration) — `issue` / `validate` (JOINs `fdes` to return the handle) / single-shot `consume`; expired tickets pruned on lookup.
- **`EnrollmentTickets`** interface + **`EnrollmentService`** — resolves an FDE handle, issues/authorizes/consumes.
- **`WebauthnAuthHandler`**:
  - `register/start` & `register/finish` now authorize via an **`X-Enrollment-Ticket`** header (the ticket binds the ceremony to its FDE; `finish` consumes it) **or** an `ADMIN` token. Both paths kept.
  - New **`POST /v1/auth/register/ticket`** (ADMIN) mints a ticket and returns an `enroll_url` at the configured RP origin.
- **`sail fde enroll <handle>`** — host-side command that mints a ticket against the control-plane DB and prints the enroll URL (origin read from `host.yaml`).
- `ServerStartCommand` builds the `EnrollmentService` and passes the primary RP origin when passkeys are configured.

### Bootstrap (resolves the chicken-and-egg)
Registration is ADMIN-gated, but `sail server start` already creates an admin API token on the host. So the first passkey is enrolled with no special bootstrap token:
```
sail fde add uday          # create the FDE
sail fde enroll uday       # mint a ticket → prints https://<origin>/enroll?ticket=…
# open that URL in a browser to create the passkey (web page lands in brick 7c)
```

### Testing
- Store + service unit tests (issue/validate/consume, expiry, single-shot, unknown FDE).
- Handler: ticket-auth paths (valid/invalid ticket for start & finish), mint endpoint (admin-gated, unknown FDE → 404, enroll_url present/omitted), and a **real ticket-based enrollment→login round-trip over HTTP** (mint → enroll via ticket → reuse rejected → login issues a session).
- **100% line/method on the new `api.*` classes**; full suite green (sail-core + sail-infra); all JaCoCo gates met. **No new dependencies.**

### Remaining in brick 7
- 7c — the web pages (`/enroll`, `/login`) served at the RP origin that actually run `navigator.credentials`, plus `sail login` with a loopback callback.