### PR TITLE
Security hardening pass (six-dimension audit) — 0.13.59

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -153,6 +153,48 @@ partial tampering, not a compromised release account or workflow.
 Actions currently use major-version tags such as `actions/checkout@v4`. This is conventional, but
 not a maximum supply-chain posture.
 
+## Hardening pass — 2026-06-12 (0.13.59)
+
+A six-dimension audit (secret leakage, authn/authz, injection, hand-rolled WebAuthn crypto,
+web/file-perms/SSRF, credential lifecycle) over the auth surface. Confirmed clean: SQL fully
+parameterized, command execution argv-based (no shell injection), authorized_keys fail-closed,
+tokens/sessions/tickets stored only as SHA-256 of 256-bit `SecureRandom` values, WebAuthn
+signatures genuinely verified with constant-time challenge/rpId compares, algorithm-confusion
+blocked, signCount anti-clone correct, `redirect_uri` loopback validation not bypassable, no
+reflected/DOM XSS. Fixed:
+
+- **Authorization fails safe.** `Role.fromAttribute` mapped a missing/blank role to ADMIN; now
+  every unknown value resolves to VIEWER. `TokenStore.create` validates the role. (Both role
+  columns are already `NOT NULL`+CHECK, so this is defense in depth.)
+- **Session auth requires an active FDE.** `SessionAwareAuth` now rejects a session whose FDE is
+  not `active`, matching the SSH gateway.
+- **WebAuthn parser hardening.** CBOR rejects an array whose declared count exceeds the remaining
+  input (allocation-bomb DoS); RSA COSE keys are bounded to 2048–8192-bit moduli with an odd
+  exponent ≥ 3; `clientDataJSON` is parsed strictly (duplicate keys rejected) to remove a
+  parser-divergence avenue on the signed fields.
+- **Enrollment tickets are atomically single-use.** `EnrollmentTicketStore.consume` uses
+  `UPDATE … WHERE consumed_at IS NULL RETURNING`, and the handler consumes *before* registering,
+  closing a race that could enroll multiple passkeys from one ticket.
+- **Token DB unreachable to other local users.** The per-user `~/.sail` data directory is created
+  `0700` (`SailPaths.ensureDataDir`); the group-shared `/var/lib/sail` is left to provisioning.
+- **FDE handles validated at creation** (`NameValidator.requireValidFdeHandle`), so a malformed
+  handle can never reach the `authorized_keys` renderer (where it would fail-closed the whole-file
+  regeneration and lock out key sync).
+- **Webhook SSRF resolves and range-checks bytes.** `WebhookUrlSafety` now resolves the host and
+  checks each address (incl. IPv4-mapped IPv6 like `::ffff:169.254.169.254`, full 169.254/16,
+  CGNAT 100.64/10, ULA fc00::/7) instead of string prefixes; fail-closed on resolution failure.
+- **No-store on passkey responses** so a session-token body is never cached.
+
+Open items deliberately deferred (need a product decision or larger change, tracked separately):
+- **Route privilege tiers.** The main router maps mutating verbs to WRITE, so a `member` can
+  dispatch agents and approve reviews. Whether dispatch/review-approve/spec-delete should require
+  ADMIN is a product decision, not a safe unilateral change.
+- **API token expiry/rotation** and a **background sweep** of expired sessions/tickets/challenges
+  (currently enforced on read, pruned lazily).
+- **WebAuthn `userHandle` binding** at finish (defense in depth; route-layer authz already
+  prevents takeover).
+- `--token` on the CLI is visible via `/proc`/shell history; prefer `SAIL_TOKEN`/config.
+
 ## Recommended Follow-Ups
 - Add release signing with cosign or minisign and verify signatures in `install.sh`, `sail upgrade`,
   and the auto-upgrader.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.58</version>
+    <version>0.13.59</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.58</version>
+        <version>0.13.59</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/config/WebhookUrlSafety.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/WebhookUrlSafety.java
@@ -53,49 +53,73 @@ public final class WebhookUrlSafety {
     }
   }
 
