### PR TITLE
Config plumbing: shared host.yaml + block YAML + webauthn config keys — 0.13.58

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.57</version>
+    <version>0.13.58</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.57</version>
+        <version>0.13.58</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/config/YamlUtil.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/YamlUtil.java
@@ -14,6 +14,7 @@ import org.snakeyaml.engine.v2.api.Dump;
 import org.snakeyaml.engine.v2.api.DumpSettings;
 import org.snakeyaml.engine.v2.api.Load;
 import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.common.FlowStyle;
 
 /**
  * Thin facade over SnakeYAML Engine for parsing and emitting YAML. Also handles JSON since YAML 1.2
@@ -56,9 +57,13 @@ public final class YamlUtil {
     return result instanceof List<?> l ? (List<Map<String, Object>>) l : List.of();
   }
 
-  /** Dump a Map to a YAML string. */
+  /**
+   * Dumps in block style: these files ({@code host.yaml}, {@code config.yaml}, {@code sail.yaml})
+   * are declarative configuration the operator edits by hand, and the default flow style emits a
+   * single-line {@code {...}} map that is hostile to both editing and diffing.
+   */
   public static String dumpToString(Map<String, Object> map) {
-    var dump = new Dump(DumpSettings.builder().build());
+    var dump = new Dump(DumpSettings.builder().setDefaultFlowStyle(FlowStyle.BLOCK).build());
     return dump.dumpToString(map);
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
@@ -79,9 +79,23 @@ public final class SailPaths {
     return SAIL_DIR.resolve("update-check.yaml");
   }
 
-  /** Returns the host config file path: {@code ~/.sail/host.yaml}. */
+  /**
+   * Returns the host config file path. Resolution mirrors {@link #dataDir()}: the shared system
+   * copy {@code /var/lib/sail/host.yaml} when it exists (a host provisioned for SSH-key FDE login),
+   * otherwise {@code ~/.sail/host.yaml}. The shared location matters for the same reason the
+   * database moved: commands arriving through the {@code sail} user's SSH gateway must read host
+   * configuration (e.g. the webauthn origin for enrollment URLs), and the operator's home is
+   * unreadable to them. Solo/dev installs stay under {@code ~/.sail} unchanged.
+   */
   public static Path hostConfigPath() {
-    return SAIL_DIR.resolve("host.yaml");
+    return hostConfigPath(Files.exists(SYSTEM_DATA_DIR.resolve("host.yaml")));
+  }
+
+  /** Pure resolver; visible for tests so resolution can be exercised without the environment. */
+  static Path hostConfigPath(boolean provisionedSystemConfig) {
+    return provisionedSystemConfig
+        ? SYSTEM_DATA_DIR.resolve("host.yaml")
+        : SAIL_DIR.resolve("host.yaml");
   }
 
   /** Returns the client config file path: {@code ~/.sail/config.yaml}. */

--- a/sail-core/src/test/java/ai/singlr/sail/config/YamlUtilTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/YamlUtilTest.java
@@ -52,6 +52,20 @@ class YamlUtilTest {
   }
 
   @Test
+  void dumpToStringEmitsBlockStyleForHandEditing() {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("host", "devbox");
+    map.put("webauthn", Map.of("origins", List.of("http://localhost:7070")));
+
+    var yaml = YamlUtil.dumpToString(map);
+
+    assertFalse(yaml.contains("{"), yaml);
+    assertTrue(yaml.contains("host: devbox\n"), yaml);
+    assertTrue(yaml.contains("origins:\n"), yaml);
+    assertEquals(map, YamlUtil.parseMap(yaml));
+  }
+
+  @Test
   void dumpJsonProducesFlowStyleOutput() {
     var map = new LinkedHashMap<String, Object>();
     map.put("name", "snap-1");

--- a/sail-core/src/test/java/ai/singlr/sail/engine/SailPathsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/SailPathsTest.java
@@ -42,8 +42,13 @@ class SailPathsTest {
   }
 
   @Test
-  void hostConfigPathIsUnderSingDir() {
-    assertEquals(HOME.resolve(".sail/host.yaml"), SailPaths.hostConfigPath());
+  void hostConfigPathFallsBackToHomeWhenNoSharedCopy() {
+    assertEquals(HOME.resolve(".sail/host.yaml"), SailPaths.hostConfigPath(false));
+  }
+
+  @Test
+  void hostConfigPathPrefersTheSharedSystemCopy() {
+    assertEquals(Path.of("/var/lib/sail/host.yaml"), SailPaths.hostConfigPath(true));
   }
 
   @Test

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.57</version>
+        <version>0.13.58</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.57</version>
+        <version>0.13.58</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostConfigSetCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostConfigSetCommand.java
@@ -6,12 +6,15 @@
 package ai.singlr.sail.commands;
 
 import ai.singlr.sail.config.HostYaml;
+import ai.singlr.sail.config.WebauthnConfig;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.NetworkDetector;
 import ai.singlr.sail.engine.SailPaths;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -25,9 +28,14 @@ import picocli.CommandLine.Spec;
     mixinStandardHelpOptions = true)
 public final class HostConfigSetCommand implements Runnable {
 
-  private static final Set<String> SETTABLE_KEYS = Set.of("server-ip");
+  private static final Set<String> SETTABLE_KEYS =
+      Set.of("server-ip", "webauthn-rp-id", "webauthn-rp-name", "webauthn-origin");
+  private static final Set<String> WEBAUTHN_KEYS =
+      Set.of("webauthn-rp-id", "webauthn-rp-name", "webauthn-origin");
+  private static final Pattern RP_ID = Pattern.compile("[a-z0-9]([a-z0-9.-]*[a-z0-9])?");
+  private static final Pattern ORIGIN = Pattern.compile("https?://\\S+[^/]");
 
-  @Parameters(index = "0", description = "Configuration key (e.g. 'server-ip').")
+  @Parameters(index = "0", description = "Configuration key (e.g. 'server-ip', 'webauthn-rp-id').")
   private String key;
 
   @Parameters(index = "1", description = "Value to set.")
@@ -57,10 +65,7 @@ public final class HostConfigSetCommand implements Runnable {
           "Unknown config key: '" + key + "'. Settable keys: " + String.join(", ", SETTABLE_KEYS));
     }
 
-    if ("server-ip".equals(key) && !NetworkDetector.isValidIpv4(value)) {
-      throw new IllegalArgumentException(
-          "Invalid IPv4 address: '" + value + "'. Expected format: 192.168.1.100");
-    }
+    validate(key, value);
 
     var hostYamlPath = SailPaths.hostConfigPath();
     if (!Files.exists(hostYamlPath)) {
@@ -86,24 +91,82 @@ public final class HostConfigSetCommand implements Runnable {
       return;
     }
 
-    System.out.println(Ansi.AUTO.string("  @|bold,green \u2713|@ " + key + " = " + value));
+    System.out.println(Ansi.AUTO.string("  @|bold,green ✓|@ " + key + " = " + value));
+    if (WEBAUTHN_KEYS.contains(key)) {
+      System.out.println(
+          Ansi.AUTO.string("  @|faint Restart to apply: sudo systemctl restart sail-api|@"));
+    }
   }
 
-  private static HostYaml applyChange(HostYaml current, String key, String value) {
+  static void validate(String key, String value) {
+    switch (key) {
+      case "server-ip" -> {
+        if (!NetworkDetector.isValidIpv4(value)) {
+          throw new IllegalArgumentException(
+              "Invalid IPv4 address: '" + value + "'. Expected format: 192.168.1.100");
+        }
+      }
+      case "webauthn-rp-id" -> {
+        if (!RP_ID.matcher(value).matches()) {
+          throw new IllegalArgumentException(
+              "Invalid RP id: '"
+                  + value
+                  + "'. Expected a lowercase hostname, e.g. sail.example.dev or localhost.");
+        }
+      }
+      case "webauthn-origin" -> {
+        if (!ORIGIN.matcher(value).matches()) {
+          throw new IllegalArgumentException(
+              "Invalid origin: '"
+                  + value
+                  + "'. Expected e.g. https://sail.example.dev (no trailing slash — browsers"
+                  + " send the origin without one, and the match is exact).");
+        }
+      }
+      default -> {}
+    }
+  }
+
+  static HostYaml applyChange(HostYaml current, String key, String value) {
+    var webauthn = current.webauthn();
     return switch (key) {
-      case "server-ip" ->
-          new HostYaml(
-              current.storageBackend(),
-              current.pool(),
-              current.poolDisk(),
-              current.bridge(),
-              current.baseProfile(),
-              current.image(),
-              current.incusVersion(),
-              value,
-              current.initializedAt(),
-              current.webauthn());
+      case "server-ip" -> withServerIp(current, value);
+      case "webauthn-rp-id" ->
+          withWebauthn(current, new WebauthnConfig(value, webauthn.rpName(), webauthn.origins()));
+      case "webauthn-rp-name" ->
+          withWebauthn(current, new WebauthnConfig(webauthn.rpId(), value, webauthn.origins()));
+      case "webauthn-origin" ->
+          withWebauthn(
+              current, new WebauthnConfig(webauthn.rpId(), webauthn.rpName(), List.of(value)));
       default -> throw new IllegalArgumentException("Unhandled key: " + key);
     };
+  }
+
+  private static HostYaml withServerIp(HostYaml current, String serverIp) {
+    return new HostYaml(
+        current.storageBackend(),
+        current.pool(),
+        current.poolDisk(),
+        current.bridge(),
+        current.baseProfile(),
+        current.image(),
+        current.incusVersion(),
+        serverIp,
+        current.initializedAt(),
+        current.webauthn());
+  }
+
+  private static HostYaml withWebauthn(HostYaml current, WebauthnConfig webauthn) {
+    return new HostYaml(
+        current.storageBackend(),
+        current.pool(),
+        current.poolDisk(),
+        current.bridge(),
+        current.baseProfile(),
+        current.image(),
+        current.incusVersion(),
+        current.serverIp(),
+        current.initializedAt(),
+        webauthn);
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -11,6 +11,7 @@ import ai.singlr.sail.engine.ContainerSpecImporter;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.Spinner;
+import ai.singlr.sail.engine.SshIdentityProvisioner;
 import ai.singlr.sail.store.DataMigration;
 import ai.singlr.sail.store.DataMigrator;
 import ai.singlr.sail.store.MigrationRunner;
@@ -21,6 +22,9 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
 import java.util.Optional;
 import picocli.CommandLine.Command;
@@ -88,8 +92,47 @@ public final class MigrateCommand implements Runnable {
       var runs =
           applyMigrations(
               db, dbPath.toString(), importer::importAll, prompter, animate, jsonOutput);
+      relocateHostConfig(jsonOutput);
       syncAuthorizedKeys(db, jsonOutput);
       return runs;
+    }
+  }
+
+  /**
+   * Moves {@code host.yaml} into the shared data directory on provisioned hosts, so commands
+   * arriving through the {@code sail} user's SSH gateway can read host configuration (e.g. the
+   * webauthn origin printed by {@code fde enroll}). Same upgrade-convergence rationale as {@link
+   * #syncAuthorizedKeys}: this is the step guaranteed to run new-binary code during an upgrade.
+   * No-op unless this host is provisioned (shared dir exists), the process is root, a legacy file
+   * exists, and the shared copy does not.
+   */
+  private static void relocateHostConfig(boolean jsonOutput) {
+    var legacy = SailPaths.sailDir().resolve("host.yaml");
+    var shared = Path.of(SshIdentityProvisioner.DEFAULT_DATA_DIR).resolve("host.yaml");
+    if (!SailPaths.isRoot()
+        || !Files.isDirectory(shared.getParent())
+        || Files.exists(shared)
+        || !Files.exists(legacy)) {
+      return;
+    }
+    try {
+      Files.move(legacy, shared);
+      var view = Files.getFileAttributeView(shared, PosixFileAttributeView.class);
+      view.setGroup(
+          shared
+              .getFileSystem()
+              .getUserPrincipalLookupService()
+              .lookupPrincipalByGroupName(SshIdentityProvisioner.SAIL_USER));
+      Files.setPosixFilePermissions(shared, PosixFilePermissions.fromString("rw-r-----"));
+      if (!jsonOutput) {
+        System.out.println(
+            Ansi.AUTO.string("  @|green ✓|@ host.yaml moved to " + shared.getParent()));
+      }
+    } catch (Exception e) {
+      System.err.println(
+          "  host.yaml relocation failed: "
+              + e.getMessage()
+              + ". Converge manually with 'sudo sail host ssh-identity'.");
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/SshIdentityProvisioner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/SshIdentityProvisioner.java
@@ -127,6 +127,34 @@ public final class SshIdentityProvisioner {
                     + SAIL_USER
                     + " \"$f\" && chmod 660 \"$f\"; done; true")),
         new Run(
+            "Move host.yaml into " + dataDir + " (readable by gateway commands)",
+            List.of(
+                "sh",
+                "-c",
+                "[ -e \""
+                    + source
+                    + "/host.yaml\" ] && [ ! -e \""
+                    + dataDir
+                    + "/host.yaml\" ] && mv \""
+                    + source
+                    + "/host.yaml\" \""
+                    + dataDir
+                    + "/host.yaml\"; true")),
+        new Run(
+            "Set host.yaml group access",
+            List.of(
+                "sh",
+                "-c",
+                "[ -e \""
+                    + dataDir
+                    + "/host.yaml\" ] && chgrp "
+                    + SAIL_USER
+                    + " \""
+                    + dataDir
+                    + "/host.yaml\" && chmod 640 \""
+                    + dataDir
+                    + "/host.yaml\"; true")),
+        new Run(
             "Create the systemd drop-in directory",
             List.of("install", "-d", "-m", "755", Path.of(DROP_IN).getParent().toString())),
         new WriteFile(

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/HostConfigSetCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/HostConfigSetCommandTest.java
@@ -133,4 +133,71 @@ class HostConfigSetCommandTest {
       throw new RuntimeException(e);
     }
   }
+
+  private static final HostYaml BASE =
+      HostYaml.fromMap(java.util.Map.of("storage_backend", "dir", "server_ip", "10.0.0.1"));
+
+  @Test
+  void webauthnRpIdIsSetWithoutDisturbingOtherFields() {
+    var updated = HostConfigSetCommand.applyChange(BASE, "webauthn-rp-id", "localhost");
+
+    assertEquals("localhost", updated.webauthn().rpId());
+    assertEquals("10.0.0.1", updated.serverIp());
+    assertEquals("dir", updated.storageBackend());
+  }
+
+  @Test
+  void webauthnKeysComposeIntoAConfiguredBlock() {
+    var step1 = HostConfigSetCommand.applyChange(BASE, "webauthn-rp-id", "localhost");
+    var step2 = HostConfigSetCommand.applyChange(step1, "webauthn-rp-name", "Sail devbox");
+    var step3 = HostConfigSetCommand.applyChange(step2, "webauthn-origin", "http://localhost:7070");
+
+    assertEquals(
+        new ai.singlr.sail.config.WebauthnConfig(
+            "localhost", "Sail devbox", java.util.List.of("http://localhost:7070")),
+        step3.webauthn());
+    assertTrue(step3.webauthn().isConfigured());
+  }
+
+  @Test
+  void serverIpChangePreservesTheWebauthnBlock() {
+    var withWebauthn = HostConfigSetCommand.applyChange(BASE, "webauthn-rp-id", "localhost");
+
+    var updated = HostConfigSetCommand.applyChange(withWebauthn, "server-ip", "10.0.0.2");
+
+    assertEquals("10.0.0.2", updated.serverIp());
+    assertEquals("localhost", updated.webauthn().rpId());
+  }
+
+  @Test
+  void validateAcceptsRealisticValues() {
+    HostConfigSetCommand.validate("server-ip", "192.168.1.100");
+    HostConfigSetCommand.validate("webauthn-rp-id", "sail.example.dev");
+    HostConfigSetCommand.validate("webauthn-rp-id", "localhost");
+    HostConfigSetCommand.validate("webauthn-rp-name", "anything goes");
+    HostConfigSetCommand.validate("webauthn-origin", "https://sail.example.dev");
+    HostConfigSetCommand.validate("webauthn-origin", "http://localhost:7070");
+  }
+
+  @Test
+  void validateRejectsMalformedValues() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> HostConfigSetCommand.validate("server-ip", "not-an-ip"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> HostConfigSetCommand.validate("webauthn-rp-id", "Has Spaces"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> HostConfigSetCommand.validate("webauthn-origin", "sail.example.dev"));
+  }
+
+  @Test
+  void validateRejectsTrailingSlashOrigin() {
+    var thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> HostConfigSetCommand.validate("webauthn-origin", "http://localhost:7070/"));
+    assertTrue(thrown.getMessage().contains("trailing slash"));
+  }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/SshIdentityProvisionerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/SshIdentityProvisionerTest.java
@@ -59,6 +59,26 @@ class SshIdentityProvisionerTest {
   }
 
   @Test
+  void hostYamlMoveIsGuardedAndGroupReadable() {
+    var commands =
+        plan().stream()
+            .filter(SshIdentityProvisioner.Run.class::isInstance)
+            .map(s -> String.join(" ", ((SshIdentityProvisioner.Run) s).command()))
+            .toList();
+    var move =
+        commands.stream().filter(c -> c.contains("host.yaml\" \"")).findFirst().orElseThrow();
+    assertTrue(move.contains("[ -e") && move.contains("! -e"), move);
+    assertTrue(move.contains("/root/.sail/host.yaml"), move);
+    assertTrue(move.contains("/var/lib/sail/host.yaml"), move);
+    var access =
+        commands.stream()
+            .filter(c -> c.contains("chmod 640") && c.contains("host.yaml"))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(access.contains("chgrp sail"), access);
+  }
+
+  @Test
   void authorizedKeysIsNeverTruncatedWhenPresent() {
     var step =
         plan().stream()


### PR DESCRIPTION
Closes the two findings from Phase 3 of the E2E campaign, plus the DX gap that caused them.

1. **host.yaml → `/var/lib/sail` (shared, 640 root:sail).** `fde enroll` over the gateway runs as the `sail` user, which couldn't read `/root/.sail/host.yaml` — so the enrollment URL hint vanished. Same fix as the database move: `SailPaths.hostConfigPath()` auto-detects the shared copy, provisioning gains guarded move/group steps, and `migrate` converges existing hosts on upgrade (the step guaranteed to run new-binary code). Bonus: `RuntimeMode` routes through the same path, so every user on a provisioned host now detects host mode correctly.
2. **Block-style YAML everywhere.** The flow-style `{...}` single-line host.yaml forced a careful hand-replacement during Phase 3. `YamlUtil.dumpToString` now emits block style — these are operator-edited declarative files.
3. **`sail host config set webauthn-rp-id|webauthn-rp-name|webauthn-origin`** with validation (hostname-shaped RP id; origin must carry a scheme and must not end in `/` — browsers send the origin without one and the match is exact) and a restart hint. The Phase 3 setup becomes three commands instead of a YAML hand-edit.

Tests: provisioner plan guards, path resolver branches, block-style round-trip, applyChange/validate matrix. 5,389 tests green, all gates.