### PR TITLE
SSH-key↔FDE registry (ssh-cli-identity brick 1) — 0.13.47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.46</version>
+    <version>0.13.47</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.46</version>
+        <version>0.13.47</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/ssh/SshPublicKey.java
+++ b/sail-core/src/main/java/ai/singlr/sail/ssh/SshPublicKey.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.ssh;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Set;
+
+/**
+ * A parsed OpenSSH public key — the unit that binds an engineer's SSH key to their FDE. Parsing is
+ * strict and fail-closed: the line must be {@code <type> <base64-blob> [comment]}, the type must be
+ * one we support, the blob must be valid base64 whose embedded algorithm name matches the declared
+ * type (so a random base64 string can't masquerade as a key). The {@link #fingerprint()} is the
+ * standard OpenSSH {@code SHA256:} fingerprint and is the registry's stable primary key.
+ */
+public record SshPublicKey(String type, String blob, String comment, String fingerprint) {
+
+  private static final Set<String> SUPPORTED_TYPES =
+      Set.of(
+          "ssh-ed25519",
+          "ssh-rsa",
+          "ecdsa-sha2-nistp256",
+          "ecdsa-sha2-nistp384",
+          "ecdsa-sha2-nistp521");
+
+  /** Parses an {@code authorized_keys}-style line. Throws {@link IllegalArgumentException}. */
+  public static SshPublicKey parse(String input) {
+    if (input == null || input.isBlank()) {
+      throw new IllegalArgumentException("SSH public key is empty.");
+    }
+    var parts = input.strip().split("\\s+", 3);
+    if (parts.length < 2) {
+      throw new IllegalArgumentException(
+          "Not a valid SSH public key. Expected '<type> <base64> [comment]'.");
+    }
+    var type = parts[0];
+    var blob = parts[1];
+    var comment = parts.length == 3 ? parts[2] : null;
+    if (!SUPPORTED_TYPES.contains(type)) {
+      throw new IllegalArgumentException(
+          "Unsupported SSH key type '" + type + "'. Supported: " + SUPPORTED_TYPES + ".");
+    }
+    byte[] decoded;
+    try {
+      decoded = Base64.getDecoder().decode(blob);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("SSH public key blob is not valid base64.");
+    }
+    if (!declaredTypeMatchesBlob(type, decoded)) {
+      throw new IllegalArgumentException(
+          "SSH public key blob does not encode the declared type '" + type + "'.");
+    }
+    return new SshPublicKey(type, blob, comment, fingerprintOf(decoded));
+  }
+
+  /** The canonical single-line form for an {@code authorized_keys} entry. */
+  public String line() {
+    return comment == null || comment.isBlank()
+        ? type + " " + blob
+        : type + " " + blob + " " + comment;
+  }
+
+  private static boolean declaredTypeMatchesBlob(String type, byte[] blob) {
+    if (blob.length < 4) {
+      return false;
+    }
+    var length =
+        ((blob[0] & 0xff) << 24)
+            | ((blob[1] & 0xff) << 16)
+            | ((blob[2] & 0xff) << 8)
+            | (blob[3] & 0xff);
+    if (length <= 0 || length > 64 || length > blob.length - 4) {
+      return false;
+    }
+    return type.equals(new String(blob, 4, length, StandardCharsets.US_ASCII));
+  }
+
+  private static String fingerprintOf(byte[] blob) {
+    try {
+      var digest = MessageDigest.getInstance("SHA-256").digest(blob);
+      return "SHA256:" + Base64.getEncoder().withoutPadding().encodeToString(digest);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 unavailable", e);
+    }
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/FdeSshKeyStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FdeSshKeyStore.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import ai.singlr.sail.ssh.SshPublicKey;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The SSH keys an FDE authenticates the terminal with — the registry that maps an inbound SSH key,
+ * by its OpenSSH {@code SHA256:} fingerprint, to the principal acting on the CLI. The full {@code
+ * authorized_keys} line is retained so the host can render the {@code sail} user's authorized_keys
+ * from this table; the fingerprint is the stable identity used for lookup and revocation. Deleting
+ * a row revokes the key everywhere.
+ */
+public final class FdeSshKeyStore {
+
+  private static final String SELECT =
+      "SELECT k.fingerprint, k.fde_id, f.handle, k.public_key, k.comment, k.created_at"
+          + " FROM fde_ssh_keys k JOIN fdes f ON f.id = k.fde_id";
+
+  private final Sqlite db;
+
+  public FdeSshKeyStore(Sqlite db) {
+    this.db = db;
+  }
+
+  public record SshKeyInfo(
+      String fingerprint,
+      String fdeId,
+      String fdeHandle,
+      String publicKey,
+      String comment,
+      String createdAt) {}
+
+  /** Registers {@code key} to {@code fdeId}. Throws if the fingerprint is already registered. */
+  public void add(String fdeId, SshPublicKey key) {
+    db.execute(
+        "INSERT INTO fde_ssh_keys (fingerprint, fde_id, public_key, comment, created_at)"
+            + " VALUES (?, ?, ?, ?, ?)",
+        key.fingerprint(),
+        fdeId,
+        key.line(),
+        key.comment(),
+        Instant.now().toString());
+  }
+
+  public Optional<SshKeyInfo> findByFingerprint(String fingerprint) {
+    return db.queryOne(SELECT + " WHERE k.fingerprint = ?", FdeSshKeyStore::map, fingerprint);
+  }
+
+  public List<SshKeyInfo> list() {
+    return db.query(SELECT + " ORDER BY f.handle, k.created_at", FdeSshKeyStore::map);
+  }
+
+  public List<SshKeyInfo> listForFde(String fdeId) {
+    return db.query(
+        SELECT + " WHERE k.fde_id = ? ORDER BY k.created_at", FdeSshKeyStore::map, fdeId);
+  }
+
+  public boolean remove(String fingerprint) {
+    db.execute("DELETE FROM fde_ssh_keys WHERE fingerprint = ?", fingerprint);
+    return db.changes() > 0;
+  }
+
+  private static SshKeyInfo map(Sqlite.Row row) {
+    return new SshKeyInfo(
+        row.text(0), row.text(1), row.text(2), row.text(3), row.text(4), row.text(5));
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -226,7 +226,15 @@ public final class SchemaManager {
               expires_at TEXT NOT NULL,
               consumed_at TEXT
           )""",
-          "ALTER TABLE fdes ADD COLUMN role TEXT NOT NULL DEFAULT 'member'");
+          "ALTER TABLE fdes ADD COLUMN role TEXT NOT NULL DEFAULT 'member'",
+          """
+          CREATE TABLE IF NOT EXISTS fde_ssh_keys (
+              fingerprint TEXT PRIMARY KEY,
+              fde_id TEXT NOT NULL REFERENCES fdes(id) ON DELETE CASCADE,
+              public_key TEXT NOT NULL,
+              comment TEXT,
+              created_at TEXT NOT NULL
+          )""");
 
   private final Sqlite db;
 

--- a/sail-core/src/test/java/ai/singlr/sail/ssh/SshPublicKeyTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/ssh/SshPublicKeyTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.ssh;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class SshPublicKeyTest {
+
+  @Test
+  void parsesTypeBlobCommentAndFingerprint() {
+    var line = TestSshKeys.ed25519("uday", "uday@laptop");
+    var key = SshPublicKey.parse(line);
+    assertEquals("ssh-ed25519", key.type());
+    assertEquals("uday@laptop", key.comment());
+    assertTrue(key.fingerprint().startsWith("SHA256:"));
+    assertEquals(line, key.line());
+  }
+
+  @Test
+  void fingerprintIsStableAndDistinctPerKey() {
+    var a = SshPublicKey.parse(TestSshKeys.ed25519("a", null));
+    var a2 = SshPublicKey.parse(TestSshKeys.ed25519("a", "different-comment"));
+    var b = SshPublicKey.parse(TestSshKeys.ed25519("b", null));
+    assertEquals(
+        a.fingerprint(), a2.fingerprint(), "fingerprint depends on the key, not the comment");
+    assertNotEquals(a.fingerprint(), b.fingerprint());
+  }
+
+  @Test
+  void commentlessLineOmitsTrailingSpace() {
+    var key = SshPublicKey.parse(TestSshKeys.ed25519("k", null));
+    assertNull(key.comment());
+    assertFalse(key.line().endsWith(" "));
+  }
+
+  @Test
+  void rejectsEmptyAndMalformed() {
+    assertThrows(IllegalArgumentException.class, () -> SshPublicKey.parse(""));
+    assertThrows(IllegalArgumentException.class, () -> SshPublicKey.parse("   "));
+    assertThrows(IllegalArgumentException.class, () -> SshPublicKey.parse("ssh-ed25519"));
+    assertThrows(IllegalArgumentException.class, () -> SshPublicKey.parse((String) null));
+  }
+
+  @Test
+  void rejectsUnsupportedType() {
+    assertThrows(
+        IllegalArgumentException.class, () -> SshPublicKey.parse("ssh-dss AAAAB3Nz comment"));
+  }
+
+  @Test
+  void rejectsInvalidBase64() {
+    assertThrows(
+        IllegalArgumentException.class, () -> SshPublicKey.parse("ssh-ed25519 not!base64"));
+  }
+
+  @Test
+  void rejectsBlobWhoseEmbeddedTypeMismatches() {
+    // valid base64, valid key, but relabeled with a different (supported) type
+    var realEd25519Blob = SshPublicKey.parse(TestSshKeys.ed25519("x", null)).blob();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SshPublicKey.parse("ssh-rsa " + realEd25519Blob + " spoofed"));
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/ssh/TestSshKeys.java
+++ b/sail-core/src/test/java/ai/singlr/sail/ssh/TestSshKeys.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.ssh;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+
+/** Builds well-formed {@code ssh-ed25519} public-key lines for tests (no real key pair needed). */
+public final class TestSshKeys {
+
+  private TestSshKeys() {}
+
+  /**
+   * A valid ed25519 line whose 32-byte key body is derived from {@code seed} (distinct per seed).
+   */
+  public static String ed25519(String seed, String comment) {
+    return line(digest(seed), comment);
+  }
+
+  private static String line(byte[] pub32, String comment) {
+    var out = new ByteArrayOutputStream();
+    sshString(out, "ssh-ed25519".getBytes(StandardCharsets.US_ASCII));
+    sshString(out, pub32);
+    var blob = Base64.getEncoder().encodeToString(out.toByteArray());
+    return comment == null ? "ssh-ed25519 " + blob : "ssh-ed25519 " + blob + " " + comment;
+  }
+
+  private static void sshString(ByteArrayOutputStream out, byte[] bytes) {
+    out.write(bytes.length >>> 24);
+    out.write(bytes.length >>> 16);
+    out.write(bytes.length >>> 8);
+    out.write(bytes.length);
+    out.writeBytes(bytes);
+  }
+
+  private static byte[] digest(String seed) {
+    try {
+      return MessageDigest.getInstance("SHA-256").digest(seed.getBytes(StandardCharsets.UTF_8));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/FdeSshKeyStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FdeSshKeyStoreTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sail.ssh.SshPublicKey;
+import ai.singlr.sail.ssh.TestSshKeys;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FdeSshKeyStoreTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private FdeSshKeyStore store;
+  private String fdeId;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    fdeId = new FdeStore(db).add("uday", null, null, "admin").id();
+    store = new FdeSshKeyStore(db);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  private SshPublicKey key(String seed, String comment) {
+    return SshPublicKey.parse(TestSshKeys.ed25519(seed, comment));
+  }
+
+  @Test
+  void addsAndResolvesByFingerprintToHandle() {
+    var key = key("uday", "uday@laptop");
+    store.add(fdeId, key);
+
+    var found = store.findByFingerprint(key.fingerprint()).orElseThrow();
+    assertEquals("uday", found.fdeHandle());
+    assertEquals(fdeId, found.fdeId());
+    assertEquals("uday@laptop", found.comment());
+    assertEquals(key.line(), found.publicKey());
+  }
+
+  @Test
+  void findByUnknownFingerprintIsEmpty() {
+    assertTrue(store.findByFingerprint("SHA256:nope").isEmpty());
+  }
+
+  @Test
+  void listsAllAndPerFde() {
+    var other = new FdeStore(db).add("nova", null, null).id();
+    store.add(fdeId, key("uday", "a"));
+    store.add(fdeId, key("uday2", "b"));
+    store.add(other, key("nova", "c"));
+
+    assertEquals(3, store.list().size());
+    assertEquals(2, store.listForFde(fdeId).size());
+  }
+
+  @Test
+  void removeRevokesAndIsIdempotent() {
+    var key = key("uday", null);
+    store.add(fdeId, key);
+    assertTrue(store.remove(key.fingerprint()));
+    assertFalse(store.remove(key.fingerprint()));
+    assertTrue(store.findByFingerprint(key.fingerprint()).isEmpty());
+  }
+
+  @Test
+  void duplicateFingerprintIsRejected() {
+    var key = key("uday", "first");
+    store.add(fdeId, key);
+    assertThrows(SqliteException.class, () -> store.add(fdeId, key("uday", "second")));
+  }
+}

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.46</version>
+        <version>0.13.47</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.46</version>
+        <version>0.13.47</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
@@ -9,9 +9,12 @@ import ai.singlr.sail.auth.EnrollmentService;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.ssh.SshPublicKey;
 import ai.singlr.sail.store.EnrollmentTicketStore;
+import ai.singlr.sail.store.FdeSshKeyStore;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.Sqlite;
+import ai.singlr.sail.store.SqliteException;
 import java.nio.file.Files;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
@@ -28,7 +31,12 @@ import picocli.CommandLine.Spec;
     name = "fde",
     description = "Manage Forward Deployed Engineers (FDEs).",
     mixinStandardHelpOptions = true,
-    subcommands = {FdeCommand.Add.class, FdeCommand.ListFdes.class, FdeCommand.Enroll.class})
+    subcommands = {
+      FdeCommand.Add.class,
+      FdeCommand.ListFdes.class,
+      FdeCommand.Enroll.class,
+      FdeCommand.Key.class
+    })
 public final class FdeCommand implements Runnable {
 
   @Override
@@ -156,6 +164,141 @@ public final class FdeCommand implements Runnable {
       }
       var webauthn = HostYaml.fromMap(YamlUtil.parseFile(path)).webauthn();
       return webauthn.isConfigured() ? webauthn.origins().getFirst() : null;
+    }
+  }
+
+  @Command(
+      name = "key",
+      description = "Manage the SSH keys an FDE authenticates the terminal with.",
+      mixinStandardHelpOptions = true,
+      subcommands = {Key.Add.class, Key.ListKeys.class, Key.Remove.class})
+  static final class Key implements Runnable {
+
+    @Override
+    public void run() {
+      new picocli.CommandLine(this).usage(System.out);
+    }
+
+    @Command(
+        name = "add",
+        description = "Register an SSH public key for an FDE.",
+        mixinStandardHelpOptions = true)
+    static final class Add implements Runnable {
+
+      @Parameters(index = "0", description = "FDE handle (must already exist).")
+      private String handle;
+
+      @Parameters(
+          index = "1",
+          description = "SSH public key line, e.g. \"ssh-ed25519 AAAA... me@host\".")
+      private String publicKey;
+
+      @Spec private CommandSpec spec;
+
+      @Override
+      public void run() {
+        CliCommand.run(
+            spec,
+            () -> {
+              try (var db = Sqlite.open(dbPath())) {
+                var fde =
+                    new FdeStore(db)
+                        .byHandle(handle)
+                        .orElseThrow(
+                            () ->
+                                new IllegalArgumentException(
+                                    "Unknown FDE '"
+                                        + handle
+                                        + "'. Add it with 'sail fde add "
+                                        + handle
+                                        + "'."));
+                var key = SshPublicKey.parse(publicKey);
+                try {
+                  new FdeSshKeyStore(db).add(fde.id(), key);
+                } catch (SqliteException e) {
+                  throw new IllegalArgumentException(
+                      "That key (" + key.fingerprint() + ") is already registered.");
+                }
+                System.out.println(
+                    Ansi.AUTO.string(
+                        "  @|green ✓|@ Registered key for "
+                            + fde.handle()
+                            + ": "
+                            + key.fingerprint()));
+              }
+            });
+      }
+    }
+
+    @Command(
+        name = "list",
+        description = "List registered SSH keys.",
+        mixinStandardHelpOptions = true)
+    static final class ListKeys implements Runnable {
+
+      @Parameters(index = "0", arity = "0..1", description = "Optional FDE handle to filter by.")
+      private String handle;
+
+      @Spec private CommandSpec spec;
+
+      @Override
+      public void run() {
+        CliCommand.run(
+            spec,
+            () -> {
+              try (var db = Sqlite.open(dbPath())) {
+                var keyStore = new FdeSshKeyStore(db);
+                var keys =
+                    handle == null
+                        ? keyStore.list()
+                        : new FdeStore(db)
+                            .byHandle(handle)
+                            .map(fde -> keyStore.listForFde(fde.id()))
+                            .orElseThrow(
+                                () ->
+                                    new IllegalArgumentException("Unknown FDE '" + handle + "'."));
+                if (keys.isEmpty()) {
+                  System.out.println("  No SSH keys. Register one with 'sail fde key add'.");
+                  return;
+                }
+                for (var key : keys) {
+                  System.out.printf(
+                      "  %-16s  %-12s  %s%n",
+                      key.fdeHandle(),
+                      key.comment() == null ? "" : key.comment(),
+                      key.fingerprint());
+                }
+              }
+            });
+      }
+    }
+
+    @Command(
+        name = "rm",
+        description = "Remove a registered SSH key by fingerprint.",
+        mixinStandardHelpOptions = true)
+    static final class Remove implements Runnable {
+
+      @Parameters(index = "0", description = "The key's SHA256: fingerprint.")
+      private String fingerprint;
+
+      @Spec private CommandSpec spec;
+
+      @Override
+      public void run() {
+        CliCommand.run(
+            spec,
+            () -> {
+              try (var db = Sqlite.open(dbPath())) {
+                if (new FdeSshKeyStore(db).remove(fingerprint)) {
+                  System.out.println(Ansi.AUTO.string("  @|green ✓|@ Removed key " + fingerprint));
+                } else {
+                  System.out.println(
+                      Ansi.AUTO.string("  @|yellow ⚠|@ No key with fingerprint " + fingerprint));
+                }
+              }
+            });
+      }
     }
   }
 }


### PR DESCRIPTION
## Brick 1 of "SSH key as the terminal identity" (spec: `ssh-cli-identity`)

The Mac thin client SSH-execs commands on the host, where they run as the **shared admin token** — so per-FDE roles never apply to the CLI. The fix (decided with Uday): make the **SSH key the terminal identity**, mapped to an FDE, via a locked-down `sail` user + forced-command gateway (Gitea pattern). Passkeys/OIDC stay as the *web* door.

This first brick is the **registry** — pure DB, **zero system-level changes**, so it carries no risk of SSH lockout. The `sail`-user / sshd / gateway bricks land separately and get rolled out carefully against the live box.

### What's new
- **`fde_ssh_keys`** table (append-only migration).
- **`SshPublicKey`** (`ai.singlr.sail.ssh`) — strict, fail-closed OpenSSH public-key parser, pure JDK. Computes the standard `SHA256:` fingerprint; rejects malformed/oversized base64 and blobs whose embedded algorithm name doesn't match the declared type (so a random string can't masquerade as a key).
- **`FdeSshKeyStore`** — `add` / `findByFingerprint` (JOINs to the FDE handle) / `list` / `listForFde` / `remove`. The fingerprint is the stable identity for lookup and revocation; the full `authorized_keys` line is retained for the later sync brick.
- **`sail fde key add <handle> "<pubkey>"` / `list [handle]` / `rm <fingerprint>`**.

### Design
Full spec at `~/workspace/specs/ssh-cli-identity/spec.md` — principle (two doors to one identity), locked decisions (SSH-key→FDE; dedicated `sail` user), brick plan, and the **risk note**: provisioning must be additive/reversible and never disrupt existing root/admin SSH.

### Testing
- `SshPublicKey`: parse, fingerprint stability/distinctness, and every rejection path. `FdeSshKeyStore`: add/resolve/list/per-FDE/remove/duplicate. New core classes fully covered; full suite green; all gates met. **No new dependencies.**

### Next (not in this PR — needs careful rollout)
2. `sail _gateway` entrypoint (session-mint + `SAIL_TOKEN` + exec, command allowlist).
3. `sail` user provisioning + `authorized_keys` sync from the registry (the risky, lockout-sensitive brick).
4. Client onboarding (`sail init` → `sail@host`).