### PR TITLE
Client-safe upgrade + gateway lane never password-prompts — 0.13.54

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.53</version>
+    <version>0.13.54</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.53</version>
+        <version>0.13.54</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.53</version>
+        <version>0.13.54</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.53</version>
+        <version>0.13.54</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostKeysCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostKeysCommand.java
@@ -34,7 +34,10 @@ public final class HostKeysCommand implements Runnable {
 
   @Command(
       name = "sync",
-      description = "Regenerate the sail user's authorized_keys from registered FDE keys.",
+      description =
+          "Repair the sail user's authorized_keys from the registry (key changes sync"
+              + " automatically; this is only needed when a sync was skipped or the file was"
+              + " edited by hand).",
       mixinStandardHelpOptions = true)
   static final class Sync implements Runnable {
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.engine.AuthorizedKeysSync;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerSpecImporter;
 import ai.singlr.sail.engine.SailPaths;
@@ -84,8 +85,34 @@ public final class MigrateCommand implements Runnable {
           new ContainerSpecImporter(
               shell, new ContainerManager(shell), new SpecStore(db), SailPaths.projectsDir());
       var animate = !jsonOutput && System.console() != null;
-      return applyMigrations(
-          db, dbPath.toString(), importer::importAll, prompter, animate, jsonOutput);
+      var runs =
+          applyMigrations(
+              db, dbPath.toString(), importer::importAll, prompter, animate, jsonOutput);
+      syncAuthorizedKeys(db, jsonOutput);
+      return runs;
+    }
+  }
+
+  /**
+   * Converges the {@code sail} user's {@code authorized_keys} with the SSH-key registry on
+   * provisioned hosts. Living here (not in {@code upgrade}) is load-bearing: an upgrade is executed
+   * by the OLD binary, which re-execs the NEW binary's {@code migrate} — so this is the one step
+   * guaranteed to run new-binary code on every upgrade path. Quiet when there is nothing to do
+   * (unprovisioned host, non-root) and never fatal.
+   */
+  private static void syncAuthorizedKeys(Sqlite db, boolean jsonOutput) {
+    try {
+      if (new AuthorizedKeysSync().sync(db) instanceof AuthorizedKeysSync.Synced synced
+          && !jsonOutput) {
+        System.out.println(
+            Ansi.AUTO.string(
+                "  @|green ✓|@ authorized_keys synced (" + synced.keyCount() + " key(s))"));
+      }
+    } catch (Exception e) {
+      System.err.println(
+          "  authorized_keys sync failed: "
+              + e.getMessage()
+              + ". Converge manually with 'sudo sail host keys sync'.");
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/UpgradeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/UpgradeCommand.java
@@ -8,7 +8,6 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.SailVersion;
 import ai.singlr.sail.api.ServerConnectionConfig;
 import ai.singlr.sail.config.YamlUtil;
-import ai.singlr.sail.engine.AuthorizedKeysSync;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.PlatformDetector;
 import ai.singlr.sail.engine.ReleaseFetcher;
@@ -114,7 +113,7 @@ public final class UpgradeCommand implements Runnable {
 
     if (!json) {
       System.out.println(
-          Banner.stepLine(1, 3, "Downloading sail " + versionTag + "...", Ansi.AUTO));
+          Banner.stepLine(1, 4, "Downloading sail " + versionTag + "...", Ansi.AUTO));
     }
     byte[] binary;
     if (dryRun) {
@@ -129,12 +128,12 @@ public final class UpgradeCommand implements Runnable {
       if (!json) {
         System.out.println(
             Banner.stepDoneLine(
-                1, 3, "Downloaded (" + (binary.length / 1024 / 1024) + " MB)", Ansi.AUTO));
+                1, 4, "Downloaded (" + (binary.length / 1024 / 1024) + " MB)", Ansi.AUTO));
       }
     }
 
     if (!json) {
-      System.out.println(Banner.stepLine(2, 3, "Verifying checksum...", Ansi.AUTO));
+      System.out.println(Banner.stepLine(2, 4, "Verifying checksum...", Ansi.AUTO));
     }
     if (dryRun) {
       System.out.println("[dry-run] Verify SHA-256 checksum");
@@ -154,7 +153,7 @@ public final class UpgradeCommand implements Runnable {
                 + "\n  The download may be corrupted. Try again.");
       }
       if (!json) {
-        System.out.println(Banner.stepDoneLine(2, 3, "Checksum verified", Ansi.AUTO));
+        System.out.println(Banner.stepDoneLine(2, 4, "Checksum verified", Ansi.AUTO));
       }
     }
 
@@ -179,11 +178,18 @@ public final class UpgradeCommand implements Runnable {
       }
     }
 
