### PR TITLE
One-command FDE onboarding + gateway-by-default client (ssh-cli-identity brick 4 + DX consolidation) — 0.13.53

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Sail Architecture
 
 > Status: living document. Captures the positioning and design decisions behind `sail`.
-> Last substantive update: 2026-05-29.
+> Last substantive update: 2026-06-12.
 
 ## What Sail is
 
@@ -94,11 +94,15 @@ Coverage discipline: `ai.singlr.sail.api.*` is held to **100% line/method** JaCo
 - **Host mode** — `~/.sail/host.yaml` exists. Commands execute locally: lifecycle
   commands drive `incus`/`podman`; API commands hit the local server.
 - **Client mode** — `~/.sail/config.yaml` exists (and no host config). Commands are
-  forwarded to the host over SSH by `RemoteCommandRunner`:
-  - **Local** (`--version`, `upgrade`, `init`) run on the client.
+  forwarded to the host over SSH by `RemoteCommandRunner`, in two lanes:
+  - **Local** (`--version`, `upgrade`, `init`, `login`) run on the client.
   - **Host-only** (`host …`) error with guidance to SSH in.
-  - **Everything else** is forwarded over SSH; the host renders output, the client
-    displays it.
+  - **FDE-gateway commands** (`spec`, `agent`, `events`, `fde`) target `sail@host`.
+    The engineer's SSH key hits a forced command (`sail _gateway --fde <handle>`)
+    that resolves their FDE, mints a short-lived session, and re-execs the command —
+    so the loopback API sees *who* is acting and `Authorizer` enforces their role.
+  - **Everything else** (project lifecycle, interactive shells) is forwarded as the
+    plain SSH host, because it needs host privileges the `sail` user must never have.
 
 This is why the loopback-only API is not a limitation for the Mac client: commands
 run *on the host*, where the API is reachable at `127.0.0.1:7070`.
@@ -111,7 +115,7 @@ bytes and SHA-256 checksum, and strips the Gatekeeper quarantine flag. An FDE ru
 
 ```
 curl -fsSL .../install.sh | bash      # downloads darwin-arm64
-sail init my-server                   # writes ~/.sail/config.yaml { host: my-server }
+sail init my-server                   # writes ~/.sail/config.yaml { host, user: sail }
 sail project up acme                  # forwarded over SSH, runs on my-server
 ```
 
@@ -120,10 +124,25 @@ and proxy settings.
 
 ## Security model
 
-The deployment is **single-trust**: one operator, one bare-metal server.
+**One ingress by design.** The only network surface a sail host exposes is sshd, which
+the operator runs anyway; the API binds `127.0.0.1` and is never network-reachable.
+There are exactly two identity doors, both landing on the same `fdes` row, role, and
+`Authorizer`:
 
-- **Auth** — bearer token, stored `0600` under `~/.sail/` (`0700`). No RBAC or
-  multi-user identity yet (see *Known gaps*).
+1. **Terminal: SSH key → FDE.** Each registered key is pinned in the `sail` user's
+   `authorized_keys` to `command="sail _gateway --fde <handle>",restrict` — no shell,
+   no forwarding, a default-deny command classification, and a short-lived session
+   minted per invocation. `sail fde add <handle> --key "<pubkey>"` is the whole
+   enrollment; removing the key revokes SSH and API access in one step.
+2. **Web (opt-in, off by default): passkeys.** For Mast/browser clients only. Requires
+   the operator to deploy a TLS-terminating reverse proxy and configure the `webauthn`
+   block; until then the endpoints answer 503.
+
+- **Auth** — FDE identity with capability roles (`admin`/`member`/`viewer`) enforced
+  at the API boundary (GET ⇒ READ, mutating ⇒ WRITE, sensitive routes ⇒ ADMIN), plus
+  anti-spoof attribution (`created_by`/`updated_by`/`decided_by` stamped server-side).
+  Host-local bearer tokens remain for the operator and back-compat, stored `0600`
+  under `~/.sail/` (`0700`); scoping them down further is tracked in *Known gaps*.
 - **API transport — sail serves plain HTTP on `127.0.0.1`; it does not do TLS at all.**
   The loopback API is reached by the CLI via SSH tunnel / SSH command-forwarding; for
   network or browser access (Mast, passkeys), the operator fronts sail with a
@@ -147,20 +166,28 @@ See `SECURITY_AUDIT.md` for the full checklist and accepted risks.
 
 ## Known gaps / evolution
 
-These are the deliberate edges between today's single-trust CLI tool and the
-multi-FDE platform that must support Mast:
+These are the deliberate edges between today's CLI tool and the multi-FDE platform
+that must support Mast:
 
-1. **Single-trust → multi-FDE identity + authz.** The largest gap before Mast. One
-   shared bearer token does not model many FDEs coordinating on shared specs.
-   *(Tracked as a design spec.)*
-2. **Two remote-config models.** `ClientConfig` (SSH-forward via `host`) and
+1. **Project lifecycle is host-privileged, not API-backed.** `project up` drives
+   `incus` directly, so it cannot ride the FDE gateway — engineers need admin SSH for
+   it. The k8s-shaped fix is for the control plane to own provisioning (the API runs
+   as root on the host already) and for the CLI to become a pure client. This is the
+   largest remaining gap before "a member-role FDE can create containers and get
+   going" without host privileges.
+2. **Host admin token rides along for back-compat** (missing role ⇒ ADMIN). Once
+   SSH-key + passkey identity is proven in the field, scope it down to break-glass.
+3. **Two remote-config models.** `ClientConfig` (SSH-forward via `host`/`user`) and
    `ServerConnectionConfig` (HTTP API via `server` + `token`) both read
    `~/.sail/config.yaml` with different keys. SSH-forwarding papers over this today;
    direct API access from a client (Mast, or a future direct-mode CLI) needs them
