### PR TITLE
Session authentication + FDE roles (brick 7c-0) — 0.13.42

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.41</version>
+    <version>0.13.42</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.41</version>
+        <version>0.13.42</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Forward Deployed Engineers — the human principals that own API tokens and are attributed on the
@@ -24,26 +25,42 @@ public final class FdeStore {
     this.db = db;
   }
 
+  public static final String DEFAULT_ROLE = "member";
+  private static final Set<String> ROLES = Set.of("admin", "member", "viewer");
+
   public record Fde(
       String id,
       String handle,
       String displayName,
       String email,
+      String role,
       String status,
       String createdAt) {}
 
-  /**
-   * Creates an FDE with a generated id and {@code active} status. Throws if the handle is taken.
-   */
+  /** Creates an FDE with the default {@code member} role. */
   public Fde add(String handle, String displayName, String email) {
-    var fde = new Fde(generateId(), handle, displayName, email, "active", Instant.now().toString());
+    return add(handle, displayName, email, DEFAULT_ROLE);
+  }
+
+  /**
+   * Creates an FDE with a generated id and {@code active} status. Throws if the handle is taken or
+   * the role is not one of {@code admin}, {@code member}, {@code viewer}.
+   */
+  public Fde add(String handle, String displayName, String email, String role) {
+    if (!ROLES.contains(role)) {
+      throw new IllegalArgumentException(
+          "Invalid role: " + role + ". Must be one of " + ROLES + ".");
+    }
+    var fde =
+        new Fde(generateId(), handle, displayName, email, role, "active", Instant.now().toString());
     db.execute(
-        "INSERT INTO fdes (id, handle, display_name, email, status, created_at)"
-            + " VALUES (?, ?, ?, ?, ?, ?)",
+        "INSERT INTO fdes (id, handle, display_name, email, role, status, created_at)"
+            + " VALUES (?, ?, ?, ?, ?, ?, ?)",
         fde.id(),
         fde.handle(),
         fde.displayName(),
         fde.email(),
+        fde.role(),
         fde.status(),
         fde.createdAt());
     return fde;
@@ -62,10 +79,11 @@ public final class FdeStore {
   }
 
   private static final String SELECT =
-      "SELECT id, handle, display_name, email, status, created_at FROM fdes";
+      "SELECT id, handle, display_name, email, role, status, created_at FROM fdes";
 
   private static Fde map(Sqlite.Row row) {
-    return new Fde(row.text(0), row.text(1), row.text(2), row.text(3), row.text(4), row.text(5));
+    return new Fde(
+        row.text(0), row.text(1), row.text(2), row.text(3), row.text(4), row.text(5), row.text(6));
   }
 
   private static String generateId() {

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -225,7 +225,8 @@ public final class SchemaManager {
               created_at TEXT NOT NULL,
               expires_at TEXT NOT NULL,
               consumed_at TEXT
-          )""");
+          )""",
+          "ALTER TABLE fdes ADD COLUMN role TEXT NOT NULL DEFAULT 'member'");
 
   private final Sqlite db;
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/FdeStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FdeStoreTest.java
@@ -38,7 +38,19 @@ class FdeStoreTest {
     assertEquals("uday", fde.handle());
     assertEquals("Uday Chandra", fde.displayName());
     assertEquals("uday@singlr.ai", fde.email());
+    assertEquals("member", fde.role());
     assertEquals("active", fde.status());
+  }
+
+  @Test
+  void addStoresAndRoundTripsExplicitRole() {
+    store.add("admin-user", null, null, "admin");
+    assertEquals("admin", store.byHandle("admin-user").orElseThrow().role());
+  }
+
+  @Test
+  void addRejectsUnknownRole() {
+    assertThrows(IllegalArgumentException.class, () -> store.add("bad", null, null, "superuser"));
   }
 
   @Test

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.41</version>
+        <version>0.13.42</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.41</version>
+        <version>0.13.42</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiServer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiServer.java
@@ -109,7 +109,12 @@ public final class SailApiServer implements AutoCloseable {
     this(host, port, operations, auth, eventBus, auditSubscriber, socketPath, null);
   }
 
-  SailApiServer(
+  /**
+   * Full control-plane constructor with a caller-supplied {@link ApiAuth} (e.g. {@link
+   * SessionAwareAuth}, which accepts both login sessions and API tokens), the UDS path, and the
+   * passkey endpoints mounted at {@code /v1/auth} when {@code passkeyHandler} is non-null.
+   */
+  public SailApiServer(
       String host,
       int port,
       ApiOperations operations,

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SessionAwareAuth.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SessionAwareAuth.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.store.AuthSessionStore;
+import ai.singlr.sail.store.FdeStore;
+import com.sun.net.httpserver.HttpExchange;
+import java.util.Objects;
+
+/**
+ * Accepts two kinds of bearer credential. A token prefixed {@code sess_} is a login session minted
+ * by the passkey/OIDC flow: it is resolved against the {@link AuthSessionStore}, mapped to its FDE,
+ * and the FDE's role is stamped on the exchange so {@link Authorizer} governs it exactly like a
+ * token's role. Anything else is delegated to the wrapped {@link ApiAuth} (the machine/CI {@code
+ * api_tokens} path). The exchange attributes ({@code token.name}, {@code token.fde}, {@code
+ * token.role}) are identical in shape across both paths, so every downstream consumer —
+ * attribution, authorization, {@code --assignee me} — is unaffected by which credential
+ * authenticated the call.
+ */
+public final class SessionAwareAuth implements ApiAuth {
+
+  private static final String BEARER = "Bearer ";
+  private static final String SESSION_PREFIX = "sess_";
+
+  private final AuthSessionStore sessions;
+  private final FdeStore fdes;
+  private final ApiAuth tokenAuth;
+
+  public SessionAwareAuth(AuthSessionStore sessions, FdeStore fdes, ApiAuth tokenAuth) {
+    this.sessions = Objects.requireNonNull(sessions, "sessions");
+    this.fdes = Objects.requireNonNull(fdes, "fdes");
+    this.tokenAuth = Objects.requireNonNull(tokenAuth, "tokenAuth");
+  }
+
+  @Override
+  public void require(HttpExchange exchange) {
+    var headers = exchange.getRequestHeaders().get("Authorization");
+    if (headers != null && headers.size() == 1) {
+      var header = headers.getFirst();
+      if (header.startsWith(BEARER + SESSION_PREFIX)) {
+        authenticateSession(exchange, header.substring(BEARER.length()));
+        return;
+      }
+    }
+    tokenAuth.require(exchange);
+  }
+
+  private void authenticateSession(HttpExchange exchange, String token) {
+    var fde =
+        sessions
+            .validate(token)
+            .flatMap(session -> fdes.byId(session.fdeId()))
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.INVALID_BEARER_TOKEN, "Session token is invalid or expired."));
+    exchange.setAttribute("token.name", fde.handle());
+    exchange.setAttribute("token.fde", fde.handle());
+    exchange.setAttribute("token.role", fde.role());
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
@@ -52,6 +52,12 @@ public final class FdeCommand implements Runnable {
     @Option(names = "--email", description = "Email address.")
     private String email;
 
+    @Option(
+        names = "--role",
+        description = "Authorization role: admin, member, or viewer.",
+        defaultValue = FdeStore.DEFAULT_ROLE)
+    private String role;
+
     @Spec private CommandSpec spec;
 
     @Override
@@ -60,8 +66,10 @@ public final class FdeCommand implements Runnable {
           spec,
           () -> {
             try (var db = Sqlite.open(dbPath())) {
-              var fde = new FdeStore(db).add(handle, displayName, email);
-              System.out.println(Ansi.AUTO.string("  @|green ✓|@ FDE added: " + fde.handle()));
+              var fde = new FdeStore(db).add(handle, displayName, email, role);
+              System.out.println(
+                  Ansi.AUTO.string(
+                      "  @|green ✓|@ FDE added: " + fde.handle() + " (" + fde.role() + ")"));
             }
           });
     }
@@ -85,8 +93,11 @@ public final class FdeCommand implements Runnable {
               }
               for (var fde : fdes) {
                 System.out.printf(
-                    "  %-16s  %-20s  %s%n",
-                    fde.handle(), fde.displayName() == null ? "" : fde.displayName(), fde.status());
+                    "  %-16s  %-20s  %-8s  %s%n",
+                    fde.handle(),
+                    fde.displayName() == null ? "" : fde.displayName(),
+                    fde.role(),
+                    fde.status());
               }
             }
           });

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -9,6 +9,7 @@ import ai.singlr.sail.api.EventBus;
 import ai.singlr.sail.api.SailApiOperations;
 import ai.singlr.sail.api.SailApiServer;
 import ai.singlr.sail.api.ServerConnectionConfig;
