### PR TITLE
sail login with loopback callback (brick 7c-2) — 0.13.44

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.43</version>
+    <version>0.13.44</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.43</version>
+        <version>0.13.44</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.43</version>
+        <version>0.13.44</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.43</version>
+        <version>0.13.44</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/Sail.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/Sail.java
@@ -10,6 +10,7 @@ import ai.singlr.sail.commands.ClientInitCommand;
 import ai.singlr.sail.commands.EventsCommand;
 import ai.singlr.sail.commands.FdeCommand;
 import ai.singlr.sail.commands.HostCommand;
+import ai.singlr.sail.commands.LoginCommand;
 import ai.singlr.sail.commands.MigrateCommand;
 import ai.singlr.sail.commands.ProjectCommand;
 import ai.singlr.sail.commands.ServerCommand;
@@ -31,6 +32,7 @@ import picocli.CommandLine.Help.Ansi;
       ProjectCommand.class,
       ServerCommand.class,
       FdeCommand.class,
+      LoginCommand.class,
       SpecCommand.class,
       AgentCommand.class,
       EventsCommand.class,

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ServerConnectionConfig.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ServerConnectionConfig.java
@@ -62,6 +62,21 @@ public record ServerConnectionConfig(String serverUrl, String token) {
     saveLocalConfig(DEFAULT_URL, token, configPath);
   }
 
