### PR TITLE
sail spec history/restore — CLI + API (db-sync brick 2b) — 0.13.62

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.61</version>
+    <version>0.13.62</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.61</version>
+        <version>0.13.62</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.61</version>
+        <version>0.13.62</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.61</version>
+        <version>0.13.62</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.api;
 
 import ai.singlr.sail.engine.GitSpecSync;
+import ai.singlr.sail.store.ChangeLog;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.SessionStore;
 import ai.singlr.sail.store.SpecStore;
@@ -542,6 +543,57 @@ record SpecUpdateRequest(
 record SpecContentRequest(String body, String plan) {
   static SpecContentRequest fromMap(Map<String, Object> map) {
     return new SpecContentRequest((String) map.get("body"), (String) map.get("plan"));
+  }
+}
+
+record SpecRestoreRequest(String rev) {
+  static SpecRestoreRequest fromMap(Map<String, Object> map) {
+    return new SpecRestoreRequest((String) map.get("rev"));
+  }
+}
+
+record SpecRevisionView(String rev, String actor, String recordedAt, String origin, boolean deleted)
+    implements Mappable {
+  static SpecRevisionView from(ChangeLog.Entry e) {
+    return new SpecRevisionView(e.rev(), e.actor(), e.recordedAt(), e.origin(), e.deleted());
+  }
+
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("rev", rev);
+    if (actor != null) m.put("actor", actor);
+    m.put("recorded_at", recordedAt);
+    m.put("origin", origin);
+    m.put("deleted", deleted);
+    return m;
+  }
+}
+
+record GlobalSpecHistoryResponse(String specId, List<SpecRevisionView> revisions)
+    implements Mappable {
+  static GlobalSpecHistoryResponse from(String specId, List<ChangeLog.Entry> entries) {
+    return new GlobalSpecHistoryResponse(
+        specId, entries.stream().map(SpecRevisionView::from).toList());
+  }
+
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("spec_id", specId);
+    m.put("revisions", revisions);
+    m.put("total", revisions.size());
+    return m;
+  }
+}
+
+record GlobalSpecRestoredResponse(GlobalSpecView spec, String fromRev) implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("spec", spec.toMap());
+    m.put("from_rev", fromRev);
+    return m;
   }
 }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiOperations.java
