### PR TITLE
Project catalog in the DB (db-sync brick 1) — 0.13.60

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.59</version>
+    <version>0.13.60</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.59</version>
+        <version>0.13.60</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Project-definition catalog on SQLite. Each project's full descriptor (the canonical {@code
+ * sail.yaml}) is stored verbatim as the {@code definition} blob — the catalog never queries inside
+ * a definition, it loads it whole and hands it to the provisioner — alongside the handful of
+ * columns the board lists and joins on (name, attribution, timestamps).
+ *
+ * <p>This is the shared coordination record that replicates across devboxes (see the {@code
+ * db-sync} spec). Containers and run state are local and live elsewhere; this table is only the
+ * definition every box agrees on.
+ */
+public final class ProjectStore {
+
+  private final Sqlite db;
+
+  public ProjectStore(Sqlite db) {
+    this.db = db;
+  }
+
+  public record ProjectRow(
+      String name,
+      String definition,
+      String createdBy,
+      String createdAt,
+      String updatedBy,
+      String updatedAt) {}
+
+  /**
+   * Inserts the project or replaces its definition if it already exists, preserving the original
+   * {@code created_by}/{@code created_at}. Idempotent: re-applying the same definition is a no-op
+   * beyond bumping {@code updated_at}.
+   */
+  public void upsert(String name, String definition, String actor) {
+    var now = Instant.now().toString();
+    db.transaction(
+        () -> {
+          var existing = findByName(name);
+          if (existing.isPresent()) {
+            db.execute(
+                "UPDATE projects SET definition = ?, updated_by = ?, updated_at = ? WHERE name = ?",
+                definition,
+                actor,
+                now,
+                name);
+          } else {
+            db.execute(
+                "INSERT INTO projects (name, definition, created_by, created_at, updated_by,"
+                    + " updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+                name,
+                definition,
+                actor,
+                now,
+                actor,
+                now);
+          }
+        });
+  }
+
+  public Optional<ProjectRow> findByName(String name) {
+    return db.queryOne(SELECT + " WHERE name = ?", ProjectStore::map, name);
+  }
+
+  public List<ProjectRow> list() {
+    return db.query(SELECT + " ORDER BY name", ProjectStore::map);
+  }
+
+  public boolean delete(String name) {
+    db.execute("DELETE FROM projects WHERE name = ?", name);
+    return db.changes() > 0;
+  }
+
+  private static final String SELECT =
+      "SELECT name, definition, created_by, created_at, updated_by, updated_at FROM projects";
+
+  private static ProjectRow map(Sqlite.Row row) {
+    return new ProjectRow(
+        row.text(0), row.text(1), row.text(2), row.text(3), row.text(4), row.text(5));
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -234,6 +234,15 @@ public final class SchemaManager {
               public_key TEXT NOT NULL,
               comment TEXT,
               created_at TEXT NOT NULL
+          )""",
+          """
+          CREATE TABLE IF NOT EXISTS projects (
+              name TEXT PRIMARY KEY,
+              definition TEXT NOT NULL,
+              created_by TEXT,
+              created_at TEXT NOT NULL,
+              updated_by TEXT,
+              updated_at TEXT NOT NULL
           )""");
 
   private final Sqlite db;

--- a/sail-core/src/test/java/ai/singlr/sail/store/ProjectStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ProjectStoreTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ProjectStoreTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private ProjectStore store;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    store = new ProjectStore(db);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  @Test
+  void upsertInsertsAndRoundTripsTheDefinitionBlob() {
+    store.upsert("acme", "name: acme\nresources:\n  cpu: 2\n", "uday");
+
+    var row = store.findByName("acme").orElseThrow();
+    assertEquals("acme", row.name());
+    assertEquals("name: acme\nresources:\n  cpu: 2\n", row.definition());
+    assertEquals("uday", row.createdBy());
+    assertEquals("uday", row.updatedBy());
+    assertEquals(row.createdAt(), row.updatedAt());
+  }
+
+  @Test
+  void upsertReplacesDefinitionPreservingCreationProvenance() {
+    store.upsert("acme", "v1", "uday");
+    var created = store.findByName("acme").orElseThrow();
+
+    store.upsert("acme", "v2", "ada");
+
+    var updated = store.findByName("acme").orElseThrow();
+    assertEquals("v2", updated.definition());
+    assertEquals("uday", updated.createdBy(), "created_by is preserved across an update");
+    assertEquals(created.createdAt(), updated.createdAt(), "created_at is preserved");
+    assertEquals("ada", updated.updatedBy());
+    assertTrue(updated.updatedAt().compareTo(updated.createdAt()) >= 0, "updated_at is monotonic");
+  }
+
+  @Test
+  void listIsOrderedByName() {
+    store.upsert("zeta", "z", null);
+    store.upsert("alpha", "a", null);
+    store.upsert("mu", "m", null);
+
+    assertEquals(
+        List.of("alpha", "mu", "zeta"),
+        store.list().stream().map(ProjectStore.ProjectRow::name).toList());
+  }
+
+  @Test
+  void findByNameIsEmptyWhenAbsent() {
+    assertTrue(store.findByName("ghost").isEmpty());
+  }
+
+  @Test
+  void deleteRemovesAndReportsWhetherARowWentAway() {
+    store.upsert("acme", "x", null);
+
+    assertTrue(store.delete("acme"));
+    assertTrue(store.findByName("acme").isEmpty());
+    assertFalse(store.delete("acme"));
+  }
+
+  @Test
+  void definitionMayBeNullActorButNotNullBlob() {
+    store.upsert("acme", "x", null);
+    assertNull(store.findByName("acme").orElseThrow().createdBy());
+    assertThrows(SqliteException.class, () -> store.upsert("broken", null, null));
+  }
+}

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.59</version>
+        <version>0.13.60</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.59</version>
+        <version>0.13.60</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.engine.AuthorizedKeysSync;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerSpecImporter;
+import ai.singlr.sail.engine.ProjectImporter;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.Spinner;
@@ -15,6 +16,7 @@ import ai.singlr.sail.engine.SshIdentityProvisioner;
 import ai.singlr.sail.store.DataMigration;
 import ai.singlr.sail.store.DataMigrator;
 import ai.singlr.sail.store.MigrationRunner;
+import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.RebucketSpecsMigration;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
@@ -92,9 +94,23 @@ public final class MigrateCommand implements Runnable {
       var runs =
           applyMigrations(
               db, dbPath.toString(), importer::importAll, prompter, animate, jsonOutput);
+      importProjects(db, jsonOutput);
       relocateHostConfig(jsonOutput);
       syncAuthorizedKeys(db, jsonOutput);
       return runs;
+    }
+  }
+
+  /**
+   * Backfills the project catalog from on-disk descriptors, so projects created before the catalog
+   * existed appear in the DB (the shared, replicated source of truth). Repeatable and idempotent;
+   * quiet when nothing was imported.
+   */
+  private static void importProjects(Sqlite db, boolean jsonOutput) {
+    var report = new ProjectImporter(SailPaths.projectsDir(), new ProjectStore(db)).importAll();
+    if (!jsonOutput && report.imported() > 0) {
+      System.out.println(
+          Ansi.AUTO.string("  @|green ✓|@ project catalog: " + report.imported() + " imported"));
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCreateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCreateCommand.java
@@ -14,6 +14,7 @@ import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerState;
 import ai.singlr.sail.engine.GitCredentials;
 import ai.singlr.sail.engine.NameValidator;
+import ai.singlr.sail.engine.ProjectCatalog;
 import ai.singlr.sail.engine.ProjectPhase;
 import ai.singlr.sail.engine.ProjectProvisioner;
 import ai.singlr.sail.engine.ProvisionListener;
@@ -116,6 +117,9 @@ public final class ProjectCreateCommand implements Runnable {
     Files.createDirectories(projectDir);
     var canonicalYaml = projectDir.resolve(SailPaths.PROJECT_DESCRIPTOR);
     syncProjectBundle(singYamlPath, canonicalYaml);
+    if (!dryRun) {
+      ProjectCatalog.record(config.name(), Files.readString(canonicalYaml), null);
+    }
 
     var hostYamlPath = SailPaths.hostConfigPath();
     if (!Files.exists(hostYamlPath)) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectPullCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectPullCommand.java
@@ -167,6 +167,7 @@ public final class ProjectPullCommand implements Runnable {
       Files.createDirectories(outputPath.getParent());
     }
     Files.writeString(outputPath, resolvedYaml);
+    ai.singlr.sail.engine.ProjectCatalog.record(name, resolvedYaml, null);
 
     var outputDir = outputPath.getParent() != null ? outputPath.getParent() : Path.of(".");
     var filesPulled = pullFilesDirectory(token, name, outputDir);

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectCatalog.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectCatalog.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import ai.singlr.sail.store.ProjectStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+
+/**
+ * Records a project's definition into the control-plane catalog (the {@code projects} table) so it
+ * becomes the shared, replicated source of truth. Best-effort by design: the on-disk {@code
+ * sail.yaml} and the container are the operations that must succeed, so a catalog write that fails
+ * (DB momentarily unavailable) prints a hint and is recovered by the import migration on the next
+ * {@code sail migrate} — it never aborts project creation.
+ */
+public final class ProjectCatalog {
+
+  private ProjectCatalog() {}
+
+  /**
+   * Returns true if the definition was recorded; false (with a printed hint) on best-effort miss.
+   */
+  public static boolean record(String name, String definition, String actor) {
+    try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+      new SchemaManager(db).migrate();
+      new ProjectStore(db).upsert(name, definition, actor);
+      return true;
+    } catch (Exception e) {
+      System.err.println(
+          "  Note: project '"
+              + name
+              + "' was not recorded in the catalog ("
+              + e.getMessage()
+              + "). Run 'sail migrate' to backfill.");
+      return false;
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectImporter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectImporter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import ai.singlr.sail.store.ProjectStore;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Imports on-disk project descriptors ({@code ~/.sail/projects/<name>/sail.yaml}) into the
+ * control-plane catalog. Repeatable and idempotent — {@code sail migrate} runs it every time so a
+ * project created before the catalog existed (or by any path that wrote only the file) is brought
+ * into the DB, while {@code ProjectStore.upsert} keeps an already-catalogued project a no-op beyond
+ * its timestamp. This is the read-from-disk counterpart to {@code ProjectCatalog}'s write path,
+ * mirroring how {@link ContainerSpecImporter} reconciles specs.
+ */
+public final class ProjectImporter {
+
+  private final Path projectsDir;
+  private final ProjectStore store;
+
+  public ProjectImporter(Path projectsDir, ProjectStore store) {
+    this.projectsDir = projectsDir;
+    this.store = store;
+  }
+
+  public record Report(int imported, int skipped, List<String> notes) {
+    public static Report empty() {
+      return new Report(0, 0, List.of());
+    }
+  }
+
+  public Report importAll() {
+    if (!Files.isDirectory(projectsDir)) {
+      return Report.empty();
+    }
+    var imported = 0;
+    var skipped = 0;
+    var notes = new ArrayList<String>();
+    try (Stream<Path> entries = Files.list(projectsDir)) {
+      for (var dir : entries.filter(Files::isDirectory).sorted().toList()) {
+        var descriptor = dir.resolve(SailPaths.PROJECT_DESCRIPTOR);
+        if (!Files.isRegularFile(descriptor)) {
+          continue;
+        }
+        var name = dir.getFileName().toString();
+        try {
+          store.upsert(name, Files.readString(descriptor), null);
+          imported++;
+        } catch (IOException e) {
+          skipped++;
+          notes.add("could not import " + name + ": " + e.getMessage());
+        }
+      }
+    } catch (IOException e) {
+      return new Report(
+          imported, skipped, List.of("could not scan " + projectsDir + ": " + e.getMessage()));
+    }
+    return new Report(imported, skipped, List.copyOf(notes));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectImporterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectImporterTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sail.store.ProjectStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ProjectImporterTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private ProjectStore store;
+  private Path projectsDir;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    store = new ProjectStore(db);
+    projectsDir = tempDir.resolve("projects");
+    Files.createDirectories(projectsDir);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  private void writeProject(String name, String definition) throws IOException {
+    var dir = projectsDir.resolve(name);
+    Files.createDirectories(dir);
+    Files.writeString(dir.resolve(SailPaths.PROJECT_DESCRIPTOR), definition);
+  }
+
+  @Test
+  void importsEveryDescriptorIntoTheCatalog() throws IOException {
+    writeProject("acme", "name: acme\n");
+    writeProject("beta", "name: beta\n");
+
+    var report = new ProjectImporter(projectsDir, store).importAll();
+
+    assertEquals(2, report.imported());
+    assertEquals("name: acme\n", store.findByName("acme").orElseThrow().definition());
+    assertEquals("name: beta\n", store.findByName("beta").orElseThrow().definition());
+  }
+
+  @Test
+  void isIdempotentAndPicksUpDefinitionChanges() throws IOException {
+    writeProject("acme", "name: acme\nv: 1\n");
+    new ProjectImporter(projectsDir, store).importAll();
+
+    writeProject("acme", "name: acme\nv: 2\n");
+    var report = new ProjectImporter(projectsDir, store).importAll();
+
+    assertEquals(1, report.imported());
+    assertEquals(1, store.list().size());
+    assertEquals("name: acme\nv: 2\n", store.findByName("acme").orElseThrow().definition());
+  }
+
+  @Test
+  void skipsDirectoriesWithoutADescriptor() throws IOException {
+    Files.createDirectories(projectsDir.resolve("empty"));
+    writeProject("acme", "name: acme\n");
+
+    var report = new ProjectImporter(projectsDir, store).importAll();
+
+    assertEquals(1, report.imported());
+    assertTrue(store.findByName("empty").isEmpty());
+  }
+
+  @Test
+  void emptyWhenProjectsDirIsAbsent() {
+    var report = new ProjectImporter(tempDir.resolve("nonexistent"), store).importAll();
+
+    assertEquals(0, report.imported());
+    assertEquals(0, report.skipped());
+    assertTrue(store.list().isEmpty());
+  }
+}


### PR DESCRIPTION
First brick of the local-first DB-sync arc (full design: `~/workspace/specs/db-sync/spec.md`). Moves project definitions toward the **database** as the shared, replicable source of truth, replacing the GitHub/file sync path. **No sync yet — self-contained and useful on its own** (the DB now holds the project catalog).

## Changes
- **`projects` table** (schema migration): `name` PK + `definition` blob (the canonical `sail.yaml`, stored verbatim — the catalog loads it whole, never queries inside it) + `created_by`/`created_at` + `updated_by`/`updated_at`.
- **`ProjectStore`** — `upsert` (insert-or-replace, preserving original `created_by`/`created_at`), `findByName`, `list`, `delete`. Mirrors `SpecStore`.
- **`ProjectCatalog`** — best-effort write helper. `sail project create` and `sail project pull` now record the definition into the catalog after writing the on-disk `sail.yaml`. A catalog miss prints a hint and is recovered by the importer — **it never aborts container provisioning**, which is the operation that must succeed.
- **`ProjectImporter`** — repeatable, idempotent scan of `~/.sail/projects` that backfills the catalog; wired into `sail migrate` (mirrors `ContainerSpecImporter`), so existing projects appear in the DB on the next migrate/upgrade.

## Deliberately out of scope this brick
The 27 file-based descriptor readers (`project up`, the provisioner, agent commands) are **untouched** — switching them to DB-first with file fallback is a later brick, so provisioning behavior is unchanged and the blast radius stays small.

Tests: `ProjectStoreTest` (upsert/provenance/list/delete/null-blob), `ProjectImporterTest` (import/idempotent/skip-empty/absent-dir). 5,445 tests green.