### PR TITLE
Auto-detect /var/lib/sail control-plane DB (ssh-cli-identity fix) — 0.13.52

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.51</version>
+    <version>0.13.52</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.51</version>
+        <version>0.13.52</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
@@ -27,19 +27,31 @@ public final class SailPaths {
     return SAIL_DIR;
   }
 
+  private static final Path SYSTEM_DATA_DIR = Path.of("/var/lib/sail");
+
   /**
-   * Returns the control-plane data directory: {@code $SAIL_DATA_DIR} when set, otherwise {@link
-   * #sailDir()}. A multi-FDE host points this at a shared system path (e.g. {@code /var/lib/sail})
-   * so the {@code sail} user's SSH gateway and the {@code sail-api} service reach the same
-   * database; when unset, solo/dev installs keep everything under {@code ~/.sail} unchanged.
+   * Returns the control-plane data directory. Resolution: {@code $SAIL_DATA_DIR} when set;
+   * otherwise the shared system directory {@code /var/lib/sail} when it already holds the database
+   * (a host provisioned for SSH-key FDE login); otherwise {@link #sailDir()}. Auto-detecting the
+   * provisioned location matters because every context must agree on the database without relying
+   * on an env var being exported everywhere — the operator's interactive shell, the {@code sail}
+   * user's SSH gateway (a non-login {@code bash -c}), and the {@code sail-api} service all reach
+   * it. Solo/dev installs with no system database keep everything under {@code ~/.sail} unchanged.
    */
   public static Path dataDir() {
-    return dataDir(System.getenv("SAIL_DATA_DIR"));
+    return dataDir(
+        System.getenv("SAIL_DATA_DIR"), Files.isReadable(SYSTEM_DATA_DIR.resolve("sail.db")));
   }
 
-  /** Pure resolver; visible for tests so the lookup can be exercised without setting an env var. */
-  static Path dataDir(String configured) {
-    return configured != null && !configured.isBlank() ? Path.of(configured) : SAIL_DIR;
+  /** Pure resolver; visible for tests so resolution can be exercised without the environment. */
+  static Path dataDir(String configured, boolean provisionedSystemDb) {
+    if (configured != null && !configured.isBlank()) {
+      return Path.of(configured);
+    }
+    if (provisionedSystemDb) {
+      return SYSTEM_DATA_DIR;
+    }
+    return SAIL_DIR;
   }
 
   /** Returns the control-plane database path: {@code <dataDir>/sail.db}. */

--- a/sail-core/src/test/java/ai/singlr/sail/engine/SailPathsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/SailPathsTest.java
@@ -165,14 +165,20 @@ class SailPathsTest {
   }
 
   @Test
-  void dataDirUsesConfiguredValueWhenSet() {
-    assertEquals(Path.of("/var/lib/sail"), SailPaths.dataDir("/var/lib/sail"));
+  void dataDirEnvOverrideWinsEvenOverProvisionedSystemDir() {
+    assertEquals(Path.of("/custom/dir"), SailPaths.dataDir("/custom/dir", false));
+    assertEquals(Path.of("/custom/dir"), SailPaths.dataDir("/custom/dir", true));
   }
 
   @Test
-  void dataDirFallsBackToSailDirWhenUnsetOrBlank() {
-    assertEquals(SailPaths.sailDir(), SailPaths.dataDir(null));
-    assertEquals(SailPaths.sailDir(), SailPaths.dataDir("   "));
+  void dataDirAutoDetectsProvisionedSystemDir() {
+    assertEquals(Path.of("/var/lib/sail"), SailPaths.dataDir(null, true));
+  }
+
+  @Test
+  void dataDirFallsBackToSailDirWhenUnsetAndNoSystemDb() {
+    assertEquals(SailPaths.sailDir(), SailPaths.dataDir(null, false));
+    assertEquals(SailPaths.sailDir(), SailPaths.dataDir("   ", false));
   }
 
   @Test

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.51</version>
+        <version>0.13.52</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.51</version>
+        <version>0.13.52</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>


### PR DESCRIPTION
## Caught in preview review of `sail host ssh-identity`

The systemd drop-in exports `SAIL_DATA_DIR=/var/lib/sail` only for the **service**. After provisioning moves the DB there, the operator's interactive `sail fde add` / `sail host keys sync`, and the `sail` user's **gateway** (a non-login `bash -c` that sources no profile), have no such env — they'd fall back to `~/.sail/sail.db` (now gone) and silently operate on a *different, empty* database than the service. Confusing and broken.

## Fix
`SailPaths.dataDir()` now **auto-detects** the provisioned location:
1. `$SAIL_DATA_DIR` if set (explicit override, supports custom locations),
2. else `/var/lib/sail` when it already holds `sail.db` (provisioned host),
3. else `~/.sail` (solo/dev — unchanged).

Every context agrees on the database with no env plumbing. The drop-in's env stays as a belt-and-suspenders override.

## Testing
`dataDir(...)`: env override wins even over a provisioned system dir; auto-detect picks `/var/lib/sail` when present; unset + no system DB → `~/.sail`. Full suite green; gates met. No new dependencies.