### PR TITLE
sail _gateway: SSH forced-command entry point (ssh-cli-identity brick 2) — 0.13.48

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.47</version>
+    <version>0.13.48</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.47</version>
+        <version>0.13.48</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/ssh/CommandTokenizer.java
+++ b/sail-core/src/main/java/ai/singlr/sail/ssh/CommandTokenizer.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.ssh;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Splits the single command string SSH delivers in {@code SSH_ORIGINAL_COMMAND} into an argument
+ * vector, honoring single quotes, double quotes, and backslash escapes the way a POSIX shell would.
+ * The gateway parses the command itself — rather than handing it to a shell — so it can authorize
+ * the request against an allow-list before executing, with no shell ever interpreting the string.
+ */
+public final class CommandTokenizer {
+
+  private CommandTokenizer() {}
+
+  /** Tokenizes {@code input}. Throws {@link IllegalArgumentException} on an unterminated quote. */
+  public static List<String> split(String input) {
+    var tokens = new ArrayList<String>();
+    var current = new StringBuilder();
+    var inToken = false;
+    var inSingle = false;
+    var inDouble = false;
+
+    for (var i = 0; i < input.length(); i++) {
+      var c = input.charAt(i);
+      if (inSingle) {
+        if (c == '\'') {
+          inSingle = false;
+        } else {
+          current.append(c);
+        }
+        inToken = true;
+      } else if (inDouble) {
+        if (c == '"') {
+          inDouble = false;
+        } else if (c == '\\'
+            && i + 1 < input.length()
+            && isDoubleQuoteEscape(input.charAt(i + 1))) {
+          current.append(input.charAt(++i));
+        } else {
+          current.append(c);
+        }
+        inToken = true;
+      } else if (c == '\'') {
+        inSingle = true;
+        inToken = true;
+      } else if (c == '"') {
+        inDouble = true;
+        inToken = true;
+      } else if (c == '\\' && i + 1 < input.length()) {
+        current.append(input.charAt(++i));
+        inToken = true;
+      } else if (Character.isWhitespace(c)) {
+        if (inToken) {
+          tokens.add(current.toString());
+          current.setLength(0);
+          inToken = false;
+        }
+      } else {
+        current.append(c);
+        inToken = true;
+      }
+    }
+    if (inSingle || inDouble) {
+      throw new IllegalArgumentException("Unterminated quote in command.");
+    }
+    if (inToken) {
+      tokens.add(current.toString());
+    }
+    return tokens;
+  }
+
+  private static boolean isDoubleQuoteEscape(char next) {
+    return next == '"' || next == '\\' || next == '$' || next == '`';
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/ssh/SshGateway.java
+++ b/sail-core/src/main/java/ai/singlr/sail/ssh/SshGateway.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.ssh;
+
+import ai.singlr.sail.store.AuthSessionStore;
+import ai.singlr.sail.store.FdeStore;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Decides what a forced-command SSH session may run and as whom. When an engineer's key hits the
+ * {@code sail} user's forced command, this resolves their FDE (passed as {@code --fde} on the
+ * authorized_keys line), validates the requested command against an allow-list, mints a short-lived
+ * session for that FDE, and returns the argument vector to exec with {@code SAIL_TOKEN} set — so
+ * the downstream command authenticates to the loopback API as the FDE and {@code Authorizer}
+ * enforces its role. Default-deny: only API-backed, role-governed commands are permitted;
+ * database-direct admin commands ({@code fde}, {@code host}, {@code server}, {@code migrate}) are
+ * not, because they would bypass the API and run with the {@code sail} user's full access
+ * regardless of role.
+ */
+public final class SshGateway {
+
+  static final Duration SESSION_TTL = Duration.ofMinutes(10);
+  static final Set<String> ALLOWED_COMMANDS = Set.of("spec", "dispatch", "agent", "events");
+
+  private SshGateway() {}
+
+  public sealed interface Decision permits Authorized, Rejected {}
+
+  /** The command is permitted; exec {@code args} with {@code SAIL_TOKEN} = {@code sessionToken}. */
+  public record Authorized(List<String> args, String sessionToken) implements Decision {}
+
+  /** The command is refused; {@code reason} is safe to show the caller. */
+  public record Rejected(String reason) implements Decision {}
+
+  public static Decision authorize(
+      String originalCommand, String fdeHandle, FdeStore fdes, AuthSessionStore sessions) {
+    if (originalCommand == null || originalCommand.isBlank()) {
+      return new Rejected(
+          "No command supplied. Interactive shells are not permitted; run a 'sail' command.");
+    }
+    List<String> tokens;
+    try {
+      tokens = CommandTokenizer.split(originalCommand);
+    } catch (IllegalArgumentException e) {
+      return new Rejected(e.getMessage());
+    }
+    if (!tokens.isEmpty() && tokens.getFirst().equals("sail")) {
+      tokens = tokens.subList(1, tokens.size());
+    }
+    if (tokens.isEmpty()) {
+      return new Rejected("No 'sail' subcommand supplied.");
+    }
+    var subcommand = tokens.getFirst();
+    if (!ALLOWED_COMMANDS.contains(subcommand)) {
+      return new Rejected("'" + subcommand + "' is not permitted over an SSH-key session.");
+    }
+    var fde = fdes.byHandle(fdeHandle);
+    if (fde.isEmpty() || !"active".equals(fde.get().status())) {
+      return new Rejected("Unknown or disabled FDE.");
+    }
+    var session = sessions.create(fde.get().id(), SESSION_TTL);
+    return new Authorized(List.copyOf(tokens), session.token());
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/ssh/CommandTokenizerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/ssh/CommandTokenizerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.ssh;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CommandTokenizerTest {
+
+  @Test
+  void splitsSimpleCommand() {
+    assertEquals(List.of("sail", "spec", "list"), CommandTokenizer.split("sail spec list"));
+  }
+
+  @Test
+  void collapsesRepeatedWhitespace() {
+    assertEquals(List.of("sail", "spec"), CommandTokenizer.split("  sail   spec  "));
+  }
+
+  @Test
+  void emptyAndBlankProduceNoTokens() {
+    assertTrue(CommandTokenizer.split("").isEmpty());
+    assertTrue(CommandTokenizer.split("   ").isEmpty());
+  }
+
+  @Test
+  void honorsDoubleQuotes() {
+    assertEquals(
+        List.of("sail", "spec", "create", "my spec title"),
+        CommandTokenizer.split("sail spec create \"my spec title\""));
+  }
+
+  @Test
+  void honorsSingleQuotesLiterally() {
+    assertEquals(
+        List.of("sail", "spec", "set", "a \"b\" c"),
+        CommandTokenizer.split("sail spec set 'a \"b\" c'"));
+  }
+
+  @Test
+  void honorsBackslashEscapeOutsideQuotes() {
+    assertEquals(List.of("a b", "c"), CommandTokenizer.split("a\\ b c"));
+  }
+
+  @Test
+  void honorsEscapesInsideDoubleQuotes() {
+    assertEquals(List.of("a\"b\\c"), CommandTokenizer.split("\"a\\\"b\\\\c\""));
+  }
+
+  @Test
+  void literalBackslashInsideDoubleQuotesWhenNotAnEscape() {
+    assertEquals(List.of("a\\b"), CommandTokenizer.split("\"a\\b\""));
+  }
+
+  @Test
+  void rejectsUnterminatedQuotes() {
+    assertThrows(IllegalArgumentException.class, () -> CommandTokenizer.split("sail \"oops"));
+    assertThrows(IllegalArgumentException.class, () -> CommandTokenizer.split("sail 'oops"));
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/ssh/SshGatewayTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/ssh/SshGatewayTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.ssh;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sail.store.AuthSessionStore;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SshGatewayTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private FdeStore fdes;
+  private AuthSessionStore sessions;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    fdes = new FdeStore(db);
+    sessions = new AuthSessionStore(db);
+    fdes.add("uday", null, null, "member");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  private SshGateway.Decision authorize(String command, String handle) {
+    return SshGateway.authorize(command, handle, fdes, sessions);
+  }
+
+  @Test
+  void permitsAllowedCommandAndMintsUsableSession() {
+    var decision = authorize("sail spec list", "uday");
+    var authorized = assertInstanceOf(SshGateway.Authorized.class, decision);
+    assertEquals(java.util.List.of("spec", "list"), authorized.args());
+    assertTrue(authorized.sessionToken().startsWith("sess_"));
+    assertTrue(sessions.validate(authorized.sessionToken()).isPresent());
+  }
+
+  @Test
+  void stripsLeadingSailToken() {
+    var authorized = assertInstanceOf(SshGateway.Authorized.class, authorize("spec list", "uday"));
+    assertEquals(java.util.List.of("spec", "list"), authorized.args());
+  }
+
+  @Test
+  void rejectsDisallowedCommand() {
+    var rejected = assertInstanceOf(SshGateway.Rejected.class, authorize("sail fde list", "uday"));
+    assertTrue(rejected.reason().contains("fde"));
+    assertTrue(sessions.validate("sess_anything").isEmpty());
+  }
+
+  @Test
+  void rejectsAdminDirectCommands() {
+    assertInstanceOf(SshGateway.Rejected.class, authorize("sail host status", "uday"));
+    assertInstanceOf(SshGateway.Rejected.class, authorize("sail migrate", "uday"));
+    assertInstanceOf(SshGateway.Rejected.class, authorize("sail server start", "uday"));
+  }
+
+  @Test
+  void rejectsEmptyOrShellRequest() {
+    assertInstanceOf(SshGateway.Rejected.class, authorize(null, "uday"));
+    assertInstanceOf(SshGateway.Rejected.class, authorize("   ", "uday"));
+    assertInstanceOf(SshGateway.Rejected.class, authorize("sail", "uday"));
+  }
+
+  @Test
+  void rejectsUnterminatedQuote() {
+    assertInstanceOf(SshGateway.Rejected.class, authorize("sail spec create \"oops", "uday"));
+  }
+
+  @Test
+  void rejectsUnknownFde() {
+    assertInstanceOf(SshGateway.Rejected.class, authorize("sail spec list", "ghost"));
+  }
+
+  @Test
+  void rejectsDisabledFde() {
+    db.execute("UPDATE fdes SET status = 'disabled' WHERE handle = ?", "uday");
+    assertInstanceOf(SshGateway.Rejected.class, authorize("sail spec list", "uday"));
+  }
+
+  @Test
+  void noSessionIsMintedWhenRejected() {
+    authorize("sail fde list", "uday");
+    db.execute("UPDATE fdes SET status = 'disabled' WHERE handle = ?", "uday");
+    authorize("sail spec list", "uday");
+    assertEquals(
+        0L, db.queryOne("SELECT COUNT(*) FROM sessions", row -> row.integer(0)).orElse(0L));
+  }
+}

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.47</version>
+        <version>0.13.48</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.47</version>
+        <version>0.13.48</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/Sail.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/Sail.java
@@ -9,6 +9,7 @@ import ai.singlr.sail.commands.AgentCommand;
 import ai.singlr.sail.commands.ClientInitCommand;
 import ai.singlr.sail.commands.EventsCommand;
 import ai.singlr.sail.commands.FdeCommand;
+import ai.singlr.sail.commands.GatewayCommand;
 import ai.singlr.sail.commands.HostCommand;
 import ai.singlr.sail.commands.LoginCommand;
 import ai.singlr.sail.commands.MigrateCommand;
@@ -38,6 +39,7 @@ import picocli.CommandLine.Help.Ansi;
       EventsCommand.class,
       MigrateCommand.class,
       UpgradeCommand.class,
+      GatewayCommand.class,
     })
 public final class Sail implements Runnable {
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/GatewayCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/GatewayCommand.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.engine.Banner;
+import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.ssh.SshGateway;
+import ai.singlr.sail.store.AuthSessionStore;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.Sqlite;
+import java.util.ArrayList;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Option;
+
+/**
+ * Internal entry point for the {@code sail} user's SSH forced command. It is not meant to be run by
+ * hand: each registered key's {@code authorized_keys} line is {@code command="sail _gateway --fde
+ * <handle>"}, so sshd invokes this with the engineer's real command in {@code
+ * SSH_ORIGINAL_COMMAND}. It authorizes the request through {@link SshGateway} — resolving the FDE,
+ * checking the allow-list, minting a short-lived session — then re-execs {@code sail} with {@code
+ * SAIL_TOKEN} set so the command runs as that FDE under role-based authorization. Disallowed
+ * commands are refused without minting anything.
+ */
+@Command(name = "_gateway", description = "Internal SSH forced-command entry point.", hidden = true)
+public final class GatewayCommand implements Callable<Integer> {
+
+  @Option(names = "--fde", required = true, description = "FDE handle bound to the calling key.")
+  private String fde;
+
+  @Override
+  public Integer call() throws Exception {
+    var original = System.getenv("SSH_ORIGINAL_COMMAND");
+    try (var db = Sqlite.open(SailPaths.sailDir().resolve("sail.db"))) {
+      var decision =
+          SshGateway.authorize(original, fde, new FdeStore(db), new AuthSessionStore(db));
+      return switch (decision) {
+        case SshGateway.Rejected rejected -> {
+          System.err.println(Banner.errorLine(rejected.reason(), Ansi.AUTO));
+          yield 1;
+        }
+        case SshGateway.Authorized authorized -> exec(authorized);
+      };
+    }
+  }
+
+  private static int exec(SshGateway.Authorized authorized) throws Exception {
+    var command = new ArrayList<String>();
+    command.add(SailPaths.binaryPath().toString());
+    command.addAll(authorized.args());
+    var builder = new ProcessBuilder(command);
+    builder.environment().put("SAIL_TOKEN", authorized.sessionToken());
+    builder.inheritIO();
+    return builder.start().waitFor();
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
@@ -18,11 +18,15 @@ class CommandTaxonomyTest {
   void rootCommandsAreWorkflowGroups() {
     var command = new CommandLine(new Sail());
 
+    var userFacing =
+        command.getSubcommands().keySet().stream()
+            .filter(name -> !name.startsWith("_"))
+            .collect(java.util.stream.Collectors.toSet());
     assertEquals(
         Set.of(
             "init", "host", "project", "server", "fde", "login", "spec", "agent", "events",
             "migrate", "upgrade"),
-        command.getSubcommands().keySet());
+        userFacing);
   }
 
   @Test


### PR DESCRIPTION
## Brick 2 — the gateway (spec: `ssh-cli-identity`)

The host-side logic that converts an SSH-key session into an **FDE-scoped command**. Still **zero system-level changes** — the `sail`-user / sshd / authorized_keys wiring is brick 3, which we'll roll out carefully against the live box.

How it will be invoked (brick 3): each registered key's `authorized_keys` line is `command="sail _gateway --fde <handle>"`, so sshd runs this with the engineer's real command in `SSH_ORIGINAL_COMMAND`.

### What's new
- **`CommandTokenizer`** — POSIX-ish quote/escape-aware split of `SSH_ORIGINAL_COMMAND` into an argv. The gateway parses the command *itself* so it can authorize before executing — **no shell ever interprets the string** (no injection surface).
- **`SshGateway.authorize`** — resolves the FDE from the key's `--fde`, applies a **default-deny allow-list** (`spec`/`dispatch`/`agent`/`events` — the API-backed, role-governed commands), and **refuses db-direct/admin commands** (`fde`/`host`/`server`/`migrate`) that would bypass the API and run with the `sail` user's full access regardless of role. On success it mints a short-lived session and returns the argv + token; **no session is minted on any rejection**. Disabled/unknown FDEs and empty/shell requests are refused.
- **`GatewayCommand`** (`sail _gateway --fde <handle>`, hidden) — reads `SSH_ORIGINAL_COMMAND`, authorizes, and re-execs `sail` with `SAIL_TOKEN` set so the command authenticates to the loopback API as the FDE and `Authorizer` enforces its role. `Callable<Integer>` propagates the child exit code.

### Testing
- `CommandTokenizer`: quotes, escapes, whitespace, unterminated-quote rejection.
- `SshGateway`: allowed command mints a usable session; `sail`-prefix stripping; disallowed/admin commands refused; empty/shell/unterminated refused; unknown + disabled FDE refused; **no session minted on rejection**.
- New core classes fully covered; full suite green; all gates met. **No new dependencies.**

### Allow-list note
Conservative on purpose: only the role-governed API commands for now. Interactive `shell`/`exec` and `project` need PTY/policy decisions and are a deliberate follow-up — easy to extend the allow-list once we settle that.

### Next — brick 3 (the careful one)
`sail` user provisioning + `authorized_keys` sync from the registry. Additive, reversible, never disrupts existing root SSH; `--dry-run` first; rolled out step by step against Uday's box with a fallback shell open.