### PR TITLE
sail fde rm + key rm by handle (FDE lifecycle) — 0.13.55

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.54</version>
+    <version>0.13.55</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.54</version>
+        <version>0.13.55</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
@@ -78,6 +78,28 @@ public final class FdeStore {
     return db.query(SELECT + " ORDER BY handle", FdeStore::map);
   }
 
+  /** Returns the number of FDEs that are active admins — the principals who can administer. */
+  public long activeAdminCount() {
+    return db.queryOne(
+            "SELECT COUNT(*) FROM fdes WHERE role = 'admin' AND status = 'active'",
+            row -> row.integer(0))
+        .orElse(0L);
+  }
+
+  /**
+   * Removes an FDE and every credential that authenticates as it. SSH keys, sessions, passkeys, and
+   * enrollment tickets cascade via their foreign keys; owned API tokens are deleted explicitly
+   * because {@code api_tokens.fde_id} predates the cascade constraints. Spec attribution ({@code
+   * created_by}/{@code updated_by}) stores the handle as historical text and is untouched.
+   */
+  public void remove(String fdeId) {
+    db.transaction(
+        () -> {
+          db.execute("DELETE FROM api_tokens WHERE fde_id = ?", fdeId);
+          db.execute("DELETE FROM fdes WHERE id = ?", fdeId);
+        });
+  }
+
   private static final String SELECT =
       "SELECT id, handle, display_name, email, role, status, created_at FROM fdes";
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/FdeStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FdeStoreTest.java
@@ -32,6 +32,53 @@ class FdeStoreTest {
   }
 
   @Test
+  void removeDeletesTheFdeItsTokensAndCascadesCredentials() {
+    var fde = store.add("ghost", null, null, "member");
+    new TokenStore(db).create("ghost-token", "member", fde.id());
+    new AuthSessionStore(db).create(fde.id(), java.time.Duration.ofMinutes(5));
+    new FdeSshKeyStore(db)
+        .add(
+            fde.id(),
+            ai.singlr.sail.ssh.SshPublicKey.parse(
+                ai.singlr.sail.ssh.TestSshKeys.ed25519("seed", "g@m")));
+
+    store.remove(fde.id());
+
+    assertTrue(store.byHandle("ghost").isEmpty());
+    assertEquals(0L, count("api_tokens", fde.id()));
+    assertEquals(0L, count("sessions", fde.id()));
+    assertEquals(0L, count("fde_ssh_keys", fde.id()));
+  }
+
+  @Test
+  void removeLeavesOtherFdesCredentialsAlone() {
+    var ghost = store.add("ghost", null, null, "member");
+    var keeper = store.add("keeper", null, null, "member");
+    new TokenStore(db).create("keeper-token", "member", keeper.id());
+
+    store.remove(ghost.id());
+
+    assertTrue(store.byHandle("keeper").isPresent());
+    assertEquals(1L, count("api_tokens", keeper.id()));
+  }
+
+  @Test
+  void activeAdminCountTracksRoleAndStatus() {
+    assertEquals(0L, store.activeAdminCount());
+    var admin = store.add("ada", null, null, "admin");
+    store.add("bob", null, null, "member");
+    assertEquals(1L, store.activeAdminCount());
+    db.execute("UPDATE fdes SET status = 'disabled' WHERE id = ?", admin.id());
+    assertEquals(0L, store.activeAdminCount());
+  }
+
+  private long count(String table, String fdeId) {
+    return db.queryOne(
+            "SELECT COUNT(*) FROM " + table + " WHERE fde_id = ?", row -> row.integer(0), fdeId)
+        .orElse(-1L);
+  }
+
+  @Test
   void addAssignsGeneratedIdAndActiveStatus() {
     var fde = store.add("uday", "Uday Chandra", "uday@singlr.ai");
     assertTrue(fde.id().startsWith("fde_"));

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.54</version>
+        <version>0.13.55</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.54</version>
+        <version>0.13.55</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
@@ -35,6 +35,7 @@ import picocli.CommandLine.Spec;
     subcommands = {
       FdeCommand.Add.class,
       FdeCommand.ListFdes.class,
+      FdeCommand.Remove.class,
       FdeCommand.Enroll.class,
       FdeCommand.Key.class
     })
@@ -122,6 +123,70 @@ public final class FdeCommand implements Runnable {
               }
             }
           });
