### PR TITLE
Quality pass over the 0.13.53–55 arc — 0.13.56

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.55</version>
+    <version>0.13.56</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.55</version>
+        <version>0.13.56</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/config/HostYaml.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/HostYaml.java
@@ -5,6 +5,8 @@
 
 package ai.singlr.sail.config;
 
+import ai.singlr.sail.engine.SailPaths;
+import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -59,6 +61,16 @@ public record HostYaml(
   public static final String DEFAULT_IMAGE = "ubuntu/24.04";
   public static final String BACKEND_DIR = "dir";
   public static final String BACKEND_ZFS = "zfs";
+
+  /**
+   * Returns true when this machine is a configured Sail host. The named check matters: {@code
+   * RuntimeMode.detect()} defaults to host mode when NO config exists (backward compatibility), so
+   * callers that must act only on real hosts — like the upgrade's database and service steps —
+   * check for the host config explicitly.
+   */
+  public static boolean exists() {
+    return Files.exists(SailPaths.hostConfigPath());
+  }
 
   public boolean isDir() {
     return BACKEND_DIR.equals(storageBackend);

--- a/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
@@ -182,7 +182,8 @@ public final class SailPaths {
     return SAIL_DIR.resolve("run/api.sock");
   }
 
-  private static boolean isRoot() {
+  /** Returns true when the current process runs as root — the single privilege check. */
+  public static boolean isRoot() {
     return "root".equals(ProcessHandle.current().info().user().orElse(""));
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.ssh.SshPublicKey;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.HexFormat;
@@ -87,14 +88,43 @@ public final class FdeStore {
   }
 
   /**
+   * Creates an FDE and registers its SSH key in one transaction, so a rejected key (already
+   * registered to someone else) rolls the FDE back instead of leaving a half-onboarded principal.
+   */
+  public Fde addWithKey(
+      String handle, String displayName, String email, String role, SshPublicKey key) {
+    return db.transaction(
+        () -> {
+          var fde = add(handle, displayName, email, role);
+          new FdeSshKeyStore(db).add(fde.id(), key);
+          return fde;
+        });
+  }
+
+  /**
    * Removes an FDE and every credential that authenticates as it. SSH keys, sessions, passkeys, and
    * enrollment tickets cascade via their foreign keys; owned API tokens are deleted explicitly
    * because {@code api_tokens.fde_id} predates the cascade constraints. Spec attribution ({@code
    * created_by}/{@code updated_by}) stores the handle as historical text and is untouched.
+   *
+   * <p>Refuses to remove the last active admin. The guard runs inside the delete transaction so two
+   * concurrent removals cannot both pass it and leave the host with no administrator.
    */
   public void remove(String fdeId) {
     db.transaction(
         () -> {
+          var fde =
+              byId(fdeId)
+                  .orElseThrow(() -> new IllegalArgumentException("No FDE with id " + fdeId + "."));
+          if ("admin".equals(fde.role())
+              && "active".equals(fde.status())
+              && activeAdminCount() <= 1) {
+            throw new IllegalStateException(
+                "'"
+                    + fde.handle()
+                    + "' is the last active admin FDE. Add another admin first:"
+                    + " sail fde add <handle> --role admin");
+          }
           db.execute("DELETE FROM api_tokens WHERE fde_id = ?", fdeId);
           db.execute("DELETE FROM fdes WHERE id = ?", fdeId);
         });

--- a/sail-core/src/main/java/ai/singlr/sail/store/Sqlite.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/Sqlite.java
@@ -137,10 +137,19 @@ public final class Sqlite implements AutoCloseable {
   }
 
   public void transaction(Runnable work) {
+    transaction(
+        () -> {
+          work.run();
+          return null;
+        });
+  }
+
+  public <T> T transaction(java.util.function.Supplier<T> work) {
     execute("BEGIN");
     try {
-      work.run();
+      var result = work.get();
       execute("COMMIT");
+      return result;
     } catch (Exception e) {
       try {
         execute("ROLLBACK");

--- a/sail-core/src/test/java/ai/singlr/sail/store/FdeStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FdeStoreTest.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.store;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import ai.singlr.sail.ssh.SshPublicKey;
 import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,6 +61,78 @@ class FdeStoreTest {
 
     assertTrue(store.byHandle("keeper").isPresent());
     assertEquals(1L, count("api_tokens", keeper.id()));
+  }
+
+  @Test
+  void removeRefusesTheLastActiveAdmin() {
+    var lone = store.add("lone", null, null, "admin");
+
+    var thrown = assertThrows(IllegalStateException.class, () -> store.remove(lone.id()));
+
+    assertTrue(thrown.getMessage().contains("last active admin"));
+    assertTrue(store.byHandle("lone").isPresent());
+  }
+
+  @Test
+  void removeAllowsAnAdminWhenAnotherActiveAdminRemains() {
+    var first = store.add("first", null, null, "admin");
+    store.add("second", null, null, "admin");
+
+    store.remove(first.id());
+
+    assertTrue(store.byHandle("first").isEmpty());
+    assertEquals(1L, store.activeAdminCount());
+  }
+
+  @Test
+  void removeAllowsADisabledAdminEvenWhenItIsTheOnlyOne() {
+    var retired = store.add("retired", null, null, "admin");
+    db.execute("UPDATE fdes SET status = 'disabled' WHERE id = ?", retired.id());
+
+    store.remove(retired.id());
+
+    assertTrue(store.byHandle("retired").isEmpty());
+  }
+
+  @Test
+  void removeAllowsTheLastMemberEvenWhenNoAdminsExist() {
+    var member = store.add("solo", null, null, "member");
+
+    store.remove(member.id());
+
+    assertTrue(store.byHandle("solo").isEmpty());
+  }
+
+  @Test
+  void removeThrowsForUnknownId() {
+    assertThrows(IllegalArgumentException.class, () -> store.remove("fde_missing"));
+  }
+
+  @Test
+  void addWithKeyRollsBackTheFdeWhenTheKeyIsTaken() {
+    var keyLine = ai.singlr.sail.ssh.TestSshKeys.ed25519("shared", "a@b");
+    var owner = store.add("owner", null, null, "member");
+    new FdeSshKeyStore(db).add(owner.id(), SshPublicKey.parse(keyLine));
+
+    assertThrows(
+        SqliteException.class,
+        () -> store.addWithKey("intruder", null, null, "member", SshPublicKey.parse(keyLine)));
+
+    assertTrue(store.byHandle("intruder").isEmpty());
+  }
+
+  @Test
+  void addWithKeyCreatesBothAtomically() {
+    var fde =
+        store.addWithKey(
+            "fresh",
+            "Fresh",
+            null,
+            "member",
+            SshPublicKey.parse(ai.singlr.sail.ssh.TestSshKeys.ed25519("fresh", "f@m")));
+
+    assertTrue(store.byHandle("fresh").isPresent());
+    assertEquals(1, new FdeSshKeyStore(db).listForFde(fde.id()).size());
   }
 
   @Test

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.55</version>
+        <version>0.13.56</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.55</version>
+        <version>0.13.56</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ServerConnectionConfig.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ServerConnectionConfig.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.Set;
 
 /**
@@ -77,15 +78,26 @@ public record ServerConnectionConfig(String serverUrl, String token) {
     saveLocalConfig(serverUrl, token, configPath);
   }
 
+  /**
+   * Writes {@code server} and {@code token} while preserving every other key in the file. The
+   * client config ({@code host}, {@code user}) shares this file on an engineer's machine, so a
+   * plain overwrite would destroy the client's host pointer and silently flip the CLI out of client
+   * mode the first time they sign in.
+   */
   public static void saveLocalConfig(String serverUrl, String token, Path configPath)
       throws IOException {
-    var yaml = "server: " + serverUrl + "\ntoken: " + token + "\n";
+    var config =
+        Files.exists(configPath)
+            ? new LinkedHashMap<>(YamlUtil.parseFile(configPath))
+            : new LinkedHashMap<String, Object>();
+    config.put("server", serverUrl);
+    config.put("token", token);
     Files.createDirectories(configPath.getParent());
     Files.setPosixFilePermissions(configPath.getParent(), OWNER_ONLY_DIR);
     if (!Files.exists(configPath)) {
       Files.createFile(configPath, PosixFilePermissions.asFileAttribute(OWNER_ONLY_FILE));
     }
-    Files.writeString(configPath, yaml);
+    YamlUtil.dumpToFile(config, configPath);
     Files.setPosixFilePermissions(configPath, OWNER_ONLY_FILE);
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ConsoleHelper.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ConsoleHelper.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.engine.SailPaths;
 import java.io.BufferedReader;
 import java.io.Console;
 import java.io.InputStreamReader;
@@ -88,6 +89,6 @@ final class ConsoleHelper {
 
   /** Returns {@code true} if the current process is running as root. */
   static boolean isRoot() {
-    return "root".equals(ProcessHandle.current().info().user().orElse(""));
+    return SailPaths.isRoot();
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
@@ -17,6 +17,7 @@ import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.SqliteException;
 import java.nio.file.Files;
+import java.util.Optional;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -67,9 +68,7 @@ public final class FdeCommand implements Runnable {
   private static void applyKeys(Sqlite db) throws Exception {
     switch (new AuthorizedKeysSync().sync(db)) {
       case AuthorizedKeysSync.Synced synced ->
-          System.out.println(
-              Ansi.AUTO.string(
-                  "  @|green ✓|@ authorized_keys synced (" + synced.keyCount() + " key(s))"));
+          System.out.println(Ansi.AUTO.string("  @|green ✓|@ " + synced.describe()));
       case AuthorizedKeysSync.NeedsRoot _ ->
           System.out.println(
               Ansi.AUTO.string("  @|faint Run 'sudo sail host keys sync' to apply.|@"));
@@ -113,16 +112,39 @@ public final class FdeCommand implements Runnable {
       CliCommand.run(
           spec,
           () -> {
+            var key = publicKey == null ? null : SshPublicKey.parse(publicKey);
             try (var db = Sqlite.open(dbPath())) {
-              var fde = new FdeStore(db).add(handle, displayName, email, role);
+              var fdeStore = new FdeStore(db);
+              if (fdeStore.byHandle(handle).isPresent()) {
+                throw new IllegalArgumentException("FDE '" + handle + "' already exists.");
+              }
+              var fde =
+                  key == null
+                      ? fdeStore.add(handle, displayName, email, role)
+                      : addWithKey(fdeStore, key);
               System.out.println(
                   Ansi.AUTO.string(
                       "  @|green ✓|@ FDE added: " + fde.handle() + " (" + fde.role() + ")"));
-              if (publicKey != null) {
-                registerKey(db, fde, publicKey);
+              if (key != null) {
+                System.out.println(
+                    Ansi.AUTO.string(
+                        "  @|green ✓|@ Registered key for "
+                            + fde.handle()
+                            + ": "
+                            + key.fingerprint()));
+                applyKeys(db);
               }
             }
           });
+    }
+
+    private FdeStore.Fde addWithKey(FdeStore fdeStore, SshPublicKey key) {
+      try {
+        return fdeStore.addWithKey(handle, displayName, email, role, key);
+      } catch (SqliteException e) {
+        throw new IllegalArgumentException(
+            "That key (" + key.fingerprint() + ") is already registered.");
+      }
     }
   }
 
@@ -152,7 +174,6 @@ public final class FdeCommand implements Runnable {
                       .byHandle(handle)
                       .orElseThrow(
                           () -> new IllegalArgumentException("Unknown FDE '" + handle + "'."));
-              requireNotLastAdmin(fdeStore, fde);
               if (!confirmed()) {
                 System.out.println(Ansi.AUTO.string("  @|faint Cancelled.|@"));
                 return;
@@ -175,18 +196,6 @@ public final class FdeCommand implements Runnable {
       System.out.print("  Remove FDE '" + handle + "' and revoke all its credentials? [y/N] ");
       var answer = System.console() != null ? System.console().readLine() : "y";
       return answer != null && answer.strip().equalsIgnoreCase("y");
-    }
-
-    private static void requireNotLastAdmin(FdeStore fdeStore, FdeStore.Fde fde) {
-      if ("admin".equals(fde.role())
-          && "active".equals(fde.status())
-          && fdeStore.activeAdminCount() <= 1) {
-        throw new IllegalStateException(
-            "'"
-                + fde.handle()
-                + "' is the last active admin FDE. Add another admin first:"
-                + " sail fde add <handle> --role admin");
-      }
     }
   }
 
@@ -387,26 +396,30 @@ public final class FdeCommand implements Runnable {
               try (var db = Sqlite.open(dbPath())) {
                 var keyStore = new FdeSshKeyStore(db);
                 var fingerprint =
-                    target.startsWith("SHA256:") ? target : resolveByHandle(db, keyStore);
-                if (fingerprint == null) {
+                    target.startsWith("SHA256:")
+                        ? Optional.of(target)
+                        : resolveByHandle(db, keyStore);
+                if (fingerprint.isEmpty()) {
                   return;
                 }
-                if (keyStore.remove(fingerprint)) {
-                  System.out.println(Ansi.AUTO.string("  @|green ✓|@ Removed key " + fingerprint));
+                if (keyStore.remove(fingerprint.get())) {
+                  System.out.println(
+                      Ansi.AUTO.string("  @|green ✓|@ Removed key " + fingerprint.get()));
                   applyKeys(db);
                 } else {
                   System.out.println(
-                      Ansi.AUTO.string("  @|yellow ⚠|@ No key with fingerprint " + fingerprint));
+                      Ansi.AUTO.string(
+                          "  @|yellow ⚠|@ No key with fingerprint " + fingerprint.get()));
                 }
               }
             });
       }
 
       /**
-       * Resolves a handle to the single key it owns, or null after printing guidance — no keys, or
+       * Resolves a handle to the single key it owns, or empty after printing guidance — no keys, or
        * several (removing all on an ambiguous request would be a surprise revocation).
        */
-      private String resolveByHandle(Sqlite db, FdeSshKeyStore keyStore) {
+      private Optional<String> resolveByHandle(Sqlite db, FdeSshKeyStore keyStore) {
         var fde =
             new FdeStore(db)
                 .byHandle(target)
@@ -421,16 +434,16 @@ public final class FdeCommand implements Runnable {
         if (keys.isEmpty()) {
           System.out.println(
               Ansi.AUTO.string("  @|yellow ⚠|@ No SSH keys registered for '" + target + "'."));
-          return null;
+          return Optional.empty();
         }
         if (keys.size() > 1) {
           System.out.println("  '" + target + "' has " + keys.size() + " keys; specify one:");
           for (var key : keys) {
             System.out.println("    sail fde key rm " + key.fingerprint());
           }
-          return null;
+          return Optional.empty();
         }
-        return keys.getFirst().fingerprint();
+        return Optional.of(keys.getFirst().fingerprint());
       }
     }
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostSshIdentityCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostSshIdentityCommand.java
@@ -101,18 +101,29 @@ public final class HostSshIdentityCommand implements Runnable {
     }
   }
 
+  /**
+   * After the provisioning steps both non-{@code Synced} outcomes signal a failed step (root was
+   * required up front, and the plan just created the sail user's {@code .ssh}), so they fail loud
+   * instead of letting the operator believe SSH login works.
+   */
   private static void syncKeys() throws Exception {
     try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
-      if (new AuthorizedKeysSync().sync(db) instanceof AuthorizedKeysSync.Synced synced) {
-        System.out.println(
-            Ansi.AUTO.string(
-                "  @|green ✓|@ authorized_keys synced (" + synced.keyCount() + " key(s))"));
+      switch (new AuthorizedKeysSync().sync(db)) {
+        case AuthorizedKeysSync.Synced synced ->
+            System.out.println(Ansi.AUTO.string("  @|green ✓|@ " + synced.describe()));
+        case AuthorizedKeysSync.NeedsRoot _ ->
+            throw new IllegalStateException(
+                "authorized_keys sync lost root privileges mid-run; re-run as root.");
+        case AuthorizedKeysSync.NotProvisioned _ ->
+            throw new IllegalStateException(
+                "The sail user's .ssh directory is missing even though provisioning succeeded;"
+                    + " inspect /home/sail and re-run 'sudo sail host ssh-identity'.");
       }
     }
   }
 
   private static void requireRoot() {
-    if (!"root".equals(ProcessHandle.current().info().user().orElse(""))) {
+    if (!SailPaths.isRoot()) {
       throw new IllegalStateException(
           "This command must run as root: it creates a system user, relocates the database, and"
               + " edits a systemd unit. Preview with --dry-run, or re-run with sudo.");

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -104,9 +104,7 @@ public final class MigrateCommand implements Runnable {
     try {
       if (new AuthorizedKeysSync().sync(db) instanceof AuthorizedKeysSync.Synced synced
           && !jsonOutput) {
-        System.out.println(
-            Ansi.AUTO.string(
-                "  @|green ✓|@ authorized_keys synced (" + synced.keyCount() + " key(s))"));
+        System.out.println(Ansi.AUTO.string("  @|green ✓|@ " + synced.describe()));
       }
     } catch (Exception e) {
       System.err.println(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/UpgradeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/UpgradeCommand.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.commands;
 
 import ai.singlr.sail.SailVersion;
 import ai.singlr.sail.api.ServerConnectionConfig;
+import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.PlatformDetector;
@@ -179,11 +180,11 @@ public final class UpgradeCommand implements Runnable {
     }
 
     RestartStatus restartStatus;
-    if (Files.exists(SailPaths.hostConfigPath())) {
+    if (HostYaml.exists()) {
       migrateDatabase(dryRun);
       restartStatus = restartSailApi(dryRun);
     } else {
-      restartStatus = RestartStatus.NOT_INSTALLED;
+      restartStatus = RestartStatus.SKIPPED_CLIENT;
       if (!json) {
         System.out.println(
             Ansi.AUTO.string(
@@ -429,7 +430,8 @@ public final class UpgradeCommand implements Runnable {
     NOT_RUNNING("not_running"),
     RESTARTED("restarted"),
     FAILED("failed"),
-    DRY_RUN("dry_run");
+    DRY_RUN("dry_run"),
+    SKIPPED_CLIENT("skipped_client");
 
     private final String wireValue;
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/AuthorizedKeysSync.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/AuthorizedKeysSync.java
@@ -27,7 +27,12 @@ public final class AuthorizedKeysSync {
   public sealed interface Outcome permits Synced, NeedsRoot, NotProvisioned {}
 
   /** The file was regenerated from the registry. */
-  public record Synced(int keyCount, Path destination) implements Outcome {}
+  public record Synced(int keyCount, Path destination) implements Outcome {
+    /** The one human-facing phrase for a successful sync, shared by every caller that prints it. */
+    public String describe() {
+      return "authorized_keys synced (" + keyCount + " key(s))";
+    }
+  }
 
   /** The caller lacks root; the registry changed but the file did not. */
   public record NeedsRoot() implements Outcome {}
@@ -42,7 +47,7 @@ public final class AuthorizedKeysSync {
   public AuthorizedKeysSync() {
     this(
         Path.of(SshIdentityProvisioner.SAIL_HOME, ".ssh", "authorized_keys"),
-        "root".equals(ProcessHandle.current().info().user().orElse("")),
+        SailPaths.isRoot(),
         new ShellExecutor(false));
   }
 
@@ -59,15 +64,14 @@ public final class AuthorizedKeysSync {
   }
 
   public Outcome sync(Sqlite db) throws Exception {
-    var keys = new FdeSshKeyStore(db).list();
-    var content = AuthorizedKeysRenderer.render(keys, SailPaths.binaryPath().toString());
     if (!root) {
       return new NeedsRoot();
     }
     if (!Files.isDirectory(destination.getParent())) {
       return new NotProvisioned();
     }
-    install(content);
+    var keys = new FdeSshKeyStore(db).list();
+    install(AuthorizedKeysRenderer.render(keys, SailPaths.binaryPath().toString()));
     return new Synced(keys.size(), destination);
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/RemoteCommandRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/RemoteCommandRunner.java
@@ -117,7 +117,7 @@ public final class RemoteCommandRunner {
     }
   }
 
-  private String connectionFailureMessage(String target) {
+  String connectionFailureMessage(String target) {
     var message =
         "Cannot connect to "
             + target

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ServerConnectionConfigTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ServerConnectionConfigTest.java
@@ -55,6 +55,19 @@ class ServerConnectionConfigTest {
   }
 
   @Test
+  void savePreservesClientConfigKeys() throws IOException {
+    var configPath = tempDir.resolve("config.yaml");
+    java.nio.file.Files.writeString(configPath, "host: devbox\nuser: sail\n");
+
+    ServerConnectionConfig.saveSessionToken("sess_new", configPath);
+
+    var client = ai.singlr.sail.config.ClientConfig.load(configPath);
+    assertEquals("devbox", client.host());
+    assertEquals("sail", client.user());
+    assertEquals("sess_new", ServerConnectionConfig.resolve(null, null, configPath).token());
+  }
+
+  @Test
   void defaultUrlIsLocalhostWhenNotProvided() throws IOException {
     var config = ServerConnectionConfig.resolve(null, "some-token", missingConfig());
     assertEquals("http://localhost:7070", config.serverUrl());

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/RemoteCommandRunnerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/RemoteCommandRunnerTest.java
@@ -57,6 +57,27 @@ class RemoteCommandRunnerTest {
   }
 
   @Test
+  void gatewayFailureMessageExplainsKeyRegistration() {
+    var runner = new RemoteCommandRunner(CONFIG);
+
+    var message = runner.connectionFailureMessage("sail@kubera-server");
+
+    assertTrue(message.contains("Cannot connect to sail@kubera-server"));
+    assertTrue(message.contains("sail fde add"));
+    assertTrue(message.contains("sail host keys sync"));
+  }
+
+  @Test
+  void plainLaneFailureMessageOmitsGatewayGuidance() {
+    var runner = new RemoteCommandRunner(CONFIG);
+
+    var message = runner.connectionFailureMessage("kubera-server");
+
+    assertTrue(message.contains("Cannot connect to kubera-server"));
+    assertFalse(message.contains("sail fde add"));
+  }
+
+  @Test
   void gatewayLaneForbidsPasswordFallback() {
     var runner = new RemoteCommandRunner(CONFIG);
 


### PR DESCRIPTION
Multi-angle review (line-scan, removed-behavior, cross-file tracer, reuse/simplification/efficiency/altitude) over v0.13.52..HEAD, findings verified and fixed.

## Correctness
- **`sail login` no longer destroys the client config.** `saveLocalConfig` rewrote `config.yaml` as a literal `server:`+`token:` string, dropping `{host, user}` — flipping a Mac out of client mode on first sign-in (latent since 0.13.46, would have detonated in passkey testing). Now merges into the existing map. Regression test included.
- **Last-admin guard is atomic.** The check lived outside the delete transaction — across the interactive confirmation prompt — so concurrent `fde rm` could leave zero admins. Now enforced inside `FdeStore.remove`'s transaction.
- **`fde add --key` is atomic** (`FdeStore.addWithKey`): a rejected key rolls back the FDE; duplicate handles error before any insert.
- **`host ssh-identity` fails loud** if the post-provision sync reports NeedsRoot/NotProvisioned — both signal a failed provisioning step that was previously silent.

## Robustness / cleanliness
- `Sqlite.transaction(Supplier<T>)` overload; Runnable variant delegates.
- `AuthorizedKeysSync` checks privileges before rendering; `Synced.describe()` is the single success phrase for all three printers.
- `SailPaths.isRoot()` consolidates four copies of the privilege check; `HostYaml.exists()` names the host-machine concept the upgrade gate uses.
- `Optional` instead of null control flow in `key rm` resolution; `upgrade --json` reports `skipped_client` instead of overloading `not_installed`.

## Coverage (new logic-layer code)
FdeStore 46/46 lines + 8/8 branches; SshGateway 23/23; AuthorizedKeysRenderer 15/15; ServerConnectionConfig 42/42; AuthorizedKeysSync 25/29 (the 4 = env-bound production constructor). 5,371 tests green, all gates met.