### PR TITLE
Run sail login locally on the client (not over SSH) — 0.13.46

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.45</version>
+    <version>0.13.46</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.45</version>
+        <version>0.13.46</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.45</version>
+        <version>0.13.46</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.45</version>
+        <version>0.13.46</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/RemoteCommandRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/RemoteCommandRunner.java
@@ -23,7 +23,8 @@ import picocli.CommandLine.Help.Ansi;
  */
 public final class RemoteCommandRunner {
 
-  private static final Set<String> LOCAL_COMMANDS = Set.of("--version", "-V", "upgrade", "init");
+  private static final Set<String> LOCAL_COMMANDS =
+      Set.of("--version", "-V", "upgrade", "init", "login");
   private static final Set<String> INTERACTIVE_COMMANDS = Set.of("shell", "exec");
   private static final Set<String> HOST_ONLY_COMMANDS = Set.of("host");
   private static final int SSH_CONNECTION_FAILURE = 255;
@@ -40,7 +41,8 @@ public final class RemoteCommandRunner {
    * <p>Routes commands into three categories:
    *
    * <ul>
-   *   <li>Local: {@code --version}, {@code upgrade} — run on the client, not forwarded
+   *   <li>Local: {@code --version}, {@code upgrade}, {@code init}, {@code login} — run on the
+   *       client, not forwarded ({@code login} drives the client's browser and a loopback callback)
    *   <li>Host-only: {@code host init}, {@code host config} — error with guidance
    *   <li>Everything else: forwarded to the remote host via SSH
    * </ul>

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/RemoteCommandRunnerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/RemoteCommandRunnerTest.java
@@ -73,11 +73,12 @@ class RemoteCommandRunnerTest {
   }
 
   @Test
-  void isLocalCommandRecognizesVersionUpgradeAndInit() {
+  void isLocalCommandRecognizesVersionUpgradeInitAndLogin() {
     assertTrue(RemoteCommandRunner.isLocalCommand("--version"));
     assertTrue(RemoteCommandRunner.isLocalCommand("-V"));
     assertTrue(RemoteCommandRunner.isLocalCommand("upgrade"));
     assertTrue(RemoteCommandRunner.isLocalCommand("init"));
+    assertTrue(RemoteCommandRunner.isLocalCommand("login"));
     assertFalse(RemoteCommandRunner.isLocalCommand("spec"));
     assertFalse(RemoteCommandRunner.isLocalCommand("dispatch"));
   }


### PR DESCRIPTION
## Gap: `sail login` would be SSH-forwarded to the headless host

In client mode (Mac), `RemoteCommandRunner` forwards commands to the host over SSH. `sail login` was not in `LOCAL_COMMANDS`, so on a Mac it would run **on the host** — which has no browser and whose loopback callback the Mac browser can't reach. The passkey login can only work if `sail login` runs on the client.

## Fix
- Add `login` to `LOCAL_COMMANDS` (with `--version` / `upgrade` / `init`). On a client, `sail login` now runs locally: it opens the client's browser, listens on the client's loopback for the callback, and reaches the control plane at `--origin`. Test + javadoc updated.

## Honest scope note
This makes the *login command* run in the right place. It does **not** yet make the everyday forwarded commands (`sail spec list`, etc.) authenticate with the resulting client-side session — those still SSH-exec on the host and use the host's token. Wiring a direct-API client that authenticates with a session is the separate "remote-model unification" deferred in the `multi-fde-auth` spec.

Full suite green; all gates met. No new dependencies.