### PR TITLE
Sync engine + two-node harness (db-sync brick 3b) — 0.13.64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.63</version>
+    <version>0.13.64</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.63</version>
+        <version>0.13.64</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/store/ChangeLog.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ChangeLog.java
@@ -69,6 +69,15 @@ public final class ChangeLog {
         entityId);
   }
 
+  /** The highest sequence recorded for an entity type; 0 if none. The sync high-water mark. */
+  public long maxSeq(String entityType) {
+    return db.queryOne(
+            "SELECT COALESCE(MAX(seq), 0) FROM change_log WHERE entity_type = ?",
+            row -> row.integer(0),
+            entityType)
+        .orElse(0L);
+  }
+
   /** Returns a specific revision of an entity, if it was ever recorded. */
   public Optional<Entry> at(String entityType, String entityId, String rev) {
     return db.queryOne(

--- a/sail-core/src/main/java/ai/singlr/sail/store/ConflictDetector.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ConflictDetector.java
@@ -57,9 +57,15 @@ public final class ConflictDetector {
       return new Converged();
     }
     if (localDeleted) {
+      if (base == null) {
+        return new TakeRemote();
+      }
       return equalSnapshots(base, remote) ? new KeepLocal() : new Conflict(List.of(DELETED_FIELD));
     }
     if (remoteDeleted) {
+      if (base == null) {
+        return new KeepLocal();
+      }
       return equalSnapshots(base, local) ? new TakeRemote() : new Conflict(List.of(DELETED_FIELD));
     }
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -254,17 +254,44 @@ public final class SpecStore {
         });
   }
 
