### PR TITLE
fde rm: skip keys sync when the FDE had no SSH keys — 0.13.57

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.56</version>
+    <version>0.13.57</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.56</version>
+        <version>0.13.57</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.56</version>
+        <version>0.13.57</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.56</version>
+        <version>0.13.57</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
@@ -178,13 +178,16 @@ public final class FdeCommand implements Runnable {
                 System.out.println(Ansi.AUTO.string("  @|faint Cancelled.|@"));
                 return;
               }
+              var hadSshKeys = !new FdeSshKeyStore(db).listForFde(fde.id()).isEmpty();
               fdeStore.remove(fde.id());
               System.out.println(Ansi.AUTO.string("  @|green ✓|@ FDE removed: " + fde.handle()));
               System.out.println(
                   Ansi.AUTO.string(
                       "  @|faint Owned tokens, SSH keys, sessions, passkeys, and enrollment"
                           + " tickets are revoked.|@"));
-              applyKeys(db);
+              if (hadSshKeys) {
+                applyKeys(db);
+              }
             }
           });
     }


### PR DESCRIPTION
Field finding from Uday: `sail fde rm e2e-member --force` over the gateway printed `Run 'sudo sail host keys sync' to apply` even though e2e-member had no registered SSH keys — there was nothing to apply. The sync (and its NeedsRoot hint) now runs only when the removed FDE actually had keys.

Also documented the revocation semantics this surfaced: `fde rm` is enforced by the database (gateway re-resolves the FDE per connection — stale authorized_keys lines are rejected), while `fde key rm` with a still-active FDE relies on the file until a sync runs; the spec's deferred SSH_USER_AUTH fingerprint cross-check is the proper closure for that.

5,371 tests green.