+  /**
+   * Persists a login {@code token} (typically a session minted by {@code sail login}) while
+   * preserving the existing configured server URL, so signing in does not repoint the CLI.
+   */
+  public static void saveSessionToken(String token, Path configPath) throws IOException {
+    var serverUrl = DEFAULT_URL;
+    if (Files.exists(configPath)) {
+      var existing = (String) YamlUtil.parseFile(configPath).get("server");
+      if (existing != null && !existing.isBlank()) {
+        serverUrl = existing;
+      }
+    }
+    saveLocalConfig(serverUrl, token, configPath);
+  }
+
   public static void saveLocalConfig(String serverUrl, String token, Path configPath)
       throws IOException {
     var yaml = "server: " + serverUrl + "\ntoken: " + token + "\n";

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/LoginCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/LoginCommand.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.api.ServerConnectionConfig;
+import ai.singlr.sail.config.HostYaml;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.SailPaths;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Spec;
+
+/**
+ * Signs in with a passkey and stores the resulting session token. Opens the control-plane {@code
+ * /login} page in a browser (the passkey ceremony must run at the Relying Party origin), passing a
+ * loopback {@code /callback} as the redirect target and a one-time {@code state} nonce; the page
+ * redirects the minted session token back to that loopback, which this command captures and writes
+ * to the client config so subsequent {@code sail} calls authenticate as the FDE.
+ */
+@Command(
+    name = "login",
+    description = "Sign in with a passkey and store a session token.",
+    mixinStandardHelpOptions = true)
+public final class LoginCommand implements Runnable {
+
+  @Option(
+      names = "--origin",
+      description =
+          "Control-plane origin, e.g. https://sail.example.dev. Defaults to the configured"
+              + " webauthn origin from host.yaml.")
+  private String origin;
+
+  @Option(
+      names = "--timeout",
+      description = "Seconds to wait for the browser sign-in to complete.",
+      defaultValue = "180")
+  private int timeoutSeconds;
+
+  @Spec private CommandSpec spec;
+
+  @Override
+  public void run() {
+    CliCommand.run(
+        spec,
+        () -> {
+          var resolvedOrigin = origin != null ? origin : configuredOrigin();
+          if (resolvedOrigin == null) {
+            throw new IllegalArgumentException(
+                "No control-plane origin. Pass --origin or configure the webauthn block in"
+                    + " host.yaml.");
+          }
+          var state = randomState();
+          try (var callback = new LoopbackCallbackServer(state)) {
+            callback.start();
+            var url =
+                resolvedOrigin
+                    + "/login?redirect_uri="
+                    + URLEncoder.encode(callback.redirectUri(), StandardCharsets.UTF_8)
+                    + "&state="
+                    + state;
+            System.out.println("  Opening your browser to sign in:");
+            System.out.println(Ansi.AUTO.string("    @|cyan " + url + "|@"));
+            openBrowser(url);
+            System.out.println("  Waiting for sign-in to complete…");
+            var token = callback.awaitToken(Duration.ofSeconds(timeoutSeconds));
+            var configPath = SailPaths.clientConfigPath();
+            ServerConnectionConfig.saveSessionToken(token, configPath);
+            System.out.println(
+                Ansi.AUTO.string("  @|green ✓|@ Signed in. Session saved to " + configPath));
+          }
+        });
+  }
+
+  private static String configuredOrigin() throws IOException {
+    var path = SailPaths.hostConfigPath();
+    if (!Files.exists(path)) {
+      return null;
+    }
+    var webauthn = HostYaml.fromMap(YamlUtil.parseFile(path)).webauthn();
+    return webauthn.isConfigured() ? webauthn.origins().getFirst() : null;
+  }
+
+  private static void openBrowser(String url) {
+    var os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+    var command = os.contains("mac") ? List.of("open", url) : List.of("xdg-open", url);
+    try {
+      new ProcessBuilder(command).start();
+    } catch (IOException ignored) {
+      System.out.println("  (Could not open a browser automatically — open the URL above.)");
+    }
+  }
+
+  private static String randomState() {
+    var bytes = new byte[16];
+    new SecureRandom().nextBytes(bytes);
+    return HexFormat.of().formatHex(bytes);
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/LoopbackCallbackServer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/LoopbackCallbackServer.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A short-lived loopback HTTP listener that receives the session token from a browser passkey
+ * login. {@code sail login} opens the browser at the control-plane {@code /login} page passing this
+ * listener's {@code /callback} as the redirect target and an opaque {@code state} nonce; the page
+ * redirects back with the minted token. The token is accepted only when the returned {@code state}
+ * matches the one issued, so a stale or forged callback cannot inject a token. Binds {@code
+ * 127.0.0.1} only — never reachable off the machine.
+ */
+public final class LoopbackCallbackServer implements AutoCloseable {
+
+  private static final String DONE_PAGE =
+      """
+      <!doctype html><meta charset="utf-8"><title>Sail</title>
+      <body style="font-family:system-ui,sans-serif;max-width:32rem;margin:4rem auto">
+      <h1>Signed in to Sail</h1><p>You can close this tab and return to the terminal.</p></body>
+      """;
+  private static final String ERROR_PAGE =
+      """
+      <!doctype html><meta charset="utf-8"><title>Sail</title>
+      <body style="font-family:system-ui,sans-serif;max-width:32rem;margin:4rem auto">
+      <h1>Login could not be completed</h1><p>Return to the terminal and try again.</p></body>
+      """;
+
+  private final HttpServer server;
+  private final String state;
+  private final CompletableFuture<String> token = new CompletableFuture<>();
+
+  public LoopbackCallbackServer(String state) throws IOException {
+    this.state = state;
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/callback", this::handle);
+  }
+
+  public void start() {
+    server.start();
+  }
+
+  public int port() {
+    return server.getAddress().getPort();
+  }
+
+  /** The loopback URL the login page must redirect the token back to. */
+  public String redirectUri() {
+    return "http://127.0.0.1:" + port() + "/callback";
+  }
+
+  /**
+   * Blocks until a valid callback arrives, or throws {@link TimeoutException} after {@code wait}.
+   */
+  public String awaitToken(Duration wait)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return token.get(wait.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  private void handle(HttpExchange exchange) throws IOException {
+    var query = parseQuery(exchange.getRequestURI().getRawQuery());
+    var received = query.get("token");
+    var accepted = state.equals(query.get("state")) && received != null && !received.isBlank();
+    var body = accepted ? DONE_PAGE : ERROR_PAGE;
+    var bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().set("Content-Type", "text/html; charset=utf-8");
+    exchange.sendResponseHeaders(accepted ? 200 : 400, bytes.length);
+    try (var output = exchange.getResponseBody()) {
+      output.write(bytes);
+    }
+    exchange.close();
+    if (accepted) {
+      token.complete(received);
+    }
+  }
+
+  @Override
+  public void close() {
+    server.stop(0);
+  }
+
+  private static Map<String, String> parseQuery(String raw) {
+    var values = new LinkedHashMap<String, String>();
+    if (raw == null || raw.isBlank()) {
+      return values;
+    }
+    for (var part : raw.split("&")) {
+      var separator = part.indexOf('=');
+      if (separator >= 0) {
+        values.put(
+            URLDecoder.decode(part.substring(0, separator), StandardCharsets.UTF_8),
+            URLDecoder.decode(part.substring(separator + 1), StandardCharsets.UTF_8));
+      }
+    }
+    return values;
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ServerConnectionConfigTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ServerConnectionConfigTest.java
@@ -36,6 +36,25 @@ class ServerConnectionConfigTest {
   }
 
   @Test
+  void saveSessionTokenPreservesExistingServerUrl() throws IOException {
+    var configPath = tempDir.resolve("config.yaml");
+    ServerConnectionConfig.saveLocalConfig("https://sail.acme.dev", "sail_old", configPath);
+    ServerConnectionConfig.saveSessionToken("sess_new", configPath);
+    var resolved = ServerConnectionConfig.resolve(null, null, configPath);
+    assertEquals("https://sail.acme.dev", resolved.serverUrl());
+    assertEquals("sess_new", resolved.token());
+  }
+
+  @Test
+  void saveSessionTokenDefaultsServerUrlWhenNoConfig() throws IOException {
+    var configPath = tempDir.resolve("fresh-config.yaml");
+    ServerConnectionConfig.saveSessionToken("sess_new", configPath);
+    var resolved = ServerConnectionConfig.resolve(null, null, configPath);
+    assertEquals("http://localhost:7070", resolved.serverUrl());
+    assertEquals("sess_new", resolved.token());
+  }
+
+  @Test
   void defaultUrlIsLocalhostWhenNotProvided() throws IOException {
     var config = ServerConnectionConfig.resolve(null, "some-token", missingConfig());
     assertEquals("http://localhost:7070", config.serverUrl());

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
@@ -20,8 +20,8 @@ class CommandTaxonomyTest {
 
     assertEquals(
         Set.of(
-            "init", "host", "project", "server", "fde", "spec", "agent", "events", "migrate",
-            "upgrade"),
+            "init", "host", "project", "server", "fde", "login", "spec", "agent", "events",
+            "migrate", "upgrade"),
         command.getSubcommands().keySet());
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/LoopbackCallbackServerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/LoopbackCallbackServerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LoopbackCallbackServerTest {
+
+  private LoopbackCallbackServer callback;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    callback = new LoopbackCallbackServer("state-nonce");
+    callback.start();
+  }
+
+  @AfterEach
+  void tearDown() {
+    callback.close();
+  }
+
+  private HttpResponse<String> hit(String query) throws Exception {
+    var request =
+        HttpRequest.newBuilder(URI.create(callback.redirectUri() + "?" + query)).GET().build();
+    return HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  @Test
+  void validCallbackCompletesWithToken() throws Exception {
+    var response = hit("token=sess_abc&state=state-nonce");
+    assertEquals(200, response.statusCode());
+    assertTrue(response.body().contains("Signed in"));
+    assertEquals("sess_abc", callback.awaitToken(Duration.ofSeconds(5)));
+  }
+
+  @Test
+  void redirectUriIsLoopback() {
+    assertTrue(callback.redirectUri().startsWith("http://127.0.0.1:"));
+    assertTrue(callback.redirectUri().endsWith("/callback"));
+  }
+
+  @Test
+  void mismatchedStateIsRejectedButRecovers() throws Exception {
+    assertEquals(400, hit("token=sess_evil&state=wrong").statusCode());
+    assertEquals(200, hit("token=sess_good&state=state-nonce").statusCode());
+    assertEquals("sess_good", callback.awaitToken(Duration.ofSeconds(5)));
+  }
+
+  @Test
+  void missingTokenIsRejected() throws Exception {
+    assertEquals(400, hit("state=state-nonce").statusCode());
+  }
+}


### PR DESCRIPTION
## Brick 7c-2 — `sail login`

Closes the passkey loop: one command signs in with a passkey and stores the session token, automating the browser hand-off the `/login` page (brick 7c-1) already supports — the same pattern as `gh auth login` / `kubectl oidc-login`.

### What's new
- **`LoopbackCallbackServer`** — a `127.0.0.1`-only listener that receives the session token the login page redirects back. Accepts the token **only when the returned `state` nonce matches** the one issued (a stale or forged callback can't inject a token), and is never reachable off the machine.
- **`sail login`** — resolves the control-plane origin (`--origin`, else the `host.yaml` webauthn origin), starts the callback listener, opens the browser to `<origin>/login?redirect_uri=<loopback>&state=<nonce>`, waits (default 180s), and writes the captured session token to the client config via `ServerConnectionConfig.saveSessionToken` (preserving the configured server URL).
- Registered as a root `sail` command.

### The full passkey flow now works end to end
```
sail fde add uday --role admin
sail fde enroll uday        # → https://<origin>/enroll?ticket=…   (browser: create passkey)
sail login                  # → opens browser, touch passkey, session saved
sail spec list              # authenticates as uday, authorized by role
```

### Testing
- `LoopbackCallbackServer`: valid callback completes with the token; mismatched `state` rejected (400) and recovers; missing token rejected; redirect URI is loopback. 
- `ServerConnectionConfig.saveSessionToken`: preserves an existing server URL; defaults when absent (**100% `api.*`**).
- `CommandTaxonomyTest` updated for the new root command. Full suite green (1498 infra tests); all JaCoCo gates met. **No new dependencies.**
- Note: `LoginCommand`'s browser-open + blocking orchestration is exercised manually/E2E (consistent with other CLI commands); its core (`LoopbackCallbackServer`) is fully unit-tested.

### Passkey arc complete
Bricks 1–6 (WebAuthn engine) → 7a (storage) → 7b (API) → 7d (enrollment tickets) → 7c-0 (session auth) → 7c-1 (web pages) → **7c-2 (`sail login`)**. Native passkey login is now usable end to end, pure-JDK, zero new dependencies.