@@ -62,6 +62,10 @@ public interface ApiOperations {
 
   Result<GlobalSpecContentResponse> setGlobalSpecContent(String specId, SpecContentRequest request);
 
+  Result<GlobalSpecHistoryResponse> globalSpecHistory(String specId);
+
+  Result<GlobalSpecRestoredResponse> restoreGlobalSpec(String specId, SpecRestoreRequest request);
+
   Result<GlobalBoardResponse> globalBoard(String project);
 
   Result<SessionListResponse> agentSessions(String project);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -43,6 +43,8 @@ public final class ApiRouter implements HttpHandler {
   private static final String BOARD = "board";
   private static final String CONTENT = "content";
   private static final String REVIEWS = "reviews";
+  private static final String HISTORY = "history";
+  private static final String RESTORE = "restore";
   private static final String SESSIONS = "sessions";
   private static final String APPROVE = "approve";
   private static final String DISMISS = "dismiss";
@@ -236,6 +238,16 @@ public final class ApiRouter implements HttpHandler {
       if (REVIEWS.equals(sub)) {
         requireMethod(request, GET);
         return ApiResponse.from(operations.reviewsForSpec(specId));
+      }
+      if (HISTORY.equals(sub)) {
+        requireMethod(request, GET);
+        return ApiResponse.from(operations.globalSpecHistory(specId));
+      }
+      if (RESTORE.equals(sub)) {
+        requireMethod(request, POST);
+        return ApiResponse.from(
+            operations.restoreGlobalSpec(
+                specId, SpecRestoreRequest.fromMap(JsonBody.readMap(exchange))));
       }
     }
     throw notFound();

--- a/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
@@ -147,6 +147,25 @@ final class GlobalSpecOperations {
     return new GlobalBoardResponse(specStore.board(project));
   }
 
+  GlobalSpecHistoryResponse history(String specId) {
+    requireStore();
+    return GlobalSpecHistoryResponse.from(specId, specStore.history(specId));
+  }
+
+  GlobalSpecRestoredResponse restore(String specId, SpecRestoreRequest request) {
+    requireStore();
+    if (request.rev() == null || request.rev().isBlank()) {
+      throw new ApiException(ErrorCode.INVALID_REQUEST, "rev is required.");
+    }
+    try {
+      specStore.restore(specId, request.rev());
+    } catch (IllegalArgumentException e) {
+      throw new ApiException(ErrorCode.INVALID_REQUEST, e.getMessage());
+    }
+    var row = specStore.findById(specId).orElseThrow();
+    return new GlobalSpecRestoredResponse(GlobalSpecView.from(row), request.rev());
+  }
+
   private SpecStore.SpecRow findOrThrow(String specId) {
     return specStore
         .findById(specId)

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -931,6 +931,17 @@ public final class SailApiOperations implements ApiOperations {
   }
 
   @Override
+  public Result<GlobalSpecHistoryResponse> globalSpecHistory(String specId) {
+    return safe(() -> globalSpecOps.history(specId));
+  }
+
+  @Override
+  public Result<GlobalSpecRestoredResponse> restoreGlobalSpec(
+      String specId, SpecRestoreRequest request) {
+    return safe(() -> globalSpecOps.restore(specId, request));
+  }
+
+  @Override
   public Result<GlobalBoardResponse> globalBoard(String project) {
     return safe(() -> globalSpecOps.board(project));
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecHistoryCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecHistoryCommand.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.api.SailApiClient;
+import ai.singlr.sail.api.ServerConnectionConfig;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.NameValidator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+@Command(
+    name = "history",
+    description = "Show a spec's revision history (every saved version).",
+    mixinStandardHelpOptions = true)
+public final class ApiSpecHistoryCommand implements Runnable {
+
+  @Parameters(index = "0", description = "Spec ID.")
+  private String specId;
+
+  @Option(names = "--server", description = "Server URL.")
+  private String server;
+
+  @Option(names = "--token", description = "API token.")
+  private String token;
+
+  @Option(names = "--json", description = "Output in JSON format.")
+  private boolean json;
+
+  @Spec private CommandSpec commandSpec;
+
+  @Override
+  public void run() {
+    CliCommand.run(commandSpec, this::execute);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void execute() throws Exception {
+    NameValidator.requireValidSpecId(specId);
+    var config = ServerConnectionConfig.resolve(server, token);
+    try (var client = new SailApiClient(config.serverUrl(), config.token())) {
+      var result = client.get("/v1/specs/" + specId + "/history");
+
+      if (json) {
+        System.out.println(YamlUtil.dumpJson(new LinkedHashMap<>(result)));
+        return;
+      }
+
+      var revisions = (List<Map<String, Object>>) result.getOrDefault("revisions", List.of());
+      if (revisions.isEmpty()) {
+        System.out.println(
+            Ansi.AUTO.string("  @|faint No recorded history for spec '" + specId + "'.|@"));
+        return;
+      }
+      System.out.println(Ansi.AUTO.string("  @|bold History:|@ " + specId));
+      for (var rev : revisions) {
+        var marker = Boolean.TRUE.equals(rev.get("deleted")) ? " @|red (deleted)|@" : "";
+        System.out.println(
+            Ansi.AUTO.string(
+                "  @|cyan "
+                    + rev.get("rev")
+                    + "|@  "
+                    + rev.get("recorded_at")
+                    + "  @|faint "
+                    + rev.getOrDefault("origin", "")
+                    + (rev.get("actor") != null ? " by " + rev.get("actor") : "")
+                    + "|@"
+                    + marker));
+      }
+      System.out.println();
+      System.out.println(
+          Ansi.AUTO.string("  @|faint Restore one with: sail spec restore " + specId + " <rev>|@"));
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecRestoreCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecRestoreCommand.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.api.SailApiClient;
+import ai.singlr.sail.api.ServerConnectionConfig;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.NameValidator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+@Command(
+    name = "restore",
+    description = "Restore a spec to a prior revision (recorded as a new version — reversible).",
+    mixinStandardHelpOptions = true)
+public final class ApiSpecRestoreCommand implements Runnable {
+
+  @Parameters(index = "0", description = "Spec ID.")
+  private String specId;
+
+  @Parameters(index = "1", description = "Revision to restore (from 'sail spec history').")
+  private String rev;
+
+  @Option(names = "--server", description = "Server URL.")
+  private String server;
+
+  @Option(names = "--token", description = "API token.")
+  private String token;
+
+  @Option(names = "--json", description = "Output in JSON format.")
+  private boolean json;
+
+  @Spec private CommandSpec commandSpec;
+
+  @Override
+  public void run() {
+    CliCommand.run(commandSpec, this::execute);
+  }
+
+  private void execute() throws Exception {
+    NameValidator.requireValidSpecId(specId);
+    var config = ServerConnectionConfig.resolve(server, token);
+    try (var client = new SailApiClient(config.serverUrl(), config.token())) {
+      var result = client.post("/v1/specs/" + specId + "/restore", Map.of("rev", rev));
+
+      if (json) {
+        System.out.println(YamlUtil.dumpJson(new LinkedHashMap<>(result)));
+        return;
+      }
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|green ✓|@ Restored spec '" + specId + "' from revision " + rev + "."));
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SpecCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SpecCommand.java
@@ -19,6 +19,8 @@ import picocli.CommandLine.Command;
       ApiSpecContentCommand.class,
       ApiSpecDeleteCommand.class,
       ApiSpecBoardCommand.class,
+      ApiSpecHistoryCommand.class,
+      ApiSpecRestoreCommand.class,
       DispatchCommand.class,
     })
 public final class SpecCommand implements Runnable {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -659,6 +659,42 @@ class ApiRouterTest {
   }
 
   @Test
+  void globalSpecHistoryGetReturns200() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/specs/auth-flow/history", "token");
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"spec_id\": \"auth-flow\""));
+      assertTrue(response.body().contains("\"rev\": \"1-abc\""));
+      assertTrue(response.body().contains("\"total\": 1"));
+    }
+  }
+
+  @Test
+  void globalSpecHistoryRejectsNonGet() throws Exception {
+    try (var server = server()) {
+      var response = post(server, "/v1/specs/auth-flow/history", "token", "{}");
+      assertEquals(405, response.statusCode());
+    }
+  }
+
+  @Test
+  void globalSpecRestorePostReturns200() throws Exception {
+    try (var server = server()) {
+      var response = post(server, "/v1/specs/auth-flow/restore", "token", "{\"rev\": \"2-abc\"}");
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"from_rev\": \"2-abc\""));
+    }
+  }
+
+  @Test
+  void globalSpecRestoreRejectsNonPost() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/specs/auth-flow/restore", "token");
+      assertEquals(405, response.statusCode());
+    }
+  }
+
+  @Test
   void specReviewsListReturns200() throws Exception {
     try (var server = server()) {
       var response = get(server, "/v1/specs/auth-flow/reviews", "token");
@@ -1102,6 +1138,41 @@ class ApiRouterTest {
     public Result<GlobalSpecContentResponse> setGlobalSpecContent(
         String specId, SpecContentRequest request) {
       return Result.success(new GlobalSpecContentResponse(specId, request.body(), request.plan()));
+    }
+
+    @Override
+    public Result<GlobalSpecHistoryResponse> globalSpecHistory(String specId) {
+      return Result.success(
+          new GlobalSpecHistoryResponse(
+              specId,
+              java.util.List.of(
+                  new SpecRevisionView("1-abc", "uday", "2026-06-13T00:00:00Z", "local", false))));
+    }
+
+    @Override
+    public Result<GlobalSpecRestoredResponse> restoreGlobalSpec(
+        String specId, SpecRestoreRequest request) {
+      return Result.success(
+          new GlobalSpecRestoredResponse(
+              GlobalSpecView.from(
+                  new ai.singlr.sail.store.SpecStore.SpecRow(
+                      specId,
+                      "proj",
+                      "t",
+                      ai.singlr.sail.config.SpecStatus.fromWire("pending"),
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      0,
+                      null,
+                      "",
+                      "",
+                      null,
+                      java.util.List.of(),
+                      java.util.List.of())),
+              request.rev()));
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
@@ -231,4 +231,65 @@ class GlobalSpecOperationsTest {
     var ex = assertThrows(ApiException.class, () -> noStore.list(SpecStore.SpecFilter.all()));
     assertEquals(ErrorCode.INTERNAL, ex.failure().errorCode());
   }
+
+  @Test
+  void historyListsEveryRevisionOldestFirst() {
+    ops.create(createReq(Map.of()).withCreatedBy("uday"));
+    ops.setContent("auth", new SpecContentRequest("body one", "plan"));
+
+    var history = ops.history("auth");
+
+    assertEquals("auth", history.specId());
+    assertEquals(2, history.revisions().size());
+    assertEquals("local", history.revisions().getFirst().origin());
+  }
+
+  @Test
+  void historyIsEmptyForAnUnknownSpec() {
+    assertTrue(ops.history("ghost").revisions().isEmpty());
+  }
+
+  @Test
+  void restoreBringsBackPriorContentAsANewRevision() {
+    ops.create(createReq(Map.of()).withCreatedBy("uday"));
+    ops.setContent("auth", new SpecContentRequest("good", "good plan"));
+    var goodRev = ops.history("auth").revisions().getLast().rev();
+    ops.setContent("auth", new SpecContentRequest("clobbered", "clobbered"));
+
+    var restored = ops.restore("auth", new SpecRestoreRequest(goodRev));
+
+    assertEquals(goodRev, restored.fromRev());
+    assertEquals("good", ops.content("auth").body());
+    assertEquals("restore", ops.history("auth").revisions().getLast().origin());
+  }
+
+  @Test
+  void restoreRejectsABlankRev() {
+    ops.create(createReq(Map.of()));
+    var ex =
+        assertThrows(ApiException.class, () -> ops.restore("auth", new SpecRestoreRequest("  ")));
+    assertEquals(ErrorCode.INVALID_REQUEST, ex.failure().errorCode());
+  }
+
+  @Test
+  void restoreRejectsAnUnknownRev() {
+    ops.create(createReq(Map.of()));
+    var ex =
+        assertThrows(ApiException.class, () -> ops.restore("auth", new SpecRestoreRequest("99-x")));
+    assertEquals(ErrorCode.INVALID_REQUEST, ex.failure().errorCode());
+    assertTrue(ex.failure().errorMessage().contains("99-x"));
+  }
+
+  @Test
+  void historyAndRestoreWithoutStoreThrowInternal() {
+    var noStore = new GlobalSpecOperations(null);
+    assertEquals(
+        ErrorCode.INTERNAL,
+        assertThrows(ApiException.class, () -> noStore.history("x")).failure().errorCode());
+    assertEquals(
+        ErrorCode.INTERNAL,
+        assertThrows(ApiException.class, () -> noStore.restore("x", new SpecRestoreRequest("1-a")))
+            .failure()
+            .errorCode());
+  }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -217,6 +217,37 @@ class TestOperations implements ApiOperations {
   }
 
   @Override
+  public Result<GlobalSpecHistoryResponse> globalSpecHistory(String specId) {
+    return Result.success(new GlobalSpecHistoryResponse(specId, java.util.List.of()));
+  }
+
+  @Override
+  public Result<GlobalSpecRestoredResponse> restoreGlobalSpec(
+      String specId, SpecRestoreRequest request) {
+    return Result.success(
+        new GlobalSpecRestoredResponse(
+            GlobalSpecView.from(
+                new SpecStore.SpecRow(
+                    specId,
+                    "proj",
+                    "t",
+                    ai.singlr.sail.config.SpecStatus.fromWire("pending"),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    0,
+                    null,
+                    "",
+                    "",
+                    null,
+                    java.util.List.of(),
+                    java.util.List.of())),
+            request.rev()));
+  }
+
+  @Override
   public Result<GlobalBoardResponse> globalBoard(String project) {
     return Result.success(
         new GlobalBoardResponse(new SpecStore.BoardSummary(0, 0, 0, 0, 0, 0, null)));

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
@@ -70,7 +70,17 @@ class CommandTaxonomyTest {
     var spec = new CommandLine(new SpecCommand());
 
     assertEquals(
-        Set.of("list", "show", "create", "edit", "content", "delete", "board", "dispatch"),
+        Set.of(
+            "list",
+            "show",
+            "create",
+            "edit",
+            "content",
+            "delete",
+            "board",
+            "history",
+            "restore",
+            "dispatch"),
         spec.getSubcommands().keySet());
   }
 


### PR DESCRIPTION
Surfaces the durability spine (0.13.61) through the control plane. The journal already protected every spec mutation; this makes **history and restore usable**.

## API
- `GET /v1/specs/{id}/history` (READ) — revision list (rev, actor, recorded_at, origin, deleted).
- `POST /v1/specs/{id}/restore` (WRITE, body `{"rev": ...}`) — restore to a prior revision.
- New models: `GlobalSpecHistoryResponse`, `SpecRevisionView`, `GlobalSpecRestoredResponse`, `SpecRestoreRequest`. `GlobalSpecOperations.history/restore`; `SailApiOperations` delegates; both test fakes implement the new interface methods.

## CLI
- `sail spec history <id>` — table of revisions (timestamp / origin / actor, tombstone marker), with a restore hint.
- `sail spec restore <id> <rev>` — both ride the FDE gateway via the existing `spec` routing.

`history` works for **deleted** specs (the tombstone journal); `restore` re-creates them. Authorized per-route by the `Authorizer` — a viewer can read history, member+ can restore.

api.* 100% line/method gate met; 5,495 tests green. (Two expected test updates: the `CommandTaxonomyTest` spec-subcommand set, and a `Result.Failure` accessor name `errorMessage()`.)