### PR TITLE
Fix migrate ordering (schema before spec import) + progress spinner — 0.13.45

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.44</version>
+    <version>0.13.45</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.44</version>
+        <version>0.13.45</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.44</version>
+        <version>0.13.45</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.44</version>
+        <version>0.13.45</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -9,6 +9,7 @@ import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerSpecImporter;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.engine.Spinner;
 import ai.singlr.sail.store.DataMigration;
 import ai.singlr.sail.store.DataMigrator;
 import ai.singlr.sail.store.MigrationRunner;
@@ -79,20 +80,48 @@ public final class MigrateCommand implements Runnable {
     try (var db = Sqlite.open(dbPath)) {
       var prompter = nonInteractive ? DataMigration.Prompter.NON_INTERACTIVE : ttyPrompter();
       var shell = new ShellExecutor(false);
-      var importReport =
+      var importer =
           new ContainerSpecImporter(
-                  shell, new ContainerManager(shell), new SpecStore(db), SailPaths.projectsDir())
-              .importAll();
-      var result = MigrationRunner.applyAll(db, REGISTRY, prompter);
-      if (!jsonOutput) {
-        printSummary(
-            dbPath.toString(),
-            result.schemaBefore(),
-            result.schemaAfter(),
-            importReport,
-            result.dataRuns());
-      }
-      return result.dataRuns();
+              shell, new ContainerManager(shell), new SpecStore(db), SailPaths.projectsDir());
+      var animate = !jsonOutput && System.console() != null;
+      return applyMigrations(
+          db, dbPath.toString(), importer::importAll, prompter, animate, jsonOutput);
+    }
+  }
+
+  /**
+   * Applies schema migrations first, then imports specs from project containers. The order is
+   * load-bearing: the spec importer queries {@code specs} through {@link SpecStore}, whose SELECT
+   * lists the running binary's columns, so the on-disk schema must be brought current before the
+   * import runs — otherwise an upgrade that added a spec column fails the import with an "unknown
+   * column" error before the schema catches up. Visible for tests to lock that ordering.
+   */
+  static List<DataMigrator.Run> applyMigrations(
+      Sqlite db,
+      String dbPath,
+      java.util.function.Supplier<ContainerSpecImporter.Report> specImport,
+      DataMigration.Prompter prompter,
+      boolean animate,
+      boolean jsonOutput) {
+    var result =
+        phase(
+            animate,
+            "Migrating database schema",
+            () -> MigrationRunner.applyAll(db, REGISTRY, prompter));
+    var importReport = phase(animate, "Probing project containers for specs", specImport);
+    if (!jsonOutput) {
+      printSummary(
+          dbPath, result.schemaBefore(), result.schemaAfter(), importReport, result.dataRuns());
+    }
+    return result.dataRuns();
+  }
+
+  private static <T> T phase(boolean animate, String message, java.util.function.Supplier<T> work) {
+    if (!animate) {
+      return work.get();
+    }
+    try (var ignored = Spinner.start(System.out, message)) {
+      return work.get();
     }
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sail.engine.ContainerSpecImporter;
+import ai.singlr.sail.store.DataMigration;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MigrateCommandTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  @Test
+  void schemaIsFullyMigratedBeforeSpecImportRuns() {
+    var versionWhenImportRan = new AtomicInteger(-1);
+
+    MigrateCommand.applyMigrations(
+        db,
+        "test.db",
+        () -> {
+          versionWhenImportRan.set(new SchemaManager(db).currentVersion());
+          return ContainerSpecImporter.Report.empty();
+        },
+        DataMigration.Prompter.NON_INTERACTIVE,
+        false,
+        true);
+
+    var finalVersion = new SchemaManager(db).currentVersion();
+    assertTrue(finalVersion > 0, "schema should have migrated from empty");
+    assertEquals(
+        finalVersion,
+        versionWhenImportRan.get(),
+        "schema must be fully migrated before the spec import queries SpecStore");
+  }
+
+  @Test
+  void specImportSeesCurrentSchemaColumns() {
+    MigrateCommand.applyMigrations(
+        db,
+        "test.db",
+        () -> {
+          assertDoesNotThrow(() -> new ai.singlr.sail.store.SpecStore(db).findById("none"));
+          return ContainerSpecImporter.Report.empty();
+        },
+        DataMigration.Prompter.NON_INTERACTIVE,
+        false,
+        true);
+  }
+}


### PR DESCRIPTION
## Bug: `sail migrate` / `sail upgrade` crashed on `no such column: updated_by`

Found on a real upgrade (0.13.13 → 0.13.44). `MigrateCommand` ran the **container spec import before the schema migrations**:

```java
var importReport = new ContainerSpecImporter(…, new SpecStore(db), …).importAll(); // queries specs FIRST
var result = MigrationRunner.applyAll(db, REGISTRY, prompter);                       // schema migration SECOND
```

`ContainerSpecImporter` queries `specs` through `SpecStore`, whose SELECT lists the **running binary's** columns (including `updated_by`). On an upgrade that added a spec column, the on-disk schema is still behind when the import runs → `no such column: updated_by`, import aborts. A `sail server start` afterwards masked it, because startup runs `MigrationRunner.applyAll` and brings the schema current — so a *second*, manual `sail migrate` then succeeds. (That's exactly the populated-prod-DB upgrade risk flagged at release time.)

## Fix
- **Schema migrations run first, then the spec import.** Extracted a testable `applyMigrations(db, …, specImport, …)` seam.
- `MigrateCommandTest` locks the invariant two ways: the schema is at its **final version when the import callback runs**, and a real `SpecStore.findById` succeeds at import time (would throw on the old order).

## Also: progress feedback (requested)
The container spec scan can take a while and looked frozen. Each phase now runs under the existing `Spinner` when interactive (TTY, non-`--json`):
- `Migrating database schema ⠹`
- `Probing project containers for specs ⠹`

Non-TTY (e.g. the `sail upgrade` subprocess) and `--json` stay plain.

## Notes
- Schema final version for 0.13.44/45 is **39** — confirmed all passkey tables (`webauthn_credentials`, `sessions`, `webauthn_challenges`, `enrollment_tickets`, `fdes.role`) are included. Boxes already at v39 are fully migrated; this fix prevents the crash on the *next* upgrade and any future spec-column addition.
- Full suite green; all JaCoCo gates met. No new dependencies.