### PR TITLE
Conflict-detection state machine + sync tables (db-sync brick 3a) — 0.13.63

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.62</version>
+    <version>0.13.63</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.62</version>
+        <version>0.13.63</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/store/ConflictDetector.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ConflictDetector.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Pure three-way merge for one synced entity. Given the common ancestor ({@code base} — the
+ * snapshot the local row descended from on main), the current {@code local} state, and the current
+ * {@code remote} (main) state, it classifies the sync outcome at <em>field</em> granularity: edits
+ * to different fields auto-merge; only edits to the <em>same</em> field with different values are a
+ * true {@link Conflict} that must go to the user (the locked db-sync decision — no silent
+ * last-write-wins).
+ *
+ * <p>A {@code null} snapshot means the entity is deleted/absent on that side, so delete-vs-edit is
+ * detected as a conflict rather than a silent resurrection or silent deletion. Stateless and
+ * side-effect-free: the engine (brick 3b) supplies the three snapshots and acts on the result.
+ */
+public final class ConflictDetector {
+
+  private ConflictDetector() {}
+
+  public sealed interface Resolution permits Converged, TakeRemote, KeepLocal, Merged, Conflict {}
+
+  /** Local and remote already agree; nothing to do. */
+  public record Converged() implements Resolution {}
+
+  /** Only remote moved since base; adopt remote wholesale (fast-forward), including a delete. */
+  public record TakeRemote() implements Resolution {}
+
+  /** Only local moved since base; main fast-forwards to local, including a delete. */
+  public record KeepLocal() implements Resolution {}
+
+  /** Both moved on disjoint fields; {@code result} is the field-level auto-merge. */
+  public record Merged(Map<String, Object> result) implements Resolution {}
+
+  /** Both changed the same field(s) differently (or delete-vs-edit); needs a human decision. */
+  public record Conflict(List<String> fields) implements Resolution {}
+
+  /** The single field name used to report a delete-vs-edit conflict. */
+  public static final String DELETED_FIELD = "<deleted>";
+
+  public static Resolution detect(
+      Map<String, Object> base, Map<String, Object> local, Map<String, Object> remote) {
+    var localDeleted = local == null;
+    var remoteDeleted = remote == null;
+
+    if (localDeleted && remoteDeleted) {
+      return new Converged();
+    }
+    if (localDeleted) {
+      return equalSnapshots(base, remote) ? new KeepLocal() : new Conflict(List.of(DELETED_FIELD));
+    }
+    if (remoteDeleted) {
+      return equalSnapshots(base, local) ? new TakeRemote() : new Conflict(List.of(DELETED_FIELD));
+    }
+
+    if (equalSnapshots(local, remote)) {
+      return new Converged();
+    }
+
+    var safeBase = base == null ? Map.<String, Object>of() : base;
+    var localChanged = changedFields(safeBase, local);
+    var remoteChanged = changedFields(safeBase, remote);
+
+    if (remoteChanged.isEmpty()) {
+      return new KeepLocal();
+    }
+    if (localChanged.isEmpty()) {
+      return new TakeRemote();
+    }
+
+    var conflicts = new ArrayList<String>();
+    for (var field : localChanged) {
+      if (remoteChanged.contains(field) && !Objects.equals(local.get(field), remote.get(field))) {
+        conflicts.add(field);
+      }
+    }
+    if (!conflicts.isEmpty()) {
+      return new Conflict(List.copyOf(conflicts));
+    }
+    return new Merged(merge(safeBase, local, remote, localChanged, remoteChanged));
+  }
+
+  private static Map<String, Object> merge(
+      Map<String, Object> base,
+      Map<String, Object> local,
+      Map<String, Object> remote,
+      LinkedHashSet<String> localChanged,
+      LinkedHashSet<String> remoteChanged) {
+    var result = new LinkedHashMap<String, Object>();
+    for (var field : allKeys(base, local, remote)) {
+      if (localChanged.contains(field)) {
+        result.put(field, local.get(field));
+      } else if (remoteChanged.contains(field)) {
+        result.put(field, remote.get(field));
+      } else {
+        result.put(field, base.get(field));
+      }
+    }
+    return result;
+  }
+
+  private static LinkedHashSet<String> changedFields(
+      Map<String, Object> base, Map<String, Object> side) {
+    var changed = new LinkedHashSet<String>();
+    for (var key : allKeys(base, side)) {
+      if (!Objects.equals(base.get(key), side.get(key))) {
+        changed.add(key);
+      }
+    }
+    return changed;
+  }
+
+  private static boolean equalSnapshots(Map<String, Object> a, Map<String, Object> b) {
+    var left = a == null ? Map.<String, Object>of() : a;
+    var right = b == null ? Map.<String, Object>of() : b;
+    for (var key : allKeys(left, right)) {
+      if (!Objects.equals(left.get(key), right.get(key))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @SafeVarargs
+  private static LinkedHashSet<String> allKeys(Map<String, Object>... maps) {
+    var keys = new LinkedHashSet<String>();
+    for (var map : maps) {
+      keys.addAll(map.keySet());
+    }
+    return keys;
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -258,7 +258,29 @@ public final class SchemaManager {
               snapshot TEXT NOT NULL
           )""",
           "CREATE INDEX IF NOT EXISTS idx_change_log_entity"
-              + " ON change_log(entity_type, entity_id, seq)");
+              + " ON change_log(entity_type, entity_id, seq)",
+          "ALTER TABLE specs ADD COLUMN base_rev TEXT",
+          """
+          CREATE TABLE IF NOT EXISTS sync_conflicts (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              entity_type TEXT NOT NULL,
+              entity_id TEXT NOT NULL,
+              base_snapshot TEXT,
+              local_snapshot TEXT,
+              remote_snapshot TEXT,
+              fields TEXT NOT NULL,
+              detected_at TEXT NOT NULL,
+              status TEXT NOT NULL DEFAULT 'pending',
+              resolved_rev TEXT
+          )""",
+          "CREATE INDEX IF NOT EXISTS idx_sync_conflicts_pending"
+              + " ON sync_conflicts(status, entity_type, entity_id)",
+          """
+          CREATE TABLE IF NOT EXISTS sync_state (
+              peer TEXT PRIMARY KEY,
+              checkpoint INTEGER NOT NULL DEFAULT 0,
+              updated_at TEXT NOT NULL
+          )""");
 
   private final Sqlite db;
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/SyncConflicts.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SyncConflicts.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Pending sync conflicts awaiting a human decision. When {@link ConflictDetector} reports a true
+ * {@code Conflict}, the engine records the three snapshots (base / local / remote) and the
+ * conflicting field names here; the local row keeps its current value untouched, so the FDE's work
+ * is never overwritten while the conflict is open. Resolving a conflict marks it {@code resolved}
+ * with the revision the user chose, leaving an auditable trail.
+ */
+public final class SyncConflicts {
+
+  private static final String PENDING = "pending";
+  private static final String RESOLVED = "resolved";
+
+  private final Sqlite db;
+
+  public SyncConflicts(Sqlite db) {
+    this.db = db;
+  }
+
+  public record Conflict(
+      long id,
+      String entityType,
+      String entityId,
+      String baseSnapshot,
+      String localSnapshot,
+      String remoteSnapshot,
+      List<String> fields,
+      String detectedAt,
+      String status,
+      String resolvedRev) {}
+
+  /** Records a pending conflict and returns its id. One open conflict per entity at a time. */
+  public long record(
+      String entityType,
+      String entityId,
+      String baseSnapshot,
+      String localSnapshot,
+      String remoteSnapshot,
+      List<String> fields) {
+    return db.transaction(
+        () -> {
+          db.execute(
+              "DELETE FROM sync_conflicts WHERE entity_type = ? AND entity_id = ? AND status = ?",
+              entityType,
+              entityId,
+              PENDING);
+          db.execute(
+              "INSERT INTO sync_conflicts (entity_type, entity_id, base_snapshot, local_snapshot,"
+                  + " remote_snapshot, fields, detected_at, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+              entityType,
+              entityId,
+              baseSnapshot,
+              localSnapshot,
+              remoteSnapshot,
+              String.join("\n", fields),
+              Instant.now().toString(),
+              PENDING);
+          return db.queryOne("SELECT last_insert_rowid()", row -> row.integer(0)).orElseThrow();
+        });
+  }
+
+  /** Every open conflict, oldest first. */
+  public List<Conflict> pending() {
+    return db.query(SELECT + " WHERE status = ? ORDER BY id", SyncConflicts::map, PENDING);
+  }
+
+  public Optional<Conflict> pendingFor(String entityType, String entityId) {
+    return db.queryOne(
+        SELECT + " WHERE status = ? AND entity_type = ? AND entity_id = ?",
+        SyncConflicts::map,
+        PENDING,
+        entityType,
+        entityId);
+  }
+
+  /** Marks a conflict resolved with the revision the user settled on. */
+  public boolean resolve(long id, String resolvedRev) {
+    db.execute(
+        "UPDATE sync_conflicts SET status = ?, resolved_rev = ? WHERE id = ? AND status = ?",
+        RESOLVED,
+        resolvedRev,
+        id,
+        PENDING);
+    return db.changes() > 0;
+  }
+
+  private static final String SELECT =
+      "SELECT id, entity_type, entity_id, base_snapshot, local_snapshot, remote_snapshot, fields,"
+          + " detected_at, status, resolved_rev FROM sync_conflicts";
+
+  private static Conflict map(Sqlite.Row row) {
+    var fields = row.text(6);
+    return new Conflict(
+        row.integer(0),
+        row.text(1),
+        row.text(2),
+        row.text(3),
+        row.text(4),
+        row.text(5),
+        fields.isEmpty() ? List.of() : List.of(fields.split("\n")),
+        row.text(7),
+        row.text(8),
+        row.text(9));
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/SyncState.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SyncState.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import java.time.Instant;
+
+/**
+ * Per-peer sync checkpoint: the highest main sequence this node has applied from a given peer (the
+ * main devbox). Pulls are incremental from the checkpoint, so a sync resumes cleanly after an
+ * interruption without re-applying or skipping changes. Keyed by peer so a node can, in principle,
+ * track more than one upstream (only one — main — in the star topology, but the key keeps it
+ * honest).
+ */
+public final class SyncState {
+
+  private final Sqlite db;
+
+  public SyncState(Sqlite db) {
+    this.db = db;
+  }
+
+  /** The last applied checkpoint for {@code peer}; 0 if this node has never synced with it. */
+  public long checkpoint(String peer) {
+    return db.queryOne(
+            "SELECT checkpoint FROM sync_state WHERE peer = ?", row -> row.integer(0), peer)
+        .orElse(0L);
+  }
+
+  /** Advances the checkpoint for {@code peer}. Monotonic: never moves the checkpoint backward. */
+  public void advance(String peer, long checkpoint) {
+    db.execute(
+        """
+        INSERT INTO sync_state (peer, checkpoint, updated_at) VALUES (?, ?, ?)
+        ON CONFLICT(peer) DO UPDATE SET checkpoint = max(checkpoint, excluded.checkpoint),
+            updated_at = excluded.updated_at""",
+        peer,
+        checkpoint,
+        Instant.now().toString());
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/ConflictDetectorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ConflictDetectorTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ConflictDetectorTest {
+
+  private static Map<String, Object> snap(Object... kv) {
+    var m = new LinkedHashMap<String, Object>();
+    for (var i = 0; i < kv.length; i += 2) {
+      m.put((String) kv[i], kv[i + 1]);
+    }
+    return m;
+  }
+
+  @Test
+  void identicalLocalAndRemoteConverge() {
+    var base = snap("title", "A", "status", "pending");
+    var both = snap("title", "B", "status", "pending");
+    assertInstanceOf(ConflictDetector.Converged.class, ConflictDetector.detect(base, both, both));
+  }
+
+  @Test
+  void onlyRemoteChangedTakesRemote() {
+    var base = snap("title", "A", "status", "pending");
+    var local = snap("title", "A", "status", "pending");
+    var remote = snap("title", "A", "status", "in_progress");
+    assertInstanceOf(
+        ConflictDetector.TakeRemote.class, ConflictDetector.detect(base, local, remote));
+  }
+
+  @Test
+  void onlyLocalChangedKeepsLocal() {
+    var base = snap("title", "A", "status", "pending");
+    var local = snap("title", "A2", "status", "pending");
+    var remote = snap("title", "A", "status", "pending");
+    assertInstanceOf(
+        ConflictDetector.KeepLocal.class, ConflictDetector.detect(base, local, remote));
+  }
+
+  @Test
+  void disjointFieldEditsAutoMerge() {
+    var base = snap("title", "A", "status", "pending", "assignee", null);
+    var local = snap("title", "A2", "status", "pending", "assignee", null);
+    var remote = snap("title", "A", "status", "in_progress", "assignee", null);
+
+    var resolution = ConflictDetector.detect(base, local, remote);
+
+    var merged = assertInstanceOf(ConflictDetector.Merged.class, resolution);
+    assertEquals("A2", merged.result().get("title"));
+    assertEquals("in_progress", merged.result().get("status"));
+  }
+
+  @Test
+  void sameFieldDifferentValuesConflict() {
+    var base = snap("title", "A");
+    var local = snap("title", "Local");
+    var remote = snap("title", "Remote");
+
+    var conflict =
+        assertInstanceOf(
+            ConflictDetector.Conflict.class, ConflictDetector.detect(base, local, remote));
+    assertEquals(java.util.List.of("title"), conflict.fields());
+  }
+
+  @Test
+  void sameFieldSameNewValueIsNotAConflict() {
+    var base = snap("title", "A");
+    var converged = snap("title", "Same");
+    assertInstanceOf(
+        ConflictDetector.Converged.class, ConflictDetector.detect(base, converged, converged));
+  }
+
+  @Test
+  void mixedMergeAndConflictReportsOnlyConflictingFields() {
+    var base = snap("title", "A", "status", "pending", "branch", "main");
+    var local = snap("title", "Local", "status", "in_progress", "branch", "main");
+    var remote = snap("title", "Remote", "status", "pending", "branch", "feat");
+
+    var conflict =
+        assertInstanceOf(
+            ConflictDetector.Conflict.class, ConflictDetector.detect(base, local, remote));
+    assertEquals(java.util.List.of("title"), conflict.fields());
+  }
+
+  @Test
+  void localDeleteWithUnchangedRemotePropagatesTheDelete() {
+    var base = snap("title", "A");
+    assertInstanceOf(
+        ConflictDetector.KeepLocal.class, ConflictDetector.detect(base, null, snap("title", "A")));
+  }
+
+  @Test
+  void remoteDeleteWithUnchangedLocalAcceptsTheDelete() {
+    var base = snap("title", "A");
+    assertInstanceOf(
+        ConflictDetector.TakeRemote.class, ConflictDetector.detect(base, snap("title", "A"), null));
+  }
+
+  @Test
+  void deleteVersusEditConflicts() {
+    var base = snap("title", "A");
+    var edited = snap("title", "Edited");
+
+    var localDeleteRemoteEdit = ConflictDetector.detect(base, null, edited);
+    var remoteDeleteLocalEdit = ConflictDetector.detect(base, edited, null);
+
+    assertInstanceOf(ConflictDetector.Conflict.class, localDeleteRemoteEdit);
+    assertInstanceOf(ConflictDetector.Conflict.class, remoteDeleteLocalEdit);
+    assertEquals(
+        java.util.List.of(ConflictDetector.DELETED_FIELD),
+        ((ConflictDetector.Conflict) localDeleteRemoteEdit).fields());
+  }
+
+  @Test
+  void bothDeletedConverge() {
+    assertInstanceOf(
+        ConflictDetector.Converged.class, ConflictDetector.detect(snap("title", "A"), null, null));
+  }
+
+  @Test
+  void noCommonAncestorIdenticalConvergesDifferentConflicts() {
+    var same = snap("title", "X");
+    assertInstanceOf(ConflictDetector.Converged.class, ConflictDetector.detect(null, same, same));
+
+    var local = snap("title", "X");
+    var remote = snap("title", "Y");
+    assertInstanceOf(ConflictDetector.Conflict.class, ConflictDetector.detect(null, local, remote));
+  }
+
+  @Test
+  void newFieldAddedOnlyLocallyMergesWithoutConflict() {
+    var base = snap("title", "A");
+    var local = snap("title", "A", "assignee", "uday");
+    var remote = snap("title", "A2");
+
+    var merged =
+        assertInstanceOf(
+            ConflictDetector.Merged.class, ConflictDetector.detect(base, local, remote));
+    assertEquals("uday", merged.result().get("assignee"));
+    assertEquals("A2", merged.result().get("title"));
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/SyncConflictsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SyncConflictsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SyncConflictsTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private SyncConflicts conflicts;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    conflicts = new SyncConflicts(db);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  @Test
+  void recordThenReadPending() {
+    var id =
+        conflicts.record(
+            "spec", "auth", "{base}", "{local}", "{remote}", List.of("title", "status"));
+
+    var pending = conflicts.pending();
+    assertEquals(1, pending.size());
+    var c = pending.getFirst();
+    assertEquals(id, c.id());
+    assertEquals("auth", c.entityId());
+    assertEquals("{local}", c.localSnapshot());
+    assertEquals(List.of("title", "status"), c.fields());
+    assertEquals("pending", c.status());
+  }
+
+  @Test
+  void recordingAgainReplacesTheOpenConflictForThatEntity() {
+    conflicts.record("spec", "auth", "b1", "l1", "r1", List.of("title"));
+    conflicts.record("spec", "auth", "b2", "l2", "r2", List.of("status"));
+
+    var pending = conflicts.pending();
+    assertEquals(1, pending.size());
+    assertEquals("l2", pending.getFirst().localSnapshot());
+  }
+
+  @Test
+  void pendingForFindsByEntity() {
+    conflicts.record("spec", "auth", "b", "l", "r", List.of("title"));
+    assertTrue(conflicts.pendingFor("spec", "auth").isPresent());
+    assertTrue(conflicts.pendingFor("spec", "other").isEmpty());
+  }
+
+  @Test
+  void resolveMarksResolvedAndRemovesFromPending() {
+    var id = conflicts.record("spec", "auth", "b", "l", "r", List.of("title"));
+
+    assertTrue(conflicts.resolve(id, "5-merged"));
+    assertTrue(conflicts.pending().isEmpty());
+    assertFalse(conflicts.resolve(id, "5-merged"), "already resolved");
+  }
+
+  @Test
+  void emptyFieldListRoundTrips() {
+    conflicts.record("spec", "auth", "b", "l", "r", List.of());
+    assertEquals(List.of(), conflicts.pending().getFirst().fields());
+  }
+
+  @Test
+  void conflictsAreScopedAndOrderedById() {
+    conflicts.record("spec", "a", "b", "l", "r", List.of("x"));
+    conflicts.record("spec", "b", "b", "l", "r", List.of("y"));
+
+    var pending = conflicts.pending();
+    assertEquals(2, pending.size());
+    assertTrue(pending.get(0).id() < pending.get(1).id());
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/SyncStateTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SyncStateTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SyncStateTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private SyncState state;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    state = new SyncState(db);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  @Test
+  void checkpointDefaultsToZero() {
+    assertEquals(0L, state.checkpoint("main"));
+  }
+
+  @Test
+  void advanceThenReadBack() {
+    state.advance("main", 42);
+    assertEquals(42L, state.checkpoint("main"));
+  }
+
+  @Test
+  void advanceIsMonotonicAndNeverGoesBackward() {
+    state.advance("main", 42);
+    state.advance("main", 10);
+    assertEquals(42L, state.checkpoint("main"));
+  }
+
+  @Test
+  void checkpointsAreTrackedPerPeer() {
+    state.advance("main", 5);
+    state.advance("backup", 9);
+    assertEquals(5L, state.checkpoint("main"));
+    assertEquals(9L, state.checkpoint("backup"));
+  }
+}

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.62</version>
+        <version>0.13.63</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.62</version>
+        <version>0.13.63</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>


### PR DESCRIPTION
The algorithmic heart of the sync engine — **pure, exhaustively tested, no DB coupling**. The engine that drives it is brick 3b; this PR is the decision logic and the tables it will write.

## ConflictDetector (pure)
Three-way **field-level** merge over snapshot maps. `detect(base, local, remote)` →
- **Converged** — local and remote agree.
- **TakeRemote** / **KeepLocal** — only one side moved (fast-forward), including a delete.
- **Merged(result)** — both moved on *disjoint* fields → auto-merge.
- **Conflict(fields)** — both changed the *same* field differently → needs a human (the locked no-silent-LWW decision).

A `null` snapshot = deleted, so **delete-vs-edit conflicts** (no silent resurrection/deletion); both-deleted converges; no common ancestor (base null) converges if identical else conflicts.

## Tables + stores
- `specs.base_rev` (the main rev a local row descended from).
- `sync_conflicts` (base/local/remote snapshots + conflicting fields + status + resolved_rev) — `SyncConflicts` store: `record` (one open conflict per entity; re-recording replaces), `pending`, `pendingFor`, `resolve`. **The local row is never touched while a conflict is open** — the FDE's work is preserved.
- `sync_state` (per-peer checkpoint) — `SyncState` store: `checkpoint`/`advance`, monotonic.

13 `ConflictDetector` tests cover the full matrix; `SyncState` + `SyncConflicts` store tests. 5,541 tests green.