+    }
+  }
+
+  @Command(
+      name = "rm",
+      description = "Remove an FDE and revoke everything that authenticates as it.",
+      mixinStandardHelpOptions = true)
+  static final class Remove implements Runnable {
+
+    @Parameters(index = "0", description = "FDE handle.")
+    private String handle;
+
+    @Option(names = "--force", description = "Skip confirmation.")
+    private boolean force;
+
+    @Spec private CommandSpec spec;
+
+    @Override
+    public void run() {
+      CliCommand.run(
+          spec,
+          () -> {
+            try (var db = Sqlite.open(dbPath())) {
+              var fdeStore = new FdeStore(db);
+              var fde =
+                  fdeStore
+                      .byHandle(handle)
+                      .orElseThrow(
+                          () -> new IllegalArgumentException("Unknown FDE '" + handle + "'."));
+              requireNotLastAdmin(fdeStore, fde);
+              if (!confirmed()) {
+                System.out.println(Ansi.AUTO.string("  @|faint Cancelled.|@"));
+                return;
+              }
+              fdeStore.remove(fde.id());
+              System.out.println(Ansi.AUTO.string("  @|green ✓|@ FDE removed: " + fde.handle()));
+              System.out.println(
+                  Ansi.AUTO.string(
+                      "  @|faint Owned tokens, SSH keys, sessions, passkeys, and enrollment"
+                          + " tickets are revoked.|@"));
+              applyKeys(db);
+            }
+          });
+    }
+
+    private boolean confirmed() {
+      if (force) {
+        return true;
+      }
+      System.out.print("  Remove FDE '" + handle + "' and revoke all its credentials? [y/N] ");
+      var answer = System.console() != null ? System.console().readLine() : "y";
+      return answer != null && answer.strip().equalsIgnoreCase("y");
+    }
+
+    private static void requireNotLastAdmin(FdeStore fdeStore, FdeStore.Fde fde) {
+      if ("admin".equals(fde.role())
+          && "active".equals(fde.status())
+          && fdeStore.activeAdminCount() <= 1) {
+        throw new IllegalStateException(
+            "'"
+                + fde.handle()
+                + "' is the last active admin FDE. Add another admin first:"
+                + " sail fde add <handle> --role admin");
+      }
     }
   }
 
@@ -305,12 +370,12 @@ public final class FdeCommand implements Runnable {
 
     @Command(
         name = "rm",
-        description = "Remove a registered SSH key by fingerprint.",
+        description = "Remove a registered SSH key by FDE handle or SHA256: fingerprint.",
         mixinStandardHelpOptions = true)
     static final class Remove implements Runnable {
 
-      @Parameters(index = "0", description = "The key's SHA256: fingerprint.")
-      private String fingerprint;
+      @Parameters(index = "0", description = "FDE handle, or a key's SHA256: fingerprint.")
+      private String target;
 
       @Spec private CommandSpec spec;
 
@@ -320,7 +385,13 @@ public final class FdeCommand implements Runnable {
             spec,
             () -> {
               try (var db = Sqlite.open(dbPath())) {
-                if (new FdeSshKeyStore(db).remove(fingerprint)) {
+                var keyStore = new FdeSshKeyStore(db);
+                var fingerprint =
+                    target.startsWith("SHA256:") ? target : resolveByHandle(db, keyStore);
+                if (fingerprint == null) {
+                  return;
+                }
+                if (keyStore.remove(fingerprint)) {
                   System.out.println(Ansi.AUTO.string("  @|green ✓|@ Removed key " + fingerprint));
                   applyKeys(db);
                 } else {
@@ -329,6 +400,37 @@ public final class FdeCommand implements Runnable {
                 }
               }
             });
+      }
+
+      /**
+       * Resolves a handle to the single key it owns, or null after printing guidance — no keys, or
+       * several (removing all on an ambiguous request would be a surprise revocation).
+       */
+      private String resolveByHandle(Sqlite db, FdeSshKeyStore keyStore) {
+        var fde =
+            new FdeStore(db)
+                .byHandle(target)
+                .orElseThrow(
+                    () ->
+                        new IllegalArgumentException(
+                            "'"
+                                + target
+                                + "' is neither a known FDE handle nor a SHA256:"
+                                + " fingerprint. See 'sail fde key list'."));
+        var keys = keyStore.listForFde(fde.id());
+        if (keys.isEmpty()) {
+          System.out.println(
+              Ansi.AUTO.string("  @|yellow ⚠|@ No SSH keys registered for '" + target + "'."));
+          return null;
+        }
+        if (keys.size() > 1) {
+          System.out.println("  '" + target + "' has " + keys.size() + " keys; specify one:");
+          for (var key : keys) {
+            System.out.println("    sail fde key rm " + key.fingerprint());
+          }
+          return null;
+        }
+        return keys.getFirst().fingerprint();
       }
     }
   }


### PR DESCRIPTION
Field DX findings from Uday cleaning up the e2e test FDEs: `fde key rm` demanded a fingerprint nobody knows offhand, and there was no way to delete an FDE at all (the known lifecycle gap).

- **`sail fde rm <handle> [--force]`** — removes the FDE and revokes everything that authenticates as it: owned API tokens (deleted explicitly — `api_tokens.fde_id` has no FK, so dangling tokens would have remained valid credentials), SSH keys / sessions / passkeys / enrollment tickets (FK cascade with `foreign_keys=ON`), then re-syncs `authorized_keys`. Confirmation prompt unless `--force`; refuses to remove the **last active admin**. `created_by`/`updated_by` attribution keeps the handle as historical text.
- **`sail fde key rm <handle|SHA256:...>`** — handle with a single key removes it and syncs; multiple keys prints the exact `rm SHA256:...` commands to choose from rather than bulk-revoking on an ambiguous request.

Both work over the FDE gateway for admin-role keys (DB-direct; the authorized_keys write prints the sudo hint when not root).

Full reactor green at 0.13.55 (5,351 tests; new FdeStore remove/cascade/admin-count tests).