### PR TITLE
sail host ssh-identity: provision sail user + shared data dir (ssh-cli-identity brick 3b) — 0.13.50

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.49</version>
+    <version>0.13.50</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.49</version>
+        <version>0.13.50</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.49</version>
+        <version>0.13.50</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.49</version>
+        <version>0.13.50</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostCommand.java
@@ -16,7 +16,8 @@ import picocli.CommandLine.Command;
       HostStatusCommand.class,
       HostUpdateCommand.class,
       HostConfigCommand.class,
-      HostServiceCommand.class
+      HostServiceCommand.class,
+      HostSshIdentityCommand.class
     })
 public final class HostCommand implements Runnable {
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostSshIdentityCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostSshIdentityCommand.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.engine.SshIdentityProvisioner;
+import java.nio.file.Files;
+import java.util.List;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Spec;
+
+/**
+ * Provisions a host for SSH-key FDE login: the locked-down {@code sail} user, the shared {@code
+ * /var/lib/sail} data directory, the database moved into it, and a systemd drop-in pointing {@code
+ * sail-api} there. Previews by default and only mutates with {@code --apply}, because it creates a
+ * system user and relocates the control-plane database. The plan touches no global sshd config and
+ * never alters the operator's existing root SSH.
+ */
+@Command(
+    name = "ssh-identity",
+    description = "Enable SSH-key login for FDEs (provision the sail user + shared data dir).",
+    mixinStandardHelpOptions = true)
+public final class HostSshIdentityCommand implements Runnable {
+
+  @Option(
+      names = "--apply",
+      description =
+          "Execute the plan. Without this flag the command only previews (requires root).")
+  private boolean apply;
+
+  @Spec private CommandSpec spec;
+
+  @Override
+  public void run() {
+    CliCommand.run(
+        spec,
+        () -> {
+          var plan =
+              SshIdentityProvisioner.plan(
+                  SailPaths.sailDir(), SshIdentityProvisioner.DEFAULT_DATA_DIR);
+          printPlan(plan);
+          if (!apply) {
+            System.out.println();
+            System.out.println(
+                Ansi.AUTO.string(
+                    "  @|faint Preview only. Re-run as root with --apply to execute.|@"));
+            return;
+          }
+          requireRoot();
+          execute(plan);
+          System.out.println();
+          System.out.println(
+              Ansi.AUTO.string(
+                  "  @|green ✓|@ SSH-key login enabled. Register keys with"
+                      + " 'sail fde key add <handle> <pubkey>' then 'sail host keys sync'."));
+        });
+  }
+
+  private static void printPlan(List<SshIdentityProvisioner.Step> plan) {
+    System.out.println("  Plan to enable SSH-key FDE login:");
+    System.out.println();
+    var number = 1;
+    for (var step : plan) {
+      System.out.println(Ansi.AUTO.string("  @|bold " + number++ + ".|@ " + step.description()));
+      switch (step) {
+        case SshIdentityProvisioner.Run run ->
+            System.out.println(
+                Ansi.AUTO.string("     @|faint $ " + String.join(" ", run.command()) + "|@"));
+        case SshIdentityProvisioner.WriteFile write -> {
+          System.out.println(Ansi.AUTO.string("     @|faint write " + write.path() + ":|@"));
+          for (var line : write.content().stripTrailing().split("\n")) {
+            System.out.println(Ansi.AUTO.string("       @|faint " + line + "|@"));
+          }
+        }
+      }
+    }
+  }
+
+  private static void execute(List<SshIdentityProvisioner.Step> plan) throws Exception {
+    var shell = new ShellExecutor(false);
+    for (var step : plan) {
+      switch (step) {
+        case SshIdentityProvisioner.Run run -> {
+          var result = shell.exec(run.command());
+          if (!result.ok()) {
+            throw new IllegalStateException(
+                "Step failed: " + step.description() + "\n" + result.stderr());
+          }
+        }
+        case SshIdentityProvisioner.WriteFile write ->
+            Files.writeString(write.path(), write.content());
+      }
+      System.out.println(Ansi.AUTO.string("  @|green ✓|@ " + step.description()));
+    }
+  }
+
+  private static void requireRoot() {
+    if (!"root".equals(ProcessHandle.current().info().user().orElse(""))) {
+      throw new IllegalStateException(
+          "--apply must run as root: it creates a system user, relocates the database, and edits"
+              + " a systemd unit. SSH to the host and run it there as root.");
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/SshIdentityProvisioner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/SshIdentityProvisioner.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Builds the ordered, idempotent plan that turns a single-operator host into one that authenticates
+ * FDEs by their SSH key: a locked-down {@code sail} system user (whose forced-command keys run the
+ * gateway), a group-shared control-plane data directory, the database moved into it, and a systemd
+ * drop-in pointing {@code sail-api} at it. The plan is pure data so it can be previewed verbatim
+ * ({@code --dry-run} default) and unit-tested; it touches no global sshd config and never alters
+ * the operator's existing root SSH — the per-key forced commands live only in the {@code sail}
+ * user's own {@code authorized_keys}.
+ *
+ * <p>Every step is safe to re-run: user creation is guarded by {@code id}, directories use {@code
+ * install -d}, the database move skips files already relocated, and {@code authorized_keys} is
+ * never truncated if it already exists.
+ */
+public final class SshIdentityProvisioner {
+
+  public static final String SAIL_USER = "sail";
+  public static final String SAIL_HOME = "/home/sail";
+  public static final String DEFAULT_DATA_DIR = "/var/lib/sail";
+  public static final String DROP_IN =
+      "/etc/systemd/system/sail-api.service.d/10-sail-data-dir.conf";
+
+  private static final List<String> DB_FILES = List.of("sail.db", "sail.db-wal", "sail.db-shm");
+
+  private SshIdentityProvisioner() {}
+
+  /** A single provisioning action; either a shell command or a file write. */
+  public sealed interface Step permits Run, WriteFile {
+    String description();
+  }
+
+  public record Run(String description, List<String> command) implements Step {}
+
+  public record WriteFile(String description, Path path, String content) implements Step {}
+
+  /**
+   * @param sourceDataDir where the database currently lives (the operator's {@code ~/.sail})
+   * @param dataDir the shared system data directory to move it into
+   */
+  public static List<Step> plan(Path sourceDataDir, String dataDir) {
+    var source = sourceDataDir.toString();
+    return List.of(
+        new Run(
+            "Create the locked-down '" + SAIL_USER + "' system user",
+            List.of(
+                "sh",
+                "-c",
+                "id -u "
+                    + SAIL_USER
+                    + " >/dev/null 2>&1 || useradd --system --create-home --home-dir "
+                    + SAIL_HOME
+                    + " --shell /bin/bash "
+                    + SAIL_USER)),
+        new Run(
+            "Restrict the sail home directory (sshd StrictModes)",
+            List.of("chmod", "700", SAIL_HOME)),
+        new Run(
+            "Create the sail user's .ssh directory",
+            List.of(
+                "install",
+                "-d",
+                "-m",
+                "700",
+                "-o",
+                SAIL_USER,
+                "-g",
+                SAIL_USER,
+                SAIL_HOME + "/.ssh")),
+        new Run(
+            "Create authorized_keys (preserved if it already exists)",
+            List.of(
+                "sh",
+                "-c",
+                "test -f "
+                    + SAIL_HOME
+                    + "/.ssh/authorized_keys || install -m 600 -o "
+                    + SAIL_USER
+                    + " -g "
+                    + SAIL_USER
+                    + " /dev/null "
+                    + SAIL_HOME
+                    + "/.ssh/authorized_keys")),
+        new Run(
+            "Create the shared control-plane data directory (setgid, group " + SAIL_USER + ")",
+            List.of("install", "-d", "-m", "2770", "-o", "root", "-g", SAIL_USER, dataDir)),
+        new Run(
+            "Stop sail-api before moving the database",
+            List.of(
+                "sh",
+                "-c",
+                "systemctl is-active --quiet sail-api && systemctl stop sail-api || true")),
+        new Run(
+            "Move the control-plane database into " + dataDir,
+            List.of(
+                "sh",
+                "-c",
+                "for f in "
+                    + String.join(" ", DB_FILES)
+                    + "; do [ -e \""
+                    + source
+                    + "/$f\" ] && [ ! -e \""
+                    + dataDir
+                    + "/$f\" ] && mv \""
+                    + source
+                    + "/$f\" \""
+                    + dataDir
+                    + "/$f\"; done; true")),
+        new Run(
+            "Set database ownership and permissions for group access",
+            List.of(
+                "sh",
+                "-c",
+                "cd "
+                    + dataDir
+                    + " && for f in "
+                    + String.join(" ", DB_FILES)
+                    + "; do [ -e \"$f\" ] && chgrp "
+                    + SAIL_USER
+                    + " \"$f\" && chmod 660 \"$f\"; done; true")),
+        new Run(
+            "Create the systemd drop-in directory",
+            List.of("install", "-d", "-m", "755", Path.of(DROP_IN).getParent().toString())),
+        new WriteFile(
+            "Point sail-api at the shared data directory",
+            Path.of(DROP_IN),
+            "[Service]\nEnvironment=SAIL_DATA_DIR=" + dataDir + "\nUMask=0007\n"),
+        new Run("Reload systemd units", List.of("systemctl", "daemon-reload")),
+        new Run(
+            "Start sail-api on the shared data directory",
+            List.of("systemctl", "start", "sail-api")));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/SshIdentityProvisionerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/SshIdentityProvisionerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SshIdentityProvisionerTest {
+
+  private List<SshIdentityProvisioner.Step> plan() {
+    return SshIdentityProvisioner.plan(Path.of("/root/.sail"), "/var/lib/sail");
+  }
+
+  private String runCommand(List<SshIdentityProvisioner.Step> plan, int index) {
+    return String.join(" ", ((SshIdentityProvisioner.Run) plan.get(index)).command());
+  }
+
+  @Test
+  void firstStepCreatesSailUserIdempotently() {
+    var first = runCommand(plan(), 0);
+    assertTrue(first.contains("id -u sail"), first);
+    assertTrue(first.contains("|| useradd"), first);
+    assertTrue(first.contains("--system"), first);
+    assertTrue(first.contains("/home/sail"), first);
+  }
+
+  @Test
+  void dataDirectoryIsSetgidAndGroupShared() {
+    var step =
+        plan().stream()
+            .filter(SshIdentityProvisioner.Run.class::isInstance)
+            .map(s -> String.join(" ", ((SshIdentityProvisioner.Run) s).command()))
+            .filter(c -> c.contains("/var/lib/sail") && c.contains("install -d"))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(step.contains("-m 2770"), step);
+    assertTrue(step.contains("-g sail"), step);
+  }
+
+  @Test
+  void databaseMoveIsGuardedAgainstOverwriteAndMissingSource() {
+    var move =
+        plan().stream()
+            .filter(SshIdentityProvisioner.Run.class::isInstance)
+            .map(s -> String.join(" ", ((SshIdentityProvisioner.Run) s).command()))
+            .filter(c -> c.contains("mv "))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(move.contains("/root/.sail/$f"), move);
+    assertTrue(move.contains("/var/lib/sail/$f"), move);
+    assertTrue(move.contains("sail.db-wal"), move);
+    assertTrue(move.contains("[ -e") && move.contains("! -e"), move);
+  }
+
+  @Test
+  void authorizedKeysIsNeverTruncatedWhenPresent() {
+    var step =
+        plan().stream()
+            .filter(SshIdentityProvisioner.Run.class::isInstance)
+            .map(s -> String.join(" ", ((SshIdentityProvisioner.Run) s).command()))
+            .filter(c -> c.contains("authorized_keys"))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(step.contains("test -f"), step);
+    assertTrue(step.contains("|| install"), step);
+  }
+
+  @Test
+  void dropInPointsServiceAtSharedDataDirWithGroupUmask() {
+    var write =
+        plan().stream()
+            .filter(SshIdentityProvisioner.WriteFile.class::isInstance)
+            .map(SshIdentityProvisioner.WriteFile.class::cast)
+            .findFirst()
+            .orElseThrow();
+    assertEquals(Path.of(SshIdentityProvisioner.DROP_IN), write.path());
+    assertTrue(
+        write.content().contains("Environment=SAIL_DATA_DIR=/var/lib/sail"), write.content());
+    assertTrue(write.content().contains("UMask=0007"), write.content());
+  }
+
+  @Test
+  void planStopsBeforeMovingAndStartsAfterReload() {
+    var descriptions = plan().stream().map(SshIdentityProvisioner.Step::description).toList();
+    var stop = indexOfContaining(descriptions, "Stop sail-api");
+    var move = indexOfContaining(descriptions, "Move the control-plane database");
+    var reload = indexOfContaining(descriptions, "Reload systemd");
+    var start = indexOfContaining(descriptions, "Start sail-api");
+    assertTrue(stop < move, "must stop the service before moving the database");
+    assertTrue(move < reload && reload < start, "must reload before starting");
+  }
+
+  private static int indexOfContaining(List<String> items, String needle) {
+    for (var i = 0; i < items.size(); i++) {
+      if (items.get(i).contains(needle)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+}


### PR DESCRIPTION
## Brick 3b — host provisioning (the supervised step)

Turns a single-operator host into one that authenticates FDEs by SSH key. **Previews by default; only mutates with `--apply`, and only as root** — because it creates a system user and relocates the control-plane DB.

### What it does (the exact, idempotent plan)
1. Create the locked-down `sail` system user (guarded by `id` — re-runnable).
2–4. Its `700` home (sshd StrictModes-safe) + `700 .ssh` + a `600` `authorized_keys` that is **never truncated** if present.
5. `/var/lib/sail` — `2770` setgid, group `sail` (shared between `sail-api` and the `sail` user).
6–8. Stop `sail-api`, **move** `sail.db`(+`-wal`/`-shm`) only when present and not already moved, then `chgrp sail` + `chmod 660`.
9–10. systemd **drop-in** `…/sail-api.service.d/10-sail-data-dir.conf` = `Environment=SAIL_DATA_DIR=/var/lib/sail` + `UMask=0007` (so service-created DB files are group-writable). A drop-in is additive/reversible — your main unit is untouched.
11–12. `daemon-reload`, start.

**No `sshd_config` change**; the operator's existing root SSH is never altered (per-key forced commands live only in the `sail` user's `authorized_keys`, added in brick 3c).

### Safety
`sail host ssh-identity` prints the whole plan; nothing runs without `--apply`. Every step is idempotent, so a re-run after a partial failure is safe. The DB move is reversible (move it back). `--apply` refuses unless root.

### Testing
`SshIdentityProvisioner.plan()` is pure data, fully unit-tested: user creation is `id`-guarded; data dir is `2770 -g sail`; DB move is guarded against overwrite + missing source and includes `-wal`/`-shm`; `authorized_keys` is `test -f`-guarded; the drop-in carries `SAIL_DATA_DIR` + `UMask`; and stop precedes move while reload precedes start. Full suite green; all gates met. **No new dependencies.**

### Next — brick 3c
`sail host keys sync` (+ on `sail fde key add/rm`): render the `sail` user's `authorized_keys` from `fde_ssh_keys` with `command="sail _gateway --fde <handle>",restrict <key>`. Then it's live end to end.