### PR TITLE
Per-actor attribution: carry the real author through spec sync

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/ConflictDetector.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ConflictDetector.java
@@ -103,7 +103,7 @@ public final class ConflictDetector {
       LinkedHashSet<String> localChanged,
       LinkedHashSet<String> remoteChanged) {
     var result = new LinkedHashMap<String, Object>();
-    for (var field : allKeys(base, local, remote)) {
+    for (var field : workKeys(base, local, remote)) {
       if (localChanged.contains(field)) {
         result.put(field, local.get(field));
       } else if (remoteChanged.contains(field)) {
@@ -112,13 +112,19 @@ public final class ConflictDetector {
         result.put(field, base.get(field));
       }
     }
+    local.forEach(
+        (key, value) -> {
+          if (isMetadata(key)) {
+            result.put(key, value);
+          }
+        });
     return result;
   }
 
   private static LinkedHashSet<String> changedFields(
       Map<String, Object> base, Map<String, Object> side) {
     var changed = new LinkedHashSet<String>();
-    for (var key : allKeys(base, side)) {
+    for (var key : workKeys(base, side)) {
       if (!Objects.equals(base.get(key), side.get(key))) {
         changed.add(key);
       }
@@ -129,7 +135,7 @@ public final class ConflictDetector {
   private static boolean equalSnapshots(Map<String, Object> a, Map<String, Object> b) {
     var left = a == null ? Map.<String, Object>of() : a;
     var right = b == null ? Map.<String, Object>of() : b;
-    for (var key : allKeys(left, right)) {
+    for (var key : workKeys(left, right)) {
       if (!Objects.equals(left.get(key), right.get(key))) {
         return false;
       }
@@ -137,12 +143,26 @@ public final class ConflictDetector {
     return true;
   }
 
+  /**
+   * Keys carrying an FDE's work, excluding reserved metadata ({@code _}-prefixed, e.g. {@code
+   * _actor} — who authored the revision). Metadata rides with a snapshot so it propagates, but it
+   * never counts toward a conflict and never becomes a clashing field; a merge keeps the local
+   * box's metadata since the local box produced the merged result.
+   */
   @SafeVarargs
-  private static LinkedHashSet<String> allKeys(Map<String, Object>... maps) {
+  private static LinkedHashSet<String> workKeys(Map<String, Object>... maps) {
     var keys = new LinkedHashSet<String>();
     for (var map : maps) {
-      keys.addAll(map.keySet());
+      for (var key : map.keySet()) {
+        if (!isMetadata(key)) {
+          keys.add(key);
+        }
+      }
     }
     return keys;
+  }
+
+  private static boolean isMetadata(String key) {
+    return key.startsWith("_");
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -446,7 +446,24 @@ public final class SpecStore implements ConflictResolver {
         m.put(field, full.get(field));
       }
     }
+    var author = full.get("updated_by");
+    if (author != null) {
+      m.put(ACTOR, author);
+    }
     return m;
+  }
+
+  /**
+   * Reserved metadata key carrying the author of a revision through the sync protocol. It rides
+   * inside the comparable snapshot but {@link ConflictDetector} ignores reserved ({@code
+   * _}-prefixed) keys, so attribution propagates without ever causing a false conflict. The
+   * receiving side reads it to attribute the synced row to its real author instead of {@code sync}.
+   */
+  private static final String ACTOR = "_actor";
+
+  private static String authorOf(Map<String, Object> snapshot) {
+    var author = snapshot.get(ACTOR);
+    return author == null ? "sync" : author.toString();
   }
 
   /** Comparable snapshot of the current state, or null if the spec is absent/deleted. */
@@ -521,7 +538,7 @@ public final class SpecStore implements ConflictResolver {
           } else {
             var full = new LinkedHashMap<>(snapshot);
             full.put("id", id);
-            full.put("updated_by", "sync");
+            full.put("updated_by", authorOf(snapshot));
             applySnapshot(id, full);
             recordRevision(id, rev, "sync", false, true);
           }
@@ -551,7 +568,7 @@ public final class SpecStore implements ConflictResolver {
           }
           var full = new LinkedHashMap<>(snapshot);
           full.put("id", id);
-          full.put("updated_by", "sync");
+          full.put("updated_by", authorOf(snapshot));
           applySnapshot(id, full);
           return new PushOutcome.Accepted(recordRevision(id, null, "sync", false, false));
         });
@@ -608,7 +625,7 @@ public final class SpecStore implements ConflictResolver {
   private static Map<String, Object> withSync(String id, Map<String, Object> snapshot) {
     var full = new LinkedHashMap<>(snapshot);
     full.put("id", id);
-    full.put("updated_by", "sync");
+    full.put("updated_by", authorOf(snapshot));
     return full;
   }
 
@@ -619,7 +636,9 @@ public final class SpecStore implements ConflictResolver {
     var keys = new LinkedHashSet<String>();
     keys.addAll(a.keySet());
     keys.addAll(b.keySet());
-    return keys.stream().allMatch(key -> Objects.equals(a.get(key), b.get(key)));
+    return keys.stream()
+        .filter(key -> !key.startsWith("_"))
+        .allMatch(key -> Objects.equals(a.get(key), b.get(key)));
   }
 
   public Optional<SpecContent> getContent(String specId) {

--- a/sail-core/src/test/java/ai/singlr/sail/store/ConflictDetectorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ConflictDetectorTest.java
@@ -160,4 +160,43 @@ class ConflictDetectorTest {
     assertEquals("uday", merged.result().get("assignee"));
     assertEquals("A2", merged.result().get("title"));
   }
+
+  @Test
+  void differingMetadataNeverBlocksConverge() {
+    var base = snap("title", "A", "_actor", "ada");
+    var local = snap("title", "B", "_actor", "ada");
+    var remote = snap("title", "B", "_actor", "bob");
+
+    assertInstanceOf(
+        ConflictDetector.Converged.class,
+        ConflictDetector.detect(base, local, remote),
+        "identical work fields converge even though _actor differs");
+  }
+
+  @Test
+  void metadataIsNeverReportedAsAClashingField() {
+    var base = snap("title", "A", "_actor", "ada");
+    var local = snap("title", "B", "_actor", "ada");
+    var remote = snap("title", "C", "_actor", "bob");
+
+    var conflict =
+        assertInstanceOf(
+            ConflictDetector.Conflict.class, ConflictDetector.detect(base, local, remote));
+    assertEquals(java.util.List.of("title"), conflict.fields(), "_actor is never a clashing field");
+  }
+
+  @Test
+  void aMergeKeepsTheLocalBoxsMetadata() {
+    var base = snap("title", "A", "status", "pending", "_actor", "base");
+    var local = snap("title", "A2", "status", "pending", "_actor", "ada");
+    var remote = snap("title", "A", "status", "in_progress", "_actor", "bob");
+
+    var merged =
+        assertInstanceOf(
+            ConflictDetector.Merged.class, ConflictDetector.detect(base, local, remote));
+    assertEquals("A2", merged.result().get("title"));
+    assertEquals("in_progress", merged.result().get("status"));
+    assertEquals(
+        "ada", merged.result().get("_actor"), "the merging box authored the merged result");
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/sync/TwoNodeSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/TwoNodeSyncTest.java
@@ -173,6 +173,57 @@ class TwoNodeSyncTest {
     assertTrue(main.specs.findById("local").isEmpty());
   }
 
+  private SpecStore.SpecRow specBy(String id, String title, String author) {
+    return new SpecStore.SpecRow(
+        id,
+        "proj",
+        title,
+        SpecStatus.fromWire("pending"),
+        null,
+        null,
+        null,
+        null,
+        null,
+        0,
+        author,
+        "",
+        "",
+        author,
+        List.of(),
+        List.of());
+  }
+
+  @Test
+  void theAuthorOfASyncedSpecPropagatesInsteadOfBecomingSync() {
+    nodeA.specs.create(specBy("auth", "Auth", "ada"));
+
+    syncToMain(nodeA);
+    assertEquals(
+        "ada",
+        main.specs.findById("auth").orElseThrow().updatedBy(),
+        "main attributes the row to its real author, not 'sync'");
+
+    syncToMain(nodeB);
+    assertEquals(
+        "ada",
+        nodeB.specs.findById("auth").orElseThrow().updatedBy(),
+        "the author reaches the other node too");
+  }
+
+  @Test
+  void aSyncedEditCarriesTheEditorNotTheOriginalAuthor() {
+    nodeA.specs.create(specBy("auth", "Auth", "ada"));
+    syncToMain(nodeA);
+    syncToMain(nodeB);
+
+    nodeB.specs.update(specBy("auth", "Auth, revised", "bob"));
+    syncToMain(nodeB);
+    syncToMain(nodeA);
+
+    assertEquals("bob", main.specs.findById("auth").orElseThrow().updatedBy());
+    assertEquals("bob", nodeA.specs.findById("auth").orElseThrow().updatedBy());
+  }
+
   @Test
   void checkpointAdvancesToMainHighWaterMark() {
     nodeA.specs.create(spec("auth", "Auth", "pending"));


### PR DESCRIPTION
A spec that synced between devboxes was attributed to **"sync"** on the receiving side, erasing who actually made the change. The real author now travels end-to-end, so the board, spec views, and API show the originating FDE.

## Approach
The author rides **inside the comparable snapshot** under a reserved `_actor` key, rather than threading a new parameter through every interface, wire record, and engine call (and all their tests).

- `ConflictDetector` ignores reserved (`_`-prefixed) keys, so `_actor` propagates through the existing wire/engine/replicas **unchanged** and never causes a false conflict or becomes a clashing field. An auto-merge keeps the merging box's author.
- `SpecStore.applyRevision` / `commitRevision` / `resolveConflict` read `_actor` and set `updated_by` to it instead of the hardcoded `"sync"` (falling back to `"sync"` only when no author travels — e.g. files, which have no author concept and are untouched).

## Proven
Two-node harness: ada's create reaches main and the other node attributed to **ada**; a synced edit carries the editor **bob**, not the original author. New `ConflictDetector` tests cover the reserved-key semantics (no false conflict, never a clashing field, merge keeps local's metadata).

The advisory `board_updated` event stays count-based: it carries no per-spec detail, and a round can pull many specs from many authors, so a single author field would be ambiguous. The win is at the data level, where it's displayed.

`mvn verify` green: 1606 tests, coverage gates hold.