-  /** Returns true if the hostname is, or resolves to, a private/loopback/link-local address. */
+  /**
+   * Returns true if the hostname is, or resolves to, a private/internal address. The host is
+   * resolved to its IP(s) and every resolved address is range-checked on its raw bytes, so a
+   * public-looking name that resolves to an internal address — and obfuscated forms (decimal/hex
+   * IPs, IPv4-mapped IPv6 like {@code ::ffff:169.254.169.254}) — are all caught. Resolution failure
+   * is treated as unsafe (fail closed). Note: the connector re-resolves at send time, so the
+   * send-time recheck remains the defense against DNS rebinding between this check and connect.
+   */
   public static boolean isPrivateHost(String host) {
-    var lower = host.toLowerCase();
-    if (lower.equals("localhost") || lower.equals("[::1]")) {
+    var bare = host.toLowerCase();
+    if (bare.startsWith("[") && bare.endsWith("]")) {
+      bare = bare.substring(1, bare.length() - 1);
+    }
+    if (bare.equals("localhost")) {
       return true;
     }
-
-    var bare =
-        lower.startsWith("[") && lower.endsWith("]")
-            ? lower.substring(1, lower.length() - 1)
-            : lower;
-
-    if (bare.startsWith("127.")
-        || bare.startsWith("10.")
-        || bare.startsWith("192.168.")
-        || bare.equals("169.254.169.254")
-        || bare.equals("0.0.0.0")
-        || bare.equals("::1")) {
-      return true;
-    }
-
-    if (bare.startsWith("172.")) {
-      try {
-        var parts = bare.split("\\.");
-        if (parts.length >= 2) {
-          var secondOctet = Integer.parseInt(parts[1]);
-          if (secondOctet >= 16 && secondOctet <= 31) {
-            return true;
-          }
-        }
-      } catch (NumberFormatException ignored) {
-      }
-    }
-
-    if (bare.startsWith("fd") || bare.startsWith("fc") || bare.startsWith("fe80")) {
-      return true;
-    }
-
     try {
-      var addr = InetAddress.getByName(bare);
-      return addr.isLoopbackAddress() || addr.isSiteLocalAddress() || addr.isLinkLocalAddress();
+      for (var addr : InetAddress.getAllByName(bare)) {
+        if (isPrivateAddress(addr)) {
+          return true;
+        }
+      }
+      return false;
     } catch (Exception e) {
       return true;
     }
+  }
+
+  private static boolean isPrivateAddress(InetAddress addr) {
+    if (addr.isLoopbackAddress()
+        || addr.isLinkLocalAddress()
+        || addr.isSiteLocalAddress()
+        || addr.isAnyLocalAddress()
+        || addr.isMulticastAddress()) {
+      return true;
+    }
+    var bytes = addr.getAddress();
+    if (bytes.length == 4) {
+      return isPrivateV4(bytes);
+    }
+    if ((bytes[0] & 0xfe) == 0xfc) {
+      return true;
+    }
+    if (isV4Mapped(bytes)) {
+      return isPrivateV4(new byte[] {bytes[12], bytes[13], bytes[14], bytes[15]});
+    }
+    return false;
+  }
+
+  private static boolean isPrivateV4(byte[] b) {
+    var o0 = b[0] & 0xff;
+    var o1 = b[1] & 0xff;
+    return o0 == 0
+        || o0 == 10
+        || o0 == 127
+        || (o0 == 169 && o1 == 254)
+        || (o0 == 172 && o1 >= 16 && o1 <= 31)
+        || (o0 == 192 && o1 == 168)
+        || (o0 == 100 && o1 >= 64 && o1 <= 127);
+  }
+
+  private static boolean isV4Mapped(byte[] b) {
+    for (var i = 0; i < 10; i++) {
+      if (b[i] != 0) {
+        return false;
+      }
+    }
+    return (b[10] & 0xff) == 0xff && (b[11] & 0xff) == 0xff;
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/config/YamlUtil.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/YamlUtil.java
@@ -35,6 +35,27 @@ public final class YamlUtil {
     return result instanceof Map<?, ?> m ? (Map<String, Object>) m : Map.of();
   }
 
+  /**
+   * Parses a JSON/YAML object, rejecting duplicate keys. Used for security-critical inputs (e.g.
+   * {@code clientDataJSON}) where a document carrying two values for the same field could let a
+   * verifier read one while a signature covers the other — a parser-divergence attack the default
+   * last-key-wins parse would silently allow.
+   */
+  @SuppressWarnings("unchecked")
+  public static Map<String, Object> parseMapStrict(String yamlOrJson) {
+    if (yamlOrJson == null || yamlOrJson.isBlank()) {
+      return Map.of();
+    }
+    var load = new Load(LoadSettings.builder().setAllowDuplicateKeys(false).build());
+    Object result;
+    try {
+      result = load.loadFromString(yamlOrJson);
+    } catch (org.snakeyaml.engine.v2.exceptions.YamlEngineException e) {
+      throw new IllegalArgumentException("Malformed document: " + e.getMessage(), e);
+    }
+    return result instanceof Map<?, ?> m ? (Map<String, Object>) m : Map.of();
+  }
+
   /** Parse a YAML file into a Map. */
   public static Map<String, Object> parseFile(Path path) throws IOException {
     try (var in = Files.newInputStream(path)) {

--- a/sail-core/src/main/java/ai/singlr/sail/engine/NameValidator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/NameValidator.java
@@ -20,6 +20,7 @@ public final class NameValidator {
   private static final Pattern SNAPSHOT_LABEL = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9._-]*$");
   private static final Pattern SERVICE_NAME = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9._-]*$");
   private static final Pattern POSIX_USERNAME = Pattern.compile("^[a-z_][a-z0-9_-]*$");
+  private static final Pattern FDE_HANDLE = Pattern.compile("^[A-Za-z0-9][A-Za-z0-9._-]*$");
   private static final int MAX_USERNAME_LENGTH = 32;
   private static final Pattern VERSION = Pattern.compile("^\\d+(\\.\\d+)*$");
   private static final Pattern SAFE_PATH = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9._/-]*$");
@@ -53,6 +54,24 @@ public final class NameValidator {
               + specId
               + "'. Must match [a-z0-9][a-z0-9-]*, max "
               + MAX_SPEC_ID_LENGTH
+              + " characters.");
+    }
+  }
+
+  /**
+   * Validates an FDE handle. The handle is interpolated into the {@code sail} user's {@code
+   * authorized_keys} forced command, so the conservative charset (no whitespace, quotes, or
+   * newlines) is a security boundary, not just hygiene — it is enforced at creation so a malformed
+   * handle can never reach the renderer, where it would otherwise fail the whole-file regeneration
+   * and lock out key sync for every FDE.
+   */
+  public static void requireValidFdeHandle(String handle) {
+    if (handle == null || handle.length() > MAX_LENGTH || !FDE_HANDLE.matcher(handle).matches()) {
+      throw new IllegalArgumentException(
+          "Invalid FDE handle: '"
+              + handle
+              + "'. Must match [A-Za-z0-9][A-Za-z0-9._-]*, max "
+              + MAX_LENGTH
               + " characters.");
     }
   }