+import ai.singlr.sail.api.SessionAwareAuth;
 import ai.singlr.sail.api.SpecStoreAuditPersister;
 import ai.singlr.sail.api.TokenAuth;
 import ai.singlr.sail.api.WebauthnAuthHandler;
@@ -150,9 +151,19 @@ public final class ServerStartCommand implements Runnable {
     var passkeyHandler =
         new WebauthnAuthHandler(
             passkeyService, enrollment, new TokenAuth(tokenStore), enrollOrigin);
+    var auth =
+        new SessionAwareAuth(new AuthSessionStore(db), new FdeStore(db), new TokenAuth(tokenStore));
 
     try (var server =
-        new SailApiServer(host, port, operations, tokenStore, bus, persister, passkeyHandler)) {
+        new SailApiServer(
+            host,
+            port,
+            operations,
+            auth,
+            bus,
+            persister,
+            SailPaths.apiSocketPath(),
+            passkeyHandler)) {
       server.start();
       System.out.println(
           Ansi.AUTO.string(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SessionAwareAuthTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SessionAwareAuthTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sail.store.AuthSessionStore;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import ai.singlr.sail.store.TokenStore;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SessionAwareAuthTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private FdeStore fdes;
+  private AuthSessionStore sessions;
+  private TokenStore tokenStore;
+  private SailApiServer server;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    fdes = new FdeStore(db);
+    sessions = new AuthSessionStore(db);
+    tokenStore = new TokenStore(db);
+    var auth = new SessionAwareAuth(sessions, fdes, new TokenAuth(tokenStore));
+    server =
+        new SailApiServer(
+            "127.0.0.1", 0, new TestOperations(), auth, new EventBus(), null, null, null);
+    server.start();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (server != null) server.close();
+    if (db != null) db.close();
+  }
+
+  private String sessionFor(String handle, String role) {
+    var fde = fdes.add(handle, null, null, role);
+    return sessions.create(fde.id(), Duration.ofMinutes(30)).token();
+  }
+
+  @Test
+  void adminSessionCanReadAndWrite() throws Exception {
+    var session = sessionFor("admin-fde", "admin");
+    assertEquals(200, send("GET", "/v1/specs/board", session).statusCode());
+    assertNotEquals(403, send("POST", "/v1/specs", session).statusCode());
+  }
+
+  @Test
+  void viewerSessionCanReadButNotWrite() throws Exception {
+    var session = sessionFor("viewer-fde", "viewer");
+    assertEquals(200, send("GET", "/v1/specs/board", session).statusCode());
+    assertEquals(403, send("POST", "/v1/specs", session).statusCode());
+  }
+
+  @Test
+  void apiTokenStillAuthenticatesViaDelegate() throws Exception {
+    var token = tokenStore.create("ci-bot", "member").token();
+    assertEquals(200, send("GET", "/v1/specs/board", token).statusCode());
+  }
+
+  @Test
+  void invalidSessionTokenIsRejected() throws Exception {
+    assertEquals(403, send("GET", "/v1/specs/board", "sess_bogus").statusCode());
+  }
+
+  @Test
+  void missingTokenDelegatesAndIsUnauthorized() throws Exception {
+    assertEquals(401, send("GET", "/v1/specs/board", null).statusCode());
+  }
+
+  @Test
+  void duplicateAuthorizationHeadersDelegateAndAreRejected() throws Exception {
+    var session = sessionFor("dup-fde", "admin");
+    var request =
+        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + server.port() + "/v1/specs/board"))
+            .header("Authorization", "Bearer " + session)
+            .header("Authorization", "Bearer " + session)
+            .GET()
+            .build();
+    var response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+    assertEquals(403, response.statusCode());
+  }
+
+  private HttpResponse<String> send(String method, String path, String token) throws Exception {
+    var builder = HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + server.port() + path));
+    if (token != null) {
+      builder.header("Authorization", "Bearer " + token);
+    }
+    builder.header("Content-Type", "application/json");
+    builder.method(
+        method,
+        "POST".equals(method)
+            ? HttpRequest.BodyPublishers.ofString("{}")
+            : HttpRequest.BodyPublishers.noBody());
+    return HttpClient.newHttpClient().send(builder.build(), HttpResponse.BodyHandlers.ofString());
+  }
+}