-    migrateDatabase(dryRun);
-
-    var restartStatus = restartSailApi(dryRun);
-
-    syncAuthorizedKeys(dryRun);
+    RestartStatus restartStatus;
+    if (Files.exists(SailPaths.hostConfigPath())) {
+      migrateDatabase(dryRun);
+      restartStatus = restartSailApi(dryRun);
+    } else {
+      restartStatus = RestartStatus.NOT_INSTALLED;
+      if (!json) {
+        System.out.println(
+            Ansi.AUTO.string(
+                "  @|faint Client machine (no host.yaml) — database and service steps skipped.|@"));
+      }
+    }
 
     if (json) {
       printJsonResult(
@@ -289,34 +295,6 @@ public final class UpgradeCommand implements Runnable {
    */
   private boolean reconcileUnitFile(SystemdServiceInstaller installer) throws Exception {
     return installer.reconcile();
-  }
-
-  /**
-   * Converges the {@code sail} user's {@code authorized_keys} with the SSH-key registry so a host
-   * comes fully online from an upgrade alone — keys registered before this binary's auto-sync
-   * existed are installed without any manual {@code keys sync}. Quiet when there is nothing to do
-   * (unprovisioned host, non-root upgrade) and never fatal: the binary install already succeeded.
-   */
-  private void syncAuthorizedKeys(boolean dryRun) {
-    if (dryRun) {
-      System.out.println(
-          "[dry-run] Would sync the sail user's authorized_keys from the SSH-key registry.");
-      return;
-    }
-    try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
-      if (new AuthorizedKeysSync().sync(db) instanceof AuthorizedKeysSync.Synced synced && !json) {
-        System.out.println(
-            Ansi.AUTO.string(
-                "  @|green ✓|@ authorized_keys synced (" + synced.keyCount() + " key(s))"));
-      }
-    } catch (Exception e) {
-      System.err.println(
-          Banner.errorLine(
-              "authorized_keys sync failed: "
-                  + e.getMessage()
-                  + ". Converge manually with 'sudo sail host keys sync'.",
-              Ansi.AUTO));
-    }
   }
 
   /** Bind address + port pair extracted from a sail-api unit file's {@code ExecStart}. */

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/RemoteCommandRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/RemoteCommandRunner.java
@@ -131,8 +131,10 @@ public final class RemoteCommandRunner {
     return message
         + "\n  Commands authenticate as your FDE through the '"
         + config.user()
-        + "' user. If access was denied, ask an admin to register your key:"
-        + "\n    sail fde key add <your-handle> \"<your pubkey>\"";
+        + "' user. If access was denied:"
+        + "\n    - not registered yet? an admin runs: sail fde add <handle> --key \"<your pubkey>\""
+        + "\n    - registered before the host ran 0.13.53+? upgrade the host, or run:"
+        + " sudo sail host keys sync";
   }
 
   List<String> buildSshCommand(String[] args, boolean interactive) {
@@ -141,6 +143,12 @@ public final class RemoteCommandRunner {
     if (interactive) {
       cmd.add("-t");
     }
+    if (gatewayLane(args)) {
+      cmd.add("-o");
+      cmd.add("PasswordAuthentication=no");
+      cmd.add("-o");
+      cmd.add("KbdInteractiveAuthentication=no");
+    }
     cmd.add(sshTarget(args));
     cmd.add("sail");
     cmd.addAll(List.of(args));
@@ -148,8 +156,16 @@ public final class RemoteCommandRunner {
   }
 
   String sshTarget(String[] args) {
-    var gateway = config.gatewayEnabled() && args.length > 0 && GATEWAY_COMMANDS.contains(args[0]);
-    return gateway ? config.gatewayTarget() : config.host();
+    return gatewayLane(args) ? config.gatewayTarget() : config.host();
+  }
+
+  /**
+   * Gateway identity is the SSH key by definition, so the gateway lane forbids password fallback —
+   * a missing key fails fast with guidance instead of dangling a password prompt for a locked
+   * system account.
+   */
+  private boolean gatewayLane(String[] args) {
+    return config.gatewayEnabled() && args.length > 0 && GATEWAY_COMMANDS.contains(args[0]);
   }
 
   /** Returns the classification of a command for testing. */

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/RemoteCommandRunnerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/RemoteCommandRunnerTest.java
@@ -57,6 +57,35 @@ class RemoteCommandRunnerTest {
   }
 
   @Test
+  void gatewayLaneForbidsPasswordFallback() {
+    var runner = new RemoteCommandRunner(CONFIG);
+
+    var cmd = runner.buildSshCommand(new String[] {"spec", "list"}, false);
+
+    assertEquals(
+        List.of(
+            "ssh",
+            "-o",
+            "PasswordAuthentication=no",
+            "-o",
+            "KbdInteractiveAuthentication=no",
+            "sail@kubera-server",
+            "sail",
+            "spec",
+            "list"),
+        cmd);
+  }
+
+  @Test
+  void plainLaneLeavesSshAuthenticationAlone() {
+    var runner = new RemoteCommandRunner(CONFIG);
+
+    var cmd = runner.buildSshCommand(new String[] {"project", "up", "demo"}, false);
+
+    assertEquals(List.of("ssh", "kubera-server", "sail", "project", "up", "demo"), cmd);
+  }
+
+  @Test
   void buildSshCommandForInteractive() {
     var runner = new RemoteCommandRunner(CONFIG);
 


### PR DESCRIPTION
Two field findings from Uday's first 0.13.53 rollout:

1. **`sail upgrade` created `/var/root/.sail/sail.db` + an admin token on a client Mac.** The sudo re-exec runs as root, whose home has neither `host.yaml` nor `config.yaml`, and `RuntimeMode` defaults that to host mode — so the upgrade bootstrapped a control-plane DB on a laptop. Host steps (DB migrate, token bootstrap, service reconcile) are now gated on `host.yaml`; clients print a one-line skip notice.

2. **The 0.13.52→0.13.53 host upgrade never synced authorized_keys — confirmed in the field.** An upgrade is executed by the OLD binary; 0.13.53's sync step lived in `UpgradeCommand`, which 0.13.52 doesn't have. Convergence now lives in `migrate --non-interactive` — the one step every upgrade path executes with NEW-binary code — so this and every future hop converges immediately, not one release later.

3. **`sail spec list` dangled a password prompt for `sail@host`** when the key wasn't in authorized_keys yet. The gateway lane is key-based identity by definition; it now passes `-o PasswordAuthentication=no -o KbdInteractiveAuthentication=no` and fails fast with registration/sync guidance.

Cosmetic: upgrade step counters normalized (`1/4..4/4`), `host keys sync` help text states it's a repair command.

Full reactor green at 0.13.54 (5,345 tests, all gates).