### PR TITLE
Spec change journal — durability spine (db-sync brick 2) — 0.13.61

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.60</version>
+    <version>0.13.61</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.60</version>
+        <version>0.13.61</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/store/ChangeLog.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ChangeLog.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Append-only revision journal for synced entities — the durability spine of the DB-sync design.
+ * Every mutation to a synced entity writes the row <em>and</em> appends its full post-state
+ * snapshot here in one transaction, so a prior version is always recoverable and no work is ever
+ * lost. Entries are ordered by the monotonic {@code seq}; the latest entry for an entity is its
+ * current revision (or its tombstone, when {@code deleted}).
+ *
+ * <p>This store only appends and reads; it never mutates an entry. Mutators call {@link #append}
+ * inside their own transaction so the journal can never diverge from the row it describes.
+ */
+public final class ChangeLog {
+
+  private final Sqlite db;
+
+  public ChangeLog(Sqlite db) {
+    this.db = db;
+  }
+
+  public record Entry(
+      long seq,
+      String entityType,
+      String entityId,
+      String rev,
+      String actor,
+      String recordedAt,
+      String origin,
+      boolean deleted,
+      String snapshot) {}
+
+  /** Appends a revision. {@code snapshot} is the entity's full state as JSON at this revision. */
+  public void append(
+      String entityType,
+      String entityId,
+      String rev,
+      String actor,
+      String origin,
+      boolean deleted,
+      String snapshot) {
+    db.execute(
+        "INSERT INTO change_log (entity_type, entity_id, rev, actor, recorded_at, origin,"
+            + " deleted, snapshot) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        entityType,
+        entityId,
+        rev,
+        actor,
+        Instant.now().toString(),
+        origin,
+        deleted ? 1 : 0,
+        snapshot);
+  }
+
+  /** Returns every revision of an entity in chronological order (oldest first). */
+  public List<Entry> history(String entityType, String entityId) {
+    return db.query(
+        SELECT + " WHERE entity_type = ? AND entity_id = ? ORDER BY seq",
+        ChangeLog::map,
+        entityType,
+        entityId);
+  }
+
+  /** Returns a specific revision of an entity, if it was ever recorded. */
+  public Optional<Entry> at(String entityType, String entityId, String rev) {
+    return db.queryOne(
+        SELECT + " WHERE entity_type = ? AND entity_id = ? AND rev = ?",
+        ChangeLog::map,
+        entityType,
+        entityId,
+        rev);
+  }
+
+  private static final String SELECT =
+      "SELECT seq, entity_type, entity_id, rev, actor, recorded_at, origin, deleted, snapshot"
+          + " FROM change_log";
+
+  private static Entry map(Sqlite.Row row) {
+    return new Entry(
+        row.integer(0),
+        row.text(1),
+        row.text(2),
+        row.text(3),
+        row.text(4),
+        row.text(5),
+        row.text(6),
+        row.integer(7) != 0,
+        row.text(8));
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/Revisions.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/Revisions.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/**
+ * Mints entity revision ids of the form {@code <counter>-<short content hash>}. The counter is a
+ * per-entity monotonic sequence (so revisions order unambiguously without relying on wall-clock);
+ * the hash is the first bytes of SHA-256 over the snapshot, making a revision content-addressable
+ * and identical content evident. The DB-sync engine (later brick) treats the main devbox's
+ * assignment as authoritative; single-box, the counter is simply the local revision number.
+ */
+public final class Revisions {
+
+  private static final int HASH_CHARS = 12;
+
+  private Revisions() {}
+
+  /** Returns the next revision id after {@code currentRev} for content {@code snapshot}. */
+  public static String next(String currentRev, String snapshot) {
+    return (counterOf(currentRev) + 1) + "-" + shortHash(snapshot);
+  }
+
+  /** Extracts the monotonic counter from a revision id; 0 for null/blank/malformed. */
+  public static long counterOf(String rev) {
+    if (rev == null || rev.isBlank()) {
+      return 0;
+    }
+    var dash = rev.indexOf('-');
+    var prefix = dash < 0 ? rev : rev.substring(0, dash);
+    try {
+      return Long.parseLong(prefix);
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  private static String shortHash(String content) {
+    try {
+      var digest = MessageDigest.getInstance("SHA-256");
+      var hex = HexFormat.of().formatHex(digest.digest(content.getBytes(StandardCharsets.UTF_8)));
+      return hex.substring(0, HASH_CHARS);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 unavailable", e);
+    }
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -243,7 +243,22 @@ public final class SchemaManager {
               created_at TEXT NOT NULL,
               updated_by TEXT,
               updated_at TEXT NOT NULL
-          )""");
+          )""",
+          "ALTER TABLE specs ADD COLUMN rev TEXT",
+          """
+          CREATE TABLE IF NOT EXISTS change_log (
+              seq INTEGER PRIMARY KEY AUTOINCREMENT,
+              entity_type TEXT NOT NULL,
+              entity_id TEXT NOT NULL,
+              rev TEXT NOT NULL,
+              actor TEXT,
+              recorded_at TEXT NOT NULL,
+              origin TEXT NOT NULL,
+              deleted INTEGER NOT NULL DEFAULT 0,
+              snapshot TEXT NOT NULL
+          )""",
+          "CREATE INDEX IF NOT EXISTS idx_change_log_entity"
+              + " ON change_log(entity_type, entity_id, seq)");
 
   private final Sqlite db;
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -6,21 +6,32 @@
 package ai.singlr.sail.store;
 
 import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.config.YamlUtil;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
  * Spec CRUD on SQLite. Every method maps to a small number of SQL statements. No caching, no lazy
  * loading — the database is fast enough.
+ *
+ * <p>Every mutation journals the spec's full post-state into the {@link ChangeLog} within the same
+ * transaction, so history is complete and any revision is restorable (the DB-sync no-lost-work
+ * guarantee). {@code specs.rev} tracks the current revision.
  */
 public final class SpecStore {
 
+  private static final String ENTITY = "spec";
+
   private final Sqlite db;
+  private final ChangeLog changeLog;
 
   public SpecStore(Sqlite db) {
     this.db = db;
+    this.changeLog = new ChangeLog(db);
   }
 
   public record SpecRow(
@@ -88,6 +99,7 @@ public final class SpecStore {
               "INSERT INTO spec_content (spec_id, body, plan, updated_at) VALUES (?, '', '', ?)",
               spec.id(),
               now);
+          recordRevision(spec.id(), "local", false);
         });
   }
 
@@ -173,34 +185,201 @@ public final class SpecStore {
           db.execute("DELETE FROM spec_repos WHERE spec_id = ?", spec.id());
           insertDependencies(spec.id(), spec.dependsOn());
           insertRepos(spec.id(), spec.repos());
+          recordRevision(spec.id(), "local", false);
         });
   }
 
   public void updateStatus(String id, SpecStatus status) {
-    db.execute(
-        "UPDATE specs SET status = ?, updated_at = ? WHERE id = ?",
-        status.wire(),
-        Instant.now().toString(),
-        id);
+    db.transaction(
+        () -> {
+          db.execute(
+              "UPDATE specs SET status = ?, updated_at = ? WHERE id = ?",
+              status.wire(),
+              Instant.now().toString(),
+              id);
+          recordRevision(id, "local", false);
+        });
   }
 
   public void delete(String id) {
-    db.execute("DELETE FROM specs WHERE id = ?", id);
+    db.transaction(
+        () -> {
+          recordRevision(id, "local", true);
+          db.execute("DELETE FROM specs WHERE id = ?", id);
+        });
   }
 
   public void setContent(String specId, String body, String plan) {
     var now = Instant.now().toString();
+    db.transaction(
+        () -> {
+          db.execute(
+              """
+              INSERT INTO spec_content (spec_id, body, plan, updated_at) VALUES (?, ?, ?, ?)
+              ON CONFLICT(spec_id) DO UPDATE SET body = ?, plan = ?, updated_at = ?""",
+              specId,
+              body,
+              plan,
+              now,
+              body,
+              plan,
+              now);
+          recordRevision(specId, "local", false);
+        });
+  }
+
+  /** Every recorded revision of a spec, oldest first. */
+  public List<ChangeLog.Entry> history(String id) {
+    return changeLog.history(ENTITY, id);
+  }
+
+  /**
+   * Restores a spec to a prior revision's content, recorded as a NEW revision (origin {@code
+   * restore}) — the current state is never discarded, it becomes part of history too, so a restore
+   * is itself reversible. Re-creates the spec if it had been deleted.
+   */
+  public void restore(String id, String rev) {
+    var entry =
+        changeLog
+            .at(ENTITY, id, rev)
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "No revision '" + rev + "' recorded for spec '" + id + "'."));
+    var snapshot = YamlUtil.parseMap(entry.snapshot());
+    db.transaction(
+        () -> {
+          applySnapshot(id, snapshot);
+          recordRevision(id, "restore", false);
+        });
+  }
+
+  private void recordRevision(String id, String origin, boolean deleted) {
+    var spec = findById(id).orElse(null);
+    if (spec == null) {
+      return;
+    }
+    var snapshot = snapshotJson(spec);
+    var rev = Revisions.next(currentRev(id), snapshot);
+    if (!deleted) {
+      db.execute("UPDATE specs SET rev = ? WHERE id = ?", rev, id);
+    }
+    changeLog.append(ENTITY, id, rev, spec.updatedBy(), origin, deleted, snapshot);
+  }
+
+  private String currentRev(String id) {
+    return db.queryOne("SELECT COALESCE(rev, '') FROM specs WHERE id = ?", row -> row.text(0), id)
+        .orElse("");
+  }
+
+  private String snapshotJson(SpecRow spec) {
+    var content = getContent(spec.id()).orElse(new SpecContent("", "", null));
+    var map = new LinkedHashMap<String, Object>();
+    map.put("id", spec.id());
+    map.put("project", spec.project());
+    map.put("title", spec.title());
+    map.put("status", spec.status().wire());
+    map.put("assignee", spec.assignee());
+    map.put("agent", spec.agent());
+    map.put("model", spec.model());
+    map.put("reasoning_effort", spec.reasoningEffort());
+    map.put("branch", spec.branch());
+    map.put("priority", spec.priority());
+    map.put("created_by", spec.createdBy());
+    map.put("created_at", spec.createdAt());
+    map.put("updated_by", spec.updatedBy());
+    map.put("updated_at", spec.updatedAt());
+    map.put("depends_on", spec.dependsOn());
+    map.put("repos", spec.repos());
+    map.put("body", content.body());
+    map.put("plan", content.plan());
+    return YamlUtil.dumpJson(map);
+  }
+
+  private void applySnapshot(String id, Map<String, Object> snapshot) {
+    var spec = specFromSnapshot(snapshot);
+    var now = Instant.now().toString();
+    if (findById(id).isPresent()) {
+      db.execute(
+          """
+          UPDATE specs SET project = ?, title = ?, status = ?, assignee = ?, agent = ?, model = ?,
+              reasoning_effort = ?, branch = ?, priority = ?, updated_at = ?, updated_by = ?
+          WHERE id = ?""",
+          spec.project(),
+          spec.title(),
+          spec.status().wire(),
+          spec.assignee(),
+          spec.agent(),
+          spec.model(),
+          spec.reasoningEffort(),
+          spec.branch(),
+          spec.priority(),
+          now,
+          spec.updatedBy(),
+          id);
+      db.execute("DELETE FROM spec_dependencies WHERE spec_id = ?", id);
+      db.execute("DELETE FROM spec_repos WHERE spec_id = ?", id);
+    } else {
+      db.execute(
+          """
+          INSERT INTO specs (id, project, title, status, assignee, agent, model, reasoning_effort,
+              branch, priority, created_by, created_at, updated_at, updated_by)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+          id,
+          spec.project(),
+          spec.title(),
+          spec.status().wire(),
+          spec.assignee(),
+          spec.agent(),
+          spec.model(),
+          spec.reasoningEffort(),
+          spec.branch(),
+          spec.priority(),
+          spec.createdBy(),
+          spec.createdAt(),
+          now,
+          spec.updatedBy());
+    }
+    insertDependencies(id, spec.dependsOn());
+    insertRepos(id, spec.repos());
     db.execute(
         """
         INSERT INTO spec_content (spec_id, body, plan, updated_at) VALUES (?, ?, ?, ?)
         ON CONFLICT(spec_id) DO UPDATE SET body = ?, plan = ?, updated_at = ?""",
-        specId,
-        body,
-        plan,
+        id,
+        text(snapshot, "body"),
+        text(snapshot, "plan"),
         now,
-        body,
-        plan,
+        text(snapshot, "body"),
+        text(snapshot, "plan"),
         now);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static SpecRow specFromSnapshot(Map<String, Object> s) {
+    var priority = s.get("priority");
+    return new SpecRow(
+        text(s, "id"),
+        text(s, "project"),
+        text(s, "title"),
+        SpecStatus.fromLegacy(text(s, "status")),
+        text(s, "assignee"),
+        text(s, "agent"),
+        text(s, "model"),
+        text(s, "reasoning_effort"),
+        text(s, "branch"),
+        priority instanceof Number n ? n.intValue() : 0,
+        text(s, "created_by"),
+        text(s, "created_at"),
+        text(s, "updated_at"),
+        text(s, "updated_by"),
+        (List<String>) s.getOrDefault("depends_on", List.of()),
+        (List<String>) s.getOrDefault("repos", List.of()));
+  }
+
+  private static String text(Map<String, Object> map, String key) {
+    var value = map.get(key);
+    return value == null ? null : value.toString();
   }
 
   public Optional<SpecContent> getContent(String specId) {

--- a/sail-core/src/test/java/ai/singlr/sail/store/ChangeLogTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ChangeLogTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ChangeLogTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private ChangeLog log;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    log = new ChangeLog(db);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  @Test
+  void historyIsOrderedBySequenceAndScopedToTheEntity() {
+    log.append("spec", "a", "1-x", "uday", "local", false, "{}");
+    log.append("spec", "b", "1-y", "ada", "local", false, "{}");
+    log.append("spec", "a", "2-z", "uday", "local", false, "{}");
+
+    var historyA = log.history("spec", "a");
+    assertEquals(2, historyA.size());
+    assertTrue(historyA.get(0).seq() < historyA.get(1).seq());
+    assertEquals("1-x", historyA.get(0).rev());
+    assertEquals("2-z", historyA.get(1).rev());
+    assertEquals(1, log.history("spec", "b").size());
+  }
+
+  @Test
+  void atFindsAnExactRevisionAndIsEmptyOtherwise() {
+    log.append("spec", "a", "1-x", "uday", "local", false, "{\"k\":1}");
+
+    var found = log.at("spec", "a", "1-x").orElseThrow();
+    assertEquals("uday", found.actor());
+    assertEquals("{\"k\":1}", found.snapshot());
+    assertFalse(found.deleted());
+    assertTrue(log.at("spec", "a", "9-z").isEmpty());
+  }
+
+  @Test
+  void deletedFlagRoundTrips() {
+    log.append("spec", "a", "3-x", null, "local", true, "{}");
+    assertTrue(log.history("spec", "a").getFirst().deleted());
+  }
+
+  @Test
+  void historyIsEmptyForAnUnknownEntity() {
+    assertTrue(log.history("spec", "ghost").isEmpty());
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/RevisionsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RevisionsTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class RevisionsTest {
+
+  @Test
+  void firstRevisionFromNullIsCounterOne() {
+    var rev = Revisions.next(null, "content");
+    assertTrue(rev.startsWith("1-"), rev);
+    assertEquals(1, Revisions.counterOf(rev));
+  }
+
+  @Test
+  void counterIncrementsFromPreviousRevision() {
+    var first = Revisions.next(null, "a");
+    var second = Revisions.next(first, "b");
+    assertEquals(2, Revisions.counterOf(second));
+    var third = Revisions.next(second, "c");
+    assertEquals(3, Revisions.counterOf(third));
+  }
+
+  @Test
+  void hashIsContentAddressable() {
+    assertEquals(Revisions.next(null, "same"), Revisions.next(null, "same"));
+    assertNotEquals(Revisions.next(null, "x"), Revisions.next(null, "y"));
+  }
+
+  @Test
+  void counterOfHandlesBlankAndMalformed() {
+    assertEquals(0, Revisions.counterOf(null));
+    assertEquals(0, Revisions.counterOf(""));
+    assertEquals(0, Revisions.counterOf("  "));
+    assertEquals(0, Revisions.counterOf("notanumber-abc"));
+    assertEquals(7, Revisions.counterOf("7-deadbeef"));
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecJournalTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecJournalTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sail.config.SpecStatus;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SpecJournalTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private SpecStore store;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    store = new SpecStore(db);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  private SpecStore.SpecRow spec(String id, String title, String status, String updatedBy) {
+    return new SpecStore.SpecRow(
+        id,
+        "proj",
+        title,
+        SpecStatus.fromWire(status),
+        null,
+        null,
+        null,
+        null,
+        null,
+        0,
+        "uday",
+        "",
+        "",
+        updatedBy,
+        List.of(),
+        List.of());
+  }
+
+  @Test
+  void createRecordsAnInitialRevision() {
+    store.create(spec("auth", "Auth", "pending", "uday"));
+
+    var history = store.history("auth");
+    assertEquals(1, history.size());
+    var first = history.getFirst();
+    assertEquals("1", first.rev().split("-")[0]);
+    assertEquals("local", first.origin());
+    assertFalse(first.deleted());
+    assertTrue(first.snapshot().contains("\"title\": \"Auth\""), first.snapshot());
+  }
+
+  @Test
+  void everyMutationAppendsARevisionInOrder() {
+    store.create(spec("auth", "Auth", "pending", "uday"));
+    store.update(spec("auth", "Auth v2", "pending", "ada"));
+    store.setContent("auth", "the body", "the plan");
+    store.updateStatus("auth", SpecStatus.fromWire("in_progress"));
+
+    var history = store.history("auth");
+    assertEquals(4, history.size());
+    assertEquals(
+        List.of(1L, 2L, 3L, 4L), history.stream().map(e -> Revisions.counterOf(e.rev())).toList());
+    assertTrue(history.getLast().snapshot().contains("\"the body\""));
+    assertTrue(history.getLast().snapshot().contains("in_progress"));
+  }
+
+  @Test
+  void deleteRecordsATombstoneRetainingTheLastSnapshot() {
+    store.create(spec("auth", "Auth", "pending", "uday"));
+    store.setContent("auth", "important work", "");
+
+    store.delete("auth");
+
+    assertTrue(store.findById("auth").isEmpty());
+    var history = store.history("auth");
+    assertTrue(history.getLast().deleted());
+    assertTrue(history.getLast().snapshot().contains("important work"), "work survives the delete");
+  }
+
+  @Test
+  void restoreBringsBackPriorContentAsANewRevision() {
+    store.create(spec("auth", "Auth", "pending", "uday"));
+    store.setContent("auth", "original body", "original plan");
+    var goodRev = store.history("auth").getLast().rev();
+    store.setContent("auth", "clobbered", "clobbered");
+
+    store.restore("auth", goodRev);
+
+    var content = store.getContent("auth").orElseThrow();
+    assertEquals("original body", content.body());
+    assertEquals("original plan", content.plan());
+    var last = store.history("auth").getLast();
+    assertEquals("restore", last.origin());
+    assertTrue(
+        Revisions.counterOf(last.rev()) > Revisions.counterOf(goodRev),
+        "restore is a new forward revision, not a rewind");
+  }
+
+  @Test
+  void restoreReCreatesADeletedSpec() {
+    store.create(spec("auth", "Auth", "pending", "uday"));
+    store.setContent("auth", "body", "plan");
+    var beforeDelete = store.history("auth").getLast().rev();
+    store.delete("auth");
+
+    store.restore("auth", beforeDelete);
+
+    var restored = store.findById("auth").orElseThrow();
+    assertEquals("Auth", restored.title());
+    assertEquals("body", store.getContent("auth").orElseThrow().body());
+  }
+
+  @Test
+  void restoreRejectsUnknownRevision() {
+    store.create(spec("auth", "Auth", "pending", "uday"));
+    var thrown = assertThrows(IllegalArgumentException.class, () -> store.restore("auth", "99-x"));
+    assertTrue(thrown.getMessage().contains("99-x"));
+  }
+
+  @Test
+  void specRevColumnTracksTheCurrentRevision() {
+    store.create(spec("auth", "Auth", "pending", "uday"));
+    store.update(spec("auth", "Auth v2", "pending", "ada"));
+
+    var rev = db.queryOne("SELECT rev FROM specs WHERE id = ?", row -> row.text(0), "auth");
+    assertEquals(store.history("auth").getLast().rev(), rev.orElseThrow());
+  }
+}

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.60</version>
+        <version>0.13.61</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.60</version>
+        <version>0.13.61</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>


### PR DESCRIPTION
The no-lost-work foundation of the DB-sync arc (`~/workspace/specs/db-sync/spec.md`). Every spec mutation now records its **full post-state** into an append-only journal **within the same transaction**, so a prior version is always recoverable. Still single-box — no transport yet.

## Changes
- **`change_log`** table (generic) + **`specs.rev`** column.
- **`ChangeLog`** store — `append`, `history(entity)`, `at(entity, rev)`. Append-only.
- **`Revisions`** — `<counter>-<short-hash>` ids: per-entity monotonic counter (clock-independent), content-addressable hash.
- **`SpecStore`** journals create/update/updateStatus/setContent/delete through one `recordRevision` chokepoint inside each mutator's transaction; delete writes a **tombstone** retaining the last snapshot.
- **`SpecStore.history`/`restore`** — restore applies a prior snapshot as a **new forward revision** (reversible) and re-creates a deleted spec.

`base_rev`/per-table `deleted_at` deferred to the sync engine where they're exercised. `sail spec history`/`restore` CLI+API is the immediate follow-on (2b); the spine already protects every mutation regardless of caller.

Bug caught + fixed mid-build: a `queryOne` mapper returning `null` for the nullable `rev` column tripped `Optional.of(null)` → switched to `COALESCE(rev, '')`.

Tests: `RevisionsTest`, `ChangeLogTest`, `SpecJournalTest`. 5,475 green; existing `SpecStoreTest` unchanged and passing.