-   reconciled and the transport decision made.
-3. **No API rate limiting** — relevant once long-lived desktop / Chorus clients connect.
-4. **Single platform per OS** — Mac arm64 only, Linux amd64 only.
-5. **Release signing/notarization** — checksums protect against corruption, not a
+   reconciled. Related: a passkey `sail login` session currently has no CLI consumer
+   on a forwarding client — sessions serve the browser/Mast until the direct-API
+   client exists.
+4. **Session/event actor attribution** — deferred to land with multi-node dispatch.
+5. **No API rate limiting** — relevant once long-lived desktop / Chorus clients connect.
+6. **Single platform per OS** — Mac arm64 only, Linux amd64 only.
+7. **Release signing/notarization** — checksums protect against corruption, not a
    compromised release channel.
 
 ## Design invariants to preserve

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.52</version>
+    <version>0.13.53</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.52</version>
+        <version>0.13.53</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/config/ClientConfig.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/ClientConfig.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Model for {@code ~/.sail/config.yaml} — client-side configuration on the engineer's Mac that
@@ -20,9 +21,21 @@ import java.util.Map;
  * <p>Only {@code host} is required — it can be an IP, hostname, or an SSH config alias (e.g. {@code
  * kubera-server}). SSH resolves the user, key, and proxy settings from {@code ~/.ssh/config}.
  *
+ * <p>{@code user} is the host account that turns the engineer's SSH key into their FDE identity
+ * (the forced-command gateway). It defaults to {@code sail}; commands the gateway accepts are
+ * forwarded as {@code sail@host}, everything else as plain {@code host}. Set it to an empty string
+ * to disable the gateway lane and forward everything as the SSH default user.
+ *
  * @param host the remote host — IP, hostname, or SSH config alias
+ * @param user the gateway account FDE commands are forwarded as, or blank to disable
  */
