### PR TITLE
Security hardening: ADMIN route tiers, token expiry, expired-row sweep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.72</version>
+    <version>0.13.73</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.72</version>
+        <version>0.13.73</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/store/ExpiredRowSweeper.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ExpiredRowSweeper.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Periodically deletes expired credential rows — login sessions, enrollment tickets, WebAuthn
+ * challenges, and expiring API tokens — that were never touched again after expiry. Expiry is
+ * already enforced on read (each store prunes the row it looks up), so this is purely housekeeping
+ * to stop expired-but-untouched rows accumulating; a missed sweep is harmless.
+ *
+ * <p>Each sweep runs on its <b>own</b> short-lived connection rather than sharing the server's
+ * connection: the server's {@link Sqlite} uses a single connection with {@code BEGIN}/{@code
+ * COMMIT} transactions, and a delete issued onto it from another thread could land inside an
+ * in-flight request transaction. A separate connection lets SQLite's own file locking serialize the
+ * writes, and a transient lock contention just fails this sweep — the next one cleans up.
+ */
+public final class ExpiredRowSweeper implements AutoCloseable {
+
+  /** Default cadence: hourly is far finer than any credential lifetime, yet negligible load. */
+  public static final Duration DEFAULT_INTERVAL = Duration.ofHours(1);
+
+  private final Path dbPath;
+  private final ScheduledExecutorService scheduler;
+
+  public ExpiredRowSweeper(Path dbPath) {
+    this.dbPath = dbPath;
+    this.scheduler =
+        Executors.newSingleThreadScheduledExecutor(
+            Thread.ofVirtual().name("sail-sweep-", 0).factory());
+  }
+
+  /** Starts the periodic sweep at the default interval. */
+  public void start() {
+    start(DEFAULT_INTERVAL);
+  }
+
+  public void start(Duration interval) {
+    var seconds = Math.max(1, interval.toSeconds());
+    scheduler.scheduleAtFixedRate(this::sweepQuietly, seconds, seconds, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Opens a dedicated connection, sweeps once, and never throws — failures are logged and retried.
+   */
+  void sweepQuietly() {
+    try (var db = Sqlite.open(dbPath)) {
+      sweep(db);
+    } catch (Exception e) {
+      System.err.println("sail sweep: could not prune expired rows (" + e.getMessage() + ").");
+    }
+  }
+
+  /**
+   * Deletes every row whose expiry has passed; returns how many were removed. Visible for tests.
+   */
+  static int sweep(Sqlite db) {
+    var now = Instant.now().toString();
+    var deleted = 0;
+    db.execute("DELETE FROM sessions WHERE expires_at < ?", now);
+    deleted += db.changes();
+    db.execute("DELETE FROM webauthn_challenges WHERE expires_at < ?", now);
+    deleted += db.changes();
+    db.execute("DELETE FROM enrollment_tickets WHERE expires_at < ?", now);
+    deleted += db.changes();
+    db.execute("DELETE FROM api_tokens WHERE expires_at IS NOT NULL AND expires_at < ?", now);
+    deleted += db.changes();
+    return deleted;
+  }
+
+  @Override
+  public void close() {
+    scheduler.shutdownNow();
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -291,7 +291,8 @@ public final class SchemaManager {
               base_rev TEXT,
               updated_at TEXT NOT NULL,
               UNIQUE (project, path)
-          )""");
+          )""",
+          "ALTER TABLE api_tokens ADD COLUMN expires_at TEXT");
 
   private final Sqlite db;
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/TokenStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/TokenStore.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HexFormat;
 import java.util.List;
@@ -17,10 +18,18 @@ import java.util.Optional;
 /**
  * API token management. Tokens are SHA-256 hashed before storage. The plaintext is returned exactly
  * once at creation time.
+ *
+ * <p>A token may carry an {@code expires_at}: once past, {@link #validate} rejects and prunes it,
+ * so a leaked token cannot be used indefinitely. A {@code null} expiry never expires — the
+ * convenience overloads keep that for back-compat and for break-glass bootstrap tokens; the {@code
+ * sail server token} CLI opts into a default lifetime so operator-minted tokens expire by default.
  */
 public final class TokenStore {
 
   private static final java.util.Set<String> ROLES = java.util.Set.of("admin", "member", "viewer");
+
+  /** Default lifetime the CLI applies to a newly minted token unless overridden. */
+  public static final Duration DEFAULT_TTL = Duration.ofDays(90);
 
   private final Sqlite db;
 
@@ -29,41 +38,63 @@ public final class TokenStore {
   }
 
   public record TokenInfo(
-      String name, String role, String createdAt, String lastUsedAt, String fdeHandle) {}
+      String name,
+      String role,
+      String createdAt,
+      String lastUsedAt,
+      String fdeHandle,
+      String expiresAt) {}
 
-  public record CreatedToken(String name, String token, String role) {}
+  public record CreatedToken(String name, String token, String role, String expiresAt) {}
 
   public CreatedToken create(String name, String role) {
-    return create(name, role, null);
+    return create(name, role, null, null);
   }
 
   /** Creates a token optionally owned by an FDE ({@code fdes.id}, or null for an unowned token). */
   public CreatedToken create(String name, String role, String fdeId) {
+    return create(name, role, fdeId, null);
+  }
+
+  /**
+   * Creates a token with an explicit lifetime; {@code ttl} of {@code null} never expires. The
+   * plaintext is returned once.
+   */
+  public CreatedToken create(String name, String role, String fdeId, Duration ttl) {
     if (!ROLES.contains(role)) {
       throw new IllegalArgumentException(
           "Invalid role: " + role + ". Must be one of " + ROLES + ".");
     }
     var token = generateToken();
-    var hash = sha256(token);
+    var expiresAt = ttl == null ? null : Instant.now().plus(ttl).toString();
     db.execute(
-        "INSERT INTO api_tokens (token_hash, name, role, fde_id, created_at) VALUES (?, ?, ?, ?, ?)",
-        hash,
+        "INSERT INTO api_tokens (token_hash, name, role, fde_id, created_at, expires_at)"
+            + " VALUES (?, ?, ?, ?, ?, ?)",
+        sha256(token),
         name,
         role,
         fdeId,
-        Instant.now().toString());
-    return new CreatedToken(name, token, role);
+        Instant.now().toString(),
+        expiresAt);
+    return new CreatedToken(name, token, role, expiresAt);
   }
 
+  /** Resolves a live token, or empty if unknown or expired. An expired row is pruned on lookup. */
   public Optional<TokenInfo> validate(String token) {
     var hash = sha256(token);
     var result = db.queryOne(SELECT + " WHERE t.token_hash = ?", TokenStore::map, hash);
-    result.ifPresent(
-        info ->
-            db.execute(
-                "UPDATE api_tokens SET last_used_at = ? WHERE token_hash = ?",
-                Instant.now().toString(),
-                hash));
+    if (result.isEmpty()) {
+      return Optional.empty();
+    }
+    var expiresAt = result.get().expiresAt();
+    if (expiresAt != null && Instant.parse(expiresAt).isBefore(Instant.now())) {
+      db.execute("DELETE FROM api_tokens WHERE token_hash = ?", hash);
+      return Optional.empty();
+    }
+    db.execute(
+        "UPDATE api_tokens SET last_used_at = ? WHERE token_hash = ?",
+        Instant.now().toString(),
+        hash);
     return result;
   }
 
@@ -72,11 +103,12 @@ public final class TokenStore {
   }
 
   private static final String SELECT =
-      "SELECT t.name, t.role, t.created_at, t.last_used_at, f.handle"
+      "SELECT t.name, t.role, t.created_at, t.last_used_at, f.handle, t.expires_at"
           + " FROM api_tokens t LEFT JOIN fdes f ON t.fde_id = f.id";
 
   private static TokenInfo map(Sqlite.Row row) {
-    return new TokenInfo(row.text(0), row.text(1), row.text(2), row.text(3), row.text(4));
+    return new TokenInfo(
+        row.text(0), row.text(1), row.text(2), row.text(3), row.text(4), row.text(5));
   }
 
   public boolean revoke(String name) {

--- a/sail-core/src/test/java/ai/singlr/sail/store/ExpiredRowSweeperTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ExpiredRowSweeperTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ExpiredRowSweeperTest {
+
+  @TempDir Path tempDir;
+  private Path dbPath;
+  private Sqlite db;
+
+  @BeforeEach
+  void setUp() {
+    dbPath = tempDir.resolve("test.db");
+    db = Sqlite.open(dbPath);
+    new SchemaManager(db).migrate();
+  }
+
+  @AfterEach
+  void tearDown() {
+    db.close();
+  }
+
+  private void session(String hash, Instant expiresAt) {
+    var fde = new FdeStore(db).add("uday-" + hash, null, null);
+    db.execute(
+        "INSERT INTO sessions (token_hash, fde_id, created_at, expires_at) VALUES (?, ?, ?, ?)",
+        hash,
+        fde.id(),
+        Instant.now().toString(),
+        expiresAt.toString());
+  }
+
+  @Test
+  void deletesExpiredSessionsButKeepsLiveOnes() {
+    session("live", Instant.now().plus(Duration.ofHours(1)));
+    session("dead", Instant.now().minus(Duration.ofHours(1)));
+
+    var removed = ExpiredRowSweeper.sweep(db);
+
+    assertEquals(1, removed);
+    assertEquals(
+        1L,
+        db.queryOne("SELECT COUNT(*) FROM sessions", row -> row.integer(0)).orElseThrow(),
+        "the live session survives");
+  }
+
+  @Test
+  void prunesExpiringTokensButLeavesNonExpiringOnes() {
+    var store = new TokenStore(db);
+    store.create("forever", "member");
+    store.create("doomed", "member", null, Duration.ofSeconds(-1));
+
+    var removed = ExpiredRowSweeper.sweep(db);
+
+    assertEquals(1, removed);
+    assertEquals(1, store.list().size());
+    assertEquals("forever", store.list().getFirst().name());
+  }
+
+  @Test
+  void anEmptyDatabaseSweepsNothing() {
+    assertEquals(0, ExpiredRowSweeper.sweep(db));
+  }
+
+  @Test
+  void sweepQuietlyOpensItsOwnConnectionAndRemovesExpiredRows() {
+    new TokenStore(db).create("doomed", "member", null, Duration.ofSeconds(-1));
+
+    try (var sweeper = new ExpiredRowSweeper(dbPath)) {
+      sweeper.sweepQuietly();
+    }
+
+    assertTrue(new TokenStore(db).list().isEmpty());
+  }
+
+  @Test
+  void sweepQuietlySwallowsAFailureFromAMissingDatabase() {
+    try (var sweeper = new ExpiredRowSweeper(tempDir.resolve("nonexistent/missing.db"))) {
+      assertDoesNotThrow(sweeper::sweepQuietly);
+    }
+  }
+
+  @Test
+  void startAndCloseAreClean() {
+    try (var sweeper = new ExpiredRowSweeper(dbPath)) {
+      assertDoesNotThrow(() -> sweeper.start());
+    }
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/TokenStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/TokenStoreTest.java
@@ -157,4 +157,27 @@ class TokenStoreTest {
     var hash2 = TokenStore.sha256("input-b");
     assertNotEquals(hash1, hash2);
   }
+
+  @Test
+  void aTokenWithoutAnExpiryNeverExpires() {
+    var created = store.create("ci", "member");
+    assertNull(created.expiresAt());
+    assertTrue(store.validate(created.token()).isPresent());
+  }
+
+  @Test
+  void aTokenWithinItsLifetimeValidates() {
+    var created = store.create("ci", "member", null, java.time.Duration.ofDays(90));
+    assertNotNull(created.expiresAt());
+    var info = store.validate(created.token()).orElseThrow();
+    assertEquals(created.expiresAt(), info.expiresAt());
+  }
+
+  @Test
+  void anExpiredTokenIsRejectedAndPruned() {
+    var created = store.create("ci", "member", null, java.time.Duration.ofSeconds(-1));
+
+    assertTrue(store.validate(created.token()).isEmpty(), "an expired token does not validate");
+    assertTrue(store.list().isEmpty(), "validation pruned the expired row");
+  }
 }

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.72</version>
+        <version>0.13.73</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.72</version>
+        <version>0.13.73</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -153,6 +153,7 @@ public final class ApiRouter implements HttpHandler {
       throw methodNotAllowed();
     }
     requireMethod(request, POST);
+    Authorizer.require(exchange, Capability.ADMIN);
     return ApiResponse.from(operations.dispatch(project, JsonBody.readDispatchRequest(exchange)));
   }
 
@@ -251,6 +252,7 @@ public final class ApiRouter implements HttpHandler {
       return switch (sub) {
         case APPROVE -> {
           requireMethod(request, POST);
+          Authorizer.require(exchange, Capability.ADMIN);
           yield ApiResponse.from(operations.approveReview(reviewId, actor(exchange)));
         }
         default -> throw notFound();
@@ -262,6 +264,7 @@ public final class ApiRouter implements HttpHandler {
       var findingId = request.segments().get(4);
       if (DISMISS.equals(sub)) {
         requireMethod(request, POST);
+        Authorizer.require(exchange, Capability.ADMIN);
         return ApiResponse.from(operations.dismissFinding(reviewId, findingId));
       }
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -24,6 +24,7 @@ import ai.singlr.sail.store.AuthSessionStore;
 import ai.singlr.sail.store.DataMigration;
 import ai.singlr.sail.store.EnrollmentTicketStore;
 import ai.singlr.sail.store.EventStore;
+import ai.singlr.sail.store.ExpiredRowSweeper;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.MigrationRunner;
 import ai.singlr.sail.store.PendingChallengeStore;
@@ -155,16 +156,18 @@ public final class ServerStartCommand implements Runnable {
         new SessionAwareAuth(new AuthSessionStore(db), new FdeStore(db), new TokenAuth(tokenStore));
 
     try (var server =
-        new SailApiServer(
-            host,
-            port,
-            operations,
-            auth,
-            bus,
-            persister,
-            SailPaths.apiSocketPath(),
-            passkeyHandler)) {
+            new SailApiServer(
+                host,
+                port,
+                operations,
+                auth,
+                bus,
+                persister,
+                SailPaths.apiSocketPath(),
+                passkeyHandler);
+        var sweeper = new ExpiredRowSweeper(dbPath)) {
       server.start();
+      sweeper.start();
       System.out.println(
           Ansi.AUTO.string(
               "  @|green ✓|@ Sail server listening on http://" + host + ":" + server.port()));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerTokenCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerTokenCommand.java
@@ -49,6 +49,14 @@ public final class ServerTokenCommand implements Runnable {
     @picocli.CommandLine.Option(names = "--fde", description = "Owning FDE handle.")
     private String fde;
 
+    @picocli.CommandLine.Option(
+        names = "--ttl-days",
+        description = "Token lifetime in days (default 90).")
+    private Integer ttlDays;
+
+    @picocli.CommandLine.Option(names = "--no-expiry", description = "Token never expires.")
+    private boolean noExpiry;
+
     @Spec private CommandSpec spec;
 
     @Override
@@ -56,16 +64,41 @@ public final class ServerTokenCommand implements Runnable {
       CliCommand.run(
           spec,
           () -> {
+            var ttl = resolveTtl(noExpiry, ttlDays);
             try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
               var fdeId = resolveFdeId(db);
-              var created = new TokenStore(db).create(name, role, fdeId);
+              var created = new TokenStore(db).create(name, role, fdeId, ttl);
               System.out.println(
                   Ansi.AUTO.string("  @|green ✓|@ Token created: " + created.name()));
               System.out.println(Ansi.AUTO.string("    @|bold " + created.token() + "|@"));
               System.out.println(
+                  Ansi.AUTO.string(
+                      "    @|faint "
+                          + (created.expiresAt() == null
+                              ? "Never expires."
+                              : "Expires " + created.expiresAt() + ".")
+                          + "|@"));
+              System.out.println(
                   Ansi.AUTO.string("    @|faint Save this token — it will not be shown again.|@"));
             }
           });
+    }
+
+    /** Resolves the requested lifetime; {@code null} never expires. Visible for tests. */
+    static java.time.Duration resolveTtl(boolean noExpiry, Integer ttlDays) {
+      if (noExpiry && ttlDays != null) {
+        throw new IllegalArgumentException("Pass --ttl-days or --no-expiry, not both.");
+      }
+      if (noExpiry) {
+        return null;
+      }
+      if (ttlDays == null) {
+        return TokenStore.DEFAULT_TTL;
+      }
+      if (ttlDays <= 0) {
+        throw new IllegalArgumentException("--ttl-days must be a positive number of days.");
+      }
+      return java.time.Duration.ofDays(ttlDays);
     }
 
     private String resolveFdeId(Sqlite db) {
@@ -99,8 +132,11 @@ public final class ServerTokenCommand implements Runnable {
                 return;
               }
               for (var token : tokens) {
+                var expiry =
+                    token.expiresAt() == null ? "never expires" : "expires " + token.expiresAt();
                 System.out.printf(
-                    "  %-20s  %-8s  created %s%n", token.name(), token.role(), token.createdAt());
+                    "  %-20s  %-8s  created %s  (%s)%n",
+                    token.name(), token.role(), token.createdAt(), expiry);
               }
             }
           });

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AuthorizationTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AuthorizationTest.java
@@ -70,6 +70,38 @@ class AuthorizationTest {
   }
 
   @Test
+  void memberCannotDispatch() throws Exception {
+    var member = tokenStore.create("m", "member").token();
+    var response = send("POST", "/v1/projects/acme/dispatch", member, "{}");
+    assertEquals(403, response.statusCode(), response.body());
+    assertTrue(response.body().contains("forbidden"), response.body());
+  }
+
+  @Test
+  void adminCanDispatch() throws Exception {
+    var admin = tokenStore.create("a", "admin").token();
+    assertNotEquals(403, send("POST", "/v1/projects/acme/dispatch", admin, "{}").statusCode());
+  }
+
+  @Test
+  void memberCannotApproveAReview() throws Exception {
+    var member = tokenStore.create("m", "member").token();
+    assertEquals(403, send("POST", "/v1/reviews/r1/approve", member, "{}").statusCode());
+  }
+
+  @Test
+  void adminCanApproveAReview() throws Exception {
+    var admin = tokenStore.create("a", "admin").token();
+    assertNotEquals(403, send("POST", "/v1/reviews/r1/approve", admin, "{}").statusCode());
+  }
+
+  @Test
+  void memberCannotDismissAFinding() throws Exception {
+    var member = tokenStore.create("m", "member").token();
+    assertEquals(403, send("POST", "/v1/reviews/r1/dismiss/f1", member, "{}").statusCode());
+  }
+
+  @Test
   void fdeOwnedTokenCanWrite() throws Exception {
     var fde = new ai.singlr.sail.store.FdeStore(db).add("uday", null, null);
     var token = tokenStore.create("uday-laptop", "admin", fde.id()).token();

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ServerTokenCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ServerTokenCommandTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import ai.singlr.sail.store.TokenStore;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class ServerTokenCommandTest {
+
+  @Test
+  void defaultsToTheStandardLifetime() {
+    assertEquals(TokenStore.DEFAULT_TTL, ServerTokenCommand.Create.resolveTtl(false, null));
+  }
+
+  @Test
+  void noExpiryYieldsNoLifetime() {
+    assertNull(ServerTokenCommand.Create.resolveTtl(true, null));
+  }
+
+  @Test
+  void anExplicitDayCountWins() {
+    assertEquals(Duration.ofDays(30), ServerTokenCommand.Create.resolveTtl(false, 30));
+  }
+
+  @Test
+  void noExpiryAndTtlTogetherIsRejected() {
+    var thrown =
+        assertThrows(
+            IllegalArgumentException.class, () -> ServerTokenCommand.Create.resolveTtl(true, 30));
+    assertTrue(thrown.getMessage().contains("not both"));
+  }
+
+  @Test
+  void aNonPositiveLifetimeIsRejected() {
+    assertThrows(
+        IllegalArgumentException.class, () -> ServerTokenCommand.Create.resolveTtl(false, 0));
+    assertThrows(
+        IllegalArgumentException.class, () -> ServerTokenCommand.Create.resolveTtl(false, -5));
+  }
+}


### PR DESCRIPTION
Three deferred items from the 0.13.59 security audit backlog.

## 1. Route privilege tiers
The `ADMIN` capability existed but no route used it — so a `member`-role FDE could run agents (`POST /dispatch`, code execution in a container) and approve/dismiss security reviews. Both now require `ADMIN`; members keep spec create/edit/delete.

> Decision (Uday): dispatch + review sign-off are admin-only; spec delete stays a member action.

## 2. API token expiry
- `api_tokens` gains a **nullable** `expires_at` — existing tokens are grandfathered as never-expiring.
- `TokenStore.validate` rejects **and prunes** an expired token on lookup, mirroring the session pattern.
- The `create()` convenience overloads stay non-expiring — deliberately, so the **break-glass bootstrap admin token** can't lock the operator out — while `sail server token create` defaults to a **90-day** lifetime with `--ttl-days` / `--no-expiry` overrides. `token list` shows each token's expiry.

## 3. Background sweep
`ExpiredRowSweeper` periodically deletes expired sessions, enrollment tickets, WebAuthn challenges, and expiring tokens that were never touched again after expiry (expiry is already enforced on read; this just stops dead rows accumulating). Wired into the `sail server start` lifecycle.

Critically, it sweeps on its **own short-lived connection**, not the server's shared one: that connection runs `BEGIN`/`COMMIT` request transactions, and a delete issued onto it from the sweep thread could land inside an in-flight transaction. A separate connection lets SQLite's file locking serialize the writes; a transient lock just fails the sweep and the next one cleans up.

## Quality
`mvn verify` green: 1611 infra tests, **api.\* still 100%** (`ApiRouter` fully covered, including the new ADMIN gates). New tests: member-forbidden / admin-allowed for dispatch + review routes; token expiry validate+prune; `resolveTtl` flag matrix; sweeper across all four tables + lifecycle.