--- a/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
@@ -59,6 +59,22 @@ public final class SailPaths {
     return dataDir().resolve("sail.db");
   }
 
+  /**
+   * Creates the control-plane data directory, restricting the per-user home location ({@code
+   * ~/.sail}) to owner-only ({@code 0700}) so no other local user can reach the token/session
+   * database inside it. The shared system directory ({@code /var/lib/sail}) and any explicit {@code
+   * $SAIL_DATA_DIR} are left untouched — provisioning owns their group-shared permissions
+   * deliberately (the {@code sail} gateway user needs access). Best-effort on non-POSIX systems.
+   */
+  public static void ensureDataDir(Path dir) throws IOException {
+    Files.createDirectories(dir);
+    if (dir.startsWith(SAIL_DIR)
+        && dir.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+      Files.setPosixFilePermissions(
+          dir, java.nio.file.attribute.PosixFilePermissions.fromString("rwx------"));
+    }
+  }
+
   /** Returns the projects base directory: {@code ~/.sail/projects}. */
   public static Path projectsDir() {
     return PROJECTS_DIR;

--- a/sail-core/src/main/java/ai/singlr/sail/store/EnrollmentTicketStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/EnrollmentTicketStore.java
@@ -69,13 +69,22 @@ public final class EnrollmentTicketStore {
     return info;
   }
 
-  /** Marks a ticket used. Returns true only if it was still live, so consumption is single-shot. */
+  /**
+   * Atomically marks a ticket used and reports whether THIS call was the one that consumed it. The
+   * {@code UPDATE ... WHERE consumed_at IS NULL RETURNING} runs as a single statement, so two
+   * concurrent callers cannot both observe the ticket as live — exactly one gets the returned row.
+   * Callers must treat {@code true} as the authorization to proceed (consume before acting), not
+   * consume after a separate liveness check.
+   */
   public boolean consume(String ticket) {
-    db.execute(
-        "UPDATE enrollment_tickets SET consumed_at = ? WHERE token_hash = ? AND consumed_at IS NULL",
-        Instant.now().toString(),
-        sha256(ticket));
-    return db.changes() > 0;
+    return db.queryOne(
+            "UPDATE enrollment_tickets SET consumed_at = ?"
+                + " WHERE token_hash = ? AND consumed_at IS NULL"
+                + " RETURNING token_hash",
+            row -> row.text(0),
+            Instant.now().toString(),
+            sha256(ticket))
+        .isPresent();
   }
 
   private static String generateTicket() {

--- a/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
@@ -48,6 +48,7 @@ public final class FdeStore {
    * the role is not one of {@code admin}, {@code member}, {@code viewer}.
    */
   public Fde add(String handle, String displayName, String email, String role) {
+    ai.singlr.sail.engine.NameValidator.requireValidFdeHandle(handle);
     if (!ROLES.contains(role)) {
       throw new IllegalArgumentException(
           "Invalid role: " + role + ". Must be one of " + ROLES + ".");

--- a/sail-core/src/main/java/ai/singlr/sail/store/TokenStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/TokenStore.java
@@ -20,6 +20,8 @@ import java.util.Optional;
  */
 public final class TokenStore {
 
+  private static final java.util.Set<String> ROLES = java.util.Set.of("admin", "member", "viewer");
+
   private final Sqlite db;
 
   public TokenStore(Sqlite db) {
@@ -37,6 +39,10 @@ public final class TokenStore {
 
   /** Creates a token optionally owned by an FDE ({@code fdes.id}, or null for an unowned token). */
   public CreatedToken create(String name, String role, String fdeId) {
+    if (!ROLES.contains(role)) {
+      throw new IllegalArgumentException(
+          "Invalid role: " + role + ". Must be one of " + ROLES + ".");
+    }
     var token = generateToken();
     var hash = sha256(token);
     db.execute(

--- a/sail-core/src/main/java/ai/singlr/sail/webauthn/Cbor.java
+++ b/sail-core/src/main/java/ai/singlr/sail/webauthn/Cbor.java
@@ -110,6 +110,9 @@ public final class Cbor {
   }
 
   private List<Object> readArray(int count) {
+    if (count > data.length - pos) {
+      throw new IllegalArgumentException("CBOR array count exceeds remaining input");
+    }
     var list = new ArrayList<>(count);
     for (var i = 0; i < count; i++) {
       list.add(readValue());

--- a/sail-core/src/main/java/ai/singlr/sail/webauthn/ClientData.java
+++ b/sail-core/src/main/java/ai/singlr/sail/webauthn/ClientData.java
@@ -25,7 +25,7 @@ public record ClientData(
   public static final String TYPE_GET = "webauthn.get";
 
   public static ClientData parse(byte[] clientDataJson) {
-    var map = YamlUtil.parseMap(new String(clientDataJson, StandardCharsets.UTF_8));
+    var map = YamlUtil.parseMapStrict(new String(clientDataJson, StandardCharsets.UTF_8));
     var type = requireString(map.get("type"), "type");
     var origin = requireString(map.get("origin"), "origin");
     var challengeB64 = requireString(map.get("challenge"), "challenge");

--- a/sail-core/src/main/java/ai/singlr/sail/webauthn/CoseKey.java
+++ b/sail-core/src/main/java/ai/singlr/sail/webauthn/CoseKey.java
@@ -107,12 +107,22 @@ public record CoseKey(PublicKey publicKey, long algorithm) {
     return generate("EC", new ECPublicKeySpec(new ECPoint(x, y), P256));
   }
 
+  private static final int RSA_MIN_MODULUS_BITS = 2048;
+  private static final int RSA_MAX_MODULUS_BITS = 8192;
+
   private static PublicKey rsa(Map<?, ?> cose, long alg) {
     if (alg != RS256) {
       throw new IllegalArgumentException("RSA key requires alg RS256 (-257), got " + alg);
     }
     var n = new BigInteger(1, readBytes(cose, LABEL_CRV, "n"));
     var e = new BigInteger(1, readBytes(cose, LABEL_X_OR_N, "e"));
+    if (n.bitLength() < RSA_MIN_MODULUS_BITS || n.bitLength() > RSA_MAX_MODULUS_BITS) {
+      throw new IllegalArgumentException(
+          "RSA modulus must be " + RSA_MIN_MODULUS_BITS + "-" + RSA_MAX_MODULUS_BITS + " bits");
+    }
+    if (e.bitLength() < 2 || !e.testBit(0)) {
+      throw new IllegalArgumentException("RSA public exponent must be an odd integer >= 3");
+    }
     return generate("RSA", new RSAPublicKeySpec(n, e));
   }
 

--- a/sail-core/src/test/java/ai/singlr/sail/config/WebhookUrlSafetyTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/WebhookUrlSafetyTest.java
@@ -75,6 +75,15 @@ class WebhookUrlSafetyTest {
   }
 
   @Test
+  void isPrivateHostFlagsObfuscatedAndMappedAddresses() {
+    assertTrue(WebhookUrlSafety.isPrivateHost("2130706433"), "decimal 127.0.0.1");
+    assertTrue(WebhookUrlSafety.isPrivateHost("[::ffff:169.254.169.254]"), "IPv4-mapped metadata");
+    assertTrue(WebhookUrlSafety.isPrivateHost("[::ffff:127.0.0.1]"), "IPv4-mapped loopback");
+    assertTrue(WebhookUrlSafety.isPrivateHost("100.64.0.1"), "CGNAT 100.64/10");
+    assertTrue(WebhookUrlSafety.isPrivateHost("169.254.1.1"), "full link-local /16");
+  }
+
+  @Test
   void isPrivateHostTreatsUnresolvableAsPrivate() {
     assertTrue(WebhookUrlSafety.isPrivateHost("no-such-host.invalid"));
   }

--- a/sail-core/src/test/java/ai/singlr/sail/engine/NameValidatorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/NameValidatorTest.java
@@ -248,4 +248,21 @@ class NameValidatorTest {
   void nullGitHubRepoIsInvalid() {
     assertThrows(IllegalArgumentException.class, () -> NameValidator.requireValidGitHubRepo(null));
   }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"uday", "e2e-member", "Ada.Lovelace_1", "a"})
+  void validFdeHandles(String handle) {
+    assertDoesNotThrow(() -> NameValidator.requireValidFdeHandle(handle));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"a\",command=\"x", "two\nlines", "has space", "", "-lead", ".lead"})
+  void invalidFdeHandles(String handle) {
+    assertThrows(IllegalArgumentException.class, () -> NameValidator.requireValidFdeHandle(handle));
+  }
+
+  @Test
+  void nullFdeHandleIsInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> NameValidator.requireValidFdeHandle(null));
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/store/FdeStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FdeStoreTest.java
@@ -136,6 +136,12 @@ class FdeStoreTest {
   }
 
   @Test
+  void addRejectsAnUnsafeHandle() {
+    assertThrows(
+        IllegalArgumentException.class, () -> store.add("a\",command=\"x", null, null, "member"));
+  }
+
+  @Test
   void activeAdminCountTracksRoleAndStatus() {
     assertEquals(0L, store.activeAdminCount());
     var admin = store.add("ada", null, null, "admin");

--- a/sail-core/src/test/java/ai/singlr/sail/store/TokenStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/TokenStoreTest.java
@@ -137,6 +137,13 @@ class TokenStoreTest {
   }
 
   @Test
+  void createRejectsUnknownRole() {
+    var thrown =
+        assertThrows(IllegalArgumentException.class, () -> store.create("svc", "superuser"));
+    assertTrue(thrown.getMessage().contains("Invalid role"));
+  }
+
+  @Test
   void sha256IsDeterministic() {
     var hash1 = TokenStore.sha256("test-input");
     var hash2 = TokenStore.sha256("test-input");

--- a/sail-core/src/test/java/ai/singlr/sail/webauthn/CborTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/webauthn/CborTest.java
@@ -125,4 +125,10 @@ class CborTest {
     // byte string with 8-byte length 0x80000000 (> Integer.MAX_VALUE)
     assertThrows(IllegalArgumentException.class, () -> decode("5b0000000080000000"));
   }
+
+  @Test
+  void rejectsArrayCountExceedingInput() {
+    // array header declaring 0x7fffffff elements with no element bytes (allocation bomb)
+    assertThrows(IllegalArgumentException.class, () -> decode("9a7fffffff"));
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/webauthn/ClientDataTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/webauthn/ClientDataTest.java
@@ -79,4 +79,15 @@ class ClientDataTest {
                 json(
                     "{\"type\":\"webauthn.get\",\"challenge\":\"not base64!!\",\"origin\":\"https://h\"}")));
   }
+
+  @Test
+  void rejectsDuplicateChallengeKey() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ClientData.parse(
+                json(
+                    "{\"type\":\"webauthn.get\",\"origin\":\"https://h\",\"challenge\":\"AAAA\","
+                        + "\"challenge\":\"BBBB\"}")));
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/webauthn/CoseKeyTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/webauthn/CoseKeyTest.java
@@ -143,6 +143,38 @@ class CoseKeyTest {
   }
 
   @Test
+  void rsaRejectsUndersizedModulus() throws Exception {
+    var kpg = KeyPairGenerator.getInstance("RSA");
+    kpg.initialize(1024);
+    var pub = (RSAPublicKey) kpg.generateKeyPair().getPublic();
+    var map =
+        cose(
+            1L,
+            3L,
+            3L,
+            CoseKey.RS256,
+            -1L,
+            pub.getModulus().toByteArray(),
+            -2L,
+            pub.getPublicExponent().toByteArray());
+
+    var thrown = assertThrows(IllegalArgumentException.class, () -> CoseKey.parse(map));
+    assertTrue(thrown.getMessage().contains("modulus"));
+  }
+
+  @Test
+  void rsaRejectsEvenExponent() throws Exception {
+    var kpg = KeyPairGenerator.getInstance("RSA");
+    kpg.initialize(2048);
+    var pub = (RSAPublicKey) kpg.generateKeyPair().getPublic();
+    var map =
+        cose(
+            1L, 3L, 3L, CoseKey.RS256, -1L, pub.getModulus().toByteArray(), -2L, new byte[] {0x04});
+
+    assertThrows(IllegalArgumentException.class, () -> CoseKey.parse(map));
+  }
+
+  @Test
   void rsaRejectsWrongAlg() {
     assertThrows(
         IllegalArgumentException.class, () -> CoseKey.parse(cose(1L, 3L, 3L, CoseKey.ES256)));

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.58</version>
+        <version>0.13.59</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.58</version>
+        <version>0.13.59</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Role.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Role.java
@@ -12,9 +12,11 @@ import java.util.Set;
 /**
  * Authorization role attached to an API credential. Each role grants a fixed set of {@link
  * Capability}. Roles are stored as lowercase strings on the token ({@code token.role}); {@link
- * #fromAttribute} resolves the stored value, treating a missing role as {@link #ADMIN} for backward
- * compatibility with single-operator deployments created before roles were enforced, and any
- * unrecognized value as the least-privileged {@link #VIEWER} (fail-safe).
+ * #fromAttribute} resolves the stored value, failing safe to the least-privileged {@link #VIEWER}
+ * for any missing, blank, or unrecognized value so a malformed role can never silently escalate.
+ * Every credential carries an explicit role — {@code api_tokens.role} and {@code fdes.role} are
+ * both {@code NOT NULL} with a CHECK constraint — so this fallback is defense in depth, not a path
+ * any live credential travels.
  */
 public enum Role {
   ADMIN(EnumSet.allOf(Capability.class)),
@@ -32,19 +34,18 @@ public enum Role {
   }
 
   /**
-   * Resolves the role from the {@code token.role} exchange attribute. A null or blank value means a
-   * pre-roles operator token and maps to {@link #ADMIN}; an unrecognized value maps to {@link
-   * #VIEWER} so a malformed role can never silently escalate.
+   * Resolves the role from the {@code token.role} exchange attribute. Any null, blank, or
+   * unrecognized value fails safe to {@link #VIEWER} so a malformed or absent role can never
+   * silently escalate to a privileged capability.
    */
   public static Role fromAttribute(Object attribute) {
     if (attribute == null) {
-      return ADMIN;
+      return VIEWER;
     }
     var value = attribute.toString().strip().toLowerCase(Locale.ROOT);
     return switch (value) {
-      case "", "admin" -> ADMIN;
+      case "admin" -> ADMIN;
       case "member" -> MEMBER;
-      case "viewer" -> VIEWER;
       default -> VIEWER;
     };
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SessionAwareAuth.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SessionAwareAuth.java
@@ -53,6 +53,7 @@ public final class SessionAwareAuth implements ApiAuth {
         sessions
             .validate(token)
             .flatMap(session -> fdes.byId(session.fdeId()))
+            .filter(f -> "active".equals(f.status()))
             .orElseThrow(
                 () ->
                     new ApiException(

--- a/sail-infra/src/main/java/ai/singlr/sail/api/TokenAuth.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/TokenAuth.java
@@ -10,14 +10,11 @@ import com.sun.net.httpserver.HttpExchange;
 import java.util.Objects;
 
 /**
- * Validates bearer tokens against the SQLite-backed {@link TokenStore}.
- *
- * <p>Authentication only — there is no authorization tier. Every valid token is a full-access
- * operator credential; the {@code token.role} attribute is recorded for audit/display but is
- * deliberately not enforced, because the product issues a single operator token and the security
- * boundary is the server's loopback bind (see {@code ServerStartCommand}), not a role check.
- * Introducing real role enforcement would be a deliberate feature with its own token-issuance UX
- * and schema migration; until then, do not treat the role column as an access-control mechanism.
+ * Validates bearer tokens against the SQLite-backed {@link TokenStore} and stamps the token's
+ * identity and role on the exchange. Authentication only — {@link Authorizer} is the authorization
+ * tier and enforces {@code token.role} per route (it runs immediately after this in {@code
+ * ApiRouter}). The loopback bind is an additional network boundary, not a substitute for the role
+ * check.
  */
 public final class TokenAuth implements ApiAuth {
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/WebauthnAuthHandler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/WebauthnAuthHandler.java
@@ -123,7 +123,9 @@ public final class WebauthnAuthHandler implements HttpHandler {
     var body = JsonBody.readMap(exchange);
     var ticket = enrollmentTicket(exchange);
     if (ticket != null) {
-      requireLiveTicket(ticket);
+      if (!enrollment.consume(ticket)) {
+        throw ticketDenied();
+      }
     } else {
       requireAdmin(exchange);
     }
@@ -133,9 +135,6 @@ public final class WebauthnAuthHandler implements HttpHandler {
             decode(body, "client_data_json"),
             decode(body, "attestation_object"),
             optionalString(body, "label"));
-    if (ticket != null) {
-      enrollment.consume(ticket);
-    }
     var result = new LinkedHashMap<String, Object>();
     result.put("status", "registered");
     result.put("fde", registration.fdeHandle());
@@ -155,12 +154,6 @@ public final class WebauthnAuthHandler implements HttpHandler {
     }
     requireAdmin(exchange);
     return requireString(body, "fde");
-  }
-
-  private void requireLiveTicket(String ticket) {
-    if (enrollment.authorize(ticket).isEmpty()) {
-      throw ticketDenied();
-    }
   }
 
   private static String enrollmentTicket(HttpExchange exchange) {
@@ -239,6 +232,7 @@ public final class WebauthnAuthHandler implements HttpHandler {
     var bytes =
         YamlUtil.dumpJson(new LinkedHashMap<>(response.body())).getBytes(StandardCharsets.UTF_8);
     exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+    exchange.getResponseHeaders().set("Cache-Control", "no-store");
     exchange.sendResponseHeaders(response.status(), bytes.length);
     try (var output = exchange.getResponseBody()) {
       output.write(bytes);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -78,7 +78,7 @@ public final class MigrateCommand implements Runnable {
   public static List<DataMigrator.Run> runMigrations(boolean nonInteractive, boolean jsonOutput) {
     var dbPath = SailPaths.controlPlaneDb();
     try {
-      Files.createDirectories(dbPath.getParent());
+      SailPaths.ensureDataDir(dbPath.getParent());
     } catch (Exception e) {
       throw new IllegalStateException("Could not prepare " + dbPath.getParent(), e);
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerInitCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerInitCommand.java
@@ -42,7 +42,7 @@ public final class ServerInitCommand implements Runnable {
 
   private void execute() throws Exception {
     var dbPath = SailPaths.controlPlaneDb();
-    Files.createDirectories(dbPath.getParent());
+    SailPaths.ensureDataDir(dbPath.getParent());
 
     try (var db = Sqlite.open(dbPath)) {
       var schema = new SchemaManager(db);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -92,7 +92,7 @@ public final class ServerStartCommand implements Runnable {
 
   private void execute() throws Exception {
     var dbPath = SailPaths.controlPlaneDb();
-    Files.createDirectories(dbPath.getParent());
+    SailPaths.ensureDataDir(dbPath.getParent());
 
     var db = Sqlite.open(dbPath);
     var migrationResult =

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/UpgradeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/UpgradeCommand.java
@@ -369,7 +369,7 @@ public final class UpgradeCommand implements Runnable {
    */
   private void bootstrapAdminToken(java.nio.file.Path dbPath) {
     try {
-      Files.createDirectories(dbPath.getParent());
+      SailPaths.ensureDataDir(dbPath.getParent());
       try (var db = Sqlite.open(dbPath)) {
         new SchemaManager(db).migrate();
         var tokenStore = new TokenStore(db);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/FixedTokenTestAuth.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/FixedTokenTestAuth.java
@@ -40,5 +40,7 @@ final class FixedTokenTestAuth implements ApiAuth {
     if (!MessageDigest.isEqual(expected, actual)) {
       throw new ApiException(ErrorCode.INVALID_BEARER_TOKEN, "Bearer token is invalid.");
     }
+    exchange.setAttribute("token.name", "admin");
+    exchange.setAttribute("token.role", "admin");
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoleTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoleTest.java
@@ -12,10 +12,10 @@ import org.junit.jupiter.api.Test;
 class RoleTest {
 
   @Test
-  void missingRoleIsAdminForBackwardCompatibility() {
-    assertEquals(Role.ADMIN, Role.fromAttribute(null));
-    assertEquals(Role.ADMIN, Role.fromAttribute(""));
-    assertEquals(Role.ADMIN, Role.fromAttribute("   "));
+  void missingOrBlankRoleFailsSafeToViewer() {
+    assertEquals(Role.VIEWER, Role.fromAttribute(null));
+    assertEquals(Role.VIEWER, Role.fromAttribute(""));
+    assertEquals(Role.VIEWER, Role.fromAttribute("   "));
   }
 
   @Test


### PR DESCRIPTION
A six-dimension read-only audit (secret leakage, authn/authz, injection, hand-rolled WebAuthn crypto, web/file-perms/SSRF, credential lifecycle) over the auth surface, then fixes for every confirmed finding.

**Confirmed clean** (recorded so we don't re-audit): SQL fully parameterized; command execution argv-based (no `sh -c` with user input); `authorized_keys` fail-closed (anchored handle regex + strict pubkey parse); tokens/sessions/tickets stored only as SHA-256 of 256-bit `SecureRandom` values; WebAuthn signatures genuinely verified, signed-data correct, `MessageDigest.isEqual` for challenge/rpId, algorithm-confusion blocked, signCount anti-clone correct; `redirect_uri` loopback validation not bypassable; loopback callback CSRF-safe; no reflected/DOM XSS.

## Fixes
- **Authorization fails safe.** `Role.fromAttribute` mapped missing/blank → ADMIN; now → VIEWER. `TokenStore.create` validates the role. (Both role columns are `NOT NULL`+CHECK, so this is defense in depth — but it removes a real fail-open foot-gun, and the `ApiRouterTest` churn in this PR is exactly that: the harness had been silently relying on the default-admin.)
- **Active-FDE session check** in `SessionAwareAuth`, matching the SSH gateway.
- **WebAuthn parser hardening:** CBOR array-count vs remaining-input cap (allocation-bomb DoS); RSA modulus bounded 2048–8192 bits, odd exponent ≥ 3; `clientDataJSON` parsed strictly (duplicate keys rejected, normalized to `IllegalArgumentException`).
- **Atomic single-use enrollment tickets:** `consume()` via `UPDATE … WHERE consumed_at IS NULL RETURNING`, consumed *before* registration — closes a one-ticket-many-passkeys race.
- **Token DB owner-only:** `~/.sail` created `0700` (`SailPaths.ensureDataDir`); `/var/lib/sail` group-sharing untouched.
- **FDE handle validation at creation** (`requireValidFdeHandle`) — a malformed handle can't reach the renderer and brick `keys sync`.
- **Webhook SSRF** resolves and byte-range-checks each address (IPv4-mapped IPv6, full 169.254/16, CGNAT, ULA), fail-closed.
- **`Cache-Control: no-store`** on passkey responses; corrected the stale `TokenAuth` javadoc.

## Deferred (in SECURITY_AUDIT.md "Hardening pass — 0.13.59")
Route privilege tiers (member can currently dispatch/approve — product decision); API token expiry + expired-row sweep; WebAuthn `userHandle` binding (route authz already prevents takeover); `--token` CLI `/proc` exposure.

5,425 tests green; new tests for each fix (Role fail-safe, TokenStore role reject, CBOR bomb, RSA bounds, dup-key clientData, FDE handle validation, webhook obfuscated/mapped addresses).