-public record ClientConfig(String host) {
+public record ClientConfig(String host, String user) {
+
+  public static final String GATEWAY_USER = "sail";
+
+  public ClientConfig(String host) {
+    this(host, GATEWAY_USER);
+  }
 
   public static ClientConfig fromMap(Map<String, Object> map) {
     var host = (String) map.get("host");
@@ -31,13 +44,25 @@ public record ClientConfig(String host) {
           "client config 'host' is required."
               + "\n  Set the host in ~/.sail/config.yaml: host: <server-ip-or-ssh-alias>");
     }
-    return new ClientConfig(host);
+    var user = Objects.requireNonNullElse((String) map.get("user"), GATEWAY_USER);
+    return new ClientConfig(host, user);
   }
 
   public Map<String, Object> toMap() {
     var map = new LinkedHashMap<String, Object>();
     map.put("host", host);
+    map.put("user", user);
     return map;
+  }
+
+  /** Returns true when FDE-gateway forwarding is configured (a non-blank gateway user). */
+  public boolean gatewayEnabled() {
+    return user != null && !user.isBlank();
+  }
+
+  /** The SSH destination for gateway-forwarded commands, e.g. {@code sail@devbox}. */
+  public String gatewayTarget() {
+    return user + "@" + host;
   }
 
   /** Returns true if the client config file exists at {@code ~/.sail/config.yaml}. */

--- a/sail-core/src/main/java/ai/singlr/sail/ssh/SshGateway.java
+++ b/sail-core/src/main/java/ai/singlr/sail/ssh/SshGateway.java
@@ -14,18 +14,30 @@ import java.util.Set;
 /**
  * Decides what a forced-command SSH session may run and as whom. When an engineer's key hits the
  * {@code sail} user's forced command, this resolves their FDE (passed as {@code --fde} on the
- * authorized_keys line), validates the requested command against an allow-list, mints a short-lived
- * session for that FDE, and returns the argument vector to exec with {@code SAIL_TOKEN} set — so
- * the downstream command authenticates to the loopback API as the FDE and {@code Authorizer}
- * enforces its role. Default-deny: only API-backed, role-governed commands are permitted;
- * database-direct admin commands ({@code fde}, {@code host}, {@code server}, {@code migrate}) are
- * not, because they would bypass the API and run with the {@code sail} user's full access
- * regardless of role.
+ * authorized_keys line), classifies the requested command, mints a short-lived session for that
+ * FDE, and returns the argument vector to exec with {@code SAIL_TOKEN} set — so the downstream
+ * command authenticates to the loopback API as the FDE and {@code Authorizer} enforces its role.
+ *
+ * <p>Commands are authorized by kind, default-deny:
+ *
+ * <ul>
+ *   <li>{@link #API_COMMANDS} run for every active FDE — they talk to the loopback API, where the
+ *       FDE's role decides what each request may do.
+ *   <li>{@link #ADMIN_COMMANDS} are database-direct, so no downstream check exists; the gateway
+ *       itself requires the {@code admin} role.
+ *   <li>Everything else ({@code project}, {@code host}, {@code server}, {@code migrate}, …) runs
+ *       with host privileges the {@code sail} user must never have, and is refused.
+ * </ul>
  */
 public final class SshGateway {
 
   static final Duration SESSION_TTL = Duration.ofMinutes(10);
-  static final Set<String> ALLOWED_COMMANDS = Set.of("spec", "dispatch", "agent", "events");
+
+  /** Commands the loopback API authorizes per-request by FDE role. */
+  public static final Set<String> API_COMMANDS = Set.of("spec", "agent", "events");
+
+  /** Database-direct administration commands; the gateway admits only admin-role FDEs. */
+  public static final Set<String> ADMIN_COMMANDS = Set.of("fde");
 
   private SshGateway() {}
 
@@ -56,12 +68,19 @@ public final class SshGateway {
       return new Rejected("No 'sail' subcommand supplied.");
     }
     var subcommand = tokens.getFirst();
-    if (!ALLOWED_COMMANDS.contains(subcommand)) {
-      return new Rejected("'" + subcommand + "' is not permitted over an SSH-key session.");
+    if (!API_COMMANDS.contains(subcommand) && !ADMIN_COMMANDS.contains(subcommand)) {
+      return new Rejected(
+          "'"
+              + subcommand
+              + "' requires host privileges and is not available over an SSH-key session."
+              + " SSH to the host directly to run it.");
     }
     var fde = fdes.byHandle(fdeHandle);
     if (fde.isEmpty() || !"active".equals(fde.get().status())) {
       return new Rejected("Unknown or disabled FDE.");
+    }
+    if (ADMIN_COMMANDS.contains(subcommand) && !"admin".equals(fde.get().role())) {
+      return new Rejected("'" + subcommand + "' requires the admin role.");
     }
     var session = sessions.create(fde.get().id(), SESSION_TTL);
     return new Authorized(List.copyOf(tokens), session.token());

--- a/sail-core/src/test/java/ai/singlr/sail/config/ClientConfigTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/ClientConfigTest.java
@@ -55,7 +55,30 @@ class ClientConfigTest {
 
     var rebuilt = ClientConfig.fromMap(original.toMap());
 
-    assertEquals(original.host(), rebuilt.host());
+    assertEquals(original, rebuilt);
+  }
+
+  @Test
+  void userDefaultsToGatewayUser() {
+    var config = ClientConfig.fromMap(Map.<String, Object>of("host", "devbox"));
+
+    assertEquals(ClientConfig.GATEWAY_USER, config.user());
+    assertTrue(config.gatewayEnabled());
+    assertEquals("sail@devbox", config.gatewayTarget());
+  }
+
+  @Test
+  void blankUserDisablesGateway() {
+    var config = ClientConfig.fromMap(Map.<String, Object>of("host", "devbox", "user", ""));
+
+    assertFalse(config.gatewayEnabled());
+  }
+
+  @Test
+  void explicitUserOverridesGatewayTarget() {
+    var config = ClientConfig.fromMap(Map.<String, Object>of("host", "devbox", "user", "gw"));
+
+    assertEquals("gw@devbox", config.gatewayTarget());
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/ssh/SshGatewayTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/ssh/SshGatewayTest.java
@@ -12,6 +12,7 @@ import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Path;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ class SshGatewayTest {
   void permitsAllowedCommandAndMintsUsableSession() {
     var decision = authorize("sail spec list", "uday");
     var authorized = assertInstanceOf(SshGateway.Authorized.class, decision);
-    assertEquals(java.util.List.of("spec", "list"), authorized.args());
+    assertEquals(List.of("spec", "list"), authorized.args());
     assertTrue(authorized.sessionToken().startsWith("sess_"));
     assertTrue(sessions.validate(authorized.sessionToken()).isPresent());
   }
@@ -54,21 +55,35 @@ class SshGatewayTest {
   @Test
   void stripsLeadingSailToken() {
     var authorized = assertInstanceOf(SshGateway.Authorized.class, authorize("spec list", "uday"));
-    assertEquals(java.util.List.of("spec", "list"), authorized.args());
+    assertEquals(List.of("spec", "list"), authorized.args());
   }
 
   @Test
-  void rejectsDisallowedCommand() {
+  void rejectsFdeCommandForNonAdminRole() {
     var rejected = assertInstanceOf(SshGateway.Rejected.class, authorize("sail fde list", "uday"));
-    assertTrue(rejected.reason().contains("fde"));
+    assertTrue(rejected.reason().contains("admin role"));
     assertTrue(sessions.validate("sess_anything").isEmpty());
   }
 
   @Test
-  void rejectsAdminDirectCommands() {
-    assertInstanceOf(SshGateway.Rejected.class, authorize("sail host status", "uday"));
-    assertInstanceOf(SshGateway.Rejected.class, authorize("sail migrate", "uday"));
-    assertInstanceOf(SshGateway.Rejected.class, authorize("sail server start", "uday"));
+  void permitsFdeCommandForAdminRole() {
+    fdes.add("ada", null, null, "admin");
+    var authorized =
+        assertInstanceOf(SshGateway.Authorized.class, authorize("sail fde list", "ada"));
+    assertEquals(List.of("fde", "list"), authorized.args());
+    assertTrue(sessions.validate(authorized.sessionToken()).isPresent());
+  }
+
+  @Test
+  void rejectsHostPrivilegedCommandsEvenForAdmins() {
+    fdes.add("ada", null, null, "admin");
+    for (var handle : List.of("uday", "ada")) {
+      for (var command : List.of("host status", "migrate", "server start", "project up")) {
+        var rejected =
+            assertInstanceOf(SshGateway.Rejected.class, authorize("sail " + command, handle));
+        assertTrue(rejected.reason().contains("host privileges"));
+      }
+    }
   }
 
   @Test
@@ -97,6 +112,7 @@ class SshGatewayTest {
   @Test
   void noSessionIsMintedWhenRejected() {
     authorize("sail fde list", "uday");
+    authorize("sail project up acme", "uday");
     db.execute("UPDATE fdes SET status = 'disabled' WHERE handle = ?", "uday");
     authorize("sail spec list", "uday");
     assertEquals(

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.52</version>
+        <version>0.13.53</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.52</version>
+        <version>0.13.53</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ClientInitCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ClientInitCommand.java
@@ -47,8 +47,13 @@ public final class ClientInitCommand implements Runnable {
     System.out.println(
         Ansi.AUTO.string("  @|bold,green \u2713|@ Client configured: " + configPath));
     System.out.println(Ansi.AUTO.string("  @|faint Host:|@ " + host));
+    System.out.println(
+        Ansi.AUTO.string(
+            "  @|faint Identity:|@ your SSH key, via the '"
+                + ClientConfig.GATEWAY_USER
+                + "' gateway user"));
     System.out.println();
-    System.out.println(Ansi.AUTO.string("  Test with: @|bold sail spec list <project>|@"));
+    System.out.println(Ansi.AUTO.string("  Test with: @|bold sail spec list|@"));
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.auth.EnrollmentService;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.AuthorizedKeysSync;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.ssh.SshPublicKey;
 import ai.singlr.sail.store.EnrollmentTicketStore;
@@ -48,6 +49,37 @@ public final class FdeCommand implements Runnable {
     return SailPaths.controlPlaneDb();
   }
 
+  private static void registerKey(Sqlite db, FdeStore.Fde fde, String publicKey) throws Exception {
+    var key = SshPublicKey.parse(publicKey);
+    try {
+      new FdeSshKeyStore(db).add(fde.id(), key);
+    } catch (SqliteException e) {
+      throw new IllegalArgumentException(
+          "That key (" + key.fingerprint() + ") is already registered.");
+    }
+    System.out.println(
+        Ansi.AUTO.string(
+            "  @|green ✓|@ Registered key for " + fde.handle() + ": " + key.fingerprint()));
+    applyKeys(db);
+  }
+
+  private static void applyKeys(Sqlite db) throws Exception {
+    switch (new AuthorizedKeysSync().sync(db)) {
+      case AuthorizedKeysSync.Synced synced ->
+          System.out.println(
+              Ansi.AUTO.string(
+                  "  @|green ✓|@ authorized_keys synced (" + synced.keyCount() + " key(s))"));
+      case AuthorizedKeysSync.NeedsRoot _ ->
+          System.out.println(
+              Ansi.AUTO.string("  @|faint Run 'sudo sail host keys sync' to apply.|@"));
+      case AuthorizedKeysSync.NotProvisioned _ ->
+          System.out.println(
+              Ansi.AUTO.string(
+                  "  @|faint SSH-key login is not provisioned on this host. Run 'sudo sail host"
+                      + " ssh-identity' to enable it.|@"));
+    }
+  }
+
   @Command(name = "add", description = "Add an FDE.", mixinStandardHelpOptions = true)
   static final class Add implements Runnable {
 
@@ -66,6 +98,13 @@ public final class FdeCommand implements Runnable {
         defaultValue = FdeStore.DEFAULT_ROLE)
     private String role;
 
+    @Option(
+        names = "--key",
+        description =
+            "SSH public key line to register for terminal login, e.g."
+                + " \"ssh-ed25519 AAAA... me@host\".")
+    private String publicKey;
+
     @Spec private CommandSpec spec;
 
     @Override
@@ -78,6 +117,9 @@ public final class FdeCommand implements Runnable {
               System.out.println(
                   Ansi.AUTO.string(
                       "  @|green ✓|@ FDE added: " + fde.handle() + " (" + fde.role() + ")"));
+              if (publicKey != null) {
+                registerKey(db, fde, publicKey);
+              }
             }
           });
     }
@@ -212,21 +254,7 @@ public final class FdeCommand implements Runnable {
                                         + "'. Add it with 'sail fde add "
                                         + handle
                                         + "'."));
-                var key = SshPublicKey.parse(publicKey);
-                try {
-                  new FdeSshKeyStore(db).add(fde.id(), key);
-                } catch (SqliteException e) {
-                  throw new IllegalArgumentException(
-                      "That key (" + key.fingerprint() + ") is already registered.");
-                }
-                System.out.println(
-                    Ansi.AUTO.string(
-                        "  @|green ✓|@ Registered key for "
-                            + fde.handle()
-                            + ": "
-                            + key.fingerprint()));
-                System.out.println(
-                    Ansi.AUTO.string("  @|faint Run 'sail host keys sync' to apply.|@"));
+                registerKey(db, fde, publicKey);
               }
             });
       }
@@ -294,8 +322,7 @@ public final class FdeCommand implements Runnable {
               try (var db = Sqlite.open(dbPath())) {
                 if (new FdeSshKeyStore(db).remove(fingerprint)) {
                   System.out.println(Ansi.AUTO.string("  @|green ✓|@ Removed key " + fingerprint));
-                  System.out.println(
-                      Ansi.AUTO.string("  @|faint Run 'sail host keys sync' to apply.|@"));
+                  applyKeys(db);
                 } else {
                   System.out.println(
                       Ansi.AUTO.string("  @|yellow ⚠|@ No key with fingerprint " + fingerprint));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/GatewayCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/GatewayCommand.java
@@ -22,9 +22,9 @@ import picocli.CommandLine.Option;
  * hand: each registered key's {@code authorized_keys} line is {@code command="sail _gateway --fde
  * <handle>"}, so sshd invokes this with the engineer's real command in {@code
  * SSH_ORIGINAL_COMMAND}. It authorizes the request through {@link SshGateway} — resolving the FDE,
- * checking the allow-list, minting a short-lived session — then re-execs {@code sail} with {@code
- * SAIL_TOKEN} set so the command runs as that FDE under role-based authorization. Disallowed
- * commands are refused without minting anything.
+ * classifying the command by kind and role, minting a short-lived session — then re-execs {@code
+ * sail} with {@code SAIL_TOKEN} set so the command runs as that FDE under role-based authorization.
+ * Refused commands mint nothing.
  */
 @Command(name = "_gateway", description = "Internal SSH forced-command entry point.", hidden = true)
 public final class GatewayCommand implements Callable<Integer> {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostKeysCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostKeysCommand.java
@@ -5,15 +5,9 @@
 
 package ai.singlr.sail.commands;
 
-import ai.singlr.sail.engine.AuthorizedKeysRenderer;
+import ai.singlr.sail.engine.AuthorizedKeysSync;
 import ai.singlr.sail.engine.SailPaths;
-import ai.singlr.sail.engine.ShellExecutor;
-import ai.singlr.sail.engine.SshIdentityProvisioner;
-import ai.singlr.sail.store.FdeSshKeyStore;
 import ai.singlr.sail.store.Sqlite;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -21,10 +15,10 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Spec;
 
 /**
- * Renders and installs the {@code sail} user's {@code authorized_keys} from the SSH-key registry,
- * so the keys an admin has registered (and only those) can log in as their FDE through the gateway.
- * Idempotent — it fully regenerates the managed file each run, so adding or removing a key and
- * re-syncing is the revocation path.
+ * Repairs the {@code sail} user's {@code authorized_keys} from the SSH-key registry. Key mutations
+ * ({@code sail fde add --key}, {@code sail fde key add/rm}) sync automatically; this command exists
+ * to converge the file by hand when a mutation could not (it ran without root) or when the file was
+ * edited out from under sail.
  */
 @Command(
     name = "keys",
@@ -55,51 +49,30 @@ public final class HostKeysCommand implements Runnable {
           spec,
           () -> {
             try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
-              var keys = new FdeSshKeyStore(db).list();
-              var content = AuthorizedKeysRenderer.render(keys, SailPaths.binaryPath().toString());
+              var sync = new AuthorizedKeysSync();
               if (dryRun) {
-                System.out.print(content);
+                System.out.print(sync.render(db));
                 return;
               }
-              install(content, keys.size());
+              switch (sync.sync(db)) {
+                case AuthorizedKeysSync.Synced synced ->
+                    System.out.println(
+                        Ansi.AUTO.string(
+                            "  @|green ✓|@ Synced "
+                                + synced.keyCount()
+                                + " key(s) to "
+                                + synced.destination()));
+                case AuthorizedKeysSync.NeedsRoot _ ->
+                    throw new IllegalStateException(
+                        "Writing the sail user's authorized_keys requires root. Run it on the host"
+                            + " as root, or preview with --dry-run.");
+                case AuthorizedKeysSync.NotProvisioned _ ->
+                    throw new IllegalStateException(
+                        "The sail user is not provisioned. Run 'sudo sail host ssh-identity'"
+                            + " first.");
+              }
             }
           });
-    }
-
-    private static void install(String content, int count) throws Exception {
-      if (!"root".equals(ProcessHandle.current().info().user().orElse(""))) {
-        throw new IllegalStateException(
-            "Writing the sail user's authorized_keys requires root. Run it on the host as root,"
-                + " or preview with --dry-run.");
-      }
-      var dest = Path.of(SshIdentityProvisioner.SAIL_HOME, ".ssh", "authorized_keys");
-      if (!Files.isDirectory(dest.getParent())) {
-        throw new IllegalStateException(
-            "The sail user is not provisioned. Run 'sail host ssh-identity --apply' first.");
-      }
-      var temp = Files.createTempFile("sail-authorized-keys", "");
-      try {
-        Files.writeString(temp, content);
-        var result =
-            new ShellExecutor(false)
-                .exec(
-                    List.of(
-                        "install",
-                        "-m",
-                        "600",
-                        "-o",
-                        "sail",
-                        "-g",
-                        "sail",
-                        temp.toString(),
-                        dest.toString()));
-        if (!result.ok()) {
-          throw new IllegalStateException("Failed to write " + dest + ":\n" + result.stderr());
-        }
-      } finally {
-        Files.deleteIfExists(temp);
-      }
-      System.out.println(Ansi.AUTO.string("  @|green ✓|@ Synced " + count + " key(s) to " + dest));
     }
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostSshIdentityCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostSshIdentityCommand.java
@@ -5,9 +5,11 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.engine.AuthorizedKeysSync;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SshIdentityProvisioner;
+import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Files;
 import java.util.List;
 import picocli.CommandLine.Command;
@@ -18,10 +20,10 @@ import picocli.CommandLine.Spec;
 
 /**
  * Provisions a host for SSH-key FDE login: the locked-down {@code sail} user, the shared {@code
- * /var/lib/sail} data directory, the database moved into it, and a systemd drop-in pointing {@code
- * sail-api} there. Previews by default and only mutates with {@code --apply}, because it creates a
- * system user and relocates the control-plane database. The plan touches no global sshd config and
- * never alters the operator's existing root SSH.
+ * /var/lib/sail} data directory, the database moved into it, a systemd drop-in pointing {@code
+ * sail-api} there, and the registered keys synced into the {@code sail} user's {@code
+ * authorized_keys}. Every step is idempotent, so re-running converges a partially provisioned host.
+ * The plan touches no global sshd config and never alters the operator's existing root SSH.
  */
 @Command(
     name = "ssh-identity",
@@ -29,11 +31,8 @@ import picocli.CommandLine.Spec;
     mixinStandardHelpOptions = true)
 public final class HostSshIdentityCommand implements Runnable {
 
-  @Option(
-      names = "--apply",
-      description =
-          "Execute the plan. Without this flag the command only previews (requires root).")
-  private boolean apply;
+  @Option(names = "--dry-run", description = "Print the plan instead of executing it.")
+  private boolean dryRun;
 
   @Spec private CommandSpec spec;
 
@@ -46,20 +45,21 @@ public final class HostSshIdentityCommand implements Runnable {
               SshIdentityProvisioner.plan(
                   SailPaths.sailDir(), SshIdentityProvisioner.DEFAULT_DATA_DIR);
           printPlan(plan);
-          if (!apply) {
+          if (dryRun) {
             System.out.println();
             System.out.println(
-                Ansi.AUTO.string(
-                    "  @|faint Preview only. Re-run as root with --apply to execute.|@"));
+                Ansi.AUTO.string("  @|faint Dry run only. Re-run as root to execute.|@"));
             return;
           }
           requireRoot();
+          System.out.println();
           execute(plan);
+          syncKeys();
           System.out.println();
           System.out.println(
               Ansi.AUTO.string(
-                  "  @|green ✓|@ SSH-key login enabled. Register keys with"
-                      + " 'sail fde key add <handle> <pubkey>' then 'sail host keys sync'."));
+                  "  @|green ✓|@ SSH-key login enabled. Register engineers with"
+                      + " 'sail fde add <handle> --key \"<pubkey>\"'."));
         });
   }
 
@@ -101,11 +101,21 @@ public final class HostSshIdentityCommand implements Runnable {
     }
   }
 
+  private static void syncKeys() throws Exception {
+    try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+      if (new AuthorizedKeysSync().sync(db) instanceof AuthorizedKeysSync.Synced synced) {
+        System.out.println(
+            Ansi.AUTO.string(
+                "  @|green ✓|@ authorized_keys synced (" + synced.keyCount() + " key(s))"));
+      }
+    }
+  }
+
   private static void requireRoot() {
     if (!"root".equals(ProcessHandle.current().info().user().orElse(""))) {
       throw new IllegalStateException(
-          "--apply must run as root: it creates a system user, relocates the database, and edits"
-              + " a systemd unit. SSH to the host and run it there as root.");
+          "This command must run as root: it creates a system user, relocates the database, and"
+              + " edits a systemd unit. Preview with --dry-run, or re-run with sudo.");
     }
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/UpgradeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/UpgradeCommand.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.SailVersion;
 import ai.singlr.sail.api.ServerConnectionConfig;
 import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.AuthorizedKeysSync;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.PlatformDetector;
 import ai.singlr.sail.engine.ReleaseFetcher;
@@ -182,6 +183,8 @@ public final class UpgradeCommand implements Runnable {
 
     var restartStatus = restartSailApi(dryRun);
 
+    syncAuthorizedKeys(dryRun);
+
     if (json) {
       printJsonResult(
           currentVersion, latestVersionStr, "upgraded", binaryPath.toString(), restartStatus);
@@ -286,6 +289,34 @@ public final class UpgradeCommand implements Runnable {
    */
   private boolean reconcileUnitFile(SystemdServiceInstaller installer) throws Exception {
     return installer.reconcile();
+  }
+
+  /**
+   * Converges the {@code sail} user's {@code authorized_keys} with the SSH-key registry so a host
+   * comes fully online from an upgrade alone — keys registered before this binary's auto-sync
+   * existed are installed without any manual {@code keys sync}. Quiet when there is nothing to do
+   * (unprovisioned host, non-root upgrade) and never fatal: the binary install already succeeded.
+   */
+  private void syncAuthorizedKeys(boolean dryRun) {
+    if (dryRun) {
+      System.out.println(
+          "[dry-run] Would sync the sail user's authorized_keys from the SSH-key registry.");
+      return;
+    }
+    try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+      if (new AuthorizedKeysSync().sync(db) instanceof AuthorizedKeysSync.Synced synced && !json) {
+        System.out.println(
+            Ansi.AUTO.string(
+                "  @|green ✓|@ authorized_keys synced (" + synced.keyCount() + " key(s))"));
+      }
+    } catch (Exception e) {
+      System.err.println(
+          Banner.errorLine(
+              "authorized_keys sync failed: "
+                  + e.getMessage()
+                  + ". Converge manually with 'sudo sail host keys sync'.",
+              Ansi.AUTO));
+    }
   }
 
   /** Bind address + port pair extracted from a sail-api unit file's {@code ExecStart}. */

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/AuthorizedKeysSync.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/AuthorizedKeysSync.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import ai.singlr.sail.store.FdeSshKeyStore;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Installs the {@code sail} user's {@code authorized_keys} from the SSH-key registry — the single
+ * write path shared by {@code sail host keys sync}, the {@code sail fde} key mutations, and the
+ * upgrade reconciler. The file is fully regenerated each time, so registry membership is the only
+ * source of truth and removing a key revokes its SSH access on the next sync.
+ *
+ * <p>Syncing is environment-dependent, so callers receive an {@link Outcome} instead of an
+ * exception: writing into the sail user's home requires root, and an unprovisioned host has nowhere
+ * to write. Each caller decides whether that is an error (the explicit {@code keys sync} command)
+ * or a hint (an {@code fde key add} that registered the key but could not install it).
+ */
+public final class AuthorizedKeysSync {
+
+  public sealed interface Outcome permits Synced, NeedsRoot, NotProvisioned {}
+
+  /** The file was regenerated from the registry. */
+  public record Synced(int keyCount, Path destination) implements Outcome {}
+
+  /** The caller lacks root; the registry changed but the file did not. */
+  public record NeedsRoot() implements Outcome {}
+
+  /** The host has no provisioned {@code sail} user to install keys for. */
+  public record NotProvisioned() implements Outcome {}
+
+  private final Path destination;
+  private final boolean root;
+  private final ShellExec shell;
+
+  public AuthorizedKeysSync() {
+    this(
+        Path.of(SshIdentityProvisioner.SAIL_HOME, ".ssh", "authorized_keys"),
+        "root".equals(ProcessHandle.current().info().user().orElse("")),
+        new ShellExecutor(false));
+  }
+
+  AuthorizedKeysSync(Path destination, boolean root, ShellExec shell) {
+    this.destination = destination;
+    this.root = root;
+    this.shell = shell;
+  }
+
+  /** Renders the authorized_keys content without writing it, for {@code --dry-run}. */
+  public String render(Sqlite db) {
+    return AuthorizedKeysRenderer.render(
+        new FdeSshKeyStore(db).list(), SailPaths.binaryPath().toString());
+  }
+
+  public Outcome sync(Sqlite db) throws Exception {
+    var keys = new FdeSshKeyStore(db).list();
+    var content = AuthorizedKeysRenderer.render(keys, SailPaths.binaryPath().toString());
+    if (!root) {
+      return new NeedsRoot();
+    }
+    if (!Files.isDirectory(destination.getParent())) {
+      return new NotProvisioned();
+    }
+    install(content);
+    return new Synced(keys.size(), destination);
+  }
+
+  private void install(String content) throws Exception {
+    var temp = Files.createTempFile("sail-authorized-keys", "");
+    try {
+      Files.writeString(temp, content);
+      var result =
+          shell.exec(
+              List.of(
+                  "install",
+                  "-m",
+                  "600",
+                  "-o",
+                  "sail",
+                  "-g",
+                  "sail",
+                  temp.toString(),
+                  destination.toString()));
+      if (!result.ok()) {
+        throw new IllegalStateException("Failed to write " + destination + ":\n" + result.stderr());
+      }
+    } finally {
+      Files.deleteIfExists(temp);
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/RemoteCommandRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/RemoteCommandRunner.java
@@ -7,10 +7,13 @@ package ai.singlr.sail.engine;
 
 import ai.singlr.sail.Sail;
 import ai.singlr.sail.config.ClientConfig;
+import ai.singlr.sail.ssh.SshGateway;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import picocli.CommandLine;
 import picocli.CommandLine.Help.Ansi;
 
@@ -18,8 +21,12 @@ import picocli.CommandLine.Help.Ansi;
  * Executes SAIL commands on a remote host via SSH. Used in client mode when the binary detects it
  * is running on a Mac (or any machine without {@code /etc/sail/host.yaml}).
  *
- * <p>Commands are forwarded as-is to the host. SSH handles transport, auth, and TTY allocation.
- * Output passes through — the remote host renders ANSI colors and the local terminal displays them.
+ * <p>Commands are forwarded as-is to the host over one of two lanes. Commands the FDE gateway
+ * accepts target {@code sail@host}, where the engineer's SSH key resolves to their FDE and role —
+ * no token handling. Everything else (project lifecycle, interactive shells) targets plain {@code
+ * host}, because those run with host privileges the {@code sail} user must never have. SSH handles
+ * transport, auth, and TTY allocation; output passes through — the remote host renders ANSI colors
+ * and the local terminal displays them.
  */
 public final class RemoteCommandRunner {
 
@@ -27,6 +34,9 @@ public final class RemoteCommandRunner {
       Set.of("--version", "-V", "upgrade", "init", "login");
   private static final Set<String> INTERACTIVE_COMMANDS = Set.of("shell", "exec");
   private static final Set<String> HOST_ONLY_COMMANDS = Set.of("host");
+  private static final Set<String> GATEWAY_COMMANDS =
+      Stream.concat(SshGateway.API_COMMANDS.stream(), SshGateway.ADMIN_COMMANDS.stream())
+          .collect(Collectors.toUnmodifiableSet());
   private static final int SSH_CONNECTION_FAILURE = 255;
 
   private final ClientConfig config;
@@ -44,7 +54,8 @@ public final class RemoteCommandRunner {
    *   <li>Local: {@code --version}, {@code upgrade}, {@code init}, {@code login} — run on the
    *       client, not forwarded ({@code login} drives the client's browser and a loopback callback)
    *   <li>Host-only: {@code host init}, {@code host config} — error with guidance
-   *   <li>Everything else: forwarded to the remote host via SSH
+   *   <li>Everything else: forwarded to the remote host via SSH, as {@code sail@host} when the FDE
+   *       gateway accepts the command and as the plain host otherwise
    * </ul>
    */
   public int execute(String[] args) {
@@ -86,21 +97,14 @@ public final class RemoteCommandRunner {
   }
 
   int executeRemote(String[] args, boolean interactive) {
+    var target = sshTarget(args);
     try {
       var cmd = buildSshCommand(args, interactive);
       var pb = new ProcessBuilder(cmd);
       pb.inheritIO();
       var exitCode = pb.start().waitFor();
       if (exitCode == SSH_CONNECTION_FAILURE) {
-        System.err.println(
-            Banner.errorLine(
-                "Cannot connect to "
-                    + config.host()
-                    + "."
-                    + "\n  Check that the host is reachable and your SSH key is configured."
-                    + "\n  Config: "
-                    + SailPaths.clientConfigPath(),
-                Ansi.AUTO));
+        System.err.println(Banner.errorLine(connectionFailureMessage(target), Ansi.AUTO));
       }
       return exitCode;
     } catch (IOException e) {
@@ -113,16 +117,39 @@ public final class RemoteCommandRunner {
     }
   }
 
+  private String connectionFailureMessage(String target) {
+    var message =
+        "Cannot connect to "
+            + target
+            + "."
+            + "\n  Check that the host is reachable and your SSH key is configured."
+            + "\n  Config: "
+            + SailPaths.clientConfigPath();
+    if (target.equals(config.host())) {
+      return message;
+    }
+    return message
+        + "\n  Commands authenticate as your FDE through the '"
+        + config.user()
+        + "' user. If access was denied, ask an admin to register your key:"
+        + "\n    sail fde key add <your-handle> \"<your pubkey>\"";
+  }
+
   List<String> buildSshCommand(String[] args, boolean interactive) {
     var cmd = new ArrayList<String>();
     cmd.add("ssh");
     if (interactive) {
       cmd.add("-t");
     }
-    cmd.add(config.host());
+    cmd.add(sshTarget(args));
     cmd.add("sail");
     cmd.addAll(List.of(args));
     return List.copyOf(cmd);
+  }
+
+  String sshTarget(String[] args) {
+    var gateway = config.gatewayEnabled() && args.length > 0 && GATEWAY_COMMANDS.contains(args[0]);
+    return gateway ? config.gatewayTarget() : config.host();
   }
 
   /** Returns the classification of a command for testing. */

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/AuthorizedKeysSyncTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/AuthorizedKeysSyncTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sail.ssh.SshPublicKey;
+import ai.singlr.sail.ssh.TestSshKeys;
+import ai.singlr.sail.store.FdeSshKeyStore;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AuthorizedKeysSyncTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private ScriptedShellExecutor shell;
+  private Path destination;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    var fde = new FdeStore(db).add("uday", null, null, "admin");
+    new FdeSshKeyStore(db)
+        .add(fde.id(), SshPublicKey.parse(TestSshKeys.ed25519("seed-1", "uday@mac")));
+    shell = new ScriptedShellExecutor();
+    destination = tempDir.resolve("sail-home/.ssh/authorized_keys");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  private AuthorizedKeysSync sync(boolean root) {
+    return new AuthorizedKeysSync(destination, root, shell);
+  }
+
+  @Test
+  void needsRootWithoutPrivileges() throws Exception {
+    var outcome = sync(false).sync(db);
+    assertInstanceOf(AuthorizedKeysSync.NeedsRoot.class, outcome);
+    assertTrue(shell.invocations().isEmpty());
+  }
+
+  @Test
+  void notProvisionedWhenSailSshDirectoryIsMissing() throws Exception {
+    var outcome = sync(true).sync(db);
+    assertInstanceOf(AuthorizedKeysSync.NotProvisioned.class, outcome);
+    assertTrue(shell.invocations().isEmpty());
+  }
+
+  @Test
+  void syncsRegisteredKeysWhenProvisioned() throws Exception {
+    Files.createDirectories(destination.getParent());
+    shell.onOk("install");
+
+    var outcome = sync(true).sync(db);
+
+    var synced = assertInstanceOf(AuthorizedKeysSync.Synced.class, outcome);
+    assertEquals(1, synced.keyCount());
+    assertEquals(destination, synced.destination());
+    var invocation = shell.invocations().getFirst();
+    assertTrue(invocation.contains("install -m 600 -o sail -g sail"));
+    assertTrue(invocation.endsWith(destination.toString()));
+  }
+
+  @Test
+  void surfacesInstallFailure() throws Exception {
+    Files.createDirectories(destination.getParent());
+    shell.onFail("install", "read-only filesystem");
+
+    var thrown = assertThrows(IllegalStateException.class, () -> sync(true).sync(db));
+    assertTrue(thrown.getMessage().contains(destination.toString()));
+    assertTrue(thrown.getMessage().contains("read-only filesystem"));
+  }
+
+  @Test
+  void rendersForcedCommandLinesWithoutWriting() {
+    var content = sync(true).render(db);
+    assertTrue(content.startsWith("# Managed by sail"));
+    assertTrue(content.contains("_gateway --fde uday\",restrict ssh-ed25519 "));
+    assertTrue(shell.invocations().isEmpty());
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/RemoteCommandRunnerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/RemoteCommandRunnerTest.java
@@ -23,11 +23,37 @@ class RemoteCommandRunnerTest {
 
     assertEquals("ssh", cmd.getFirst());
     assertFalse(cmd.contains("-t"));
-    assertTrue(cmd.contains("kubera-server"));
+    assertTrue(cmd.contains("sail@kubera-server"));
     assertTrue(cmd.contains("sail"));
     assertTrue(cmd.contains("spec"));
     assertTrue(cmd.contains("list"));
     assertTrue(cmd.contains("kubera"));
+  }
+
+  @Test
+  void gatewayCommandsTargetTheSailUser() {
+    var runner = new RemoteCommandRunner(CONFIG);
+
+    assertEquals("sail@kubera-server", runner.sshTarget(new String[] {"spec", "list"}));
+    assertEquals("sail@kubera-server", runner.sshTarget(new String[] {"agent", "status"}));
+    assertEquals("sail@kubera-server", runner.sshTarget(new String[] {"events", "tail"}));
+    assertEquals("sail@kubera-server", runner.sshTarget(new String[] {"fde", "list"}));
+  }
+
+  @Test
+  void hostPrivilegedCommandsTargetThePlainHost() {
+    var runner = new RemoteCommandRunner(CONFIG);
+
+    assertEquals("kubera-server", runner.sshTarget(new String[] {"project", "up", "demo"}));
+    assertEquals("kubera-server", runner.sshTarget(new String[] {"shell", "demo"}));
+    assertEquals("kubera-server", runner.sshTarget(new String[] {}));
+  }
+
+  @Test
+  void blankGatewayUserDisablesTheGatewayLane() {
+    var runner = new RemoteCommandRunner(new ClientConfig("kubera-server", ""));
+
+    assertEquals("kubera-server", runner.sshTarget(new String[] {"spec", "list"}));
   }
 
   @Test


### PR DESCRIPTION
Closes the ssh-cli-identity arc with the DX the product mandate demands: one command per actor, no ritual.

## End-to-end experience after this release

```bash
# Operator, once (idempotent; existing boxes converge via plain `sail upgrade`):
sudo sail host ssh-identity

# Per engineer, one command (create + register key + sync authorized_keys):
sail fde add uday --role admin --key "ssh-ed25519 AAAA... uday@mac"

# Engineer's Mac, then never again:
sail init devbox
sail spec list        # rides sail@devbox — the SSH key IS the identity
```

## Changes

- **`AuthorizedKeysSync`** — single write path for the sail user's `authorized_keys` with `Synced`/`NeedsRoot`/`NotProvisioned` outcomes; `fde key add/rm` auto-sync, `fde add --key` is a one-shot, `host keys sync` becomes a repair command.
- **`host ssh-identity`** — applies by default with `--dry-run` preview (CLI-wide convention; was `--apply`), and finishes by syncing registered keys.
- **`sail upgrade` convergence** — renders `authorized_keys` from the registry on provisioned hosts after the unit reconcile/restart; quiet otherwise, never fatal.
- **Role-driven `SshGateway`** — `API_COMMANDS` (`spec`/`agent`/`events`) for every active FDE, authorized per-request downstream; `ADMIN_COMMANDS` (`fde`) admin-role only; host-privileged commands refused with guidance. Dead `dispatch` allow-list entry dropped.
- **Brick 4** — `ClientConfig.user` (default `sail`, blank disables), two-lane routing in `RemoteCommandRunner` (gateway commands → `sail@host`, host-privileged → plain host, single source of truth from `SshGateway`), clearer SSH-255 guidance, `sail init` writes `{host, user: sail}`.
- **ARCHITECTURE.md** — two-lane client mode, one-ingress security model, reworked known gaps.

## Tests

Full reactor green at 0.13.53 (5,341 tests; infra 1,517+; api.* 100% line/method gates met). New: `AuthorizedKeysSyncTest`, role-driven `SshGatewayTest` cases, two-lane `RemoteCommandRunnerTest` cases, `ClientConfig` user semantics.