### PR DESCRIPTION
## Brick 7c-0 — sessions become real API credentials

The passkey login ceremony (brick 7b) mints a **session token**, but `TokenAuth` only validated bearer tokens against `api_tokens` — so a logged-in session could not actually call the API. This brick closes that gap: it makes login sessions first-class API credentials, governed by the FDE's role. It is the keystone that makes `sail login` (next) meaningful.

### What's new
- **`fdes.role`** column (append-only migration, default `member`). `FdeStore` carries `role`, validates it against `admin`/`member`/`viewer`, and gains an `add(handle, displayName, email, role)` overload (the 3-arg form defaults to `member`).
- **`sail fde add --role`**; **`sail fde list`** shows the role.
- **`SessionAwareAuth`** (`ApiAuth`): a `Bearer sess_…` token is resolved via `AuthSessionStore` → its FDE, stamping `token.name` / `token.fde` / `token.role` on the exchange **exactly like the api_tokens path**. So `Authorizer`, attribution, and `--assignee me` behave identically regardless of which credential authenticated the call. Anything else delegates to `TokenAuth`. Invalid/expired sessions → 403.
- `SailApiServer` gains a public `(…, ApiAuth, …, socketPath, passkeyHandler)` constructor; `ServerStartCommand` wires `SessionAwareAuth` over the session + FDE stores.

### Effect
```
sail login            # (brick 7c) → session token
# subsequent API calls authenticate as the FDE, bounded by its role:
#   viewer → read, member → read+write, admin → +administration
```

### Testing
- `FdeStore` role round-trip + invalid-role rejection.
- `SessionAwareAuth`: admin session reads+writes; viewer session reads but is 403 on write; api-token delegation still works; invalid session → 403; missing token → 401; duplicate `Authorization` headers rejected.
- **100% line/method on the new `api.*` class**; full suite green (sail-core + sail-infra); all JaCoCo gates met. **No new dependencies.**

### Remaining in brick 7
- 7c-1 — web pages (`/login`, `/enroll`) served at the RP origin that run `navigator.credentials`.
- 7c-2 — `sail login` with a loopback callback that captures the session token.