-  private void recordRevision(String id, String origin, boolean deleted) {
+  private String recordRevision(String id, String origin, boolean deleted) {
+    return recordRevision(id, null, origin, deleted, false);
+  }
+
+  /**
+   * Appends a revision for the current state of {@code id}. With {@code explicitRev} null the rev
+   * is minted from the current counter; otherwise the caller-supplied rev is used verbatim (sync
+   * adopting main's authoritative rev). {@code setBaseRev} records that this revision is the new
+   * synced ancestor — set only when adopting from main, never on a local edit.
+   */
+  private String recordRevision(
+      String id, String explicitRev, String origin, boolean deleted, boolean setBaseRev) {
     var spec = findById(id).orElse(null);
     if (spec == null) {
-      return;
+      return null;
     }
-    var snapshot = snapshotJson(spec);
-    var rev = Revisions.next(currentRev(id), snapshot);
+    var map = snapshotMap(spec);
+    if (deleted) {
+      map.put("_base_rev", rawBaseRev(id));
+    }
+    var snapshot = YamlUtil.dumpJson(map);
+    var rev = explicitRev != null ? explicitRev : Revisions.next(currentRev(id), snapshot);
     if (!deleted) {
-      db.execute("UPDATE specs SET rev = ? WHERE id = ?", rev, id);
+      if (setBaseRev) {
+        db.execute("UPDATE specs SET rev = ?, base_rev = ? WHERE id = ?", rev, rev, id);
+      } else {
+        db.execute("UPDATE specs SET rev = ? WHERE id = ?", rev, id);
+      }
     }
     changeLog.append(ENTITY, id, rev, spec.updatedBy(), origin, deleted, snapshot);
+    return rev;
+  }
+
+  private String rawBaseRev(String id) {
+    var value =
+        db.queryOne("SELECT COALESCE(base_rev, '') FROM specs WHERE id = ?", row -> row.text(0), id)
+            .orElse("");
+    return value.isBlank() ? null : value;
   }
 
   private String currentRev(String id) {
@@ -273,6 +300,10 @@ public final class SpecStore {
   }
 
   private String snapshotJson(SpecRow spec) {
+    return YamlUtil.dumpJson(snapshotMap(spec));
+  }
+
+  private Map<String, Object> snapshotMap(SpecRow spec) {
     var content = getContent(spec.id()).orElse(new SpecContent("", "", null));
     var map = new LinkedHashMap<String, Object>();
     map.put("id", spec.id());
@@ -293,7 +324,7 @@ public final class SpecStore {
     map.put("repos", spec.repos());
     map.put("body", content.body());
     map.put("plan", content.plan());
-    return YamlUtil.dumpJson(map);
+    return map;
   }
 
   private void applySnapshot(String id, Map<String, Object> snapshot) {
@@ -336,7 +367,7 @@ public final class SpecStore {
           spec.branch(),
           spec.priority(),
           spec.createdBy(),
-          spec.createdAt(),
+          spec.createdAt() == null || spec.createdAt().isBlank() ? now : spec.createdAt(),
           now,
           spec.updatedBy());
     }
@@ -380,6 +411,142 @@ public final class SpecStore {
   private static String text(Map<String, Object> map, String key) {
     var value = map.get(key);
     return value == null ? null : value.toString();
+  }
+
+  private static final java.util.Set<String> SYNC_FIELDS =
+      java.util.Set.of(
+          "project",
+          "title",
+          "status",
+          "assignee",
+          "agent",
+          "model",
+          "reasoning_effort",
+          "branch",
+          "priority",
+          "depends_on",
+          "repos",
+          "body",
+          "plan");
+
+  /**
+   * The subset of a snapshot that carries an FDE's actual work — everything except the surrogate
+   * key and the timestamp/attribution metadata that every replica writes locally. Conflict
+   * detection compares only these, so two boxes never falsely conflict on {@code updated_at}.
+   */
+  private static Map<String, Object> comparable(Map<String, Object> full) {
+    if (full == null) {
+      return null;
+    }
+    var m = new LinkedHashMap<String, Object>();
+    for (var field : full.keySet()) {
+      if (SYNC_FIELDS.contains(field)) {
+        m.put(field, full.get(field));
+      }
+    }
+    return m;
+  }
+
+  /** Comparable snapshot of the current state, or null if the spec is absent/deleted. */
+  public Map<String, Object> comparableSnapshot(String id) {
+    return findById(id).map(this::snapshotMap).map(SpecStore::comparable).orElse(null);
+  }
+
+  /** Comparable snapshot recorded at a given revision (the merge base), or null if not recorded. */
+  public Map<String, Object> comparableAtRev(String id, String rev) {
+    if (rev == null || rev.isBlank()) {
+      return null;
+    }
+    return changeLog
+        .at(ENTITY, id, rev)
+        .map(e -> comparable(YamlUtil.parseMap(e.snapshot())))
+        .orElse(null);
+  }
+
+  public String revOf(String id) {
+    var rev = currentRev(id);
+    return rev.isBlank() ? null : rev;
+  }
+
+  /** The latest revision recorded for an entity, including a tombstone; null if never recorded. */
+  public String latestRev(String id) {
+    var history = changeLog.history(ENTITY, id);
+    return history.isEmpty() ? null : history.getLast().rev();
+  }
+
+  /**
+   * The revision this row last synced from main. For a live row it is the {@code base_rev} column;
+   * for a locally deleted entity the row is gone, so it is recovered from the {@code _base_rev}
+   * embedded in the tombstone — without which a local delete could not be told apart from a
+   * delete-vs-edit conflict.
+   */
+  public String baseRevOf(String id) {
+    if (findById(id).isPresent()) {
+      return rawBaseRev(id);
+    }
+    var tombstone = changeLog.history(ENTITY, id);
+    if (tombstone.isEmpty()) {
+      return null;
+    }
+    var baseRev = YamlUtil.parseMap(tombstone.getLast().snapshot()).get("_base_rev");
+    return baseRev == null ? null : baseRev.toString();
+  }
+
+  /** Every entity id this replica knows of, including those only present as a tombstone. */
+  public java.util.Set<String> syncEntityIds() {
+    return new java.util.LinkedHashSet<>(
+        db.query(
+            "SELECT DISTINCT entity_id FROM change_log WHERE entity_type = ?",
+            row -> row.text(0),
+            ENTITY));
+  }
+
+  /**
+   * Writes an authoritative state from main at its exact revision (no minting), marking it the new
+   * synced ancestor ({@code base_rev = rev}). A null snapshot adopts a deletion. Used by the sync
+   * engine; the revision is journaled with origin {@code sync}.
+   */
+  public void applyRevision(String id, Map<String, Object> snapshot, String rev) {
+    db.transaction(
+        () -> {
+          if (snapshot == null) {
+            if (findById(id).isPresent()) {
+              recordRevision(id, rev, "sync", true, false);
+              db.execute("DELETE FROM specs WHERE id = ?", id);
+            } else {
+              changeLog.append(ENTITY, id, rev, null, "sync", true, "{}");
+            }
+          } else {
+            var full = new LinkedHashMap<>(snapshot);
+            full.put("id", id);
+            full.put("updated_by", "sync");
+            applySnapshot(id, full);
+            recordRevision(id, rev, "sync", false, true);
+          }
+        });
+  }
+
+  /**
+   * Commits a state as main does — minting a fresh authoritative revision — and returns the new
+   * rev. A null snapshot commits a deletion. Used by the sync engine on the main side.
+   */
+  public String commitRevision(String id, Map<String, Object> snapshot) {
+    return db.transaction(
+        () -> {
+          if (snapshot == null) {
+            if (findById(id).isEmpty()) {
+              return revOf(id);
+            }
+            var rev = recordRevision(id, null, "sync", true, false);
+            db.execute("DELETE FROM specs WHERE id = ?", id);
+            return rev;
+          }
+          var full = new LinkedHashMap<>(snapshot);
+          full.put("id", id);
+          full.put("updated_by", "sync");
+          applySnapshot(id, full);
+          return recordRevision(id, null, "sync", false, false);
+        });
   }
 
   public Optional<SpecContent> getContent(String specId) {

--- a/sail-core/src/main/java/ai/singlr/sail/sync/LocalReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/LocalReplica.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The node (local replica) side of a sync round. Tracks the merge base it last synced from main,
+ * adopts authoritative revisions, and parks conflicts without ever overwriting the local row — the
+ * no-lost-work guarantee. Comparable snapshots ({@code null} = deleted/absent) carry only the
+ * fields that represent an FDE's work, so timestamps never cause false conflicts.
+ */
+public interface LocalReplica {
+
+  /** Every entity id this node knows of, including tombstoned ones. */
+  Set<String> entityIds();
+
+  /** Current comparable state; {@code null} if deleted or absent. */
+  Map<String, Object> current(String id);
+
+  /**
+   * The merge base — the comparable state this row last synced from main; {@code null} if never.
+   */
+  Map<String, Object> base(String id);
+
+  /** Latest local revision (including a tombstone); {@code null} if unknown. */
+  String currentRev(String id);
+
+  /** Adopts an authoritative state at main's exact rev ({@code null} snapshot = delete). */
+  void adopt(String id, Map<String, Object> snapshot, String rev);
+
+  /** Parks a conflict for human resolution; the local row is left untouched. */
+  void recordConflict(
+      String id,
+      Map<String, Object> base,
+      Map<String, Object> local,
+      Map<String, Object> remote,
+      List<String> fields);
+
+  /** Advances the checkpoint for {@code peerId} to main's high-water sequence. */
+  void advanceCheckpoint(String peerId, long seq);
+}

--- a/sail-core/src/main/java/ai/singlr/sail/sync/MainReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/MainReplica.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The authoritative (main devbox) side of a sync round, as the {@link SyncEngine} sees it. Narrow
+ * by design (interface segregation): main only ever reads its current state and commits a new
+ * authoritative revision — it never adopts, tracks a base, or records conflicts (those are a
+ * node-local concern). In brick 3b this is backed in-process by a {@code SpecReplica}; in brick 4 a
+ * transport adapter over the SSH gateway implements the same contract.
+ */
+public interface MainReplica {
+
+  /** Stable identity of this main, used as the node's checkpoint key. */
+  String id();
+
+  /** Every entity id main knows of, including tombstoned ones. */
+  Set<String> entityIds();
+
+  /** Main's current comparable state for an entity; {@code null} if deleted or absent. */
+  Map<String, Object> current(String id);
+
+  /** Main's latest revision for an entity (including a tombstone); {@code null} if unknown. */
+  String currentRev(String id);
+
+  /** Commits an authoritative state ({@code null} = delete), minting and returning the new rev. */
+  String commit(String id, Map<String, Object> snapshot);
+
+  /** Main's highest change sequence — the node advances its checkpoint to this after a round. */
+  long maxSeq();
+}

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SpecReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SpecReplica.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.store.ChangeLog;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.SyncConflicts;
+import ai.singlr.sail.store.SyncState;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Adapts a single box's spec stores to the sync roles. The same box can act as the node ({@link
+ * LocalReplica}) when it syncs up to main, and as the authority ({@link MainReplica}) when another
+ * node syncs to it — so the in-process two-node harness wires two {@code SpecReplica}s together,
+ * and brick 4 swaps the {@link MainReplica} side for a transport adapter without the engine
+ * changing. Pure delegation to {@link SpecStore} (revisions), {@link SyncConflicts} (parked
+ * conflicts), and {@link SyncState} (checkpoint) — no logic of its own beyond serialization.
+ */
+public final class SpecReplica implements LocalReplica, MainReplica {
+
+  private static final String ENTITY = "spec";
+
+  private final String id;
+  private final SpecStore specs;
+  private final ChangeLog changeLog;
+  private final SyncConflicts conflicts;
+  private final SyncState syncState;
+
+  public SpecReplica(
+      String id,
+      SpecStore specs,
+      ChangeLog changeLog,
+      SyncConflicts conflicts,
+      SyncState syncState) {
+    this.id = Objects.requireNonNull(id, "id");
+    this.specs = Objects.requireNonNull(specs, "specs");
+    this.changeLog = Objects.requireNonNull(changeLog, "changeLog");
+    this.conflicts = Objects.requireNonNull(conflicts, "conflicts");
+    this.syncState = Objects.requireNonNull(syncState, "syncState");
+  }
+
+  @Override
+  public String id() {
+    return id;
+  }
+
+  @Override
+  public Set<String> entityIds() {
+    return specs.syncEntityIds();
+  }
+
+  @Override
+  public Map<String, Object> current(String entityId) {
+    return specs.comparableSnapshot(entityId);
+  }
+
+  @Override
+  public Map<String, Object> base(String entityId) {
+    return specs.comparableAtRev(entityId, specs.baseRevOf(entityId));
+  }
+
+  @Override
+  public String currentRev(String entityId) {
+    return specs.latestRev(entityId);
+  }
+
+  @Override
+  public void adopt(String entityId, Map<String, Object> snapshot, String rev) {
+    specs.applyRevision(entityId, snapshot, rev);
+  }
+
+  @Override
+  public String commit(String entityId, Map<String, Object> snapshot) {
+    return specs.commitRevision(entityId, snapshot);
+  }
+
+  @Override
+  public long maxSeq() {
+    return changeLog.maxSeq(ENTITY);
+  }
+
+  @Override
+  public void recordConflict(
+      String entityId,
+      Map<String, Object> base,
+      Map<String, Object> local,
+      Map<String, Object> remote,
+      List<String> fields) {
+    conflicts.record(ENTITY, entityId, json(base), json(local), json(remote), fields);
+  }
+
+  @Override
+  public void advanceCheckpoint(String peerId, long seq) {
+    syncState.advance(peerId, seq);
+  }
+
+  private static String json(Map<String, Object> snapshot) {
+    return snapshot == null ? null : YamlUtil.dumpJson(snapshot);
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncEngine.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncEngine.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import ai.singlr.sail.store.ConflictDetector;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+
+/**
+ * Drives one sync round between a node ({@link LocalReplica}) and the authoritative {@link
+ * MainReplica}, reconciling every entity through the pure {@link ConflictDetector}. Main is the
+ * authority: a local-only change pushes (main mints the rev), a main-only change pulls, disjoint
+ * edits auto-merge into a new authoritative rev both sides adopt, and a true same-field conflict is
+ * parked locally with the node's row untouched.
+ *
+ * <p>The round is idempotent — a second run with no new changes converges everything and does
+ * nothing — and order-independent across entities, because each entity reconciles against its own
+ * merge base. Stateless: all state lives in the replicas, so a sync interrupted between entities
+ * re-runs cleanly.
+ */
+public final class SyncEngine {
+
+  public record Report(int pulled, int pushed, int merged, int conflicts) {
+    public int total() {
+      return pulled + pushed + merged + conflicts;
+    }
+  }
+
+  public Report reconcile(LocalReplica local, MainReplica main) {
+    var ids = new LinkedHashSet<String>();
+    ids.addAll(local.entityIds());
+    ids.addAll(main.entityIds());
+
+    var pulled = 0;
+    var pushed = 0;
+    var merged = 0;
+    var conflicts = 0;
+
+    for (var id : ids) {
+      var base = local.base(id);
+      var localSnap = local.current(id);
+      var remoteSnap = main.current(id);
+
+      switch (ConflictDetector.detect(base, localSnap, remoteSnap)) {
+        case ConflictDetector.Converged ignored -> linkSharedRevision(local, main, id, remoteSnap);
+        case ConflictDetector.TakeRemote ignored -> {
+          local.adopt(id, remoteSnap, main.currentRev(id));
+          pulled++;
+        }
+        case ConflictDetector.KeepLocal ignored -> {
+          local.adopt(id, localSnap, main.commit(id, localSnap));
+          pushed++;
+        }
+        case ConflictDetector.Merged m -> {
+          local.adopt(id, m.result(), main.commit(id, m.result()));
+          merged++;
+        }
+        case ConflictDetector.Conflict c -> {
+          local.recordConflict(id, base, localSnap, remoteSnap, c.fields());
+          conflicts++;
+        }
+      }
+    }
+
+    local.advanceCheckpoint(main.id(), main.maxSeq());
+    return new Report(pulled, pushed, merged, conflicts);
+  }
+
+  /**
+   * When local and main already agree but local has not yet recorded main's revision (e.g. they
+   * independently reached identical content), adopt main's rev so both share a merge base going
+   * forward. A no-op once the revisions are linked, so it never churns.
+   */
+  private static void linkSharedRevision(
+      LocalReplica local, MainReplica main, String id, java.util.Map<String, Object> remoteSnap) {
+    var mainRev = main.currentRev(id);
+    if (mainRev != null && !Objects.equals(local.currentRev(id), mainRev)) {
+      local.adopt(id, remoteSnap, mainRev);
+    }
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/ConflictDetectorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ConflictDetectorTest.java
@@ -121,6 +121,18 @@ class ConflictDetectorTest {
   }
 
   @Test
+  void newLocalEntityAbsentOnRemotePushes() {
+    assertInstanceOf(
+        ConflictDetector.KeepLocal.class, ConflictDetector.detect(null, snap("title", "A"), null));
+  }
+
+  @Test
+  void newRemoteEntityAbsentLocallyPulls() {
+    assertInstanceOf(
+        ConflictDetector.TakeRemote.class, ConflictDetector.detect(null, null, snap("title", "A")));
+  }
+
+  @Test
   void bothDeletedConverge() {
     assertInstanceOf(
         ConflictDetector.Converged.class, ConflictDetector.detect(snap("title", "A"), null, null));

--- a/sail-core/src/test/java/ai/singlr/sail/sync/TwoNodeSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/TwoNodeSyncTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.store.ChangeLog;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import ai.singlr.sail.store.SyncConflicts;
+import ai.singlr.sail.store.SyncState;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * In-process two-node harness: each "box" is its own SQLite DB with a full set of stores. Two nodes
+ * sync to a shared main, proving convergence, propagation, and conflict surfacing end to end
+ * through the real {@link SyncEngine} — no transport.
+ */
+class TwoNodeSyncTest {
+
+  @TempDir Path tempDir;
+  private final SyncEngine engine = new SyncEngine();
+
+  private Box main;
+  private Box nodeA;
+  private Box nodeB;
+
+  private final class Box implements AutoCloseable {
+    final String id;
+    final Sqlite db;
+    final SpecStore specs;
+    final SyncConflicts conflicts;
+    final SpecReplica replica;
+
+    Box(String id) {
+      this.id = id;
+      this.db = Sqlite.open(tempDir.resolve(id + ".db"));
+      new SchemaManager(db).migrate();
+      this.specs = new SpecStore(db);
+      this.conflicts = new SyncConflicts(db);
+      this.replica = new SpecReplica(id, specs, new ChangeLog(db), conflicts, new SyncState(db));
+    }
+
+    @Override
+    public void close() {
+      db.close();
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    main = new Box("main");
+    nodeA = new Box("A");
+    nodeB = new Box("B");
+  }
+
+  @AfterEach
+  void tearDown() {
+    nodeB.close();
+    nodeA.close();
+    main.close();
+  }
+
+  private SpecStore.SpecRow spec(String id, String title, String status) {
+    return new SpecStore.SpecRow(
+        id,
+        "proj",
+        title,
+        SpecStatus.fromWire(status),
+        null,
+        null,
+        null,
+        null,
+        null,
+        0,
+        "uday",
+        "",
+        "",
+        "uday",
+        List.of(),
+        List.of());
+  }
+
+  private void syncToMain(Box node) {
+    engine.reconcile(node.replica, main.replica);
+  }
+
+  @Test
+  void aLocalCreatePropagatesToMainAndThenToTheOtherNode() {
+    nodeA.specs.create(spec("auth", "Auth", "pending"));
+
+    syncToMain(nodeA);
+    assertEquals("Auth", main.specs.findById("auth").orElseThrow().title());
+
+    syncToMain(nodeB);
+    assertEquals("Auth", nodeB.specs.findById("auth").orElseThrow().title());
+  }
+
+  @Test
+  void disjointFieldEditsOnTwoNodesAutoMergeWithoutConflict() {
+    nodeA.specs.create(spec("auth", "Auth", "pending"));
+    syncToMain(nodeA);
+    syncToMain(nodeB);
+
+    nodeA.specs.updateStatus("auth", SpecStatus.fromWire("in_progress"));
+    nodeB.specs.setContent("auth", "node B body", "");
+
+    syncToMain(nodeA);
+    syncToMain(nodeB);
+    syncToMain(nodeA);
+
+    var a = nodeA.specs.findById("auth").orElseThrow();
+    var b = nodeB.specs.findById("auth").orElseThrow();
+    assertEquals("in_progress", a.status().wire());
+    assertEquals("in_progress", b.status().wire());
+    assertEquals("node B body", nodeA.specs.getContent("auth").orElseThrow().body());
+    assertEquals("node B body", nodeB.specs.getContent("auth").orElseThrow().body());
+    assertTrue(nodeA.conflicts.pending().isEmpty());
+    assertTrue(nodeB.conflicts.pending().isEmpty());
+  }
+
+  @Test
+  void sameFieldEditsOnTwoNodesConflictOnTheSecondAndLeaveItsWorkUntouched() {
+    nodeA.specs.create(spec("auth", "Auth", "pending"));
+    syncToMain(nodeA);
+    syncToMain(nodeB);
+
+    nodeA.specs.update(spec("auth", "Title from A", "pending"));
+    nodeB.specs.update(spec("auth", "Title from B", "pending"));
+
+    syncToMain(nodeA);
+    syncToMain(nodeB);
+
+    assertEquals("Title from A", main.specs.findById("auth").orElseThrow().title());
+    var pending = nodeB.conflicts.pending();
+    assertEquals(1, pending.size());
+    assertEquals(List.of("title"), pending.getFirst().fields());
+    assertEquals(
+        "Title from B",
+        nodeB.specs.findById("auth").orElseThrow().title(),
+        "node B's work is left untouched while the conflict is open");
+  }
+
+  @Test
+  void aLocalDeletePropagatesToMainAndTheOtherNode() {
+    nodeA.specs.create(spec("auth", "Auth", "pending"));
+    syncToMain(nodeA);
+    syncToMain(nodeB);
+
+    nodeA.specs.delete("auth");
+    syncToMain(nodeA);
+    assertTrue(main.specs.findById("auth").isEmpty());
+
+    syncToMain(nodeB);
+    assertTrue(nodeB.specs.findById("auth").isEmpty());
+  }
+
+  @Test
+  void deleteOnOneNodeVersusEditOnAnotherConflicts() {
+    nodeA.specs.create(spec("auth", "Auth", "pending"));
+    syncToMain(nodeA);
+    syncToMain(nodeB);
+
+    nodeA.specs.delete("auth");
+    nodeB.specs.update(spec("auth", "Edited by B", "pending"));
+
+    syncToMain(nodeA);
+    syncToMain(nodeB);
+
+    assertTrue(main.specs.findById("auth").isEmpty(), "A's delete reached main first");
+    var pending = nodeB.conflicts.pending();
+    assertEquals(1, pending.size());
+    assertEquals(List.of("<deleted>"), pending.getFirst().fields());
+  }
+
+  @Test
+  void reSyncingWithNoChangesConvergesAndDoesNothing() {
+    nodeA.specs.create(spec("auth", "Auth", "pending"));
+    syncToMain(nodeA);
+
+    var second = engine.reconcile(nodeA.replica, main.replica);
+
+    assertEquals(0, second.total());
+  }
+
+  @Test
+  void anInterruptedRoundReRunsIdempotently() {
+    nodeA.specs.create(spec("one", "One", "pending"));
+    nodeA.specs.create(spec("two", "Two", "pending"));
+
+    engine.reconcile(nodeA.replica, main.replica);
+    var rerun = engine.reconcile(nodeA.replica, main.replica);
+
+    assertEquals(0, rerun.total());
+    assertEquals(2, main.specs.list(SpecStore.SpecFilter.all()).size());
+  }
+
+  @Test
+  void checkpointAdvancesToMainHighWaterMark() {
+    nodeA.specs.create(spec("auth", "Auth", "pending"));
+    syncToMain(nodeA);
+
+    assertEquals(main.replica.maxSeq(), new SyncState(nodeA.db).checkpoint("main"));
+    assertTrue(main.replica.maxSeq() > 0);
+  }
+}

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.63</version>
+        <version>0.13.64</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.63</version>
+        <version>0.13.64</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>


### PR DESCRIPTION
**Replicas converge.** The `SyncEngine` drives a node and the authoritative main through the pure `ConflictDetector` (3a), in-process and fully tested — no transport (brick 4).

## Design (SOLID/ISP)
- **`LocalReplica` / `MainReplica`** — segregated roles. The node tracks a merge base, adopts authoritative revisions, and parks conflicts **without overwriting its row**; main only reads and commits. Brick 4 swaps the `MainReplica` side for an SSH-transport adapter without the engine changing.
- **`SyncEngine.reconcile`** — per entity, `detect(base, local, remote)` → Converged (link shared rev) / TakeRemote (pull) / KeepLocal (push, main mints the rev) / Merged (both adopt a new authoritative rev) / Conflict (park locally). **Idempotent, order-independent, stateless**; advances the node's checkpoint to main's high-water seq.
- **`SpecReplica`** — SpecStore-backed adapter implementing both roles.

## SpecStore sync support
- **Comparable snapshot** — meaningful fields only (no `updated_at`/attribution), so two boxes never false-conflict on timestamps.
- `comparableAtRev` (merge base), `applyRevision` (adopt at main's exact rev, `base_rev=rev`), `commitRevision` (mint), `latestRev`, and `baseRevOf` that **recovers a deleted entity's `base_rev` from the tombstone** — without which a local delete couldn't be distinguished from a delete-vs-edit conflict.

## Bug caught by the harness
The detector treated a `null` side as "deleted" even with no common ancestor, so a brand-new entity false-conflicted instead of pushing/pulling. Fixed: base-null + null-side = "never existed."

## Two-node harness (8 scenarios)
create propagation, disjoint-edit auto-merge, same-field conflict (second node's work untouched), delete propagation, delete-vs-edit conflict, converge-noop, idempotent re-run, checkpoint advance. 5,561 tests green; coverage gate met.