### PR TITLE
db-sync brick 8: share arbitrary project files across FDEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.71</version>
+    <version>0.13.72</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.71</version>
+        <version>0.13.72</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/store/ConflictResolver.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ConflictResolver.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import java.util.Map;
+
+/**
+ * Rebases an entity onto main's conflicting state and writes the chosen resolution, returning the
+ * rev the row now carries. Implemented by every store whose rows sync ({@link SpecStore}, {@link
+ * FileStore}) so conflict resolution can dispatch on entity type without knowing the concrete
+ * store.
+ */
+public interface ConflictResolver {
+
+  String resolveConflict(String id, Map<String, Object> chosen, Map<String, Object> remote);
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import ai.singlr.sail.config.YamlUtil;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Shared project files on SQLite: arbitrary workspace files (configs, scripts, docs) that every FDE
+ * on a project should have, replicated through the same sync engine as specs. One row per file
+ * keyed by {@code (project, path)} — so two FDEs touching different files never conflict, only
+ * edits to the same file do. Content is stored verbatim as text (callers base64 binary), and the
+ * relative {@code path} preserves the folder structure when the tree is materialized back to disk.
+ *
+ * <p>Each mutation journals the file's full post-state into the shared {@link ChangeLog} under
+ * entity type {@code file} within one transaction — the same revision/CAS/conflict machinery {@link
+ * SpecStore} uses — so files get history, restore, and bidirectional conflict resolution for free.
+ */
+public final class FileStore {
+
+  private static final String ENTITY = "file";
+
+  private final Sqlite db;
+  private final ChangeLog changeLog;
+
+  public FileStore(Sqlite db) {
+    this.db = db;
+    this.changeLog = new ChangeLog(db);
+  }
+
+  public record FileRow(String project, String path, String content) {}
+
+  /** The change-log entity id for a file: its project and relative path. */
+  public static String idOf(String project, String path) {
+    return project + "/" + path;
+  }
+
+  /** Stores or replaces a file's content as a local edit. */
+  public void put(String project, String path, String content) {
+    var row = new FileRow(project, path, content);
+    db.transaction(
+        () -> {
+          writeRow(row);
+          recordRevision(row, null, "local", false, false);
+        });
+  }
+
+  /** Tombstones a file so the deletion propagates; a no-op if it is already absent. */
+  public boolean delete(String project, String path) {
+    return db.transaction(
+        () -> {
+          var row = findRow(idOf(project, path)).orElse(null);
+          if (row == null) {
+            return false;
+          }
+          recordRevision(row, null, "local", true, false);
+          db.execute("DELETE FROM project_files WHERE id = ?", idOf(project, path));
+          return true;
+        });
+  }
+
+  public Optional<FileRow> find(String project, String path) {
+    return findRow(idOf(project, path));
+  }
+
+  /** Every current file of a project, ordered by path. */
+  public List<FileRow> list(String project) {
+    return db.query(
+        "SELECT project, path, content FROM project_files WHERE project = ? ORDER BY path",
+        FileStore::mapRow,
+        project);
+  }
+
+  public Map<String, Object> comparableSnapshot(String id) {
+    return findRow(id).map(row -> comparable(row.content())).orElse(null);
+  }
+
+  public Map<String, Object> comparableAtRev(String id, String rev) {
+    if (rev == null || rev.isBlank()) {
+      return null;
+    }
+    return changeLog
+        .at(ENTITY, id, rev)
+        .map(e -> comparable((String) YamlUtil.parseMap(e.snapshot()).get("content")))
+        .orElse(null);
+  }
+
+  public String latestRev(String id) {
+    var history = changeLog.history(ENTITY, id);
+    return history.isEmpty() ? null : history.getLast().rev();
+  }
+
+  public String baseRevOf(String id) {
+    if (findRow(id).isPresent()) {
+      return rawBaseRev(id);
+    }
+    var tombstone = changeLog.history(ENTITY, id);
+    if (tombstone.isEmpty()) {
+      return null;
+    }
+    var baseRev = YamlUtil.parseMap(tombstone.getLast().snapshot()).get("_base_rev");
+    return baseRev == null ? null : baseRev.toString();
+  }
+
+  public LinkedHashSet<String> syncEntityIds() {
+    return new LinkedHashSet<>(
+        db.query(
+            "SELECT DISTINCT entity_id FROM change_log WHERE entity_type = ?",
+            row -> row.text(0),
+            ENTITY));
+  }
+
+  /**
+   * Adopts main's authoritative state at its exact rev (no minting), as the new synced ancestor.
+   */
+  public void applyRevision(String id, Map<String, Object> snapshot, String rev) {
+    db.transaction(
+        () -> {
+          if (snapshot == null) {
+            adoptDeletion(id, rev);
+          } else {
+            var row = rowFrom(id, snapshot);
+            writeRow(row);
+            recordRevision(row, rev, "sync", false, true);
+          }
+        });
+  }
+
+  /** Compare-and-set commit as main: accepts only if {@code expectedRev} still matches. */
+  public PushOutcome commitRevision(String id, Map<String, Object> snapshot, String expectedRev) {
+    return db.transaction(
+        () -> {
+          if (!Objects.equals(latestRev(id), expectedRev)) {
+            return new PushOutcome.Stale(latestRev(id), comparableSnapshot(id));
+          }
+          if (snapshot == null) {
+            var present = findRow(id).orElse(null);
+            if (present == null) {
+              return new PushOutcome.Accepted(latestRev(id));
+            }
+            var rev = recordRevision(present, null, "sync", true, false);
+            db.execute("DELETE FROM project_files WHERE id = ?", id);
+            return new PushOutcome.Accepted(rev);
+          }
+          var row = rowFrom(id, snapshot);
+          writeRow(row);
+          return new PushOutcome.Accepted(recordRevision(row, null, "sync", false, false));
+        });
+  }
+
+  private void adoptDeletion(String id, String rev) {
+    var present = findRow(id).orElse(null);
+    if (present == null) {
+      changeLog.append(ENTITY, id, rev, null, "sync", true, "{}");
+      return;
+    }
+    recordRevision(present, rev, "sync", true, false);
+    db.execute("DELETE FROM project_files WHERE id = ?", id);
+  }
+
+  private String recordRevision(
+      FileRow row, String explicitRev, String origin, boolean deleted, boolean setBaseRev) {
+    var id = idOf(row.project(), row.path());
+    var map = new LinkedHashMap<String, Object>();
+    map.put("project", row.project());
+    map.put("path", row.path());
+    map.put("content", row.content());
+    if (deleted) {
+      map.put("_base_rev", rawBaseRev(id));
+    }
+    var snapshot = YamlUtil.dumpJson(map);
+    var rev = explicitRev != null ? explicitRev : Revisions.next(currentRev(id), snapshot);
+    if (!deleted) {
+      if (setBaseRev) {
+        db.execute("UPDATE project_files SET rev = ?, base_rev = ? WHERE id = ?", rev, rev, id);
+      } else {
+        db.execute("UPDATE project_files SET rev = ? WHERE id = ?", rev, id);
+      }
+    }
+    changeLog.append(ENTITY, id, rev, null, origin, deleted, snapshot);
+    return rev;
+  }
+
+  private void writeRow(FileRow row) {
+    db.execute(
+        "INSERT INTO project_files (id, project, path, content, updated_at) VALUES (?, ?, ?, ?, ?)"
+            + " ON CONFLICT(id) DO UPDATE SET content = excluded.content,"
+            + " updated_at = excluded.updated_at",
+        idOf(row.project(), row.path()),
+        row.project(),
+        row.path(),
+        row.content(),
+        Instant.now().toString());
+  }
+
+  private static FileRow rowFrom(String id, Map<String, Object> snapshot) {
+    var slash = id.indexOf('/');
+    var content = snapshot.get("content");
+    return new FileRow(
+        id.substring(0, slash),
+        id.substring(slash + 1),
+        content == null ? null : content.toString());
+  }
+
+  private Optional<FileRow> findRow(String id) {
+    return db.queryOne(
+        "SELECT project, path, content FROM project_files WHERE id = ?", FileStore::mapRow, id);
+  }
+
+  private static FileRow mapRow(Sqlite.Row row) {
+    return new FileRow(row.text(0), row.text(1), row.text(2));
+  }
+
+  private String rawBaseRev(String id) {
+    var value =
+        db.queryOne(
+                "SELECT COALESCE(base_rev, '') FROM project_files WHERE id = ?",
+                row -> row.text(0),
+                id)
+            .orElse("");
+    return value.isBlank() ? null : value;
+  }
+
+  private String currentRev(String id) {
+    return db.queryOne(
+            "SELECT COALESCE(rev, '') FROM project_files WHERE id = ?", row -> row.text(0), id)
+        .orElse("");
+  }
+
+  private static Map<String, Object> comparable(String content) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("content", content);
+    return map;
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * entity type {@code file} within one transaction — the same revision/CAS/conflict machinery {@link
  * SpecStore} uses — so files get history, restore, and bidirectional conflict resolution for free.
  */
-public final class FileStore {
+public final class FileStore implements ConflictResolver {
 
   private static final String ENTITY = "file";
 
@@ -184,6 +184,66 @@ public final class FileStore {
           writeRow(row);
           return new PushOutcome.Accepted(recordRevision(row, null, "sync", false, false));
         });
+  }
+
+  /**
+   * Resolves an open file conflict locally: rebases the row onto main's conflicting content {@code
+   * remote} as the new merge base — so the next sync can never re-raise the same conflict — then
+   * writes {@code chosen} as the resolved state. Take-theirs ({@code chosen} equals {@code remote})
+   * simply adopts main's value; keep-mine writes a forward local edit the next sync pushes. A
+   * {@code null} side is a deletion. Every state stays in the {@link ChangeLog}, so no choice loses
+   * work.
+   */
+  @Override
+  public String resolveConflict(String id, Map<String, Object> chosen, Map<String, Object> remote) {
+    return db.transaction(
+        () -> {
+          var baseRev = adoptBase(id, remote);
+          if (Objects.equals(contentOf(chosen), contentOf(remote))) {
+            return baseRev;
+          }
+          return writeChosen(id, chosen);
+        });
+  }
+
+  private String adoptBase(String id, Map<String, Object> remote) {
+    if (remote == null) {
+      return adoptBaseDeletion(id);
+    }
+    var row = rowFrom(id, remote);
+    writeRow(row);
+    return recordRevision(row, null, "sync", false, true);
+  }
+
+  private String adoptBaseDeletion(String id) {
+    var present = findRow(id).orElse(null);
+    if (present == null) {
+      var rev = Revisions.next(currentRev(id), "{}");
+      changeLog.append(ENTITY, id, rev, null, "sync", true, "{}");
+      return rev;
+    }
+    var rev = recordRevision(present, null, "sync", true, false);
+    db.execute("DELETE FROM project_files WHERE id = ?", id);
+    return rev;
+  }
+
+  private String writeChosen(String id, Map<String, Object> chosen) {
+    if (chosen == null) {
+      var present = findRow(id).orElse(null);
+      if (present == null) {
+        return latestRev(id);
+      }
+      var rev = recordRevision(present, null, "resolve", true, false);
+      db.execute("DELETE FROM project_files WHERE id = ?", id);
+      return rev;
+    }
+    var row = rowFrom(id, chosen);
+    writeRow(row);
+    return recordRevision(row, null, "resolve", false, false);
+  }
+
+  private static String contentOf(Map<String, Object> snapshot) {
+    return snapshot == null ? null : (String) snapshot.get("content");
   }
 
   private void adoptDeletion(String id, String rev) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
@@ -84,6 +84,35 @@ public final class FileStore {
     return findRow(id).map(row -> comparable(row.content())).orElse(null);
   }
 
+  /** Every file id this box has touched for a project, including tombstoned ones. */
+  public List<String> idsForProject(String project) {
+    return db.query(
+        "SELECT DISTINCT entity_id FROM change_log WHERE entity_type = ? AND entity_id LIKE ?",
+        row -> row.text(0),
+        ENTITY,
+        project + "/%");
+  }
+
+  /** Projects this box has any file for, current or tombstoned — drives materialization. */
+  public LinkedHashSet<String> projectsWithFiles() {
+    var projects = new LinkedHashSet<String>();
+    for (var id : syncEntityIds()) {
+      projects.add(id.substring(0, id.indexOf('/')));
+    }
+    return projects;
+  }
+
+  /**
+   * Whether {@code content} matches any revision this box has ever recorded for the file — i.e. a
+   * copy this box itself wrote to disk. Lets materialization tell a stale copy it may safely
+   * refresh from one a human edited locally, which it must never clobber.
+   */
+  public boolean isKnownContent(String id, String content) {
+    return changeLog.history(ENTITY, id).stream()
+        .map(e -> YamlUtil.parseMap(e.snapshot()).get("content"))
+        .anyMatch(c -> Objects.equals(c, content));
+  }
+
   public Map<String, Object> comparableAtRev(String id, String rev) {
     if (rev == null || rev.isBlank()) {
       return null;

--- a/sail-core/src/main/java/ai/singlr/sail/store/PushOutcome.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/PushOutcome.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import java.util.Map;
+
+/**
+ * The result of a compare-and-set commit on a synced store ({@link SpecStore}, {@link FileStore}):
+ * {@link Accepted} with the freshly minted rev, or {@link Stale} carrying the store's present state
+ * when the pusher's expected rev no longer matches — so a concurrent change is never overwritten.
+ */
+public sealed interface PushOutcome {
+
+  /** Accepted; {@code rev} is the newly minted authoritative revision. */
+  record Accepted(String rev) implements PushOutcome {}
+
+  /** Rejected; {@code current*} is the store's present state, untouched. */
+  record Stale(String currentRev, Map<String, Object> currentSnapshot) implements PushOutcome {}
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -280,6 +280,17 @@ public final class SchemaManager {
               peer TEXT PRIMARY KEY,
               checkpoint INTEGER NOT NULL DEFAULT 0,
               updated_at TEXT NOT NULL
+          )""",
+          """
+          CREATE TABLE IF NOT EXISTS project_files (
+              id TEXT PRIMARY KEY,
+              project TEXT NOT NULL,
+              path TEXT NOT NULL,
+              content TEXT NOT NULL,
+              rev TEXT,
+              base_rev TEXT,
+              updated_at TEXT NOT NULL,
+              UNIQUE (project, path)
           )""");
 
   private final Sqlite db;

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -528,15 +528,6 @@ public final class SpecStore {
         });
   }
 
-  /** The result of a compare-and-set {@link #commitRevision}. */
-  public sealed interface PushOutcome {
-    /** Accepted; {@code rev} is the freshly minted authoritative revision. */
-    record Accepted(String rev) implements PushOutcome {}
-
-    /** Rejected; {@code current*} is main's present state, untouched. */
-    record Stale(String currentRev, Map<String, Object> currentSnapshot) implements PushOutcome {}
-  }
-
   /**
    * Compare-and-set commit as main: mints a new authoritative rev only if {@code expectedRev} still
    * equals the entity's current rev (a brand-new entity expects {@code null}); otherwise returns

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -24,7 +24,7 @@ import java.util.Optional;
  * transaction, so history is complete and any revision is restorable (the DB-sync no-lost-work
  * guarantee). {@code specs.rev} tracks the current revision.
  */
-public final class SpecStore {
+public final class SpecStore implements ConflictResolver {
 
   private static final String ENTITY = "spec";
 

--- a/sail-core/src/main/java/ai/singlr/sail/sync/FileReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/FileReplica.java
@@ -7,8 +7,8 @@ package ai.singlr.sail.sync;
 
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.store.ChangeLog;
+import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.PushOutcome;
-import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.SyncConflicts;
 import ai.singlr.sail.store.SyncState;
 import java.util.List;
@@ -17,31 +17,29 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Adapts a single box's spec stores to the sync roles. The same box can act as the node ({@link
- * LocalReplica}) when it syncs up to main, and as the authority ({@link MainReplica}) when another
- * node syncs to it — so the in-process two-node harness wires two {@code SpecReplica}s together,
- * and brick 4 swaps the {@link MainReplica} side for a transport adapter without the engine
- * changing. Pure delegation to {@link SpecStore} (revisions), {@link SyncConflicts} (parked
- * conflicts), and {@link SyncState} (checkpoint) — no logic of its own beyond serialization.
+ * Adapts one box's {@link FileStore} to the sync roles, so the {@link SyncEngine} reconciles shared
+ * project files bidirectionally with main exactly as it does specs — a different entity type
+ * ({@code file}) over the same channel. Pure delegation to {@link FileStore} (revisions), {@link
+ * SyncConflicts} (parked conflicts), and {@link SyncState} (checkpoint).
  */
-public final class SpecReplica implements LocalReplica, MainReplica {
+public final class FileReplica implements LocalReplica, MainReplica {
 
-  private static final String ENTITY = "spec";
+  private static final String ENTITY = "file";
 
   private final String id;
-  private final SpecStore specs;
+  private final FileStore files;
   private final ChangeLog changeLog;
   private final SyncConflicts conflicts;
   private final SyncState syncState;
 
-  public SpecReplica(
+  public FileReplica(
       String id,
-      SpecStore specs,
+      FileStore files,
       ChangeLog changeLog,
       SyncConflicts conflicts,
       SyncState syncState) {
     this.id = Objects.requireNonNull(id, "id");
-    this.specs = Objects.requireNonNull(specs, "specs");
+    this.files = Objects.requireNonNull(files, "files");
     this.changeLog = Objects.requireNonNull(changeLog, "changeLog");
     this.conflicts = Objects.requireNonNull(conflicts, "conflicts");
     this.syncState = Objects.requireNonNull(syncState, "syncState");
@@ -54,32 +52,32 @@ public final class SpecReplica implements LocalReplica, MainReplica {
 
   @Override
   public Set<String> entityIds() {
-    return specs.syncEntityIds();
+    return files.syncEntityIds();
   }
 
   @Override
   public Map<String, Object> current(String entityId) {
-    return specs.comparableSnapshot(entityId);
+    return files.comparableSnapshot(entityId);
   }
 
   @Override
   public Map<String, Object> base(String entityId) {
-    return specs.comparableAtRev(entityId, specs.baseRevOf(entityId));
+    return files.comparableAtRev(entityId, files.baseRevOf(entityId));
   }
 
   @Override
   public String currentRev(String entityId) {
-    return specs.latestRev(entityId);
+    return files.latestRev(entityId);
   }
 
   @Override
   public void adopt(String entityId, Map<String, Object> snapshot, String rev) {
-    specs.applyRevision(entityId, snapshot, rev);
+    files.applyRevision(entityId, snapshot, rev);
   }
 
   @Override
   public CommitOutcome commit(String entityId, Map<String, Object> snapshot, String expectedRev) {
-    return switch (specs.commitRevision(entityId, snapshot, expectedRev)) {
+    return switch (files.commitRevision(entityId, snapshot, expectedRev)) {
       case PushOutcome.Accepted a -> new CommitOutcome.Accepted(a.rev());
       case PushOutcome.Stale s -> new CommitOutcome.Rejected(s.currentRev(), s.currentSnapshot());
     };
@@ -102,7 +100,7 @@ public final class SpecReplica implements LocalReplica, MainReplica {
 
   @Override
   public void advanceCheckpoint(String peerId, long seq) {
-    syncState.advance(peerId, seq);
+    syncState.advance(peerId + ":" + ENTITY, seq);
   }
 
   private static String json(Map<String, Object> snapshot) {

--- a/sail-core/src/main/java/ai/singlr/sail/sync/RemoteMainReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/RemoteMainReplica.java
@@ -5,37 +5,38 @@
 
 package ai.singlr.sail.sync;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.io.UncheckedIOException;
 import java.io.Writer;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 /**
- * The {@link MainReplica} the {@link SyncEngine} drives when main is remote: it speaks {@link
- * SyncWire} over the SSH channel instead of touching a database, so the engine reconciles against a
- * box across the network with no change to its logic.
+ * The {@link MainReplica} the {@link SyncEngine} drives when main is remote, bound to one entity
+ * type ({@code spec}, {@code file}): it speaks {@link SyncWire} over the SSH channel instead of
+ * touching a database, so the engine reconciles against a box across the network with no change to
+ * its logic, and several typed replicas (created by a {@link SyncSession}) can ride one channel.
  *
- * <p>One {@link SyncWire.Fetch} pulls main's whole shared state up front; every read the engine
- * makes ({@link #entityIds}, {@link #current}, {@link #currentRev}) is then served from that
- * snapshot with no further round trip. Only {@link #commit} talks to main again, and each commit
- * carries back main's new high-water so {@link #maxSeq} — read once at the end of the round to set
- * the checkpoint — reflects this node's own pushes, exactly as the in-process engine sees it.
+ * <p>One {@link SyncWire.Fetch} pulls main's whole state for this type up front; every read the
+ * engine makes ({@link #entityIds}, {@link #current}, {@link #currentRev}) is then served from that
+ * snapshot with no further round trip. Only {@link #commit} talks to main again, and each accepted
+ * commit carries back main's new high-water so {@link #maxSeq} — read once at the end of the round
+ * to set the checkpoint — reflects this node's own pushes, exactly as the in-process engine sees
+ * it.
  */
-public final class RemoteMainReplica implements MainReplica, AutoCloseable {
+public final class RemoteMainReplica implements MainReplica {
 
   private final Reader in;
   private final Writer out;
+  private final String entityType;
 
   private SyncWire.Fetched fetched;
   private long maxSeq;
 
-  public RemoteMainReplica(Reader in, Writer out) {
+  public RemoteMainReplica(Reader in, Writer out, String entityType) {
     this.in = Objects.requireNonNull(in, "in");
     this.out = Objects.requireNonNull(out, "out");
+    this.entityType = Objects.requireNonNull(entityType, "entityType");
   }
 
   @Override
@@ -68,7 +69,8 @@ public final class RemoteMainReplica implements MainReplica, AutoCloseable {
 
   @Override
   public CommitOutcome commit(String entityId, Map<String, Object> snapshot, String expectedRev) {
-    var response = exchange(new SyncWire.Commit(entityId, snapshot, expectedRev));
+    var response =
+        Rpc.exchange(in, out, new SyncWire.Commit(entityType, entityId, snapshot, expectedRev));
     return switch (response) {
       case SyncWire.Committed committed -> {
         maxSeq = committed.maxSeq();
@@ -81,29 +83,9 @@ public final class RemoteMainReplica implements MainReplica, AutoCloseable {
     };
   }
 
-  /** Pulls main's FDE roster over the same channel; the node mirrors it main-authoritatively. */
-  public List<Map<String, Object>> fetchFdes() {
-    var response = exchange(new SyncWire.FetchFdes());
-    if (response instanceof SyncWire.Fdes roster) {
-      return roster.fdes();
-    }
-    throw new SyncTransportException("Expected an fde roster, got: " + response);
-  }
-
-  @Override
-  public void close() {
-    try {
-      out.write(SyncWire.encode(new SyncWire.Bye()));
-      out.write('\n');
-      out.flush();
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
-  }
-
   private SyncWire.Fetched fetched() {
     if (fetched == null) {
-      var response = exchange(new SyncWire.Fetch());
+      var response = Rpc.exchange(in, out, new SyncWire.Fetch(entityType));
       if (!(response instanceof SyncWire.Fetched f)) {
         throw new SyncTransportException("Expected a fetch response, got: " + response);
       }
@@ -111,20 +93,5 @@ public final class RemoteMainReplica implements MainReplica, AutoCloseable {
       maxSeq = f.maxSeq();
     }
     return fetched;
-  }
-
-  private SyncWire.Response exchange(SyncWire.Request request) {
-    try {
-      out.write(SyncWire.encode(request));
-      out.write('\n');
-      out.flush();
-      var line = SyncWire.readFramed(in);
-      if (line == null) {
-        throw new SyncTransportException("Sync channel closed before main replied.");
-      }
-      return SyncWire.decodeResponse(line);
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/sync/Rpc.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/Rpc.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+
+/**
+ * The node's side of one framed request/response over a sync channel — shared by the typed {@link
+ * RemoteMainReplica}s and the {@link SyncSession} that wraps them, so the encode/flush/read/decode
+ * dance has a single definition. Sequential by contract: one exchange completes before the next
+ * starts, so several typed replicas can ride the same reader/writer.
+ */
+final class Rpc {
+
+  private Rpc() {}
+
+  static SyncWire.Response exchange(Reader in, Writer out, SyncWire.Request request) {
+    send(out, request);
+    try {
+      var line = SyncWire.readFramed(in);
+      if (line == null) {
+        throw new SyncTransportException("Sync channel closed before main replied.");
+      }
+      return SyncWire.decodeResponse(line);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  static void send(Writer out, SyncWire.Request request) {
+    try {
+      out.write(SyncWire.encode(request));
+      out.write('\n');
+      out.flush();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
@@ -9,28 +9,33 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
- * Main's side of one sync session: a stateless request loop over the SSH channel's stdio. It serves
- * a node's {@link SyncWire.Fetch} from the authoritative {@link MainReplica}, mints a rev for each
- * accepted {@link SyncWire.Commit}, and returns at {@link SyncWire.Bye} or end of stream. The
- * {@code writable} gate is the push half of Door-2 authorization: a {@code viewer} opens a session
- * and pulls, but its commits are refused so only {@code member}+ work propagates to the shared
- * board.
+ * Main's side of one sync session: a stateless request loop over the SSH channel's stdio. It routes
+ * each {@link SyncWire.Fetch}/{@link SyncWire.Commit} to the authoritative {@link MainReplica} for
+ * its entity type (specs, files), serves the node's roster pull, and returns at {@link
+ * SyncWire.Bye} or end of stream. The {@code writable} gate is the push half of Door-2
+ * authorization: a {@code viewer} opens a session and pulls every type, but its commits are refused
+ * so only {@code member}+ work propagates.
  */
 public final class SyncRpcServer {
 
-  private final MainReplica main;
+  private final Map<String, MainReplica> replicas;
   private final boolean writable;
   private final FdeRoster fdeRoster;
 
   public SyncRpcServer(MainReplica main, boolean writable) {
-    this(main, writable, FdeRoster.EMPTY);
+    this(Map.of("spec", main), writable, FdeRoster.EMPTY);
   }
 
   public SyncRpcServer(MainReplica main, boolean writable, FdeRoster fdeRoster) {
-    this.main = Objects.requireNonNull(main, "main");
+    this(Map.of("spec", main), writable, fdeRoster);
+  }
+
+  public SyncRpcServer(Map<String, MainReplica> replicas, boolean writable, FdeRoster fdeRoster) {
+    this.replicas = Map.copyOf(replicas);
     this.writable = writable;
     this.fdeRoster = Objects.requireNonNull(fdeRoster, "fdeRoster");
   }
@@ -41,7 +46,7 @@ public final class SyncRpcServer {
         case SyncWire.Bye ignored -> {
           return;
         }
-        case SyncWire.Fetch ignored -> reply(out, fetched());
+        case SyncWire.Fetch fetch -> reply(out, fetched(fetch.entityType()));
         case SyncWire.FetchFdes ignored -> reply(out, new SyncWire.Fdes(fdeRoster.entries()));
         case SyncWire.Commit commit -> reply(out, onCommit(commit));
       }
@@ -54,7 +59,11 @@ public final class SyncRpcServer {
     out.flush();
   }
 
-  private SyncWire.Fetched fetched() {
+  private SyncWire.Response fetched(String entityType) {
+    var main = replicas.get(entityType);
+    if (main == null) {
+      return new SyncWire.Failed("Unknown entity type: " + entityType);
+    }
     var entities = new LinkedHashMap<String, SyncWire.Snapshot>();
     for (var id : main.entityIds()) {
       entities.put(id, new SyncWire.Snapshot(main.currentRev(id), main.current(id)));
@@ -66,6 +75,10 @@ public final class SyncRpcServer {
     if (!writable) {
       return new SyncWire.Failed(
           "Your role is read-only: it can pull the shared board but not push changes.");
+    }
+    var main = replicas.get(commit.entityType());
+    if (main == null) {
+      return new SyncWire.Failed("Unknown entity type: " + commit.entityType());
     }
     return switch (main.commit(commit.entityId(), commit.snapshot(), commit.expectedRev())) {
       case CommitOutcome.Accepted accepted -> new SyncWire.Committed(accepted.rev(), main.maxSeq());

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncSession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncSession.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import java.io.Reader;
+import java.io.Writer;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * One node-to-main sync session over a channel: it hands out a {@link RemoteMainReplica} per entity
+ * type (specs, then files) that the engine reconciles in turn, pulls the FDE roster, and ends the
+ * session with {@link SyncWire.Bye} on {@link #close}. All exchanges share the one reader/writer
+ * and run sequentially, so the typed replicas never interleave on the wire.
+ */
+public final class SyncSession implements AutoCloseable {
+
+  private final Reader in;
+  private final Writer out;
+
+  public SyncSession(Reader in, Writer out) {
+    this.in = Objects.requireNonNull(in, "in");
+    this.out = Objects.requireNonNull(out, "out");
+  }
+
+  /** A remote view of main's entities of {@code entityType} for this session's channel. */
+  public RemoteMainReplica replica(String entityType) {
+    return new RemoteMainReplica(in, out, entityType);
+  }
+
+  /** Pulls main's FDE roster; the node mirrors it main-authoritatively. */
+  public List<Map<String, Object>> fetchFdes() {
+    var response = Rpc.exchange(in, out, new SyncWire.FetchFdes());
+    if (response instanceof SyncWire.Fdes roster) {
+      return roster.fdes();
+    }
+    throw new SyncTransportException("Expected an fde roster, got: " + response);
+  }
+
+  @Override
+  public void close() {
+    Rpc.send(out, new SyncWire.Bye());
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncWire.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncWire.java
@@ -34,6 +34,7 @@ public final class SyncWire {
   private static final String ERROR = "error";
   private static final String EXPECTED = "expectedRev";
   private static final String STALE = "stale";
+  private static final String ENTITY_TYPE = "entityType";
 
   private static final String OP_FETCH = "fetch";
   private static final String OP_COMMIT = "commit";
@@ -75,17 +76,20 @@ public final class SyncWire {
 
   public sealed interface Request permits Fetch, Commit, Bye, FetchFdes {}
 
-  /** Ask main for its whole shared state — the merge view the engine reconciles against. */
-  public record Fetch() implements Request {}
+  /**
+   * Ask main for its whole shared state of one entity type — specs, files — to reconcile against.
+   */
+  public record Fetch(String entityType) implements Request {}
 
   /** Ask main for its FDE roster, which the node mirrors (main-authoritative, one-way). */
   public record FetchFdes() implements Request {}
 
   /**
-   * Push one entity to main against the rev the node fetched ({@code expectedRev}, {@code null} for
-   * a row new to main); a {@code null} snapshot pushes a deletion.
+   * Push one entity of {@code entityType} to main against the rev the node fetched ({@code
+   * expectedRev}, {@code null} for a row new to main); a {@code null} snapshot pushes a deletion.
    */
-  public record Commit(String entityId, Map<String, Object> snapshot, String expectedRev)
+  public record Commit(
+      String entityType, String entityId, Map<String, Object> snapshot, String expectedRev)
       implements Request {}
 
   /** End the session; main returns nothing. */
@@ -116,9 +120,13 @@ public final class SyncWire {
   public static String encode(Request request) {
     var map = new LinkedHashMap<String, Object>();
     switch (request) {
-      case Fetch ignored -> map.put(OP, OP_FETCH);
+      case Fetch fetch -> {
+        map.put(OP, OP_FETCH);
+        map.put(ENTITY_TYPE, fetch.entityType());
+      }
       case Commit commit -> {
         map.put(OP, OP_COMMIT);
+        map.put(ENTITY_TYPE, commit.entityType());
         map.put(ID, commit.entityId());
         map.put(SNAPSHOT, commit.snapshot());
         map.put(EXPECTED, commit.expectedRev());
@@ -166,8 +174,13 @@ public final class SyncWire {
     var map = YamlUtil.parseMap(line);
     var op = string(map, OP);
     return switch (op) {
-      case OP_FETCH -> new Fetch();
-      case OP_COMMIT -> new Commit(string(map, ID), snapshot(map, SNAPSHOT), string(map, EXPECTED));
+      case OP_FETCH -> new Fetch(string(map, ENTITY_TYPE));
+      case OP_COMMIT ->
+          new Commit(
+              string(map, ENTITY_TYPE),
+              string(map, ID),
+              snapshot(map, SNAPSHOT),
+              string(map, EXPECTED));
       case OP_BYE -> new Bye();
       case OP_FETCH_FDES -> new FetchFdes();
       case null, default -> throw new IllegalArgumentException("Unknown sync op: " + op);

--- a/sail-core/src/test/java/ai/singlr/sail/store/FileStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FileStoreTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FileStoreTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private FileStore files;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    files = new FileStore(db);
+  }
+
+  @AfterEach
+  void tearDown() {
+    db.close();
+  }
+
+  private String id(String path) {
+    return FileStore.idOf("acme", path);
+  }
+
+  @Test
+  void putAndFindAndList() {
+    files.put("acme", "a.txt", "AAA");
+    files.put("acme", "dir/b.txt", "BBB");
+
+    assertEquals("AAA", files.find("acme", "a.txt").orElseThrow().content());
+    assertEquals(
+        List.of("a.txt", "dir/b.txt"),
+        files.list("acme").stream().map(FileStore.FileRow::path).toList());
+  }
+
+  @Test
+  void deleteReturnsFalseWhenAbsentAndTrueWhenPresent() {
+    assertFalse(files.delete("acme", "missing"));
+    files.put("acme", "a.txt", "AAA");
+    assertTrue(files.delete("acme", "a.txt"));
+    assertTrue(files.find("acme", "a.txt").isEmpty());
+  }
+
+  @Test
+  void comparableSnapshotAndAtRev() {
+    files.put("acme", "a.txt", "AAA");
+    var rev = files.latestRev(id("a.txt"));
+
+    assertEquals("AAA", files.comparableSnapshot(id("a.txt")).get("content"));
+    assertEquals("AAA", files.comparableAtRev(id("a.txt"), rev).get("content"));
+    assertNull(files.comparableAtRev(id("a.txt"), null));
+    assertNull(files.comparableSnapshot(id("missing")));
+  }
+
+  @Test
+  void baseRevOfRecoversTheTombstoneBaseForADeletedFile() {
+    files.applyRevision(id("a.txt"), Map.of("content", "AAA"), "1-base");
+    assertEquals("1-base", files.baseRevOf(id("a.txt")));
+
+    files.delete("acme", "a.txt");
+    assertEquals("1-base", files.baseRevOf(id("a.txt")), "base recovered from the tombstone");
+  }
+
+  @Test
+  void commitAcceptsWhenExpectedRevMatches() {
+    files.applyRevision(id("a.txt"), Map.of("content", "AAA"), "1-base");
+
+    var outcome = files.commitRevision(id("a.txt"), Map.of("content", "BBB"), "1-base");
+
+    assertInstanceOf(PushOutcome.Accepted.class, outcome);
+    assertEquals("BBB", files.find("acme", "a.txt").orElseThrow().content());
+  }
+
+  @Test
+  void commitRejectsAStalePushAndLeavesTheFileUntouched() {
+    files.applyRevision(id("a.txt"), Map.of("content", "AAA"), "1-base");
+
+    var outcome = files.commitRevision(id("a.txt"), Map.of("content", "BBB"), "9-stale");
+
+    var stale = assertInstanceOf(PushOutcome.Stale.class, outcome);
+    assertEquals("1-base", stale.currentRev());
+    assertEquals("AAA", stale.currentSnapshot().get("content"));
+    assertEquals("AAA", files.find("acme", "a.txt").orElseThrow().content());
+  }
+
+  @Test
+  void committingADeleteOfAnAbsentFileIsANoOpAccept() {
+    assertInstanceOf(PushOutcome.Accepted.class, files.commitRevision(id("ghost"), null, null));
+    assertTrue(files.find("acme", "ghost").isEmpty());
+  }
+
+  @Test
+  void comparableAtRevWithABlankRevIsNull() {
+    assertNull(files.comparableAtRev(id("a.txt"), "  "));
+  }
+
+  @Test
+  void baseRevOfADeletedLocalFileIsNull() {
+    files.put("acme", "a.txt", "AAA");
+    files.delete("acme", "a.txt");
+    assertNull(files.baseRevOf(id("a.txt")), "a locally-created file has no synced base");
+  }
+
+  @Test
+  void aSnapshotMissingContentIsRejected() {
+    var snapshot = new java.util.HashMap<String, Object>();
+    snapshot.put("content", null);
+    assertThrows(RuntimeException.class, () -> files.applyRevision(id("a.txt"), snapshot, "1-x"));
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/FileStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FileStoreTest.java
@@ -122,4 +122,35 @@ class FileStoreTest {
     snapshot.put("content", null);
     assertThrows(RuntimeException.class, () -> files.applyRevision(id("a.txt"), snapshot, "1-x"));
   }
+
+  @Test
+  void idsForProjectIncludesTombstonedFiles() {
+    files.put("acme", "a.txt", "AAA");
+    files.put("acme", "dir/b.txt", "BBB");
+    files.put("globex", "c.txt", "CCC");
+    files.delete("acme", "a.txt");
+
+    assertEquals(
+        List.of("acme/a.txt", "acme/dir/b.txt"),
+        files.idsForProject("acme").stream().sorted().toList());
+  }
+
+  @Test
+  void projectsWithFilesSpansEveryProjectTouched() {
+    files.put("acme", "a.txt", "AAA");
+    files.put("globex", "c.txt", "CCC");
+    files.delete("globex", "c.txt");
+
+    assertEquals(java.util.Set.of("acme", "globex"), files.projectsWithFiles());
+  }
+
+  @Test
+  void isKnownContentRecognizesAnyRevisionThisBoxWrote() {
+    files.put("acme", "a.txt", "v1");
+    files.put("acme", "a.txt", "v2");
+
+    assertTrue(files.isKnownContent(id("a.txt"), "v1"), "a superseded revision is still ours");
+    assertTrue(files.isKnownContent(id("a.txt"), "v2"));
+    assertFalse(files.isKnownContent(id("a.txt"), "a local human edit"));
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/store/FileStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FileStoreTest.java
@@ -153,4 +153,54 @@ class FileStoreTest {
     assertTrue(files.isKnownContent(id("a.txt"), "v2"));
     assertFalse(files.isKnownContent(id("a.txt"), "a local human edit"));
   }
+
+  @Test
+  void resolveTakeTheirsAdoptsMainAndCannotReRaise() {
+    files.put("acme", "a.txt", "mine");
+
+    var rev =
+        files.resolveConflict(
+            id("a.txt"), Map.of("content", "theirs"), Map.of("content", "theirs"));
+
+    assertEquals("theirs", files.find("acme", "a.txt").orElseThrow().content());
+    assertEquals(rev, files.baseRevOf(id("a.txt")), "base now equals theirs, so no re-raise");
+  }
+
+  @Test
+  void resolveKeepMineRebasesOntoTheirsAndPushesMineForward() {
+    files.put("acme", "a.txt", "mine");
+
+    files.resolveConflict(id("a.txt"), Map.of("content", "mine"), Map.of("content", "theirs"));
+
+    assertEquals("mine", files.find("acme", "a.txt").orElseThrow().content());
+    assertTrue(files.isKnownContent(id("a.txt"), "theirs"), "theirs is journaled as the base");
+  }
+
+  @Test
+  void resolveTakeTheirsWhereTheirsIsADeleteRemovesTheRow() {
+    files.put("acme", "a.txt", "mine");
+
+    files.resolveConflict(id("a.txt"), null, null);
+
+    assertTrue(files.find("acme", "a.txt").isEmpty());
+  }
+
+  @Test
+  void resolveKeepMineWhereTheirsIsADeleteRestoresMine() {
+    files.applyRevision(id("a.txt"), Map.of("content", "base"), "1-base");
+    files.put("acme", "a.txt", "mine");
+
+    files.resolveConflict(id("a.txt"), Map.of("content", "mine"), null);
+
+    assertEquals("mine", files.find("acme", "a.txt").orElseThrow().content());
+  }
+
+  @Test
+  void resolveDeleteMineWhereTheirsEditsTombstonesTheRow() {
+    files.applyRevision(id("a.txt"), Map.of("content", "base"), "1-base");
+
+    files.resolveConflict(id("a.txt"), null, Map.of("content", "theirs"));
+
+    assertTrue(files.find("acme", "a.txt").isEmpty());
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/sync/FileSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/FileSyncTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sail.store.ChangeLog;
+import ai.singlr.sail.store.FileStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import ai.singlr.sail.store.SyncConflicts;
+import ai.singlr.sail.store.SyncState;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Shared project files reconcile bidirectionally through the same {@link SyncEngine} as specs: a
+ * file created on one box propagates to the other, two FDEs editing <em>different</em> files
+ * auto-converge, and two editing the <em>same</em> file conflict on its content with the local copy
+ * left untouched — exactly the per-file granularity the design buys.
+ */
+class FileSyncTest {
+
+  @TempDir Path tempDir;
+  private final SyncEngine engine = new SyncEngine();
+
+  private Box main;
+  private Box node;
+  private Box other;
+
+  private final class Box implements AutoCloseable {
+    final Sqlite db;
+    final FileStore files;
+    final SyncConflicts conflicts;
+    final FileReplica replica;
+
+    Box(String id) {
+      this.db = Sqlite.open(tempDir.resolve(id + ".db"));
+      new SchemaManager(db).migrate();
+      this.files = new FileStore(db);
+      this.conflicts = new SyncConflicts(db);
+      this.replica = new FileReplica(id, files, new ChangeLog(db), conflicts, new SyncState(db));
+    }
+
+    @Override
+    public void close() {
+      db.close();
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    main = new Box("main");
+    node = new Box("node");
+    other = new Box("other");
+  }
+
+  @AfterEach
+  void tearDown() {
+    other.close();
+    node.close();
+    main.close();
+  }
+
+  private void sync(Box box) {
+    engine.reconcile(box.replica, main.replica);
+  }
+
+  @Test
+  void aFileCreatedOnOneBoxPropagatesToTheOther() {
+    node.files.put("acme", "scripts/deploy.sh", "ZGVwbG95");
+
+    sync(node);
+    assertEquals("ZGVwbG95", main.files.find("acme", "scripts/deploy.sh").orElseThrow().content());
+
+    sync(other);
+    assertEquals("ZGVwbG95", other.files.find("acme", "scripts/deploy.sh").orElseThrow().content());
+  }
+
+  @Test
+  void editsToDifferentFilesAutoConvergeWithoutConflict() {
+    node.files.put("acme", "a.txt", "AAA");
+    sync(node);
+    sync(other);
+
+    node.files.put("acme", "a.txt", "AAA2");
+    other.files.put("acme", "b.txt", "BBB");
+
+    sync(node);
+    sync(other);
+    sync(node);
+
+    assertEquals("AAA2", node.files.find("acme", "a.txt").orElseThrow().content());
+    assertEquals("BBB", node.files.find("acme", "b.txt").orElseThrow().content());
+    assertEquals("BBB", other.files.find("acme", "b.txt").orElseThrow().content());
+    assertTrue(node.conflicts.pending().isEmpty());
+    assertTrue(other.conflicts.pending().isEmpty());
+  }
+
+  @Test
+  void editsToTheSameFileConflictAndLeaveTheLocalCopyUntouched() {
+    node.files.put("acme", "shared.conf", "v1");
+    sync(node);
+    sync(other);
+
+    node.files.put("acme", "shared.conf", "from-node");
+    other.files.put("acme", "shared.conf", "from-other");
+
+    sync(node);
+    var report = sync2(other);
+
+    assertEquals(1, report.conflicts());
+    assertEquals("from-node", main.files.find("acme", "shared.conf").orElseThrow().content());
+    var pending = other.conflicts.pendingFor("file", FileStore.idOf("acme", "shared.conf"));
+    assertEquals(List.of("content"), pending.orElseThrow().fields());
+    assertEquals("from-other", other.files.find("acme", "shared.conf").orElseThrow().content());
+  }
+
+  @Test
+  void twoBoxesCreatingTheSameFilePathConflictWithNoCommonBase() {
+    node.files.put("acme", "shared.conf", "from-node");
+    other.files.put("acme", "shared.conf", "from-other");
+
+    sync(node);
+    var report = sync2(other);
+
+    assertEquals(1, report.conflicts());
+    assertEquals(
+        List.of("content"),
+        other
+            .conflicts
+            .pendingFor("file", FileStore.idOf("acme", "shared.conf"))
+            .orElseThrow()
+            .fields());
+  }
+
+  @Test
+  void aDeleteOnOneBoxPropagates() {
+    node.files.put("acme", "old.txt", "x");
+    sync(node);
+    sync(other);
+
+    assertTrue(node.files.delete("acme", "old.txt"));
+    sync(node);
+    assertTrue(main.files.find("acme", "old.txt").isEmpty());
+
+    sync(other);
+    assertTrue(other.files.find("acme", "old.txt").isEmpty());
+  }
+
+  @Test
+  void aStaleCommitOnTheFileReplicaIsRejected() {
+    var id = FileStore.idOf("acme", "a.txt");
+    node.files.applyRevision(id, java.util.Map.of("content", "AAA"), "1-base");
+
+    var outcome = node.replica.commit(id, java.util.Map.of("content", "BBB"), "9-stale");
+
+    assertInstanceOf(CommitOutcome.Rejected.class, outcome);
+    assertEquals("AAA", node.files.find("acme", "a.txt").orElseThrow().content());
+  }
+
+  private SyncEngine.Report sync2(Box box) {
+    return engine.reconcile(box.replica, main.replica);
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/sync/RemoteMainReplicaTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/RemoteMainReplicaTest.java
@@ -13,19 +13,18 @@ import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 /**
- * The client side in isolation: a canned server reply drives {@link RemoteMainReplica} so its
- * caching and every protocol-violation guard are exercised without a real channel.
+ * The client side in isolation: a canned server reply drives a typed {@link RemoteMainReplica} so
+ * its caching and every protocol-violation guard are exercised without a real channel.
  */
 class RemoteMainReplicaTest {
 
   private static RemoteMainReplica replica(String serverLine) {
-    return new RemoteMainReplica(new StringReader(serverLine + "\n"), new StringWriter());
+    return new RemoteMainReplica(new StringReader(serverLine + "\n"), new StringWriter(), "spec");
   }
 
   @Test
@@ -63,46 +62,33 @@ class RemoteMainReplicaTest {
   }
 
   @Test
-  void fetchFdesReturnsMainsRoster() {
-    var roster = List.<Map<String, Object>>of(Map.of("handle", "ada", "role", "admin"));
-    var replica = replica(SyncWire.encode(new SyncWire.Fdes(roster)));
-
-    var pulled = replica.fetchFdes();
-    assertEquals(1, pulled.size());
-    assertEquals("ada", pulled.getFirst().get("handle"));
-  }
-
-  @Test
-  void aNonRosterReplyToFetchFdesIsRejected() {
-    var replica = replica(SyncWire.encode(new SyncWire.Committed("1-a", 1)));
-    assertThrows(SyncTransportException.class, replica::fetchFdes);
-  }
-
-  @Test
   void aChannelClosedBeforeAReplyIsReported() {
-    var replica = new RemoteMainReplica(new StringReader(""), new StringWriter());
+    var replica = new RemoteMainReplica(new StringReader(""), new StringWriter(), "spec");
     assertThrows(SyncTransportException.class, replica::entityIds);
   }
 
   @Test
-  void closeSendsBye() {
-    var out = new StringWriter();
-    try (var replica = new RemoteMainReplica(new StringReader(""), out)) {
-      assertNotNull(replica);
-    }
-    assertEquals(new SyncWire.Bye(), SyncWire.decodeRequest(out.toString().strip()));
-  }
-
-  @Test
   void aBrokenChannelOnSendRaisesUnchecked() {
-    var replica = new RemoteMainReplica(new StringReader(""), brokenWriter());
+    var replica = new RemoteMainReplica(new StringReader(""), brokenWriter(), "spec");
     assertThrows(UncheckedIOException.class, replica::entityIds);
   }
 
   @Test
-  void aBrokenChannelOnCloseRaisesUnchecked() {
-    var replica = new RemoteMainReplica(new StringReader(""), brokenWriter());
-    assertThrows(UncheckedIOException.class, replica::close);
+  void aBrokenChannelOnReadRaisesUnchecked() {
+    var replica = new RemoteMainReplica(brokenReader(), new StringWriter(), "spec");
+    assertThrows(UncheckedIOException.class, replica::entityIds);
+  }
+
+  private static java.io.Reader brokenReader() {
+    return new java.io.Reader() {
+      @Override
+      public int read(char[] buffer, int offset, int length) throws IOException {
+        throw new IOException("channel down");
+      }
+
+      @Override
+      public void close() {}
+    };
   }
 
   private static Writer brokenWriter() {

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
@@ -64,18 +64,19 @@ class SyncRpcServerTest {
 
   @Test
   void fetchIsAnswered() throws Exception {
-    assertInstanceOf(SyncWire.Fetched.class, serve(true, new SyncWire.Fetch()));
+    assertInstanceOf(SyncWire.Fetched.class, serve(true, new SyncWire.Fetch("spec")));
   }
 
   @Test
   void aWritableServerAcceptsACommit() throws Exception {
-    var response = serve(true, new SyncWire.Commit("a", Map.of(), null));
+    var response = serve(true, new SyncWire.Commit("spec", "a", Map.of(), null));
     assertEquals("1-x", assertInstanceOf(SyncWire.Committed.class, response).rev());
   }
 
   @Test
   void aReadOnlyServerRefusesACommit() throws Exception {
-    assertInstanceOf(SyncWire.Failed.class, serve(false, new SyncWire.Commit("a", Map.of(), null)));
+    assertInstanceOf(
+        SyncWire.Failed.class, serve(false, new SyncWire.Commit("spec", "a", Map.of(), null)));
   }
 
   @Test
@@ -92,5 +93,16 @@ class SyncRpcServerTest {
   @Test
   void fetchFdesDefaultsToAnEmptyRoster() throws Exception {
     assertInstanceOf(SyncWire.Fdes.class, serve(true, new SyncWire.FetchFdes()));
+  }
+
+  @Test
+  void anUnknownEntityTypeFetchIsRefused() throws Exception {
+    assertInstanceOf(SyncWire.Failed.class, serve(true, new SyncWire.Fetch("bogus")));
+  }
+
+  @Test
+  void anUnknownEntityTypeCommitIsRefused() throws Exception {
+    assertInstanceOf(
+        SyncWire.Failed.class, serve(true, new SyncWire.Commit("bogus", "a", Map.of(), null)));
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncSessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncSessionTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** The session that wraps a channel: typed replicas, the roster pull, and the closing bye. */
+class SyncSessionTest {
+
+  @Test
+  void fetchFdesReturnsMainsRoster() {
+    var roster = List.<Map<String, Object>>of(Map.of("handle", "ada", "role", "admin"));
+    try (var session =
+        new SyncSession(
+            new StringReader(SyncWire.encode(new SyncWire.Fdes(roster)) + "\n"),
+            new StringWriter())) {
+      var pulled = session.fetchFdes();
+      assertEquals(1, pulled.size());
+      assertEquals("ada", pulled.getFirst().get("handle"));
+    }
+  }
+
+  @Test
+  void aNonRosterReplyToFetchFdesIsRejected() {
+    try (var session =
+        new SyncSession(
+            new StringReader(SyncWire.encode(new SyncWire.Committed("1-a", 1)) + "\n"),
+            new StringWriter())) {
+      assertThrows(SyncTransportException.class, session::fetchFdes);
+    }
+  }
+
+  @Test
+  void closeSendsBye() {
+    var out = new StringWriter();
+    try (var session = new SyncSession(new StringReader(""), out)) {
+      assertNotNull(session.replica("spec"));
+    }
+    assertEquals(new SyncWire.Bye(), SyncWire.decodeRequest(out.toString().strip()));
+  }
+
+  @Test
+  void aBrokenChannelOnCloseRaisesUnchecked() {
+    var session = new SyncSession(new StringReader(""), brokenWriter());
+    assertThrows(UncheckedIOException.class, session::close);
+  }
+
+  private static Writer brokenWriter() {
+    return new Writer() {
+      @Override
+      public void write(char[] buffer, int offset, int length) throws IOException {
+        throw new IOException("channel down");
+      }
+
+      @Override
+      public void flush() throws IOException {
+        throw new IOException("channel down");
+      }
+
+      @Override
+      public void close() {}
+    };
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncTransportTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncTransportTest.java
@@ -8,7 +8,11 @@ package ai.singlr.sail.sync;
 import static org.junit.jupiter.api.Assertions.*;
 
 import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.store.ChangeLog;
+import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.SyncConflicts;
+import ai.singlr.sail.store.SyncState;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PipedReader;
@@ -16,6 +20,7 @@ import java.io.PipedWriter;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -79,14 +84,61 @@ class SyncTransportTest {
                   }
                 });
 
-    try (var remote = new RemoteMainReplica(clientIn, toServer)) {
-      engine.reconcile(nodeA.replica, remote);
-      var pulled = remote.fetchFdes();
+    try (var session = new SyncSession(clientIn, toServer)) {
+      engine.reconcile(nodeA.replica, session.replica("spec"));
+      var pulled = session.fetchFdes();
       assertEquals(1, pulled.size());
       assertEquals("ada", pulled.getFirst().get("handle"));
     } finally {
       serverThread.join();
     }
+  }
+
+  @Test
+  void specsAndFilesReconcileOverTheWireInOneSession() throws Exception {
+    var mainFiles = new FileStore(main.db);
+    var nodeFiles = new FileStore(nodeA.db);
+    var nodeFileReplica =
+        new FileReplica(
+            "A", nodeFiles, new ChangeLog(nodeA.db), nodeA.conflicts, new SyncState(nodeA.db));
+    var mainFileReplica =
+        new FileReplica(
+            "main",
+            mainFiles,
+            new ChangeLog(main.db),
+            new SyncConflicts(main.db),
+            new SyncState(main.db));
+
+    nodeA.specs.create(spec("auth", "Auth", "pending"));
+    nodeFiles.put("acme", "scripts/deploy.sh", "ZGVwbG95");
+
+    var toServer = new PipedWriter();
+    var serverIn = new BufferedReader(new PipedReader(toServer));
+    var toClient = new PipedWriter();
+    var clientIn = new BufferedReader(new PipedReader(toClient));
+    var server =
+        new SyncRpcServer(
+            Map.of("spec", main.replica, "file", mainFileReplica), true, FdeRoster.EMPTY);
+    var serverThread =
+        Thread.ofVirtual()
+            .start(
+                () -> {
+                  try {
+                    server.serve(serverIn, toClient);
+                  } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                  }
+                });
+
+    try (var session = new SyncSession(clientIn, toServer)) {
+      engine.reconcile(nodeA.replica, session.replica("spec"));
+      engine.reconcile(nodeFileReplica, session.replica("file"));
+    } finally {
+      serverThread.join();
+    }
+
+    assertEquals("Auth", main.specs.findById("auth").orElseThrow().title());
+    assertEquals("ZGVwbG95", mainFiles.find("acme", "scripts/deploy.sh").orElseThrow().content());
   }
 
   private SyncEngine.Report syncOverWire(SyncBox node, boolean writable) throws Exception {
@@ -107,8 +159,8 @@ class SyncTransportTest {
                   }
                 });
 
-    try (var remote = new RemoteMainReplica(clientIn, toServer)) {
-      return engine.reconcile(node.replica, remote);
+    try (var session = new SyncSession(clientIn, toServer)) {
+      return engine.reconcile(node.replica, session.replica("spec"));
     } finally {
       serverThread.join();
     }
@@ -245,7 +297,8 @@ class SyncTransportTest {
                   }
                 });
 
-    try (var remoteA = new RemoteMainReplica(clientIn, toServer)) {
+    try (var session = new SyncSession(clientIn, toServer)) {
+      var remoteA = session.replica("spec");
       remoteA.entityIds();
       syncToMain(nodeB);
       var report = engine.reconcile(nodeA.replica, remoteA);

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncWireTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncWireTest.java
@@ -28,9 +28,9 @@ class SyncWireTest {
   }
 
   @Test
-  void fetchRequestRoundTrips() {
-    var line = SyncWire.encode(new SyncWire.Fetch());
-    assertEquals(new SyncWire.Fetch(), SyncWire.decodeRequest(line));
+  void fetchRequestRoundTripsWithItsEntityType() {
+    var line = SyncWire.encode(new SyncWire.Fetch("file"));
+    assertEquals(new SyncWire.Fetch("file"), SyncWire.decodeRequest(line));
   }
 
   @Test
@@ -73,10 +73,11 @@ class SyncWireTest {
 
   @Test
   void commitRequestRoundTripsWithNestedSnapshotOnOneLine() {
-    var line = SyncWire.encode(new SyncWire.Commit("auth", snapshot(), "2-base"));
+    var line = SyncWire.encode(new SyncWire.Commit("spec", "auth", snapshot(), "2-base"));
 
     assertFalse(line.contains("\n"), "a spec body's newlines must be escaped, never framed");
     var decoded = (SyncWire.Commit) SyncWire.decodeRequest(line);
+    assertEquals("spec", decoded.entityType());
     assertEquals("auth", decoded.entityId());
     assertEquals("2-base", decoded.expectedRev());
     assertEquals("Auth", decoded.snapshot().get("title"));
@@ -87,8 +88,9 @@ class SyncWireTest {
 
   @Test
   void commitRequestCarriesDeletionAsExplicitNull() {
-    var line = SyncWire.encode(new SyncWire.Commit("auth", null, null));
+    var line = SyncWire.encode(new SyncWire.Commit("file", "acme/x", null, null));
     var decoded = (SyncWire.Commit) SyncWire.decodeRequest(line);
+    assertEquals("file", decoded.entityType());
     assertNull(decoded.snapshot());
     assertNull(decoded.expectedRev());
   }

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.71</version>
+        <version>0.13.72</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.71</version>
+        <version>0.13.72</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ConflictsCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ConflictsCommand.java
@@ -8,13 +8,17 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.store.ConflictResolver;
+import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.SyncConflicts;
 import ai.singlr.sail.sync.ConflictMerge;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,11 +29,13 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 /**
- * Lists and resolves the sync conflicts parked on this box. A conflict is opened only when a remote
- * change clashes with a local edit on the same field (or a delete races an edit); the local row is
- * never touched while it is open. {@code resolve} rebases the row onto main's version and writes
- * the chosen value, so a follow-up {@code sail sync} converges and the conflict cannot re-raise —
- * and every version stays in the change log, so no choice is destructive.
+ * Lists and resolves the sync conflicts parked on this box, across every synced entity type — specs
+ * and shared project files alike. A conflict is opened only when a remote change clashes with a
+ * local edit on the same field (or a delete races an edit); the local row is never touched while it
+ * is open. {@code resolve} rebases the row onto main's version and writes the chosen value, so a
+ * follow-up {@code sail sync} converges and the conflict cannot re-raise — and every version stays
+ * in the change log, so no choice is destructive. File content is an opaque blob, so a file
+ * conflict offers only {@code --mine}/{@code --theirs}, never a field-level {@code --merge}.
  */
 @Command(
     name = "conflicts",
@@ -38,7 +44,7 @@ import picocli.CommandLine.Parameters;
     subcommands = {ConflictsCommand.Show.class, ConflictsCommand.Resolve.class})
 public final class ConflictsCommand implements Callable<Integer> {
 
-  static final String ENTITY = "spec";
+  static final String FILE = "file";
 
   @Option(names = "--json", description = "Output the pending conflicts as JSON.")
   private boolean json;
@@ -59,6 +65,7 @@ public final class ConflictsCommand implements Callable<Integer> {
               .map(
                   c -> {
                     var row = new LinkedHashMap<String, Object>();
+                    row.put("type", c.entityType());
                     row.put("entity", c.entityId());
                     row.put("fields", c.fields());
                     row.put("detected_at", c.detectedAt());
@@ -76,7 +83,9 @@ public final class ConflictsCommand implements Callable<Integer> {
     for (var c : pending) {
       out.append(
           Ansi.AUTO.string(
-              "    @|yellow "
+              "    @|faint "
+                  + c.entityType()
+                  + "|@ @|yellow "
                   + c.entityId()
                   + "|@ — fields: "
                   + String.join(", ", c.fields())
@@ -89,22 +98,37 @@ public final class ConflictsCommand implements Callable<Integer> {
     return out.toString();
   }
 
+  /**
+   * The single open conflict for {@code entityId}, regardless of entity type. Spec and file ids
+   * share an {@code a/b} shape, so a rare cross-type id clash is reported rather than guessed.
+   */
+  static SyncConflicts.Conflict findUnique(SyncConflicts conflicts, String entityId) {
+    var matches = conflicts.pending().stream().filter(c -> c.entityId().equals(entityId)).toList();
+    if (matches.size() != 1) {
+      return null;
+    }
+    return matches.get(0);
+  }
+
+  static ConflictResolver resolverFor(Sqlite db, String entityType) {
+    return entityType.equals(FILE) ? new FileStore(db) : new SpecStore(db);
+  }
+
   @Command(
       name = "show",
       description = "Show the field-level diff of a conflict.",
       mixinStandardHelpOptions = true)
   static final class Show implements Callable<Integer> {
 
-    @Parameters(index = "0", description = "Spec id of the conflict.")
+    @Parameters(index = "0", description = "Entity id of the conflict.")
     private String entity;
 
     @Override
     public Integer call() {
       try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
-        var conflict = new SyncConflicts(db).pendingFor(ENTITY, entity).orElse(null);
+        var conflict = findUnique(new SyncConflicts(db), entity);
         if (conflict == null) {
-          System.err.println(
-              Banner.errorLine("No open conflict for spec '" + entity + "'.", Ansi.AUTO));
+          System.err.println(Banner.errorLine("No open conflict for '" + entity + "'.", Ansi.AUTO));
           return 1;
         }
         System.out.println(render(conflict));
@@ -113,6 +137,7 @@ public final class ConflictsCommand implements Callable<Integer> {
     }
 
     static String render(SyncConflicts.Conflict conflict) {
+      var isFile = conflict.entityType().equals(FILE);
       var diff =
           ConflictMerge.diff(
               parse(conflict.baseSnapshot()),
@@ -120,26 +145,54 @@ public final class ConflictsCommand implements Callable<Integer> {
               parse(conflict.remoteSnapshot()),
               conflict.fields());
       var out = new StringBuilder();
-      out.append(Ansi.AUTO.string("  Conflict on @|yellow " + conflict.entityId() + "|@:\n"));
+      out.append(
+          Ansi.AUTO.string(
+              "  Conflict on @|faint "
+                  + conflict.entityType()
+                  + "|@ @|yellow "
+                  + conflict.entityId()
+                  + "|@:\n"));
       for (var change : diff) {
         var marker =
             change.clash() ? Ansi.AUTO.string("@|red ✗|@") : Ansi.AUTO.string("@|green ·|@");
         out.append("    ").append(marker).append(' ').append(change.field()).append('\n');
-        out.append("        base:   ").append(ConflictMerge.render(change.base())).append('\n');
-        out.append("        mine:   ").append(ConflictMerge.render(change.mine())).append('\n');
-        out.append("        theirs: ").append(ConflictMerge.render(change.theirs())).append('\n');
+        out.append("        base:   ").append(show(change.base(), isFile)).append('\n');
+        out.append("        mine:   ").append(show(change.mine(), isFile)).append('\n');
+        out.append("        theirs: ").append(show(change.theirs(), isFile)).append('\n');
       }
       return out.toString().stripTrailing();
+    }
+
+    /** Renders a value, decoding a file's base64 content to readable text (or a binary summary). */
+    static String show(Object value, boolean isFile) {
+      if (!isFile || !(value instanceof String text) || text.isBlank()) {
+        return ConflictMerge.render(value);
+      }
+      var bytes = Base64.getDecoder().decode(text);
+      if (looksBinary(bytes)) {
+        return "<binary, " + bytes.length + " bytes>";
+      }
+      var decoded = new String(bytes, StandardCharsets.UTF_8);
+      return decoded.contains("\n") ? "\n" + decoded.stripTrailing() : decoded;
+    }
+
+    static boolean looksBinary(byte[] bytes) {
+      for (var b : bytes) {
+        if (b == 0 || (b > 0 && b < 0x09) || (b > 0x0d && b < 0x20)) {
+          return true;
+        }
+      }
+      return false;
     }
   }
 
   @Command(
       name = "resolve",
-      description = "Resolve a conflict: --mine, --theirs, or --merge.",
+      description = "Resolve a conflict: --mine, --theirs, or --merge (specs only).",
       mixinStandardHelpOptions = true)
   static final class Resolve implements Callable<Integer> {
 
-    @Parameters(index = "0", description = "Spec id of the conflict.")
+    @Parameters(index = "0", description = "Entity id of the conflict.")
     private String entity;
 
     @Option(names = "--mine", description = "Keep this box's version.")
@@ -170,10 +223,9 @@ public final class ConflictsCommand implements Callable<Integer> {
       }
       try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
         var conflicts = new SyncConflicts(db);
-        var conflict = conflicts.pendingFor(ENTITY, entity).orElse(null);
+        var conflict = findUnique(conflicts, entity);
         if (conflict == null) {
-          System.err.println(
-              Banner.errorLine("No open conflict for spec '" + entity + "'.", Ansi.AUTO));
+          System.err.println(Banner.errorLine("No open conflict for '" + entity + "'.", Ansi.AUTO));
           return 1;
         }
         String edited = null;
@@ -181,7 +233,7 @@ public final class ConflictsCommand implements Callable<Integer> {
           if (!mergeable(conflict)) {
             System.err.println(
                 Banner.errorLine(
-                    "--merge is not available for a delete-vs-edit conflict; use --mine or"
+                    "Field-level --merge isn't available for this conflict; use --mine or"
                         + " --theirs.",
                     Ansi.AUTO));
             return 1;
@@ -192,7 +244,7 @@ public final class ConflictsCommand implements Callable<Integer> {
           }
         }
         var chosen = choose(conflict, strategy, edited);
-        apply(new SpecStore(db), conflicts, conflict, chosen, parse(conflict.remoteSnapshot()));
+        apply(resolverFor(db, conflict.entityType()), conflicts, conflict, chosen);
         System.out.println(
             Ansi.AUTO.string(
                 "  @|green ✓|@ Resolved @|yellow "
@@ -214,10 +266,12 @@ public final class ConflictsCommand implements Callable<Integer> {
     }
 
     /**
-     * A field-level merge needs both sides present, so it is offered only outside delete-vs-edit.
+     * A field-level merge needs both sides present and a mergeable structure, so it is offered only
+     * for spec conflicts that are not delete-vs-edit. A file's content is an opaque blob.
      */
     static boolean mergeable(SyncConflicts.Conflict conflict) {
-      return parse(conflict.baseSnapshot()) != null
+      return !conflict.entityType().equals(FILE)
+          && parse(conflict.baseSnapshot()) != null
           && parse(conflict.localSnapshot()) != null
           && parse(conflict.remoteSnapshot()) != null;
     }
@@ -235,12 +289,12 @@ public final class ConflictsCommand implements Callable<Integer> {
     }
 
     static String apply(
-        SpecStore specs,
+        ConflictResolver resolver,
         SyncConflicts conflicts,
         SyncConflicts.Conflict conflict,
-        Map<String, Object> chosen,
-        Map<String, Object> remote) {
-      var rev = specs.resolveConflict(conflict.entityId(), chosen, remote);
+        Map<String, Object> chosen) {
+      var rev =
+          resolver.resolveConflict(conflict.entityId(), chosen, parse(conflict.remoteSnapshot()));
       conflicts.resolve(conflict.id(), rev);
       return rev;
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.engine.AuthorizedKeysSync;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerSpecImporter;
+import ai.singlr.sail.engine.FileImporter;
 import ai.singlr.sail.engine.ProjectImporter;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
@@ -15,6 +16,7 @@ import ai.singlr.sail.engine.Spinner;
 import ai.singlr.sail.engine.SshIdentityProvisioner;
 import ai.singlr.sail.store.DataMigration;
 import ai.singlr.sail.store.DataMigrator;
+import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.MigrationRunner;
 import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.RebucketSpecsMigration;
@@ -95,6 +97,7 @@ public final class MigrateCommand implements Runnable {
           applyMigrations(
               db, dbPath.toString(), importer::importAll, prompter, animate, jsonOutput);
       importProjects(db, jsonOutput);
+      importFiles(db, jsonOutput);
       relocateHostConfig(jsonOutput);
       syncAuthorizedKeys(db, jsonOutput);
       return runs;
@@ -111,6 +114,19 @@ public final class MigrateCommand implements Runnable {
     if (!jsonOutput && report.imported() > 0) {
       System.out.println(
           Ansi.AUTO.string("  @|green ✓|@ project catalog: " + report.imported() + " imported"));
+    }
+  }
+
+  /**
+   * Imports each project's on-disk {@code files/} tree into the synced {@link FileStore}, so the
+   * shared workspace files an FDE already has become replicated the moment they upgrade.
+   * Idempotent; quiet when nothing changed.
+   */
+  private static void importFiles(Sqlite db, boolean jsonOutput) {
+    var report = new FileImporter(SailPaths.projectsDir(), new FileStore(db)).importAll();
+    if (!jsonOutput && report.imported() > 0) {
+      System.out.println(
+          Ansi.AUTO.string("  @|green ✓|@ project files: " + report.imported() + " imported"));
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCommand.java
@@ -36,6 +36,7 @@ import picocli.CommandLine.Command;
       ProjectInstallAgentCommand.class,
       ProjectDemoCommand.class,
       ProjectSyncCommand.class,
+      ProjectFilesCommand.class,
     })
 public final class ProjectCommand implements Runnable {
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.Banner;
+import ai.singlr.sail.engine.FileMaterializer;
+import ai.singlr.sail.engine.NameValidator;
+import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.store.FileStore;
+import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/**
+ * Shares arbitrary workspace files across every FDE on a project through the same sync engine as
+ * specs — no git, no specific repo. {@code add} stores a file's bytes (base64) keyed by its
+ * relative path; the next {@code sail sync} replicates it and {@link FileMaterializer} drops it
+ * onto every other box. {@code export} runs that materialization on demand, for the main box that
+ * never calls {@code sail sync}. Removal tombstones the row so the deletion propagates too.
+ */
+@Command(
+    name = "files",
+    description = "Share project files across FDEs (add, ls, cat, rm, export).",
+    mixinStandardHelpOptions = true,
+    subcommands = {
+      ProjectFilesCommand.Add.class,
+      ProjectFilesCommand.Ls.class,
+      ProjectFilesCommand.Cat.class,
+      ProjectFilesCommand.Rm.class,
+      ProjectFilesCommand.Export.class,
+    })
+public final class ProjectFilesCommand implements Runnable {
+
+  @Override
+  public void run() {
+    new picocli.CommandLine(this).usage(System.out);
+  }
+
+  @Command(
+      name = "add",
+      description = "Share a local file with every FDE on the project.",
+      mixinStandardHelpOptions = true)
+  static final class Add implements Callable<Integer> {
+
+    @Parameters(index = "0", description = "Project name.")
+    private String project;
+
+    @Parameters(index = "1", description = "Local file to share.")
+    private Path source;
+
+    @Option(
+        names = "--as",
+        description = "Relative path to store it under (default: the file's name).")
+    private String as;
+
+    @Override
+    public Integer call() throws Exception {
+      NameValidator.requireValidProjectName(project);
+      if (!Files.isRegularFile(source)) {
+        System.err.println(Banner.errorLine("Not a file: " + source, Ansi.AUTO));
+        return 1;
+      }
+      try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+        var path = share(new FileStore(db), SailPaths.projectsDir(), project, source, as);
+        System.out.println(
+            Ansi.AUTO.string(
+                "  @|green ✓|@ Shared @|bold "
+                    + path
+                    + "|@ on @|bold "
+                    + project
+                    + "|@. Run @|bold sail sync|@ to propagate."));
+      }
+      return 0;
+    }
+
+    /**
+     * Stores {@code source} under its relative path and materializes it locally; returns the path.
+     */
+    static String share(FileStore files, Path projectsDir, String project, Path source, String as)
+        throws IOException {
+      var path = as != null && !as.isBlank() ? as : source.getFileName().toString();
+      NameValidator.requireSafePath(path, "path");
+      files.put(project, path, Base64.getEncoder().encodeToString(Files.readAllBytes(source)));
+      new FileMaterializer(files, projectsDir).materialize(project);
+      return path;
+    }
+  }
+
+  @Command(
+      name = "ls",
+      description = "List the shared files on a project.",
+      mixinStandardHelpOptions = true)
+  static final class Ls implements Callable<Integer> {
+
+    @Parameters(index = "0", description = "Project name.")
+    private String project;
+
+    @Option(names = "--json", description = "Output as JSON.")
+    private boolean json;
+
+    @Override
+    public Integer call() {
+      NameValidator.requireValidProjectName(project);
+      try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+        System.out.println(render(new FileStore(db).list(project), project, json));
+        return 0;
+      }
+    }
+
+    static String render(List<FileStore.FileRow> rows, String project, boolean json) {
+      if (json) {
+        var list =
+            rows.stream()
+                .map(
+                    r -> {
+                      var map = new LinkedHashMap<String, Object>();
+                      map.put("path", r.path());
+                      map.put("bytes", decodedSize(r.content()));
+                      return (Object) map;
+                    })
+                .toList();
+        return YamlUtil.dumpJson(list);
+      }
+      if (rows.isEmpty()) {
+        return Ansi.AUTO.string(
+            "  @|faint No shared files on |@@|bold " + project + "|@@|faint .|@");
+      }
+      var out = new StringBuilder();
+      out.append(
+          Ansi.AUTO.string("  @|bold " + rows.size() + "|@ shared file(s) on " + project + ":\n"));
+      for (var r : rows) {
+        out.append(
+            Ansi.AUTO.string(
+                "    @|green " + r.path() + "|@ @|faint (" + decodedSize(r.content()) + " B)|@\n"));
+      }
+      return out.toString().stripTrailing();
+    }
+  }
+
+  @Command(
+      name = "cat",
+      description = "Print a shared file's content to stdout.",
+      mixinStandardHelpOptions = true)
+  static final class Cat implements Callable<Integer> {
+
+    @Parameters(index = "0", description = "Project name.")
+    private String project;
+
+    @Parameters(index = "1", description = "Relative path of the file.")
+    private String path;
+
+    @Override
+    public Integer call() throws Exception {
+      NameValidator.requireValidProjectName(project);
+      try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+        var bytes = read(new FileStore(db), project, path).orElse(null);
+        if (bytes == null) {
+          System.err.println(
+              Banner.errorLine("No shared file '" + path + "' on " + project + ".", Ansi.AUTO));
+          return 1;
+        }
+        System.out.write(bytes);
+        System.out.flush();
+        return 0;
+      }
+    }
+
+    static Optional<byte[]> read(FileStore files, String project, String path) {
+      return files.find(project, path).map(row -> Base64.getDecoder().decode(row.content()));
+    }
+  }
+
+  @Command(
+      name = "rm",
+      description = "Stop sharing a file (propagates the deletion).",
+      mixinStandardHelpOptions = true)
+  static final class Rm implements Callable<Integer> {
+
+    @Parameters(index = "0", description = "Project name.")
+    private String project;
+
+    @Parameters(index = "1", description = "Relative path of the file.")
+    private String path;
+
+    @Override
+    public Integer call() throws Exception {
+      NameValidator.requireValidProjectName(project);
+      try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+        if (!unshare(new FileStore(db), SailPaths.projectsDir(), project, path)) {
+          System.err.println(
+              Banner.errorLine("No shared file '" + path + "' on " + project + ".", Ansi.AUTO));
+          return 1;
+        }
+      }
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|green ✓|@ Stopped sharing @|bold "
+                  + path
+                  + "|@. Run @|bold sail sync|@ to propagate."));
+      return 0;
+    }
+
+    /** Tombstones the file and removes the local on-disk copy; false if it was not shared. */
+    static boolean unshare(FileStore files, Path projectsDir, String project, String path)
+        throws IOException {
+      if (!files.delete(project, path)) {
+        return false;
+      }
+      new FileMaterializer(files, projectsDir).materialize(project);
+      return true;
+    }
+  }
+
+  @Command(
+      name = "export",
+      description = "Write shared files to disk now (for the main box, which never runs sync).",
+      mixinStandardHelpOptions = true)
+  static final class Export implements Callable<Integer> {
+
+    @Parameters(index = "0", arity = "0..1", description = "Project name. Omit with --all.")
+    private String project;
+
+    @Option(names = "--all", description = "Export every project that has shared files.")
+    private boolean all;
+
+    @Override
+    public Integer call() throws Exception {
+      if (all == (project != null && !project.isBlank())) {
+        System.err.println(Banner.errorLine("Pass a project name OR --all, not both.", Ansi.AUTO));
+        return 1;
+      }
+      try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+        var files = new FileStore(db);
+        var targets = all ? files.projectsWithFiles() : List.of(project);
+        var report = export(files, SailPaths.projectsDir(), targets);
+        for (var skip : report.skipped()) {
+          System.err.println(
+              Ansi.AUTO.string("  @|yellow ⚠|@ kept local edit: " + skip + " (unchanged)"));
+        }
+        System.out.println(
+            Ansi.AUTO.string(
+                "  @|green ✓|@ Exported: "
+                    + report.written()
+                    + " written, "
+                    + report.deleted()
+                    + " removed."));
+      }
+      return 0;
+    }
+
+    record ExportReport(int written, int deleted, List<String> skipped) {}
+
+    static ExportReport export(FileStore files, Path projectsDir, Collection<String> targets)
+        throws IOException {
+      var materializer = new FileMaterializer(files, projectsDir);
+      var written = 0;
+      var deleted = 0;
+      var skipped = new ArrayList<String>();
+      for (var target : targets) {
+        NameValidator.requireValidProjectName(target);
+        var report = materializer.materialize(target);
+        written += report.written();
+        deleted += report.deleted();
+        for (var skip : report.skipped()) {
+          skipped.add(target + "/" + skip);
+        }
+      }
+      return new ExportReport(written, deleted, List.copyOf(skipped));
+    }
+  }
+
+  private static int decodedSize(String base64) {
+    return Base64.getDecoder().decode(base64).length;
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
@@ -16,13 +16,15 @@ import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.SshSyncChannel;
 import ai.singlr.sail.store.ChangeLog;
 import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.SyncConflicts;
 import ai.singlr.sail.store.SyncState;
-import ai.singlr.sail.sync.RemoteMainReplica;
+import ai.singlr.sail.sync.FileReplica;
 import ai.singlr.sail.sync.SpecReplica;
 import ai.singlr.sail.sync.SyncEngine;
+import ai.singlr.sail.sync.SyncSession;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -92,17 +94,20 @@ public final class SyncCommand implements Callable<Integer> {
       return 1;
     }
     try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
-      var local =
-          new SpecReplica(
-              HostInfo.hostname(),
-              new SpecStore(db),
-              new ChangeLog(db),
-              new SyncConflicts(db),
-              new SyncState(db));
-      var fdes = new FdeStore(db);
-      return watch ? watchLoop(local, fdes, target) : runOnce(local, fdes, target);
+      var host = HostInfo.hostname();
+      var changeLog = new ChangeLog(db);
+      var conflicts = new SyncConflicts(db);
+      var syncState = new SyncState(db);
+      var boxes =
+          new Boxes(
+              new SpecReplica(host, new SpecStore(db), changeLog, conflicts, syncState),
+              new FileReplica(host, new FileStore(db), changeLog, conflicts, syncState),
+              new FdeStore(db));
+      return watch ? watchLoop(boxes, target) : runOnce(boxes, target);
     }
   }
+
+  private record Boxes(SpecReplica spec, FileReplica file, FdeStore fdes) {}
 
   /** The main target: the {@code --main} flag if given, else the configured one. */
   static String resolveMain(String flag, SyncConfig sync) {
@@ -136,18 +141,17 @@ public final class SyncCommand implements Callable<Integer> {
     }
   }
 
-  private int runOnce(SpecReplica local, FdeStore fdes, String target) throws Exception {
-    var report = reconcile(local, fdes, target);
+  private int runOnce(Boxes boxes, String target) throws Exception {
+    var report = reconcile(boxes, target);
     System.out.println(render(report, json));
     notifyBoardUpdated(report);
     return 0;
   }
 
-  private int watchLoop(SpecReplica local, FdeStore fdes, String target)
-      throws InterruptedException {
+  private int watchLoop(Boxes boxes, String target) throws InterruptedException {
     while (true) {
       try {
-        var report = reconcile(local, fdes, target);
+        var report = reconcile(boxes, target);
         System.out.println(render(report, json));
         notifyBoardUpdated(report);
       } catch (InterruptedException e) {
@@ -162,12 +166,12 @@ public final class SyncCommand implements Callable<Integer> {
     }
   }
 
-  private SyncEngine.Report reconcile(SpecReplica local, FdeStore fdes, String target)
-      throws Exception {
+  private SyncEngine.Report reconcile(Boxes boxes, String target) throws Exception {
     try (var channel = SshSyncChannel.open(target);
-        var remote = new RemoteMainReplica(channel.reader(), channel.writer())) {
-      var report = new SyncEngine().reconcile(local, remote);
-      var rejected = applyFdes(fdes, remote.fetchFdes());
+        var session = new SyncSession(channel.reader(), channel.writer())) {
+      var specReport = new SyncEngine().reconcile(boxes.spec(), session.replica("spec"));
+      var fileReport = new SyncEngine().reconcile(boxes.file(), session.replica("file"));
+      var rejected = applyFdes(boxes.fdes(), session.fetchFdes());
       if (!rejected.isEmpty()) {
         System.err.println(
             Banner.errorLine(
@@ -177,8 +181,17 @@ public final class SyncCommand implements Callable<Integer> {
                     + String.join(", ", rejected),
                 Ansi.AUTO));
       }
-      return report;
+      return combine(specReport, fileReport);
     }
+  }
+
+  /** Sums two reconcile reports (specs + files) into one round summary. */
+  static SyncEngine.Report combine(SyncEngine.Report a, SyncEngine.Report b) {
+    return new SyncEngine.Report(
+        a.pulled() + b.pulled(),
+        a.pushed() + b.pushed(),
+        a.merged() + b.merged(),
+        a.conflicts() + b.conflicts());
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
@@ -11,6 +11,7 @@ import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SyncConfig;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
+import ai.singlr.sail.engine.FileMaterializer;
 import ai.singlr.sail.engine.HostInfo;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.SshSyncChannel;
@@ -98,16 +99,18 @@ public final class SyncCommand implements Callable<Integer> {
       var changeLog = new ChangeLog(db);
       var conflicts = new SyncConflicts(db);
       var syncState = new SyncState(db);
+      var fileStore = new FileStore(db);
       var boxes =
           new Boxes(
               new SpecReplica(host, new SpecStore(db), changeLog, conflicts, syncState),
-              new FileReplica(host, new FileStore(db), changeLog, conflicts, syncState),
-              new FdeStore(db));
+              new FileReplica(host, fileStore, changeLog, conflicts, syncState),
+              new FdeStore(db),
+              fileStore);
       return watch ? watchLoop(boxes, target) : runOnce(boxes, target);
     }
   }
 
-  private record Boxes(SpecReplica spec, FileReplica file, FdeStore fdes) {}
+  private record Boxes(SpecReplica spec, FileReplica file, FdeStore fdes, FileStore files) {}
 
   /** The main target: the {@code --main} flag if given, else the configured one. */
   static String resolveMain(String flag, SyncConfig sync) {
@@ -181,7 +184,33 @@ public final class SyncCommand implements Callable<Integer> {
                     + String.join(", ", rejected),
                 Ansi.AUTO));
       }
+      materialize(boxes.files());
       return combine(specReport, fileReport);
+    }
+  }
+
+  /** Projects the synced files onto disk, warning about any local edits it deliberately left. */
+  private void materialize(FileStore files) {
+    var materializer = new FileMaterializer(files, SailPaths.projectsDir());
+    for (var project : files.projectsWithFiles()) {
+      try {
+        var report = materializer.materialize(project);
+        if (!report.skipped().isEmpty()) {
+          System.err.println(
+              Banner.errorLine(
+                  "Kept "
+                      + report.skipped().size()
+                      + " locally-modified file(s) in '"
+                      + project
+                      + "' (capture with 'sail project files add', or delete to take main's): "
+                      + String.join(", ", report.skipped()),
+                  Ansi.AUTO));
+        }
+      } catch (IOException e) {
+        System.err.println(
+            Banner.errorLine(
+                "Could not write files for '" + project + "': " + e.getMessage(), Ansi.AUTO));
+      }
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
@@ -12,10 +12,13 @@ import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.store.AuthSessionStore;
 import ai.singlr.sail.store.ChangeLog;
 import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.SyncConflicts;
 import ai.singlr.sail.store.SyncState;
+import ai.singlr.sail.sync.FileReplica;
+import ai.singlr.sail.sync.MainReplica;
 import ai.singlr.sail.sync.SpecReplica;
 import ai.singlr.sail.sync.SyncRpcServer;
 import java.io.BufferedReader;
@@ -55,10 +58,14 @@ public final class SyncServerCommand implements Callable<Integer> {
 
   static int serve(Sqlite db, String mainId, String token, BufferedReader in, Writer out)
       throws IOException {
-    var main =
-        new SpecReplica(
-            mainId, new SpecStore(db), new ChangeLog(db), new SyncConflicts(db), new SyncState(db));
-    new SyncRpcServer(main, canWrite(db, token), () -> roster(db)).serve(in, out);
+    var changeLog = new ChangeLog(db);
+    var conflicts = new SyncConflicts(db);
+    var syncState = new SyncState(db);
+    var replicas =
+        Map.<String, MainReplica>of(
+            "spec", new SpecReplica(mainId, new SpecStore(db), changeLog, conflicts, syncState),
+            "file", new FileReplica(mainId, new FileStore(db), changeLog, conflicts, syncState));
+    new SyncRpcServer(replicas, canWrite(db, token), () -> roster(db)).serve(in, out);
     return 0;
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/FileImporter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/FileImporter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import ai.singlr.sail.store.FileStore;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Imports each project's on-disk workspace files ({@code ~/.sail/projects/<name>/files/**}) into
+ * the synced {@link FileStore}, so the file tree an FDE already has becomes the shared, replicated
+ * copy the moment they upgrade — the disk-to-DB counterpart of {@link FileMaterializer}.
+ * Idempotent: a file already stored with the same content is skipped, so re-running on every
+ * upgrade neither churns revisions nor re-imports. The read-only counterpart to the git-based
+ * {@code project pull} files directory it replaces.
+ */
+public final class FileImporter {
+
+  private final Path projectsDir;
+  private final FileStore files;
+
+  public FileImporter(Path projectsDir, FileStore files) {
+    this.projectsDir = projectsDir;
+    this.files = files;
+  }
+
+  public record Report(int imported, List<String> notes) {}
+
+  public Report importAll() {
+    if (!Files.isDirectory(projectsDir)) {
+      return new Report(0, List.of());
+    }
+    var imported = 0;
+    var notes = new ArrayList<String>();
+    try (Stream<Path> projects = Files.list(projectsDir)) {
+      for (var projectDir : projects.filter(Files::isDirectory).toList()) {
+        imported += importProject(projectDir.getFileName().toString(), projectDir.resolve("files"));
+      }
+    } catch (IOException e) {
+      notes.add("Could not scan project files: " + e.getMessage());
+    }
+    return new Report(imported, List.copyOf(notes));
+  }
+
+  private int importProject(String project, Path filesDir) throws IOException {
+    if (!Files.isDirectory(filesDir)) {
+      return 0;
+    }
+    var imported = 0;
+    try (Stream<Path> tree = Files.walk(filesDir)) {
+      for (var file : tree.filter(Files::isRegularFile).toList()) {
+        var path = filesDir.relativize(file).toString();
+        var content = Base64.getEncoder().encodeToString(Files.readAllBytes(file));
+        if (files.find(project, path).map(row -> !row.content().equals(content)).orElse(true)) {
+          files.put(project, path, content);
+          imported++;
+        }
+      }
+    }
+    return imported;
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/FileMaterializer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/FileMaterializer.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import ai.singlr.sail.store.FileStore;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Projects a project's synced files from the DB onto disk at {@code
+ * ~/.sail/projects/<project>/files/<path>}, so {@code sail project up} drops them into the
+ * container. Safe by construction:
+ *
+ * <ul>
+ *   <li><b>No data loss.</b> A file on disk is overwritten or deleted only when it matches a
+ *       revision this box itself wrote ({@link FileStore#isKnownContent}); a file a human edited
+ *       locally without {@code sail project files add} matches nothing in history, so it is left
+ *       alone and reported as skipped.
+ *   <li><b>No path traversal.</b> A synced path that escapes the project's {@code files/} directory
+ *       (a malicious {@code ../}) is refused — the content comes from other FDEs over the wire.
+ * </ul>
+ */
+public final class FileMaterializer {
+
+  /** What a single file needs on disk relative to its current DB state and on-disk content. */
+  enum Action {
+    IN_SYNC,
+    WRITE,
+    DELETE,
+    SKIP_DIRTY
+  }
+
+  public record Report(int written, int deleted, List<String> skipped) {}
+
+  private final FileStore files;
+  private final Path projectsDir;
+
+  public FileMaterializer(FileStore files, Path projectsDir) {
+    this.files = files;
+    this.projectsDir = projectsDir;
+  }
+
+  public Report materialize(String project) throws IOException {
+    var filesDir = projectsDir.resolve(project).resolve("files").normalize();
+    var written = 0;
+    var deleted = 0;
+    var skipped = new ArrayList<String>();
+
+    for (var id : files.idsForProject(project)) {
+      var path = id.substring(project.length() + 1);
+      var target = files.comparableSnapshot(id);
+      var targetContent = target == null ? null : (String) target.get("content");
+
+      var destination = filesDir.resolve(path).normalize();
+      if (!destination.startsWith(filesDir)) {
+        skipped.add(path);
+        continue;
+      }
+
+      var onDisk = readBase64(destination);
+      switch (decide(targetContent, onDisk, onDisk != null && files.isKnownContent(id, onDisk))) {
+        case IN_SYNC -> {}
+        case SKIP_DIRTY -> skipped.add(path);
+        case WRITE -> {
+          writeFile(destination, targetContent);
+          written++;
+        }
+        case DELETE -> {
+          Files.deleteIfExists(destination);
+          deleted++;
+        }
+      }
+    }
+    return new Report(written, deleted, List.copyOf(skipped));
+  }
+
+  /**
+   * The action for one file: nothing if disk already matches the DB; refresh or remove if disk
+   * holds a copy this box wrote; leave a locally-edited file alone (skip) so a human's work is
+   * never lost.
+   */
+  static Action decide(String targetContent, String onDisk, boolean onDiskIsKnown) {
+    if (Objects.equals(onDisk, targetContent)) {
+      return Action.IN_SYNC;
+    }
+    if (onDisk != null && !onDiskIsKnown) {
+      return Action.SKIP_DIRTY;
+    }
+    return targetContent == null ? Action.DELETE : Action.WRITE;
+  }
+
+  private static String readBase64(Path file) throws IOException {
+    if (!Files.isRegularFile(file)) {
+      return null;
+    }
+    return Base64.getEncoder().encodeToString(Files.readAllBytes(file));
+  }
+
+  private static void writeFile(Path file, String base64) throws IOException {
+    Files.createDirectories(file.getParent());
+    Files.write(file, Base64.getDecoder().decode(base64));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ConflictsCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ConflictsCommandTest.java
@@ -9,11 +9,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.SyncConflicts;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -98,7 +100,7 @@ class ConflictsCommandTest {
         conflicts.record("spec", "auth", json(base), json(mine), json(theirs), List.of("title"));
     var conflict = conflicts.pendingFor("spec", "auth").orElseThrow();
 
-    ConflictsCommand.Resolve.apply(specs, conflicts, conflict, mine, theirs);
+    ConflictsCommand.Resolve.apply(specs, conflicts, conflict, mine);
 
     assertTrue(conflicts.pending().isEmpty(), "the conflict is marked resolved");
     assertEquals("Mine", specs.findById("auth").orElseThrow().title());
@@ -181,5 +183,97 @@ class ConflictsCommandTest {
     assertTrue(rendered.contains("Mine"));
     assertTrue(rendered.contains("Theirs"));
     assertTrue(rendered.contains("in_progress"));
+  }
+
+  private static String b64(String text) {
+    return Base64.getEncoder().encodeToString(text.getBytes());
+  }
+
+  @Test
+  void renderListJsonCarriesEntityType() {
+    conflicts.record("file", "acme/x.txt", "{}", "{}", "{}", List.of("content"));
+    var out = ConflictsCommand.renderList(conflicts.pending(), true);
+    assertTrue(out.contains("\"type\": \"file\""));
+  }
+
+  @Test
+  void findUniqueResolvesByIdAcrossTypesAndReportsAbsenceAndAmbiguity() {
+    assertNull(ConflictsCommand.findUnique(conflicts, "ghost"));
+
+    conflicts.record("file", "acme/x.txt", "{}", "{}", "{}", List.of("content"));
+    var found = ConflictsCommand.findUnique(conflicts, "acme/x.txt");
+    assertEquals("file", found.entityType());
+
+    conflicts.record("spec", "acme/x.txt", "{}", "{}", "{}", List.of("title"));
+    assertNull(
+        ConflictsCommand.findUnique(conflicts, "acme/x.txt"), "a cross-type clash is ambiguous");
+  }
+
+  @Test
+  void resolverForDispatchesOnEntityType() {
+    assertInstanceOf(FileStore.class, ConflictsCommand.resolverFor(db, "file"));
+    assertInstanceOf(SpecStore.class, ConflictsCommand.resolverFor(db, "spec"));
+  }
+
+  @Test
+  void applyResolvesAFileConflictThroughTheFileStore() {
+    var files = new FileStore(db);
+    files.put("acme", "x.txt", b64("mine"));
+    var base = Map.<String, Object>of("content", b64("base"));
+    var mine = Map.<String, Object>of("content", b64("mine"));
+    var theirs = Map.<String, Object>of("content", b64("theirs"));
+    conflicts.record(
+        "file", "acme/x.txt", json(base), json(mine), json(theirs), List.of("content"));
+    var conflict = ConflictsCommand.findUnique(conflicts, "acme/x.txt");
+
+    ConflictsCommand.Resolve.apply(
+        ConflictsCommand.resolverFor(db, conflict.entityType()), conflicts, conflict, theirs);
+
+    assertTrue(conflicts.pending().isEmpty());
+    assertEquals(b64("theirs"), files.find("acme", "x.txt").orElseThrow().content());
+  }
+
+  @Test
+  void fileConflictsAreNeverFieldMergeable() {
+    conflicts.record("file", "acme/x.txt", "{}", "{}", "{}", List.of("content"));
+    assertFalse(
+        ConflictsCommand.Resolve.mergeable(ConflictsCommand.findUnique(conflicts, "acme/x.txt")));
+  }
+
+  @Test
+  void showDecodesFileContentAndSummarizesBinary() {
+    assertEquals("hello", ConflictsCommand.Show.show(b64("hello"), true));
+    assertEquals("\nline1\nline2", ConflictsCommand.Show.show(b64("line1\nline2\n"), true));
+    assertEquals(
+        "Theirs", ConflictsCommand.Show.show("Theirs", false), "spec values render verbatim");
+
+    var binary = Base64.getEncoder().encodeToString(new byte[] {1, 2, 0, 3});
+    assertTrue(ConflictsCommand.Show.show(binary, true).startsWith("<binary, 4 bytes>"));
+    assertEquals("", ConflictsCommand.Show.show("", true), "blank content renders empty");
+    assertTrue(ConflictsCommand.Show.looksBinary(new byte[] {0}));
+    assertTrue(ConflictsCommand.Show.looksBinary(new byte[] {0x08}));
+    assertTrue(ConflictsCommand.Show.looksBinary(new byte[] {0x1f}));
+    assertFalse(ConflictsCommand.Show.looksBinary("tab\tnewline\r\n".getBytes()));
+  }
+
+  @Test
+  void showRendersAFileConflictWithDecodedContent() {
+    var conflict =
+        new SyncConflicts.Conflict(
+            1,
+            "file",
+            "acme/x.txt",
+            json(Map.of("content", b64("base"))),
+            json(Map.of("content", b64("mine"))),
+            json(Map.of("content", b64("theirs"))),
+            List.of("content"),
+            "now",
+            "pending",
+            null);
+
+    var rendered = ConflictsCommand.Show.render(conflict);
+    assertTrue(rendered.contains("acme/x.txt"));
+    assertTrue(rendered.contains("mine"));
+    assertTrue(rendered.contains("theirs"));
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectFilesCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectFilesCommandTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sail.store.FileStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+class ProjectFilesCommandTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private FileStore files;
+  private Path projectsDir;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    files = new FileStore(db);
+    projectsDir = tempDir.resolve("projects");
+  }
+
+  @AfterEach
+  void tearDown() {
+    db.close();
+  }
+
+  private Path filesDir(String project) {
+    return projectsDir.resolve(project).resolve("files");
+  }
+
+  private static String b64(String text) {
+    return Base64.getEncoder().encodeToString(text.getBytes());
+  }
+
+  @Test
+  void parentUsageListsEverySubcommand() {
+    var usage = new CommandLine(new ProjectFilesCommand()).getUsageMessage();
+    assertTrue(usage.contains("add"));
+    assertTrue(usage.contains("ls"));
+    assertTrue(usage.contains("cat"));
+    assertTrue(usage.contains("rm"));
+    assertTrue(usage.contains("export"));
+  }
+
+  @Test
+  void parentRunPrintsUsageWithoutError() {
+    assertEquals(0, new CommandLine(new ProjectFilesCommand()).execute());
+  }
+
+  @Test
+  void addStoresTheFileAndMaterializesItLocally() throws Exception {
+    var source = tempDir.resolve("deploy.sh");
+    Files.writeString(source, "echo hi");
+
+    var path =
+        ProjectFilesCommand.Add.share(files, projectsDir, "acme", source, "scripts/deploy.sh");
+
+    assertEquals("scripts/deploy.sh", path);
+    assertEquals(b64("echo hi"), files.find("acme", "scripts/deploy.sh").orElseThrow().content());
+    assertEquals("echo hi", Files.readString(filesDir("acme").resolve("scripts/deploy.sh")));
+  }
+
+  @Test
+  void addDefaultsTheStoredPathToTheSourceFileName() throws Exception {
+    var source = tempDir.resolve("notes.md");
+    Files.writeString(source, "hello");
+
+    var path = ProjectFilesCommand.Add.share(files, projectsDir, "acme", source, null);
+
+    assertEquals("notes.md", path);
+  }
+
+  @Test
+  void addRejectsAPathThatEscapesTheProject() throws Exception {
+    var source = tempDir.resolve("evil");
+    Files.writeString(source, "x");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ProjectFilesCommand.Add.share(files, projectsDir, "acme", source, "../escape"));
+  }
+
+  @Test
+  void addReportsExitOneWhenTheSourceIsMissing() {
+    var cmd = new CommandLine(new ProjectFilesCommand.Add());
+    cmd.setErr(new java.io.PrintWriter(new java.io.StringWriter()));
+    assertEquals(1, cmd.execute("acme", tempDir.resolve("nope").toString()));
+  }
+
+  @Test
+  void lsRendersHumanAndJson() {
+    files.put("acme", "a.txt", b64("AAAA"));
+    files.put("acme", "b.txt", b64("B"));
+
+    var human = ProjectFilesCommand.Ls.render(files.list("acme"), "acme", false);
+    assertTrue(human.contains("a.txt"));
+    assertTrue(human.contains("4 B"));
+
+    var json = ProjectFilesCommand.Ls.render(files.list("acme"), "acme", true);
+    assertTrue(json.contains("\"path\": \"a.txt\""));
+    assertTrue(json.contains("\"bytes\": 1"));
+  }
+
+  @Test
+  void lsIsCleanWhenEmpty() {
+    assertTrue(ProjectFilesCommand.Ls.render(List.of(), "acme", false).contains("No shared files"));
+  }
+
+  @Test
+  void catDecodesContentAndIsEmptyWhenAbsent() {
+    files.put("acme", "a.txt", b64("payload"));
+
+    assertArrayEquals(
+        "payload".getBytes(), ProjectFilesCommand.Cat.read(files, "acme", "a.txt").orElseThrow());
+    assertTrue(ProjectFilesCommand.Cat.read(files, "acme", "missing").isEmpty());
+  }
+
+  @Test
+  void rmTombstonesAndRemovesTheLocalCopy() throws Exception {
+    var source = tempDir.resolve("a.txt");
+    Files.writeString(source, "data");
+    ProjectFilesCommand.Add.share(files, projectsDir, "acme", source, "a.txt");
+    assertTrue(Files.exists(filesDir("acme").resolve("a.txt")));
+
+    var removed = ProjectFilesCommand.Rm.unshare(files, projectsDir, "acme", "a.txt");
+
+    assertTrue(removed);
+    assertTrue(files.find("acme", "a.txt").isEmpty());
+    assertFalse(Files.exists(filesDir("acme").resolve("a.txt")));
+  }
+
+  @Test
+  void rmReturnsFalseWhenTheFileWasNotShared() throws Exception {
+    assertFalse(ProjectFilesCommand.Rm.unshare(files, projectsDir, "acme", "ghost.txt"));
+  }
+
+  @Test
+  void exportWritesEveryTargetAndCountsDeletionsAndSkips() throws Exception {
+    files.put("acme", "a.txt", b64("A"));
+    var report = ProjectFilesCommand.Export.export(files, projectsDir, files.projectsWithFiles());
+    assertEquals(1, report.written());
+
+    Files.writeString(filesDir("acme").resolve("a.txt"), "LOCAL EDIT");
+    files.put("acme", "a.txt", b64("A2"));
+    var second = ProjectFilesCommand.Export.export(files, projectsDir, List.of("acme"));
+
+    assertEquals(0, second.written());
+    assertEquals(List.of("acme/a.txt"), second.skipped());
+  }
+
+  @Test
+  void exportRejectsBothProjectAndAll() {
+    var cmd = new CommandLine(new ProjectFilesCommand.Export());
+    cmd.setErr(new java.io.PrintWriter(new java.io.StringWriter()));
+    assertEquals(1, cmd.execute("acme", "--all"));
+  }
+
+  @Test
+  void exportRejectsNeitherProjectNorAll() {
+    var cmd = new CommandLine(new ProjectFilesCommand.Export());
+    cmd.setErr(new java.io.PrintWriter(new java.io.StringWriter()));
+    assertEquals(1, cmd.execute());
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SyncServerCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SyncServerCommandTest.java
@@ -16,9 +16,9 @@ import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.SyncConflicts;
 import ai.singlr.sail.store.SyncState;
-import ai.singlr.sail.sync.RemoteMainReplica;
 import ai.singlr.sail.sync.SpecReplica;
 import ai.singlr.sail.sync.SyncEngine;
+import ai.singlr.sail.sync.SyncSession;
 import ai.singlr.sail.sync.SyncTransportException;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -116,8 +116,8 @@ class SyncServerCommandTest {
                   }
                 });
 
-    try (var remote = new RemoteMainReplica(clientIn, toServer)) {
-      return new SyncEngine().reconcile(nodeReplica, remote);
+    try (var session = new SyncSession(clientIn, toServer)) {
+      return new SyncEngine().reconcile(nodeReplica, session.replica("spec"));
     } finally {
       serverThread.join();
     }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/FileImporterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/FileImporterTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sail.store.FileStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Importing is the disk-to-DB boundary: it captures the workspace files an FDE already has so they
+ * become the shared, replicated copy, and it is idempotent so every upgrade can run it for free.
+ */
+class FileImporterTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private FileStore files;
+  private Path projectsDir;
+  private FileImporter importer;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    files = new FileStore(db);
+    projectsDir = tempDir.resolve("projects");
+    importer = new FileImporter(projectsDir, files);
+  }
+
+  @AfterEach
+  void tearDown() {
+    db.close();
+  }
+
+  private void writeOnDisk(String project, String path, String text) throws Exception {
+    var file = projectsDir.resolve(project).resolve("files").resolve(path);
+    Files.createDirectories(file.getParent());
+    Files.writeString(file, text);
+  }
+
+  private static String b64(String text) {
+    return Base64.getEncoder().encodeToString(text.getBytes());
+  }
+
+  @Test
+  void importsEveryFilePreservingTheRelativeTree() throws Exception {
+    writeOnDisk("acme", "scripts/deploy.sh", "hello");
+    writeOnDisk("acme", "README.md", "docs");
+
+    var report = importer.importAll();
+
+    assertEquals(2, report.imported());
+    assertEquals(b64("hello"), files.find("acme", "scripts/deploy.sh").orElseThrow().content());
+    assertEquals(b64("docs"), files.find("acme", "README.md").orElseThrow().content());
+  }
+
+  @Test
+  void importsAcrossMultipleProjects() throws Exception {
+    writeOnDisk("acme", "a.txt", "A");
+    writeOnDisk("globex", "b.txt", "B");
+
+    var report = importer.importAll();
+
+    assertEquals(2, report.imported());
+    assertTrue(files.find("acme", "a.txt").isPresent());
+    assertTrue(files.find("globex", "b.txt").isPresent());
+  }
+
+  @Test
+  void reRunningImportsNothingWhenContentIsUnchanged() throws Exception {
+    writeOnDisk("acme", "a.txt", "A");
+    importer.importAll();
+
+    var report = importer.importAll();
+
+    assertEquals(0, report.imported());
+  }
+
+  @Test
+  void reImportsOnlyTheFileWhoseContentChanged() throws Exception {
+    writeOnDisk("acme", "a.txt", "A");
+    writeOnDisk("acme", "b.txt", "B");
+    importer.importAll();
+    writeOnDisk("acme", "a.txt", "A2");
+
+    var report = importer.importAll();
+
+    assertEquals(1, report.imported());
+    assertEquals(b64("A2"), files.find("acme", "a.txt").orElseThrow().content());
+  }
+
+  @Test
+  void isQuietWhenThereIsNoProjectsDirectory() {
+    var report = importer.importAll();
+
+    assertEquals(0, report.imported());
+    assertTrue(report.notes().isEmpty());
+  }
+
+  @Test
+  void ignoresAProjectWithNoFilesDirectory() throws Exception {
+    Files.createDirectories(projectsDir.resolve("acme"));
+
+    var report = importer.importAll();
+
+    assertEquals(0, report.imported());
+  }
+
+  @Test
+  void reportsANoteWhenTheProjectsDirectoryCannotBeScanned() throws Exception {
+    Files.createDirectories(projectsDir);
+    var perms = Files.getPosixFilePermissions(projectsDir);
+    Files.setPosixFilePermissions(projectsDir, java.util.Set.of());
+    try {
+      var report = importer.importAll();
+
+      assertEquals(0, report.imported());
+      assertEquals(1, report.notes().size());
+      assertTrue(report.notes().get(0).startsWith("Could not scan project files:"));
+    } finally {
+      Files.setPosixFilePermissions(projectsDir, perms);
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/FileMaterializerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/FileMaterializerTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sail.store.FileStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Materialization is the data-safety boundary: it refreshes copies it wrote, never clobbers a file
+ * a human edited locally, and refuses a synced path that escapes the project directory.
+ */
+class FileMaterializerTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private FileStore files;
+  private FileMaterializer materializer;
+  private Path filesDir;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    files = new FileStore(db);
+    var projectsDir = tempDir.resolve("projects");
+    materializer = new FileMaterializer(files, projectsDir);
+    filesDir = projectsDir.resolve("acme").resolve("files");
+  }
+
+  @AfterEach
+  void tearDown() {
+    db.close();
+  }
+
+  private static String b64(String text) {
+    return Base64.getEncoder().encodeToString(text.getBytes());
+  }
+
+  @Test
+  void decideCoversTheFourActions() {
+    assertEquals(FileMaterializer.Action.IN_SYNC, FileMaterializer.decide("A", "A", true));
+    assertEquals(FileMaterializer.Action.WRITE, FileMaterializer.decide("A", null, false));
+    assertEquals(FileMaterializer.Action.WRITE, FileMaterializer.decide("B", "A", true));
+    assertEquals(FileMaterializer.Action.DELETE, FileMaterializer.decide(null, "A", true));
+    assertEquals(FileMaterializer.Action.SKIP_DIRTY, FileMaterializer.decide("B", "user", false));
+  }
+
+  @Test
+  void writesANewFilePreservingFolderStructure() throws Exception {
+    files.put("acme", "scripts/deploy.sh", b64("hello"));
+
+    var report = materializer.materialize("acme");
+
+    assertEquals(1, report.written());
+    assertEquals("hello", Files.readString(filesDir.resolve("scripts/deploy.sh")));
+  }
+
+  @Test
+  void refreshesAStaleCopyThisBoxWrote() throws Exception {
+    files.put("acme", "x.txt", b64("A"));
+    materializer.materialize("acme");
+    files.put("acme", "x.txt", b64("B"));
+
+    var report = materializer.materialize("acme");
+
+    assertEquals(1, report.written());
+    assertEquals("B", Files.readString(filesDir.resolve("x.txt")));
+  }
+
+  @Test
+  void leavesALocallyEditedFileUntouchedAndReportsIt() throws Exception {
+    files.put("acme", "x.txt", b64("A"));
+    materializer.materialize("acme");
+    Files.writeString(filesDir.resolve("x.txt"), "MY LOCAL EDIT");
+    files.put("acme", "x.txt", b64("B"));
+
+    var report = materializer.materialize("acme");
+
+    assertEquals(0, report.written());
+    assertEquals(List.of("x.txt"), report.skipped());
+    assertEquals("MY LOCAL EDIT", Files.readString(filesDir.resolve("x.txt")));
+  }
+
+  @Test
+  void removesADeletedFileWhenTheDiskCopyIsOneWeWrote() throws Exception {
+    files.put("acme", "x.txt", b64("A"));
+    materializer.materialize("acme");
+    files.delete("acme", "x.txt");
+
+    var report = materializer.materialize("acme");
+
+    assertEquals(1, report.deleted());
+    assertFalse(Files.exists(filesDir.resolve("x.txt")));
+  }
+
+  @Test
+  void keepsALocallyEditedFileEvenWhenDeletedOnMain() throws Exception {
+    files.put("acme", "x.txt", b64("A"));
+    materializer.materialize("acme");
+    Files.writeString(filesDir.resolve("x.txt"), "MINE");
+    files.delete("acme", "x.txt");
+
+    var report = materializer.materialize("acme");
+
+    assertEquals(0, report.deleted());
+    assertEquals(List.of("x.txt"), report.skipped());
+    assertTrue(Files.exists(filesDir.resolve("x.txt")));
+  }
+
+  @Test
+  void refusesAPathThatEscapesTheProjectDirectory() throws Exception {
+    files.put("acme", "../../escape.txt", b64("evil"));
+
+    var report = materializer.materialize("acme");
+
+    assertEquals(List.of("../../escape.txt"), report.skipped());
+    assertFalse(Files.exists(tempDir.resolve("projects/escape.txt")));
+  }
+
+  @Test
+  void doesNothingWhenDiskAlreadyMatches() throws Exception {
+    files.put("acme", "x.txt", b64("A"));
+    materializer.materialize("acme");
+
+    var report = materializer.materialize("acme");
+
+    assertEquals(0, report.written());
+    assertEquals(0, report.deleted());
+    assertTrue(report.skipped().isEmpty());
+  }
+}


### PR DESCRIPTION
Brick 8 of the db-sync arc: share arbitrary workspace files (configs, scripts, docs) — **not** git, not tied to any GitHub repo — bidirectionally across every FDE on a project, through the same sync engine as specs.

## Design
- **One row per file**, keyed by `(project, path)`, content base64'd — *not* a zip blob. Per-file rows mean two FDEs touching different files never conflict, only same-file edits do; conflicts are legible and resolvable; no whole-archive resync. Files reuse the spec sync machinery (revisions, CAS, change-log history, three-way conflicts) for free.
- **Materialization is the data-safety boundary.** A file on disk is overwritten/deleted only when it matches a revision this box itself wrote (`isKnownContent`); a human's local edit matches nothing in history, so it's left untouched and reported as skipped (git-checkout semantics, never clobbers). Synced paths that escape the project's `files/` dir are refused (content comes from other FDEs).
- **Zero-touch upgrade.** `sail upgrade` auto-imports an FDE's existing `files/` tree into the store and materializes incoming files — no manual step.

## Slices
- **P1** — `FileStore` + `FileReplica` + `project_files` schema; extracted shared `PushOutcome`.
- **P2** — protocol carries an `entityType`; one `_sync` SSH session multiplexes specs + files (`SyncSession`, typed `RemoteMainReplica`, `Rpc`).
- **P3** — `FileMaterializer` (DB→disk, safe) + `FileImporter` (disk→DB, idempotent); wired into `sail sync` and `sail upgrade`.
- **P4** — `sail project files add|ls|cat|rm|export` CLI; `sail conflicts` is entity-type-aware (specs + files), dispatching via a new `ConflictResolver` abstraction; file conflicts offer `--mine/--theirs` (content is an opaque blob), with base64 decoded to readable text or a binary summary in `show`.

## Quality
- `mvn verify` green: **1601 tests**, all JaCoCo gates hold.
- 100% line coverage on `FileStore`, `FileMaterializer`, `FileImporter`; command logic extracted to pure statics and tested directly.
- Two-node bidirectional convergence, conflict, and delete all proven through the engine (`FileSyncTest`).