### PR TITLE
Repo-wide rigor sweep + 0.13.74

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.73</version>
+    <version>0.13.74</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -132,26 +132,33 @@
                             <rules>
                                 <rule>
                                     <element>BUNDLE</element>
+                                    <!--
+                                        Ratchet: each minimum sits just under the weakest module's
+                                        actual for that counter (line/branch/method bound by
+                                        sail-infra ~0.54/0.46/0.73; class bound by sail-harness 0.89)
+                                        so the current bar is locked in and any regression fails the
+                                        build. Raise these as coverage climbs toward 100%.
+                                    -->
                                     <limits>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.44</minimum>
+                                            <minimum>0.53</minimum>
                                         </limit>
                                         <limit>
                                             <counter>METHOD</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.67</minimum>
+                                            <minimum>0.72</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.36</minimum>
+                                            <minimum>0.45</minimum>
                                         </limit>
                                         <limit>
                                             <counter>CLASS</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.86</minimum>
+                                            <minimum>0.88</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.73</version>
+        <version>0.13.74</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/config/BranchPolicy.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/BranchPolicy.java
@@ -5,6 +5,8 @@
 
 package ai.singlr.sail.config;
 
+import ai.singlr.sail.common.Strings;
+
 /**
  * Pure resolver for the git branch name a dispatched spec should run on. Replaces the inline
  * duplicates that lived in {@code SailApiOperations.branchName} (HTTP dispatch path) and {@code
@@ -40,7 +42,7 @@ public final class BranchPolicy {
       return spec.branch();
     }
     var prefix = config.agent().branchPrefix();
-    if (prefix == null || prefix.isBlank()) {
+    if (Strings.isBlank(prefix)) {
       prefix = DEFAULT_PREFIX;
     }
     return prefix + spec.id();

--- a/sail-core/src/main/java/ai/singlr/sail/config/ClientConfig.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/ClientConfig.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.config;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.engine.SailPaths;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -39,7 +40,7 @@ public record ClientConfig(String host, String user) {
 
   public static ClientConfig fromMap(Map<String, Object> map) {
     var host = (String) map.get("host");
-    if (host == null || host.isBlank()) {
+    if (Strings.isBlank(host)) {
       throw new IllegalArgumentException(
           "client config 'host' is required."
               + "\n  Set the host in ~/.sail/config.yaml: host: <server-ip-or-ssh-alias>");
@@ -57,7 +58,7 @@ public record ClientConfig(String host, String user) {
 
   /** Returns true when FDE-gateway forwarding is configured (a non-blank gateway user). */
   public boolean gatewayEnabled() {
-    return user != null && !user.isBlank();
+    return Strings.isNotBlank(user);
   }
 
   /** The SSH destination for gateway-forwarded commands, e.g. {@code sail@devbox}. */

--- a/sail-core/src/main/java/ai/singlr/sail/config/CodeReview.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/CodeReview.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.config;
 
+import ai.singlr.sail.common.Strings;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,7 +55,7 @@ public record CodeReview(boolean enabled, String auditor) {
    * @throws IllegalArgumentException if the explicit auditor is invalid
    */
   public String resolveAuditor(String primaryType, List<String> installList, Set<String> exclude) {
-    if (auditor != null && !auditor.isBlank()) {
+    if (Strings.isNotBlank(auditor)) {
       if (!KNOWN_AGENTS.contains(auditor)) {
         throw new IllegalArgumentException(
             "Unknown code review auditor '"

--- a/sail-core/src/main/java/ai/singlr/sail/config/Notifications.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/Notifications.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.config;
 
+import ai.singlr.sail.common.Strings;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +53,7 @@ public record Notifications(String url, List<String> events) {
   @SuppressWarnings("unchecked")
   public static Notifications fromMap(Map<String, Object> map) {
     var url = (String) map.get("url");
-    if (url == null || url.isBlank()) {
+    if (Strings.isBlank(url)) {
       throw new IllegalArgumentException("notifications.url is required.");
     }
     WebhookUrlSafety.requireSafe(url);

--- a/sail-core/src/main/java/ai/singlr/sail/config/PlaceholderResolver.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/PlaceholderResolver.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.config;
 
+import ai.singlr.sail.common.Strings;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -73,7 +74,7 @@ public final class PlaceholderResolver {
       System.out.print("  " + prompt + ": ");
       System.out.flush();
       var value = readLine(reader);
-      if (value == null || value.isBlank()) {
+      if (Strings.isBlank(value)) {
         throw new IllegalArgumentException("Value required for ${" + name + "} (" + prompt + ")");
       }
       resolved.put(name, value.strip());

--- a/sail-core/src/main/java/ai/singlr/sail/config/ProjectRegistry.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/ProjectRegistry.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Snapshot of every project descriptor under {@code ~/.sail/projects/}. Holds enough to back the
@@ -65,8 +66,8 @@ public final class ProjectRegistry {
   }
 
   /** Returns the project info for {@code name}, or empty if no descriptor matches. */
-  public java.util.Optional<ProjectInfo> find(String name) {
-    return java.util.Optional.ofNullable(byName.get(name));
+  public Optional<ProjectInfo> find(String name) {
+    return Optional.ofNullable(byName.get(name));
   }
 
   /**

--- a/sail-core/src/main/java/ai/singlr/sail/config/ReviewPipelineConfig.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/ReviewPipelineConfig.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.config;
 
+import ai.singlr.sail.common.Strings;
 import java.util.List;
 import java.util.Map;
 
@@ -21,7 +22,7 @@ public record ReviewPipelineConfig(int maxIterations, List<StageConfig> stages) 
     @SuppressWarnings("unchecked")
     public static StageConfig fromMap(Map<String, Object> map) {
       var name = (String) map.get("name");
-      if (name == null || name.isBlank()) {
+      if (Strings.isBlank(name)) {
         throw new IllegalArgumentException("review_pipeline stage requires a name");
       }
       var type = StageType.parse((String) map.getOrDefault("type", "agent"));

--- a/sail-core/src/main/java/ai/singlr/sail/config/ReviewPipelineConfig.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/ReviewPipelineConfig.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.config;
 
 import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.store.Finding;
 import java.util.List;
 import java.util.Map;
 
@@ -54,19 +55,18 @@ public record ReviewPipelineConfig(int maxIterations, List<StageConfig> stages) 
       return valueOf(value.strip().toUpperCase());
     }
 
-    public boolean passes(List<ai.singlr.sail.store.Finding> findings) {
+    public boolean passes(List<Finding> findings) {
       return switch (this) {
         case NO_CRITICAL ->
             findings.stream()
-                .filter(f -> f.resolution() == ai.singlr.sail.store.Finding.Resolution.OPEN)
-                .noneMatch(f -> f.severity() == ai.singlr.sail.store.Finding.Severity.CRITICAL);
+                .filter(f -> f.resolution() == Finding.Resolution.OPEN)
+                .noneMatch(f -> f.severity() == Finding.Severity.CRITICAL);
         case NO_CRITICAL_OR_HIGH ->
             findings.stream()
-                .filter(f -> f.resolution() == ai.singlr.sail.store.Finding.Resolution.OPEN)
-                .noneMatch(f -> f.severity().isAtLeast(ai.singlr.sail.store.Finding.Severity.HIGH));
+                .filter(f -> f.resolution() == Finding.Resolution.OPEN)
+                .noneMatch(f -> f.severity().isAtLeast(Finding.Severity.HIGH));
         case ALL_CLEAR ->
-            findings.stream()
-                .noneMatch(f -> f.resolution() == ai.singlr.sail.store.Finding.Resolution.OPEN);
+            findings.stream().noneMatch(f -> f.resolution() == Finding.Resolution.OPEN);
       };
     }
   }

--- a/sail-core/src/main/java/ai/singlr/sail/config/SecurityAudit.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/SecurityAudit.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.config;
 
+import ai.singlr.sail.common.Strings;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +53,7 @@ public record SecurityAudit(boolean enabled, String auditor) {
    * @throws IllegalArgumentException if the explicit auditor is invalid
    */
   public String resolveAuditor(String primaryType, List<String> installList) {
-    if (auditor != null && !auditor.isBlank()) {
+    if (Strings.isNotBlank(auditor)) {
       if (!KNOWN_AGENTS.contains(auditor)) {
         throw new IllegalArgumentException(
             "Unknown security auditor '"

--- a/sail-core/src/main/java/ai/singlr/sail/config/Spec.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/Spec.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.config;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.engine.AgentCli;
 import ai.singlr.sail.engine.NameValidator;
 import java.util.LinkedHashMap;
@@ -85,7 +86,7 @@ public record Spec(
   @SuppressWarnings("unchecked")
   public static Spec fromMap(Map<String, Object> map) {
     var id = (String) map.get("id");
-    if (id == null || id.isBlank()) {
+    if (Strings.isBlank(id)) {
       throw new IllegalArgumentException("spec.id is required");
     }
     NameValidator.requireValidSpecId(id);
@@ -171,7 +172,7 @@ public record Spec(
   }
 
   private static String validatedAgent(String agent) {
-    if (agent == null || agent.isBlank()) {
+    if (Strings.isBlank(agent)) {
       return null;
     }
     AgentCli.fromYamlName(agent);
@@ -180,7 +181,7 @@ public record Spec(
 
   /** Validates a model id (or returns null when blank). Throws on shell-unsafe values. */
   public static String validatedModel(String model) {
-    if (model == null || model.isBlank()) {
+    if (Strings.isBlank(model)) {
       return null;
     }
     if (!MODEL_PATTERN.matcher(model).matches()) {
@@ -192,7 +193,7 @@ public record Spec(
 
   /** Validates a reasoning-effort value (or returns null when blank). Throws if not allowed. */
   public static String validatedReasoningEffort(String reasoningEffort) {
-    if (reasoningEffort == null || reasoningEffort.isBlank()) {
+    if (Strings.isBlank(reasoningEffort)) {
       return null;
     }
     if (!REASONING_EFFORTS.contains(reasoningEffort)) {

--- a/sail-core/src/main/java/ai/singlr/sail/config/SpecAuditEvent.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/SpecAuditEvent.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.config;
 
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.LinkedHashMap;
@@ -89,7 +90,7 @@ public record SpecAuditEvent(
       map.put("pid", pid);
     }
     map.put("host", host);
-    if (note != null && !note.isBlank()) {
+    if (Strings.isNotBlank(note)) {
       map.put("note", note);
     }
     return map;
@@ -151,7 +152,7 @@ public record SpecAuditEvent(
   }
 
   private static void requireNonBlank(String value, String name) {
-    if (value == null || value.isBlank()) {
+    if (Strings.isBlank(value)) {
       throw new IllegalArgumentException(name + " is required");
     }
   }

--- a/sail-core/src/main/java/ai/singlr/sail/config/SpecAuditEvent.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/SpecAuditEvent.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.config;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.LinkedHashMap;
@@ -50,27 +51,27 @@ public record SpecAuditEvent(
 
   /** Convenience factory for {@code dispatched}. */
   public static SpecAuditEvent dispatched(String agent, String host, String note) {
-    return new SpecAuditEvent(Instant.now(), "dispatched", agent, null, host, note);
+    return new SpecAuditEvent(DateTimeUtils.now(), "dispatched", agent, null, host, note);
   }
 
   /** Convenience factory for {@code restarted}. */
   public static SpecAuditEvent restarted(String agent, String host, String note) {
-    return new SpecAuditEvent(Instant.now(), "restarted", agent, null, host, note);
+    return new SpecAuditEvent(DateTimeUtils.now(), "restarted", agent, null, host, note);
   }
 
   /** Convenience factory for {@code started}, carrying the agent PID. */
   public static SpecAuditEvent started(String agent, int pid, String host) {
-    return new SpecAuditEvent(Instant.now(), "started", agent, pid, host, null);
+    return new SpecAuditEvent(DateTimeUtils.now(), "started", agent, pid, host, null);
   }
 
   /** Convenience factory for {@code stopped}, carrying the agent PID. */
   public static SpecAuditEvent stopped(String agent, int pid, String host, String note) {
-    return new SpecAuditEvent(Instant.now(), "stopped", agent, pid, host, note);
+    return new SpecAuditEvent(DateTimeUtils.now(), "stopped", agent, pid, host, note);
   }
 
   /** Convenience factory for {@code completed}. */
   public static SpecAuditEvent completed(String agent, String host, String note) {
-    return new SpecAuditEvent(Instant.now(), "completed", agent, null, host, note);
+    return new SpecAuditEvent(DateTimeUtils.now(), "completed", agent, null, host, note);
   }
 
   /** Serializes this event as a single-line JSON object. Field order is deterministic. */

--- a/sail-core/src/main/java/ai/singlr/sail/config/SpecScaffold.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/SpecScaffold.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.config;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.engine.NameValidator;
 import java.util.Locale;
 
@@ -14,7 +15,7 @@ public final class SpecScaffold {
   private SpecScaffold() {}
 
   public static String deriveId(String title) {
-    if (title == null || title.isBlank()) {
+    if (Strings.isBlank(title)) {
       throw new IllegalArgumentException("Spec title is required.");
     }
     var slug =
@@ -33,7 +34,7 @@ public final class SpecScaffold {
   }
 
   public static String markdownTemplate(String title) {
-    if (title == null || title.isBlank()) {
+    if (Strings.isBlank(title)) {
       throw new IllegalArgumentException("Spec title is required.");
     }
     return """

--- a/sail-core/src/main/java/ai/singlr/sail/config/SyncConfig.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/SyncConfig.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.config;
 
+import ai.singlr.sail.common.Strings;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -20,8 +21,8 @@ public record SyncConfig(String role, String main) {
   public static final String ROLE_NODE = "node";
 
   public SyncConfig {
-    role = role == null || role.isBlank() ? null : role;
-    main = main == null || main.isBlank() ? null : main;
+    role = Strings.isBlank(role) ? null : role;
+    main = Strings.isBlank(main) ? null : main;
   }
 
   /** An undeclared box: neither main nor pointed at one. */

--- a/sail-core/src/main/java/ai/singlr/sail/config/WebauthnConfig.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/WebauthnConfig.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.config;
 
+import ai.singlr.sail.common.Strings;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,12 +32,12 @@ public record WebauthnConfig(String rpId, String rpName, List<String> origins) {
 
   /** True when an {@code rpId} and at least one origin are present, so login can be served. */
   public boolean isConfigured() {
-    return rpId != null && !rpId.isBlank() && !origins.isEmpty();
+    return Strings.isNotBlank(rpId) && !origins.isEmpty();
   }
 
   /** The display name, falling back to the {@code rpId} when none was configured. */
   public String resolvedRpName() {
-    return rpName == null || rpName.isBlank() ? rpId : rpName;
+    return Strings.isBlank(rpName) ? rpId : rpName;
   }
 
   @SuppressWarnings("unchecked")

--- a/sail-core/src/main/java/ai/singlr/sail/config/WebhookUrlSafety.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/WebhookUrlSafety.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.config;
 
+import ai.singlr.sail.common.Strings;
 import java.net.InetAddress;
 import java.net.URI;
 
@@ -40,7 +41,7 @@ public final class WebhookUrlSafety {
     }
 
     var host = uri.getHost();
-    if (host == null || host.isBlank()) {
+    if (Strings.isBlank(host)) {
       throw new IllegalArgumentException(
           "Invalid notifications.url: '" + url + "'. No hostname found.");
     }

--- a/sail-core/src/main/java/ai/singlr/sail/config/YamlUtil.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/YamlUtil.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.config;
 
+import ai.singlr.sail.common.Strings;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -27,7 +28,7 @@ public final class YamlUtil {
   /** Parse a YAML or JSON string into a Map. Returns empty map for null/blank input. */
   @SuppressWarnings("unchecked")
   public static Map<String, Object> parseMap(String yamlOrJson) {
-    if (yamlOrJson == null || yamlOrJson.isBlank()) {
+    if (Strings.isBlank(yamlOrJson)) {
       return Map.of();
     }
     var load = new Load(LoadSettings.builder().build());
@@ -43,7 +44,7 @@ public final class YamlUtil {
    */
   @SuppressWarnings("unchecked")
   public static Map<String, Object> parseMapStrict(String yamlOrJson) {
-    if (yamlOrJson == null || yamlOrJson.isBlank()) {
+    if (Strings.isBlank(yamlOrJson)) {
       return Map.of();
     }
     var load = new Load(LoadSettings.builder().setAllowDuplicateKeys(false).build());
@@ -70,7 +71,7 @@ public final class YamlUtil {
   /** Parse a JSON array string into a list of Maps. Returns empty list for null/blank input. */
   @SuppressWarnings("unchecked")
   public static List<Map<String, Object>> parseList(String json) {
-    if (json == null || json.isBlank()) {
+    if (Strings.isBlank(json)) {
       return List.of();
     }
     var load = new Load(LoadSettings.builder().build());

--- a/sail-core/src/main/java/ai/singlr/sail/engine/AgentCli.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/AgentCli.java
@@ -5,6 +5,8 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.Strings;
+
 /**
  * Known AI coding agent CLIs that can be installed inside a project container. Each constant
  * carries the metadata needed to install and invoke the agent: the YAML config name, the binary
@@ -118,9 +120,7 @@ public enum AgentCli {
         requireNoModelOptions(model, reasoningEffort);
         var perm = fullPermissions ? " --dangerously-skip-permissions" : "";
         var settings =
-            claudeSettingsPath == null || claudeSettingsPath.isBlank()
-                ? ""
-                : " --settings " + claudeSettingsPath;
+            Strings.isBlank(claudeSettingsPath) ? "" : " --settings " + claudeSettingsPath;
         yield binaryName + " --print" + settings + perm + " -p " + task;
       }
       case CODEX -> {

--- a/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.store.Finding;
 import java.util.List;
@@ -49,7 +50,7 @@ public final class FindingParser {
   }
 
   static String extractJsonBlock(String output) {
-    if (output == null || output.isBlank()) return null;
+    if (Strings.isBlank(output)) return null;
 
     var start = output.indexOf("```json");
     if (start < 0) {

--- a/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.engine;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.store.Finding;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -32,8 +33,8 @@ public final class FindingParser {
   private static ParseResult parseJsonArray(String json) {
     try {
       var list = YamlUtil.parseList(json);
-      var findings = new java.util.ArrayList<Finding>();
-      var warnings = new java.util.ArrayList<String>();
+      var findings = new ArrayList<Finding>();
+      var warnings = new ArrayList<String>();
 
       for (var i = 0; i < list.size(); i++) {
         try {

--- a/sail-core/src/main/java/ai/singlr/sail/engine/GitSpecSync.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/GitSpecSync.java
@@ -1,5 +1,6 @@
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.Strings;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -223,7 +224,7 @@ public final class GitSpecSync {
     }
     var copy = new ArrayList<String>();
     for (var token : command) {
-      if (token == null || token.isBlank()) {
+      if (Strings.isBlank(token)) {
         throw new IllegalArgumentException("git command tokens must not be blank.");
       }
       copy.add(token);
@@ -255,11 +256,11 @@ public final class GitSpecSync {
   }
 
   private static String blankToNull(String value) {
-    return value == null || value.isBlank() ? null : value;
+    return Strings.isBlank(value) ? null : value;
   }
 
   private static String defaultBranch(String branch) {
-    return branch == null || branch.isBlank() ? "main" : branch;
+    return Strings.isBlank(branch) ? "main" : branch;
   }
 
   private static String requireSafeRemote(String remote) {

--- a/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.Strings;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,7 +46,7 @@ public final class SailPaths {
 
   /** Pure resolver; visible for tests so resolution can be exercised without the environment. */
   static Path dataDir(String configured, boolean provisionedSystemDb) {
-    if (configured != null && !configured.isBlank()) {
+    if (Strings.isNotBlank(configured)) {
       return Path.of(configured);
     }
     if (provisionedSystemDb) {
@@ -206,7 +207,7 @@ public final class SailPaths {
     if (root) {
       return Path.of("/run/sail/api.sock");
     }
-    if (xdgRuntimeDir != null && !xdgRuntimeDir.isBlank()) {
+    if (Strings.isNotBlank(xdgRuntimeDir)) {
       return Path.of(xdgRuntimeDir, "sail", "api.sock");
     }
     return SAIL_DIR.resolve("run/api.sock");

--- a/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
@@ -9,6 +9,8 @@ import ai.singlr.sail.common.Strings;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Optional;
 
 /**
  * Centralized path constants for CLI state files. All state lives under {@code ~/.sail/}: project
@@ -71,8 +73,7 @@ public final class SailPaths {
     Files.createDirectories(dir);
     if (dir.startsWith(SAIL_DIR)
         && dir.getFileSystem().supportedFileAttributeViews().contains("posix")) {
-      Files.setPosixFilePermissions(
-          dir, java.nio.file.attribute.PosixFilePermissions.fromString("rwx------"));
+      Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwx------"));
     }
   }
 
@@ -158,20 +159,20 @@ public final class SailPaths {
    * filesystem root or the user's home directory (whichever comes first). Pure I/O-free helper for
    * callers that pull additional metadata out of the descriptor.
    */
-  public static java.util.Optional<Path> findSailYamlUpward(Path start) {
+  public static Optional<Path> findSailYamlUpward(Path start) {
     var home = Path.of(System.getProperty("user.home"));
     var dir = start.toAbsolutePath().normalize();
     while (dir != null) {
       var candidate = dir.resolve(PROJECT_DESCRIPTOR);
       if (Files.isRegularFile(candidate)) {
-        return java.util.Optional.of(candidate);
+        return Optional.of(candidate);
       }
       if (dir.equals(home)) {
-        return java.util.Optional.empty();
+        return Optional.empty();
       }
       dir = dir.getParent();
     }
-    return java.util.Optional.empty();
+    return Optional.empty();
   }
 
   /**

--- a/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.gen;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.engine.AgentCli;
 import java.util.ArrayList;
@@ -647,7 +648,7 @@ public final class AgentContextGenerator {
   }
 
   private static String capitalize(String s) {
-    if (s == null || s.isEmpty()) return s;
+    if (Strings.isEmpty(s)) return s;
     return Character.toUpperCase(s.charAt(0)) + s.substring(1);
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/ssh/SshGateway.java
+++ b/sail-core/src/main/java/ai/singlr/sail/ssh/SshGateway.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.ssh;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.store.AuthSessionStore;
 import ai.singlr.sail.store.FdeStore;
 import java.time.Duration;
@@ -59,7 +60,7 @@ public final class SshGateway {
 
   public static Decision authorize(
       String originalCommand, String fdeHandle, FdeStore fdes, AuthSessionStore sessions) {
-    if (originalCommand == null || originalCommand.isBlank()) {
+    if (Strings.isBlank(originalCommand)) {
       return new Rejected(
           "No command supplied. Interactive shells are not permitted; run a 'sail' command.");
     }

--- a/sail-core/src/main/java/ai/singlr/sail/ssh/SshPublicKey.java
+++ b/sail-core/src/main/java/ai/singlr/sail/ssh/SshPublicKey.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.ssh;
 
+import ai.singlr.sail.common.Strings;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -30,7 +31,7 @@ public record SshPublicKey(String type, String blob, String comment, String fing
 
   /** Parses an {@code authorized_keys}-style line. Throws {@link IllegalArgumentException}. */
   public static SshPublicKey parse(String input) {
-    if (input == null || input.isBlank()) {
+    if (Strings.isBlank(input)) {
       throw new IllegalArgumentException("SSH public key is empty.");
     }
     var parts = input.strip().split("\\s+", 3);
@@ -60,9 +61,7 @@ public record SshPublicKey(String type, String blob, String comment, String fing
 
   /** The canonical single-line form for an {@code authorized_keys} entry. */
   public String line() {
-    return comment == null || comment.isBlank()
-        ? type + " " + blob
-        : type + " " + blob + " " + comment;
+    return Strings.isBlank(comment) ? type + " " + blob : type + " " + blob + " " + comment;
   }
 
   private static boolean declaredTypeMatchesBlob(String type, byte[] blob) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/AuthSessionStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/AuthSessionStore.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.webauthn.Hashes;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
@@ -34,7 +35,7 @@ public final class AuthSessionStore {
 
   public CreatedSession create(String fdeId, Duration ttl) {
     var token = generateToken();
-    var now = Instant.now();
+    var now = DateTimeUtils.now();
     var expiresAt = now.plus(ttl).toString();
     db.execute(
         "INSERT INTO sessions (token_hash, fde_id, created_at, expires_at) VALUES (?, ?, ?, ?)",
@@ -56,13 +57,13 @@ public final class AuthSessionStore {
     if (result.isEmpty()) {
       return Optional.empty();
     }
-    if (Instant.parse(result.get().expiresAt()).isBefore(Instant.now())) {
+    if (Instant.parse(result.get().expiresAt()).isBefore(DateTimeUtils.now())) {
       db.execute("DELETE FROM sessions WHERE token_hash = ?", hash);
       return Optional.empty();
     }
     db.execute(
         "UPDATE sessions SET last_used_at = ? WHERE token_hash = ?",
-        Instant.now().toString(),
+        DateTimeUtils.now().toString(),
         hash);
     return result;
   }

--- a/sail-core/src/main/java/ai/singlr/sail/store/ChangeLog.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ChangeLog.java
@@ -5,7 +5,7 @@
 
 package ai.singlr.sail.store;
 
-import java.time.Instant;
+import ai.singlr.sail.common.DateTimeUtils;
 import java.util.List;
 import java.util.Optional;
 
@@ -54,7 +54,7 @@ public final class ChangeLog {
         entityId,
         rev,
         actor,
-        Instant.now().toString(),
+        DateTimeUtils.now().toString(),
         origin,
         deleted ? 1 : 0,
         snapshot);

--- a/sail-core/src/main/java/ai/singlr/sail/store/DataMigration.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/DataMigration.java
@@ -6,6 +6,8 @@
 package ai.singlr.sail.store;
 
 import ai.singlr.sail.config.ProjectRegistry;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * A one-shot fix-up applied to existing data after a schema change. Schema migrations add columns;
@@ -26,9 +28,9 @@ public interface DataMigration {
   Report apply(Sqlite db, ProjectRegistry projects, Prompter prompter);
 
   /** Per-migration outcome surfaced back to the CLI for printing. */
-  record Report(int applied, int ambiguous, int skipped, java.util.List<String> notes) {
+  record Report(int applied, int ambiguous, int skipped, List<String> notes) {
     public static Report empty() {
-      return new Report(0, 0, 0, java.util.List.of());
+      return new Report(0, 0, 0, List.of());
     }
   }
 
@@ -41,9 +43,9 @@ public interface DataMigration {
      * Asks the operator to pick one of {@code candidates} for {@code context}. Returns the chosen
      * value or empty to leave the row alone.
      */
-    java.util.Optional<String> choose(String context, java.util.List<String> candidates);
+    Optional<String> choose(String context, List<String> candidates);
 
     /** Non-interactive prompter — never asks, always declines. */
-    Prompter NON_INTERACTIVE = (context, candidates) -> java.util.Optional.empty();
+    Prompter NON_INTERACTIVE = (context, candidates) -> Optional.empty();
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/store/DataMigrator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/DataMigrator.java
@@ -5,8 +5,8 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.ProjectRegistry;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -45,7 +45,7 @@ public final class DataMigrator {
       db.execute(
           "INSERT INTO data_migrations (name, applied_at) VALUES (?, ?)",
           migration.name(),
-          Instant.now().toString());
+          DateTimeUtils.now().toString());
       runs.add(new Run(migration.name(), false, report));
     }
     return List.copyOf(runs);

--- a/sail-core/src/main/java/ai/singlr/sail/store/EnrollmentTicketStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/EnrollmentTicketStore.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.webauthn.Hashes;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
@@ -37,7 +38,7 @@ public final class EnrollmentTicketStore {
 
   public CreatedTicket issue(String fdeId, Duration ttl) {
     var ticket = generateTicket();
-    var now = Instant.now();
+    var now = DateTimeUtils.now();
     var expiresAt = now.plus(ttl).toString();
     db.execute(
         "INSERT INTO enrollment_tickets (token_hash, fde_id, created_at, expires_at)"
@@ -62,7 +63,7 @@ public final class EnrollmentTicketStore {
     if (info.isEmpty()) {
       return Optional.empty();
     }
-    if (Instant.parse(info.get().expiresAt()).isBefore(Instant.now())) {
+    if (Instant.parse(info.get().expiresAt()).isBefore(DateTimeUtils.now())) {
       db.execute("DELETE FROM enrollment_tickets WHERE token_hash = ?", hash);
       return Optional.empty();
     }
@@ -82,7 +83,7 @@ public final class EnrollmentTicketStore {
                 + " WHERE token_hash = ? AND consumed_at IS NULL"
                 + " RETURNING token_hash",
             row -> row.text(0),
-            Instant.now().toString(),
+            DateTimeUtils.now().toString(),
             sha256(ticket))
         .isPresent();
   }

--- a/sail-core/src/main/java/ai/singlr/sail/store/EventStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/EventStore.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.store;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -76,7 +77,7 @@ public final class EventStore {
         db.query(
             "SELECT type, COUNT(*) FROM events GROUP BY type ORDER BY COUNT(*) DESC",
             row -> new Object[] {row.text(0), row.integer(1)});
-    var typeMap = new java.util.LinkedHashMap<String, Long>();
+    var typeMap = new LinkedHashMap<String, Long>();
     typeMap.put("total", total);
     for (var row : types) {
       typeMap.put((String) row[0], (long) row[1]);

--- a/sail-core/src/main/java/ai/singlr/sail/store/ExpiredRowSweeper.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ExpiredRowSweeper.java
@@ -5,9 +5,9 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -64,7 +64,7 @@ public final class ExpiredRowSweeper implements AutoCloseable {
    * Deletes every row whose expiry has passed; returns how many were removed. Visible for tests.
    */
   static int sweep(Sqlite db) {
-    var now = Instant.now().toString();
+    var now = DateTimeUtils.now().toString();
     var deleted = 0;
     db.execute("DELETE FROM sessions WHERE expires_at < ?", now);
     deleted += db.changes();

--- a/sail-core/src/main/java/ai/singlr/sail/store/FdeSshKeyStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FdeSshKeyStore.java
@@ -5,8 +5,8 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.ssh.SshPublicKey;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -46,7 +46,7 @@ public final class FdeSshKeyStore {
         fdeId,
         key.line(),
         key.comment(),
-        Instant.now().toString());
+        DateTimeUtils.now().toString());
   }
 
   public Optional<SshKeyInfo> findByFingerprint(String fingerprint) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.store;
 
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.ssh.SshPublicKey;
 import java.security.SecureRandom;
 import java.util.HexFormat;
@@ -112,7 +113,7 @@ public final class FdeStore {
         email,
         role,
         status,
-        createdAt == null || createdAt.isBlank() ? DateTimeUtils.now().toString() : createdAt);
+        Strings.isBlank(createdAt) ? DateTimeUtils.now().toString() : createdAt);
   }
 
   public Optional<Fde> byHandle(String handle) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.store;
 
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.ssh.SshPublicKey;
 import java.security.SecureRandom;
 import java.util.HexFormat;
@@ -50,7 +51,7 @@ public final class FdeStore {
    * the role is not one of {@code admin}, {@code member}, {@code viewer}.
    */
   public Fde add(String handle, String displayName, String email, String role) {
-    ai.singlr.sail.engine.NameValidator.requireValidFdeHandle(handle);
+    NameValidator.requireValidFdeHandle(handle);
     if (!ROLES.contains(role)) {
       throw new IllegalArgumentException(
           "Invalid role: " + role + ". Must be one of " + ROLES + ".");
@@ -93,7 +94,7 @@ public final class FdeStore {
       String role,
       String status,
       String createdAt) {
-    ai.singlr.sail.engine.NameValidator.requireValidFdeHandle(handle);
+    NameValidator.requireValidFdeHandle(handle);
     if (!ROLES.contains(role)) {
       throw new IllegalArgumentException(
           "Invalid role: " + role + ". Must be one of " + ROLES + ".");

--- a/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
@@ -5,9 +5,9 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.ssh.SshPublicKey;
 import java.security.SecureRandom;
-import java.time.Instant;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Optional;
@@ -55,7 +55,14 @@ public final class FdeStore {
           "Invalid role: " + role + ". Must be one of " + ROLES + ".");
     }
     var fde =
-        new Fde(generateId(), handle, displayName, email, role, "active", Instant.now().toString());
+        new Fde(
+            generateId(),
+            handle,
+            displayName,
+            email,
+            role,
+            "active",
+            DateTimeUtils.now().toString());
     db.execute(
         "INSERT INTO fdes (id, handle, display_name, email, role, status, created_at)"
             + " VALUES (?, ?, ?, ?, ?, ?, ?)",
@@ -105,7 +112,7 @@ public final class FdeStore {
         email,
         role,
         status,
-        createdAt == null || createdAt.isBlank() ? Instant.now().toString() : createdAt);
+        createdAt == null || createdAt.isBlank() ? DateTimeUtils.now().toString() : createdAt);
   }
 
   public Optional<Fde> byHandle(String handle) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.store;
 
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -114,7 +115,7 @@ public final class FileStore implements ConflictResolver {
   }
 
   public Map<String, Object> comparableAtRev(String id, String rev) {
-    if (rev == null || rev.isBlank()) {
+    if (Strings.isBlank(rev)) {
       return null;
     }
     return changeLog

--- a/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
@@ -5,8 +5,8 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.YamlUtil;
-import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -288,7 +288,7 @@ public final class FileStore implements ConflictResolver {
         row.project(),
         row.path(),
         row.content(),
-        Instant.now().toString());
+        DateTimeUtils.now().toString());
   }
 
   private static FileRow rowFrom(String id, Map<String, Object> snapshot) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/PendingChallengeStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/PendingChallengeStore.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
@@ -39,7 +40,7 @@ public final class PendingChallengeStore {
    */
   public String issue(String ceremony, byte[] challenge, String fdeId, Duration ttl) {
     var id = generateId();
-    var now = Instant.now();
+    var now = DateTimeUtils.now();
     db.execute(
         "INSERT INTO webauthn_challenges (id, challenge, ceremony, fde_id, created_at, expires_at)"
             + " VALUES (?, ?, ?, ?, ?, ?)",
@@ -73,7 +74,7 @@ public final class PendingChallengeStore {
     db.execute("DELETE FROM webauthn_challenges WHERE id = ?", id);
     var resolved = row.get();
     if (!ceremony.equals(resolved.challenge().ceremony())
-        || Instant.parse(resolved.expiresAt()).isBefore(Instant.now())) {
+        || Instant.parse(resolved.expiresAt()).isBefore(DateTimeUtils.now())) {
       return Optional.empty();
     }
     return Optional.of(resolved.challenge());

--- a/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
@@ -5,7 +5,7 @@
 
 package ai.singlr.sail.store;
 
-import java.time.Instant;
+import ai.singlr.sail.common.DateTimeUtils;
 import java.util.List;
 import java.util.Optional;
 
@@ -41,7 +41,7 @@ public final class ProjectStore {
    * beyond bumping {@code updated_at}.
    */
   public void upsert(String name, String definition, String actor) {
-    var now = Instant.now().toString();
+    var now = DateTimeUtils.now().toString();
     db.transaction(
         () -> {
           var existing = findByName(name);

--- a/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
@@ -6,7 +6,6 @@
 package ai.singlr.sail.store;
 
 import ai.singlr.sail.common.DateTimeUtils;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -48,7 +47,7 @@ public final class ReviewStore {
         id,
         specId,
         iteration,
-        Instant.now().toString());
+        DateTimeUtils.now().toString());
     return id;
   }
 
@@ -82,7 +81,7 @@ public final class ReviewStore {
   public void approve(String reviewId, String decidedBy) {
     db.execute(
         "UPDATE reviews SET status = 'passed', completed_at = ?, decided_by = ? WHERE id = ?",
-        Instant.now().toString(),
+        DateTimeUtils.now().toString(),
         decidedBy,
         reviewId);
   }
@@ -90,7 +89,7 @@ public final class ReviewStore {
   public void updateReviewStatus(String reviewId, String status) {
     var completedAt =
         "passed".equals(status) || "failed".equals(status) || "escalated".equals(status)
-            ? Instant.now().toString()
+            ? DateTimeUtils.now().toString()
             : null;
     db.execute(
         "UPDATE reviews SET status = ?, completed_at = COALESCE(?, completed_at) WHERE id = ?",
@@ -132,7 +131,7 @@ public final class ReviewStore {
     db.execute(
         "UPDATE review_stages SET status = 'running', reviewer = ?, started_at = ? WHERE id = ?",
         reviewer,
-        Instant.now().toString(),
+        DateTimeUtils.now().toString(),
         stageId);
   }
 
@@ -140,7 +139,7 @@ public final class ReviewStore {
     db.execute(
         "UPDATE review_stages SET status = ?, completed_at = ? WHERE id = ?",
         status,
-        Instant.now().toString(),
+        DateTimeUtils.now().toString(),
         stageId);
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/Revisions.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/Revisions.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.common.Strings;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -30,7 +31,7 @@ public final class Revisions {
 
   /** Extracts the monotonic counter from a revision id; 0 for null/blank/malformed. */
   public static long counterOf(String rev) {
-    if (rev == null || rev.isBlank()) {
+    if (Strings.isBlank(rev)) {
       return 0;
     }
     var dash = rev.indexOf('-');

--- a/sail-core/src/main/java/ai/singlr/sail/store/SessionStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SessionStore.java
@@ -6,7 +6,6 @@
 package ai.singlr.sail.store;
 
 import ai.singlr.sail.common.DateTimeUtils;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -49,7 +48,7 @@ public final class SessionStore {
         branch,
         task,
         pid != null ? pid.longValue() : null,
-        Instant.now().toString());
+        DateTimeUtils.now().toString());
     return id;
   }
 
@@ -102,7 +101,7 @@ public final class SessionStore {
     db.execute(
         "UPDATE agent_sessions SET status = ?, completed_at = ? WHERE id = ?",
         status,
-        Instant.now().toString(),
+        DateTimeUtils.now().toString(),
         id);
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecMigrator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecMigrator.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 
@@ -88,7 +89,7 @@ public final class SpecMigrator {
     var skipped = 0;
     var errors = new ArrayList<String>();
     var created = new ArrayList<SpecImport>();
-    var seenInBatch = new java.util.HashSet<String>();
+    var seenInBatch = new HashSet<String>();
 
     for (var imp : imports) {
       var spec = imp.spec();

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.store;
 
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.config.YamlUtil;
 import java.util.ArrayList;
@@ -473,7 +474,7 @@ public final class SpecStore implements ConflictResolver {
 
   /** Comparable snapshot recorded at a given revision (the merge base), or null if not recorded. */
   public Map<String, Object> comparableAtRev(String id, String rev) {
-    if (rev == null || rev.isBlank()) {
+    if (Strings.isBlank(rev)) {
       return null;
     }
     return changeLog

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -5,9 +5,9 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.config.YamlUtil;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -73,7 +73,7 @@ public final class SpecStore implements ConflictResolver {
       String nextReadyId) {}
 
   public void create(SpecRow spec) {
-    var now = Instant.now().toString();
+    var now = DateTimeUtils.now().toString();
     db.transaction(
         () -> {
           db.execute(
@@ -162,7 +162,7 @@ public final class SpecStore implements ConflictResolver {
   }
 
   public void update(SpecRow spec) {
-    var now = Instant.now().toString();
+    var now = DateTimeUtils.now().toString();
     db.transaction(
         () -> {
           db.execute(
@@ -197,7 +197,7 @@ public final class SpecStore implements ConflictResolver {
           db.execute(
               "UPDATE specs SET status = ?, updated_at = ? WHERE id = ?",
               status.wire(),
-              Instant.now().toString(),
+              DateTimeUtils.now().toString(),
               id);
           recordRevision(id, "local", false);
         });
@@ -212,7 +212,7 @@ public final class SpecStore implements ConflictResolver {
   }
 
   public void setContent(String specId, String body, String plan) {
-    var now = Instant.now().toString();
+    var now = DateTimeUtils.now().toString();
     db.transaction(
         () -> {
           db.execute(
@@ -331,7 +331,7 @@ public final class SpecStore implements ConflictResolver {
 
   private void applySnapshot(String id, Map<String, Object> snapshot) {
     var spec = specFromSnapshot(snapshot);
-    var now = Instant.now().toString();
+    var now = DateTimeUtils.now().toString();
     if (findById(id).isPresent()) {
       db.execute(
           """

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Spec CRUD on SQLite. Every method maps to a small number of SQL statements. No caching, no lazy
@@ -416,8 +417,8 @@ public final class SpecStore implements ConflictResolver {
     return value == null ? null : value.toString();
   }
 
-  private static final java.util.Set<String> SYNC_FIELDS =
-      java.util.Set.of(
+  private static final Set<String> SYNC_FIELDS =
+      Set.of(
           "project",
           "title",
           "status",
@@ -513,8 +514,8 @@ public final class SpecStore implements ConflictResolver {
   }
 
   /** Every entity id this replica knows of, including those only present as a tombstone. */
-  public java.util.Set<String> syncEntityIds() {
-    return new java.util.LinkedHashSet<>(
+  public Set<String> syncEntityIds() {
+    return new LinkedHashSet<>(
         db.query(
             "SELECT DISTINCT entity_id FROM change_log WHERE entity_type = ?",
             row -> row.text(0),

--- a/sail-core/src/main/java/ai/singlr/sail/store/Sqlite.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/Sqlite.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * Thin Panama FFI wrapper over the system {@code libsqlite3.so.0}. Opens a database with WAL mode,
@@ -144,7 +145,7 @@ public final class Sqlite implements AutoCloseable {
         });
   }
 
-  public <T> T transaction(java.util.function.Supplier<T> work) {
+  public <T> T transaction(Supplier<T> work) {
     execute("BEGIN");
     try {
       var result = work.get();

--- a/sail-core/src/main/java/ai/singlr/sail/store/SyncConflicts.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SyncConflicts.java
@@ -5,7 +5,7 @@
 
 package ai.singlr.sail.store;
 
-import java.time.Instant;
+import ai.singlr.sail.common.DateTimeUtils;
 import java.util.List;
 import java.util.Optional;
 
@@ -63,7 +63,7 @@ public final class SyncConflicts {
               localSnapshot,
               remoteSnapshot,
               String.join("\n", fields),
-              Instant.now().toString(),
+              DateTimeUtils.now().toString(),
               PENDING);
           return db.queryOne("SELECT last_insert_rowid()", row -> row.integer(0)).orElseThrow();
         });

--- a/sail-core/src/main/java/ai/singlr/sail/store/SyncState.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SyncState.java
@@ -5,7 +5,7 @@
 
 package ai.singlr.sail.store;
 
-import java.time.Instant;
+import ai.singlr.sail.common.DateTimeUtils;
 
 /**
  * Per-peer sync checkpoint: the highest main sequence this node has applied from a given peer (the
@@ -38,6 +38,6 @@ public final class SyncState {
             updated_at = excluded.updated_at""",
         peer,
         checkpoint,
-        Instant.now().toString());
+        DateTimeUtils.now().toString());
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/store/TokenStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/TokenStore.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -66,7 +67,7 @@ public final class TokenStore {
           "Invalid role: " + role + ". Must be one of " + ROLES + ".");
     }
     var token = generateToken();
-    var expiresAt = ttl == null ? null : Instant.now().plus(ttl).toString();
+    var expiresAt = ttl == null ? null : DateTimeUtils.now().plus(ttl).toString();
     db.execute(
         "INSERT INTO api_tokens (token_hash, name, role, fde_id, created_at, expires_at)"
             + " VALUES (?, ?, ?, ?, ?, ?)",
@@ -74,7 +75,7 @@ public final class TokenStore {
         name,
         role,
         fdeId,
-        Instant.now().toString(),
+        DateTimeUtils.now().toString(),
         expiresAt);
     return new CreatedToken(name, token, role, expiresAt);
   }
@@ -87,13 +88,13 @@ public final class TokenStore {
       return Optional.empty();
     }
     var expiresAt = result.get().expiresAt();
-    if (expiresAt != null && Instant.parse(expiresAt).isBefore(Instant.now())) {
+    if (expiresAt != null && Instant.parse(expiresAt).isBefore(DateTimeUtils.now())) {
       db.execute("DELETE FROM api_tokens WHERE token_hash = ?", hash);
       return Optional.empty();
     }
     db.execute(
         "UPDATE api_tokens SET last_used_at = ? WHERE token_hash = ?",
-        Instant.now().toString(),
+        DateTimeUtils.now().toString(),
         hash);
     return result;
   }

--- a/sail-core/src/main/java/ai/singlr/sail/store/TokenStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/TokenStore.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * API token management. Tokens are SHA-256 hashed before storage. The plaintext is returned exactly
@@ -27,7 +28,7 @@ import java.util.Optional;
  */
 public final class TokenStore {
 
-  private static final java.util.Set<String> ROLES = java.util.Set.of("admin", "member", "viewer");
+  private static final Set<String> ROLES = Set.of("admin", "member", "viewer");
 
   /** Default lifetime the CLI applies to a newly minted token unless overridden. */
   public static final Duration DEFAULT_TTL = Duration.ofDays(90);

--- a/sail-core/src/main/java/ai/singlr/sail/store/WebauthnCredentialStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/WebauthnCredentialStore.java
@@ -5,8 +5,8 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.webauthn.RegisteredCredential;
-import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
@@ -62,7 +62,7 @@ public final class WebauthnCredentialStore {
         credential.backupEligible() ? 1 : 0,
         credential.backupState() ? 1 : 0,
         label,
-        Instant.now().toString());
+        DateTimeUtils.now().toString());
   }
 
   public Optional<Credential> findByCredentialId(byte[] credentialId) {
@@ -82,7 +82,7 @@ public final class WebauthnCredentialStore {
     db.execute(
         "UPDATE webauthn_credentials SET sign_count = ?, last_used_at = ? WHERE credential_id = ?",
         signCount,
-        Instant.now().toString(),
+        DateTimeUtils.now().toString(),
         URL.encodeToString(credentialId));
   }
 

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.73</version>
+        <version>0.13.74</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.73</version>
+        <version>0.13.74</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>

--- a/sail-infra/src/main/java/ai/singlr/sail/api/AgentLogStreamer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/AgentLogStreamer.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
@@ -24,7 +25,7 @@ public final class AgentLogStreamer implements HttpHandler {
 
   private static final String LOG_PATH = "/home/dev/.sail/agent.log";
   private static final byte[] HEARTBEAT = ": heartbeat\n\n".getBytes(StandardCharsets.UTF_8);
-  private static final long HEARTBEAT_INTERVAL_MS = 15_000;
+  private static final long HEARTBEAT_INTERVAL_NANOS = Duration.ofSeconds(15).toNanos();
 
   private final ApiAuth auth;
   private final ShellExec shell;
@@ -86,7 +87,7 @@ public final class AgentLogStreamer implements HttpHandler {
                 new InputStreamReader(tailProcess.getInputStream(), StandardCharsets.UTF_8))) {
       writeComment(out, "streaming " + project);
       var lineNumber = since > 0 ? since : 1;
-      var lastHeartbeat = System.currentTimeMillis();
+      var lastHeartbeat = System.nanoTime();
 
       while (true) {
         if (reader.ready()) {
@@ -94,12 +95,12 @@ public final class AgentLogStreamer implements HttpHandler {
           if (line == null) break;
           writeSseData(out, lineNumber, line);
           lineNumber++;
-          lastHeartbeat = System.currentTimeMillis();
+          lastHeartbeat = System.nanoTime();
         } else {
-          if (System.currentTimeMillis() - lastHeartbeat > HEARTBEAT_INTERVAL_MS) {
+          if (System.nanoTime() - lastHeartbeat > HEARTBEAT_INTERVAL_NANOS) {
             out.write(HEARTBEAT);
             out.flush();
-            lastHeartbeat = System.currentTimeMillis();
+            lastHeartbeat = System.nanoTime();
           }
           Thread.sleep(100);
         }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiError.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiError.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.common.Strings;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,7 +17,7 @@ public record ApiError(String code, String message, String action, List<FieldErr
   }
 
   public ApiError {
-    action = action == null || action.isBlank() ? null : action;
+    action = Strings.isBlank(action) ? null : action;
     fieldErrors = fieldErrors == null ? List.of() : List.copyOf(fieldErrors);
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.store.ChangeLog;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.SessionStore;
@@ -82,7 +83,7 @@ record DispatchRequest(String specId, String mode, boolean dryRun, List<String> 
   }
 
   DispatchRequest {
-    mode = mode == null || mode.isBlank() ? "background" : mode;
+    mode = Strings.isBlank(mode) ? "background" : mode;
     repos = repos == null ? List.of() : List.copyOf(repos);
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.store.SpecStore;
@@ -384,7 +385,7 @@ public final class ApiRouter implements HttpHandler {
 
   private static String cleanPath(URI uri) {
     var path = uri.getPath();
-    return path == null || path.isBlank() ? "/" : path;
+    return Strings.isBlank(path) ? "/" : path;
   }
 
   private static ApiException notFound() {
@@ -421,7 +422,7 @@ public final class ApiRouter implements HttpHandler {
       return;
     }
     var ifMatch = ifMatchHeaders.getFirst();
-    if (ifMatch == null || ifMatch.isBlank() || "*".equals(ifMatch.trim())) {
+    if (Strings.isBlank(ifMatch) || "*".equals(ifMatch.trim())) {
       return;
     }
     var detail = operations.globalSpec(specId);
@@ -439,7 +440,7 @@ public final class ApiRouter implements HttpHandler {
   }
 
   private static String etagOf(String updatedAt) {
-    if (updatedAt == null || updatedAt.isBlank()) {
+    if (Strings.isBlank(updatedAt)) {
       return null;
     }
     return "\"" + updatedAt + "\"";
@@ -522,7 +523,7 @@ public final class ApiRouter implements HttpHandler {
   private record QueryParameters(Map<String, String> values) {
     static QueryParameters from(URI uri) {
       var query = uri.getRawQuery();
-      if (query == null || query.isBlank()) {
+      if (Strings.isBlank(query)) {
         return new QueryParameters(Map.of());
       }
       var values = new LinkedHashMap<String, String>();

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.api;
 
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
@@ -131,7 +132,7 @@ public record Event(
     }
     map.put("ts", ts.toString());
     map.put("project", project);
-    if (spec != null && !spec.isBlank()) {
+    if (Strings.isNotBlank(spec)) {
       map.put("spec", spec);
     }
     map.put("type", type);
@@ -225,7 +226,7 @@ public record Event(
   }
 
   private static void requireNonBlank(String value, String name) {
-    if (value == null || value.isBlank()) {
+    if (Strings.isBlank(value)) {
       throw new IllegalArgumentException(name + " is required");
     }
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.YamlUtil;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
@@ -93,7 +94,7 @@ public record Event(
    */
   public static Event of(String project, String spec, String type, String agent, String host) {
     return new Event(
-        CURRENT_VERSION, 0L, Instant.now(), project, spec, type, agent, host, Map.of());
+        CURRENT_VERSION, 0L, DateTimeUtils.now(), project, spec, type, agent, host, Map.of());
   }
 
   /** As {@link #of(String, String, String, String, String)} but with a data payload. */
@@ -104,7 +105,8 @@ public record Event(
       String agent,
       String host,
       Map<String, Object> data) {
-    return new Event(CURRENT_VERSION, 0L, Instant.now(), project, spec, type, agent, host, data);
+    return new Event(
+        CURRENT_VERSION, 0L, DateTimeUtils.now(), project, spec, type, agent, host, data);
   }
 
   /** Returns a copy of this event with the given bus-assigned id. */

--- a/sail-infra/src/main/java/ai/singlr/sail/api/EventStreamClient.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/EventStreamClient.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.common.Strings;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -157,7 +158,7 @@ public final class EventStreamClient implements AutoCloseable {
             .append(port)
             .append("/v1/events/stream");
     var params = new LinkedHashMap<String, String>();
-    if (project != null && !project.isBlank()) {
+    if (Strings.isNotBlank(project)) {
       params.put("project", project);
     }
     if (!params.isEmpty()) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/EventSubscriber.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/EventSubscriber.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import java.util.Set;
 import java.util.function.Predicate;
 
 /**
@@ -33,7 +34,7 @@ public interface EventSubscriber {
 
   /** Filter accepting only events whose type matches one of the given names. */
   static Predicate<Event> byType(String... types) {
-    var set = java.util.Set.of(types);
+    var set = Set.of(types);
     return e -> set.contains(e.type());
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -15,8 +15,17 @@ import ai.singlr.sail.engine.ReviewPromptBuilder;
 import ai.singlr.sail.store.Finding;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.SpecStore;
+import java.net.InetAddress;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -41,11 +50,9 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
   private final Function<String, ReviewPipelineConfig> configResolver;
   private final ReviewAgentRunner agentRunner;
   private final EventBus eventBus;
-  private final java.util.concurrent.ConcurrentHashMap<
-          String, java.util.concurrent.CompletableFuture<Void>>
-      inFlight = new java.util.concurrent.ConcurrentHashMap<>();
-  private final java.util.concurrent.ExecutorService pipelineExecutor =
-      java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor();
+  private final ConcurrentHashMap<String, CompletableFuture<Void>> inFlight =
+      new ConcurrentHashMap<>();
+  private final ExecutorService pipelineExecutor = Executors.newVirtualThreadPerTaskExecutor();
 
   public ReviewPipelineController(
       SpecStore specStore,
@@ -68,10 +75,9 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     var futures = List.copyOf(inFlight.values());
     if (futures.isEmpty()) return;
     try {
-      java.util.concurrent.CompletableFuture.allOf(
-              futures.toArray(new java.util.concurrent.CompletableFuture[0]))
-          .get(timeoutMillis, java.util.concurrent.TimeUnit.MILLISECONDS);
-    } catch (java.util.concurrent.ExecutionException | java.util.concurrent.TimeoutException e) {
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+          .get(timeoutMillis, TimeUnit.MILLISECONDS);
+    } catch (ExecutionException | TimeoutException e) {
       Thread.currentThread().interrupt();
     }
   }
@@ -87,7 +93,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     }
   }
 
-  java.util.concurrent.ExecutorService pipelineExecutor() {
+  ExecutorService pipelineExecutor() {
     return pipelineExecutor;
   }
 
@@ -146,7 +152,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     }
 
     var future =
-        java.util.concurrent.CompletableFuture.runAsync(
+        CompletableFuture.runAsync(
             () -> executePipeline(reviewId, config, event.project(), specId), pipelineExecutor);
     inFlight.put(reviewId, future);
     future.whenComplete((v, ex) -> inFlight.remove(reviewId));
@@ -267,16 +273,13 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
 
   private void publishEvent(String project, String specId, String type, String detail) {
     if (eventBus == null) return;
-    var data =
-        detail != null
-            ? java.util.Map.<String, Object>of("detail", detail)
-            : java.util.Map.<String, Object>of();
+    var data = detail != null ? Map.<String, Object>of("detail", detail) : Map.<String, Object>of();
     eventBus.publish(Event.of(project, specId, type, Event.SAIL_AGENT, hostname(), data));
   }
 
   private static String hostname() {
     try {
-      return java.net.InetAddress.getLocalHost().getHostName();
+      return InetAddress.getLocalHost().getHostName();
     } catch (Exception e) {
       return "unknown";
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.api;
 
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.BranchPolicy;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
@@ -294,7 +295,7 @@ public final class SailApiOperations implements ApiOperations {
       return;
     }
     var data = new LinkedHashMap<String, Object>();
-    if (branch != null && !branch.isBlank()) {
+    if (Strings.isNotBlank(branch)) {
       data.put("branch", branch);
     }
     data.put("mode", mode);
@@ -491,7 +492,7 @@ public final class SailApiOperations implements ApiOperations {
   }
 
   private static Spec resolveSpec(List<Spec> specs, String specId) {
-    if (specId == null || specId.isBlank()) {
+    if (Strings.isBlank(specId)) {
       return SpecDirectory.nextReady(specs);
     }
     var spec = SpecDirectory.findById(specs, specId);
@@ -533,7 +534,7 @@ public final class SailApiOperations implements ApiOperations {
         spec.agent(),
         spec.model(),
         spec.reasoningEffort(),
-        branch != null && !branch.isBlank() ? branch : null);
+        Strings.isNotBlank(branch) ? branch : null);
   }
 
   private static String branchName(SailYaml config, Spec spec) {
@@ -559,7 +560,7 @@ public final class SailApiOperations implements ApiOperations {
 
   private boolean createBranchIfNeeded(
       String project, SailYaml config, List<SailYaml.Repo> targetRepos, String branch) {
-    if (branch == null || branch.isBlank() || targetRepos.isEmpty()) {
+    if (Strings.isBlank(branch) || targetRepos.isEmpty()) {
       return false;
     }
     var created = false;

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -734,7 +734,7 @@ public final class SailApiOperations implements ApiOperations {
         report.rollbackSnapshot());
   }
 
-  private static SpecSummaryView summaryView(java.util.Map<String, Integer> counts) {
+  private static SpecSummaryView summaryView(Map<String, Integer> counts) {
     return new SpecSummaryView(
         counts.getOrDefault("pending", 0),
         counts.getOrDefault("in_progress", 0),

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.BranchPolicy;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
@@ -33,7 +34,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -677,7 +677,7 @@ public final class SailApiOperations implements ApiOperations {
         return true;
       }
       var latestTime = OffsetDateTime.parse(snapshots.getLast().createdAt()).toInstant();
-      return Instant.now().isAfter(latestTime.plus(SNAPSHOT_INTERVAL));
+      return DateTimeUtils.now().isAfter(latestTime.plus(SNAPSHOT_INTERVAL));
     } catch (Exception e) {
       System.err.println(
           "  [snapshot] Could not determine snapshot age for '"

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ServerConnectionConfig.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ServerConnectionConfig.java
@@ -90,7 +90,7 @@ public record ServerConnectionConfig(String serverUrl, String token) {
     var serverUrl = DEFAULT_URL;
     if (Files.exists(configPath)) {
       var existing = (String) YamlUtil.parseFile(configPath).get("server");
-      if (existing != null && !existing.isBlank()) {
+      if (Strings.isNotBlank(existing)) {
         serverUrl = existing;
       }
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SpecLifecycleReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SpecLifecycleReactor.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.api;
 
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.SpecAuditEvent;
 import ai.singlr.sail.config.SpecStatus;
@@ -75,7 +76,7 @@ public final class SpecLifecycleReactor implements EventSubscriber {
   @Override
   public void onEvent(Event event) {
     var specsDir = specsDirForProject.apply(event.project());
-    if (specsDir == null || specsDir.isBlank()) {
+    if (Strings.isBlank(specsDir)) {
       return;
     }
     var workspace = new SpecWorkspace(shell, event.project(), specsDir);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SpecLifecycleReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SpecLifecycleReactor.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.SpecAuditEvent;
 import ai.singlr.sail.config.SpecStatus;
@@ -15,7 +16,6 @@ import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SpecAudit;
 import ai.singlr.sail.engine.SpecWorkspace;
 import java.nio.file.Files;
-import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -113,17 +113,17 @@ public final class SpecLifecycleReactor implements EventSubscriber {
 
   private static SpecAuditEvent startedEvent(Event event) {
     return new SpecAuditEvent(
-        Instant.now(), "started", event.agent(), pidOf(event), event.host(), null);
+        DateTimeUtils.now(), "started", event.agent(), pidOf(event), event.host(), null);
   }
 
   private static SpecAuditEvent stoppedEvent(Event event) {
     return new SpecAuditEvent(
-        Instant.now(), "stopped", event.agent(), pidOf(event), event.host(), noteOf(event));
+        DateTimeUtils.now(), "stopped", event.agent(), pidOf(event), event.host(), noteOf(event));
   }
 
   private static SpecAuditEvent completedEvent(Event event) {
     return new SpecAuditEvent(
-        Instant.now(), "completed", event.agent(), null, event.host(), noteOf(event));
+        DateTimeUtils.now(), "completed", event.agent(), null, event.host(), noteOf(event));
   }
 
   private static Integer pidOf(Event event) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SpecLifecycleReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SpecLifecycleReactor.java
@@ -17,6 +17,7 @@ import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SpecAudit;
 import ai.singlr.sail.engine.SpecWorkspace;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -170,7 +171,7 @@ public final class SpecLifecycleReactor implements EventSubscriber {
    * absent, or the YAML cannot be parsed. Extracted so tests can point at a {@code @TempDir}
    * without touching the real user-home location.
    */
-  static String lookupSpecsDirAt(String project, java.nio.file.Path path) {
+  static String lookupSpecsDirAt(String project, Path path) {
     if (path == null || !Files.exists(path)) {
       return null;
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SseHandler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SseHandler.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.common.Strings;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import java.io.IOException;
@@ -191,17 +192,17 @@ public final class SseHandler implements HttpHandler {
 
   static Predicate<Event> parseFilter(URI uri) {
     var query = uri.getRawQuery();
-    if (query == null || query.isBlank()) {
+    if (Strings.isBlank(query)) {
       return EventSubscriber.all();
     }
     var values = parseQuery(query);
     Predicate<Event> result = EventSubscriber.all();
     var projectFilter = values.get("project");
-    if (projectFilter != null && !projectFilter.isBlank()) {
+    if (Strings.isNotBlank(projectFilter)) {
       result = result.and(EventSubscriber.byProject(projectFilter));
     }
     var typeFilter = values.get("type");
-    if (typeFilter != null && !typeFilter.isBlank()) {
+    if (Strings.isNotBlank(typeFilter)) {
       var types = Set.of(typeFilter.split(","));
       result = result.and(e -> types.contains(e.type()));
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SseHandler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SseHandler.java
@@ -52,6 +52,8 @@ public final class SseHandler implements HttpHandler {
   /** Heartbeat interval. SSE comments keep idle connections alive through proxies. */
   public static final long HEARTBEAT_MILLIS = 15_000L;
 
+  private static final long HEARTBEAT_NANOS = HEARTBEAT_MILLIS * 1_000_000L;
+
   /** Poll timeout when draining the per-connection queue. */
   static final long POLL_MILLIS = 1_000L;
 
@@ -129,7 +131,7 @@ public final class SseHandler implements HttpHandler {
     exchange.sendResponseHeaders(200, 0);
     try (var out = exchange.getResponseBody()) {
       writeComment(out, "subscribed");
-      var lastHeartbeat = System.currentTimeMillis();
+      var lastHeartbeat = System.nanoTime();
       while (true) {
         Event event;
         try {
@@ -141,9 +143,9 @@ public final class SseHandler implements HttpHandler {
         if (event != null) {
           writeEvent(out, event);
         }
-        if (System.currentTimeMillis() - lastHeartbeat > HEARTBEAT_MILLIS) {
+        if (System.nanoTime() - lastHeartbeat > HEARTBEAT_NANOS) {
           writeComment(out, "keepalive");
-          lastHeartbeat = System.currentTimeMillis();
+          lastHeartbeat = System.nanoTime();
         }
       }
     } catch (IOException disconnected) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/UnixSocketEventsListener.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/UnixSocketEventsListener.java
@@ -17,6 +17,8 @@ import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
 import java.util.Objects;
 import java.util.concurrent.atomic.LongAdder;
 
@@ -81,13 +83,13 @@ public final class UnixSocketEventsListener implements AutoCloseable {
     try {
       Files.setPosixFilePermissions(
           socketPath,
-          java.util.EnumSet.of(
-              java.nio.file.attribute.PosixFilePermission.OWNER_READ,
-              java.nio.file.attribute.PosixFilePermission.OWNER_WRITE,
-              java.nio.file.attribute.PosixFilePermission.GROUP_READ,
-              java.nio.file.attribute.PosixFilePermission.GROUP_WRITE,
-              java.nio.file.attribute.PosixFilePermission.OTHERS_READ,
-              java.nio.file.attribute.PosixFilePermission.OTHERS_WRITE));
+          EnumSet.of(
+              PosixFilePermission.OWNER_READ,
+              PosixFilePermission.OWNER_WRITE,
+              PosixFilePermission.GROUP_READ,
+              PosixFilePermission.GROUP_WRITE,
+              PosixFilePermission.OTHERS_READ,
+              PosixFilePermission.OTHERS_WRITE));
     } catch (UnsupportedOperationException | IOException permError) {
       System.err.println(
           "  [sail-uds] Warning: could not chmod 0666 "

--- a/sail-infra/src/main/java/ai/singlr/sail/api/WebauthnAuthHandler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/WebauthnAuthHandler.java
@@ -159,7 +159,7 @@ public final class WebauthnAuthHandler implements HttpHandler {
 
   private static String enrollmentTicket(HttpExchange exchange) {
     var value = exchange.getRequestHeaders().getFirst(TICKET_HEADER);
-    return value == null || value.isBlank() ? null : value;
+    return Strings.isBlank(value) ? null : value;
   }
 
   private static ApiException ticketDenied() {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentAttachCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentAttachCommand.java
@@ -13,7 +13,9 @@ import ai.singlr.sail.engine.ContainerState;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
+import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
@@ -81,7 +83,7 @@ public final class AgentAttachCommand implements Runnable {
     }
   }
 
-  private AgentCli resolveAgentType() throws java.io.IOException {
+  private AgentCli resolveAgentType() throws IOException {
     var sailYamlPath = SailPaths.resolveSailYaml(name, file);
     if (Files.exists(sailYamlPath)) {
       var config = SailYaml.fromMap(YamlUtil.parseFile(sailYamlPath));
@@ -100,7 +102,7 @@ public final class AgentAttachCommand implements Runnable {
   }
 
   static List<String> buildIncusExecWithTty(String container, List<String> args) {
-    var cmd = new java.util.ArrayList<String>();
+    var cmd = new ArrayList<String>();
     cmd.add("incus");
     cmd.add("exec");
     cmd.add(container);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLaunchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLaunchCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.SpecDirectory;
 import ai.singlr.sail.config.YamlUtil;
@@ -262,7 +263,7 @@ public final class AgentLaunchCommand implements Runnable {
         if (snapshotLabel != null) {
           try {
             var rollbackMap = new LinkedHashMap<String, Object>();
-            rollbackMap.put("rolled_back_at", java.time.Instant.now().toString());
+            rollbackMap.put("rolled_back_at", DateTimeUtils.now().toString());
             rollbackMap.put("exit_code", exitCode);
             rollbackMap.put("snapshot_restored", snapshotLabel);
             rollbackMap.put("task", task);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLogCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLogCommand.java
@@ -12,6 +12,7 @@ import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ShellExecutor;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -90,7 +91,7 @@ public final class AgentLogCommand implements Runnable {
                       + " --task \"...\" --background|@"));
           return;
         }
-        throw new java.io.IOException("Failed to read agent log: " + result.stderr());
+        throw new IOException("Failed to read agent log: " + result.stderr());
       }
 
       if (json) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStatusCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStatusCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.SpecDirectory;
 import ai.singlr.sail.config.YamlUtil;
@@ -103,7 +104,7 @@ public final class AgentStatusCommand implements Runnable {
         if (!info.startedAt().isBlank()) {
           try {
             var started = Instant.parse(info.startedAt());
-            elapsed = formatElapsed(Duration.between(started, Instant.now()));
+            elapsed = formatElapsed(Duration.between(started, DateTimeUtils.now()));
             var repoPaths = resolveRepoPaths(projectName);
             for (var repoPath : repoPaths) {
               try {
@@ -184,12 +185,14 @@ public final class AgentStatusCommand implements Runnable {
       try {
         var checker = new GuardrailChecker(shell);
         var repoPaths = config != null ? config.repoPaths() : List.of("/home/dev/workspace");
-        var since = !info.startedAt().isBlank() ? Instant.parse(info.startedAt()) : Instant.now();
+        var since =
+            !info.startedAt().isBlank() ? Instant.parse(info.startedAt()) : DateTimeUtils.now();
         for (var repoPath : repoPaths) {
           var activity = checker.queryGitActivity(name, repoPath, since);
           commitCount += activity.commitCount();
           if (activity.lastCommitEpoch() > 0) {
-            var minutesAgo = (Instant.now().getEpochSecond() - activity.lastCommitEpoch()) / 60;
+            var minutesAgo =
+                (DateTimeUtils.now().getEpochSecond() - activity.lastCommitEpoch()) / 60;
             if (lastCommitMinutesAgo < 0 || minutesAgo < lastCommitMinutesAgo) {
               lastCommitMinutesAgo = minutesAgo;
             }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
@@ -9,6 +9,7 @@ import ai.singlr.sail.api.Event;
 import ai.singlr.sail.api.EventStreamClient;
 import ai.singlr.sail.api.ServerConnectionConfig;
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.Guardrails;
 import ai.singlr.sail.config.Notifications;
 import ai.singlr.sail.config.SailYaml;
@@ -189,7 +190,7 @@ public final class AgentWatchCommand implements Runnable {
   }
 
   static Instant parseStartedAt(String iso) {
-    if (iso == null || iso.isBlank()) {
+    if (Strings.isBlank(iso)) {
       return DateTimeUtils.now();
     }
     try {
@@ -200,7 +201,7 @@ public final class AgentWatchCommand implements Runnable {
   }
 
   static Instant computeDeadline(Instant startedAt, String maxDurationStr) {
-    if (maxDurationStr == null || maxDurationStr.isBlank()) {
+    if (Strings.isBlank(maxDurationStr)) {
       return Instant.MAX;
     }
     try {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
@@ -27,6 +27,7 @@ import ai.singlr.sail.engine.WebhookNotifier;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
@@ -195,7 +196,7 @@ public final class AgentWatchCommand implements Runnable {
     }
     try {
       return Instant.parse(iso);
-    } catch (java.time.format.DateTimeParseException e) {
+    } catch (DateTimeParseException e) {
       return DateTimeUtils.now();
     }
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.api.Event;
 import ai.singlr.sail.api.EventStreamClient;
 import ai.singlr.sail.api.ServerConnectionConfig;
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.Guardrails;
 import ai.singlr.sail.config.Notifications;
 import ai.singlr.sail.config.SailYaml;
@@ -153,7 +154,8 @@ public final class AgentWatchCommand implements Runnable {
       if (!(result instanceof GuardrailChecker.GuardrailResult.Triggered triggered)) {
         continue;
       }
-      var elapsed = GuardrailChecker.formatDuration(Duration.between(startedAt, Instant.now()));
+      var elapsed =
+          GuardrailChecker.formatDuration(Duration.between(startedAt, DateTimeUtils.now()));
       var snapshotLabel = applyTriggerAction(triggered, shell, agentSession);
       reportTrigger(triggered, elapsed, snapshotLabel);
       notifyTriggered(notifier, notifications, triggered);
@@ -188,12 +190,12 @@ public final class AgentWatchCommand implements Runnable {
 
   static Instant parseStartedAt(String iso) {
     if (iso == null || iso.isBlank()) {
-      return Instant.now();
+      return DateTimeUtils.now();
     }
     try {
       return Instant.parse(iso);
     } catch (java.time.format.DateTimeParseException e) {
-      return Instant.now();
+      return DateTimeUtils.now();
     }
   }
 
@@ -213,7 +215,7 @@ public final class AgentWatchCommand implements Runnable {
     if (guardrailFired || deadline.equals(Instant.MAX)) {
       return Long.MAX_VALUE;
     }
-    var remaining = Duration.between(Instant.now(), deadline).toMillis();
+    var remaining = Duration.between(DateTimeUtils.now(), deadline).toMillis();
     return Math.max(0, remaining);
   }
 
@@ -346,7 +348,7 @@ public final class AgentWatchCommand implements Runnable {
       GuardrailChecker.GuardrailResult.Triggered triggered)
       throws Exception {
     var map = new LinkedHashMap<String, Object>();
-    map.put("triggered_at", Instant.now().toString());
+    map.put("triggered_at", DateTimeUtils.now().toString());
     map.put("reason", triggered.reason());
     map.put("detail", triggered.detail());
     map.put("action", triggered.action());

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecContentCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecContentCommand.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.SailApiClient;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.NameValidator;
 import java.nio.file.Files;
@@ -72,15 +73,15 @@ public final class ApiSpecContentCommand implements Runnable {
         }
         var bodyText = (String) result.get("body");
         var planText = (String) result.get("plan");
-        if (bodyText != null && !bodyText.isBlank()) {
+        if (Strings.isNotBlank(bodyText)) {
           System.out.println(bodyText);
         }
-        if (planText != null && !planText.isBlank()) {
+        if (Strings.isNotBlank(planText)) {
           System.out.println();
           System.out.println(Ansi.AUTO.string("@|bold --- Plan ---|@"));
           System.out.println(planText);
         }
-        if ((bodyText == null || bodyText.isBlank()) && (planText == null || planText.isBlank())) {
+        if ((Strings.isBlank(bodyText)) && (Strings.isBlank(planText))) {
           System.out.println(Ansi.AUTO.string("  @|faint No content for " + specId + ".|@"));
         }
       }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCreateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCreateCommand.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.SailApiClient;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
@@ -114,7 +115,7 @@ public final class ApiSpecCreateCommand implements Runnable {
     }
     try {
       var name = (String) YamlUtil.parseFile(yaml).get("name");
-      return name == null || name.isBlank() ? null : name;
+      return Strings.isBlank(name) ? null : name;
     } catch (Exception e) {
       return null;
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecListCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecListCommand.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.SailApiClient;
 import ai.singlr.sail.config.YamlUtil;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -90,10 +91,10 @@ public final class ApiSpecListCommand implements Runnable {
   @SuppressWarnings("unchecked")
   private void printGroupedByProjectAndStatus(List<Map<String, Object>> specs) {
     var statusOrder = List.of("draft", "pending", "in_progress", "review", "done");
-    var byProject = new java.util.LinkedHashMap<String, List<Map<String, Object>>>();
+    var byProject = new LinkedHashMap<String, List<Map<String, Object>>>();
     for (var spec : specs) {
       var proj = (String) spec.getOrDefault("project", "unassigned");
-      byProject.computeIfAbsent(proj, k -> new java.util.ArrayList<>()).add(spec);
+      byProject.computeIfAbsent(proj, k -> new ArrayList<>()).add(spec);
     }
     for (var projectGroup : byProject.entrySet()) {
       System.out.println(Ansi.AUTO.string("  @|bold,cyan ▸ " + projectGroup.getKey() + "|@"));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecShowCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecShowCommand.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.SailApiClient;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.NameValidator;
 import java.util.LinkedHashMap;
@@ -75,7 +76,7 @@ public final class ApiSpecShowCommand implements Runnable {
       }
 
       var body = (String) result.get("body");
-      if (body != null && !body.isBlank()) {
+      if (Strings.isNotBlank(body)) {
         System.out.println();
         System.out.println(body);
       }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/CliCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/CliCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.engine.Banner;
 import java.io.PrintStream;
 import java.util.Objects;
@@ -35,7 +36,7 @@ final class CliCommand {
     } catch (Exception e) {
       var message = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName());
       err.println(Banner.errorLine(message, Ansi.AUTO));
-      if (failureHint != null && !failureHint.isBlank()) {
+      if (Strings.isNotBlank(failureHint)) {
         err.println(failureHint);
       }
       throw new CommandLine.ExecutionException(commandSpec.commandLine(), message, e);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ConflictsCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ConflictsCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.SailPaths;
@@ -324,6 +325,6 @@ public final class ConflictsCommand implements Callable<Integer> {
   }
 
   static Map<String, Object> parse(String json) {
-    return json == null || json.isBlank() ? null : YamlUtil.parseMap(json);
+    return Strings.isBlank(json) ? null : YamlUtil.parseMap(json);
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.Event;
 import ai.singlr.sail.api.SailEventPublisher;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.BranchPolicy;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
@@ -438,7 +439,7 @@ public final class DispatchCommand implements Runnable {
    */
   static Map<String, Object> dispatchedEventData(String branchName, boolean background) {
     var data = new LinkedHashMap<String, Object>();
-    if (branchName != null && !branchName.isBlank()) {
+    if (Strings.isNotBlank(branchName)) {
       data.put("branch", branchName);
     }
     data.put("mode", background ? "background" : "foreground");

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DownCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DownCommand.java
@@ -13,6 +13,7 @@ import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ShellExecutor;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -66,7 +67,7 @@ public final class DownCommand implements Runnable {
         }
         mgr.stop(projectName);
         if (json) {
-          printJson(java.util.List.of(projectName));
+          printJson(List.of(projectName));
           return;
         }
         Banner.printContainerStatus(
@@ -74,7 +75,7 @@ public final class DownCommand implements Runnable {
       }
       case ContainerState.Stopped ignored -> {
         if (json) {
-          printJson(java.util.List.of());
+          printJson(List.of());
           return;
         }
         Banner.printBranding(System.out, Ansi.AUTO);
@@ -95,7 +96,7 @@ public final class DownCommand implements Runnable {
 
     if (running.isEmpty()) {
       if (json) {
-        printJson(java.util.List.of());
+        printJson(List.of());
         return;
       }
       Banner.printBranding(System.out, Ansi.AUTO);
@@ -136,7 +137,7 @@ public final class DownCommand implements Runnable {
                 + " stopped."));
   }
 
-  private static void printJson(java.util.List<String> stopped) {
+  private static void printJson(List<String> stopped) {
     var map = new LinkedHashMap<String, Object>();
     map.put("stopped", stopped);
     System.out.println(YamlUtil.dumpJson(map));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/EventsCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/EventsCommand.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.Event;
 import ai.singlr.sail.api.ServerConnectionConfig;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import java.io.PrintStream;
 import java.net.URI;
@@ -154,7 +155,7 @@ public final class EventsCommand implements Runnable {
 
   private URI streamUri() {
     var params = new LinkedHashMap<String, String>();
-    if (projectFilter != null && !projectFilter.isBlank()) {
+    if (Strings.isNotBlank(projectFilter)) {
       params.put("project", projectFilter);
     }
     if (typeFilter != null && !typeFilter.isEmpty()) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
@@ -17,6 +17,7 @@ import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.SqliteException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
@@ -47,7 +48,7 @@ public final class FdeCommand implements Runnable {
     new picocli.CommandLine(this).usage(System.out);
   }
 
-  private static java.nio.file.Path dbPath() {
+  private static Path dbPath() {
     return SailPaths.controlPlaneDb();
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostInitCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostInitCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
@@ -212,7 +213,7 @@ public final class HostInitCommand implements Runnable {
     var sudoUser = System.getenv("SUDO_USER");
     System.out.println();
     System.out.println(Ansi.AUTO.string("  @|bold Next step:|@ enable the sail API service."));
-    if (sudoUser != null && !sudoUser.isBlank() && !"root".equals(sudoUser)) {
+    if (Strings.isNotBlank(sudoUser) && !"root".equals(sudoUser)) {
       enableLingerForUser(shell, sudoUser);
       System.out.println(Ansi.AUTO.string("    Run as @|bold " + sudoUser + "|@ (without sudo):"));
     } else {
@@ -296,7 +297,7 @@ public final class HostInitCommand implements Runnable {
     System.out.print("  Select disk [1-" + candidates.size() + "]: ");
     System.out.flush();
     var line = ConsoleHelper.readLine();
-    if (line == null || line.isBlank()) {
+    if (Strings.isBlank(line)) {
       System.out.println("  Aborted.");
       return null;
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostInitCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostInitCommand.java
@@ -19,6 +19,7 @@ import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.ShellExecutor;
 import java.nio.file.Files;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import picocli.CommandLine.Command;
@@ -224,7 +225,7 @@ public final class HostInitCommand implements Runnable {
 
   private void enableLingerForUser(ShellExec shell, String user) {
     try {
-      var result = shell.exec(java.util.List.of("loginctl", "enable-linger", user));
+      var result = shell.exec(List.of("loginctl", "enable-linger", user));
       if (result.ok()) {
         System.out.println(
             Ansi.AUTO.string(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostServiceInstallers.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostServiceInstallers.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SystemdServiceInstaller;
@@ -36,7 +37,7 @@ final class HostServiceInstallers {
 
   static String currentUsername() {
     var name = System.getProperty("user.name");
-    if (name == null || name.isBlank()) {
+    if (Strings.isBlank(name)) {
       throw new IllegalStateException(
           "Could not determine current username (user.name system property is empty).");
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostStatusCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostStatusCommand.java
@@ -17,6 +17,7 @@ import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.ZfsQuery;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
+import java.util.List;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -81,7 +82,7 @@ public final class HostStatusCommand implements Runnable {
       HostDetector.HostInfo hostInfo,
       ZfsQuery.PoolUsage poolUsage,
       DirQuery.FsUsage fsUsage,
-      java.util.List<ContainerManager.ContainerInfo> containers) {
+      List<ContainerManager.ContainerInfo> containers) {
     var map = new LinkedHashMap<String, Object>();
     map.put("hostname", hostInfo.hostname());
     map.put("os", hostInfo.osPrettyName());

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/LoopbackCallbackServer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/LoopbackCallbackServer.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
@@ -76,7 +77,7 @@ public final class LoopbackCallbackServer implements AutoCloseable {
   private void handle(HttpExchange exchange) throws IOException {
     var query = parseQuery(exchange.getRequestURI().getRawQuery());
     var received = query.get("token");
-    var accepted = state.equals(query.get("state")) && received != null && !received.isBlank();
+    var accepted = state.equals(query.get("state")) && Strings.isNotBlank(received);
     var body = accepted ? DONE_PAGE : ERROR_PAGE;
     var bytes = body.getBytes(StandardCharsets.UTF_8);
     exchange.getResponseHeaders().set("Content-Type", "text/html; charset=utf-8");
@@ -97,7 +98,7 @@ public final class LoopbackCallbackServer implements AutoCloseable {
 
   private static Map<String, String> parseQuery(String raw) {
     var values = new LinkedHashMap<String, String>();
-    if (raw == null || raw.isBlank()) {
+    if (Strings.isBlank(raw)) {
       return values;
     }
     for (var part : raw.split("&")) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.engine.AuthorizedKeysSync;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerSpecImporter;
@@ -291,7 +292,7 @@ public final class MigrateCommand implements Runnable {
       System.out.print("  Pick 1-" + candidates.size() + " (Enter to skip): ");
       try {
         var line = reader.readLine();
-        if (line == null || line.isBlank()) {
+        if (Strings.isBlank(line)) {
           return Optional.empty();
         }
         var idx = Integer.parseInt(line.trim()) - 1;

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -32,6 +32,7 @@ import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -54,8 +55,7 @@ public final class MigrateCommand implements Runnable {
    * File-based spec discovery (see {@link ContainerSpecImporter}) deliberately runs outside this
    * registry — it's a repeatable scan, not a one-shot fix-up.
    */
-  public static final List<ai.singlr.sail.store.DataMigration> REGISTRY =
-      List.of(new RebucketSpecsMigration());
+  public static final List<DataMigration> REGISTRY = List.of(new RebucketSpecsMigration());
 
   @Option(
       names = "--non-interactive",
@@ -200,7 +200,7 @@ public final class MigrateCommand implements Runnable {
   static List<DataMigrator.Run> applyMigrations(
       Sqlite db,
       String dbPath,
-      java.util.function.Supplier<ContainerSpecImporter.Report> specImport,
+      Supplier<ContainerSpecImporter.Report> specImport,
       DataMigration.Prompter prompter,
       boolean animate,
       boolean jsonOutput) {
@@ -217,7 +217,7 @@ public final class MigrateCommand implements Runnable {
     return result.dataRuns();
   }
 
-  private static <T> T phase(boolean animate, String message, java.util.function.Supplier<T> work) {
+  private static <T> T phase(boolean animate, String message, Supplier<T> work) {
     if (!animate) {
       return work.get();
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddFileCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddFileCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
@@ -180,7 +181,7 @@ public final class ProjectAddFileCommand implements Runnable {
         out.print(ansi.string("  @|bold Search or path|@: "));
         out.flush();
         var input = ConsoleHelper.readLine();
-        if (input == null || input.isBlank()) {
+        if (Strings.isBlank(input)) {
           return List.of();
         }
         input = input.strip();
@@ -219,7 +220,7 @@ public final class ProjectAddFileCommand implements Runnable {
         out.print(ansi.string("  @|bold Pattern|@ @|faint (e.g. *.json, setup.*)|@: "));
         out.flush();
         var patternInput = ConsoleHelper.readLine();
-        if (patternInput == null || patternInput.isBlank()) {
+        if (Strings.isBlank(patternInput)) {
           return List.of();
         }
         searchPattern = patternInput.strip();
@@ -231,7 +232,7 @@ public final class ProjectAddFileCommand implements Runnable {
         out.print(ansi.string("  @|bold File path|@ @|faint (relative to ~/workspace)|@: "));
         out.flush();
         var pathInput = ConsoleHelper.readLine();
-        if (pathInput == null || pathInput.isBlank()) {
+        if (Strings.isBlank(pathInput)) {
           return List.of();
         }
         return collectManualPaths(out, ansi, pathInput.strip());
@@ -255,7 +256,7 @@ public final class ProjectAddFileCommand implements Runnable {
       out.print(ansi.string("  @|bold File path|@ @|faint (relative to ~/workspace)|@: "));
       out.flush();
       var pathInput = ConsoleHelper.readLine();
-      if (pathInput != null && !pathInput.isBlank()) {
+      if (Strings.isNotBlank(pathInput)) {
         manualPaths.add(pathInput.strip());
       }
     }
@@ -304,7 +305,7 @@ public final class ProjectAddFileCommand implements Runnable {
   }
 
   static List<String> parseDiscoveryOutput(String output, String workspaceDir) {
-    if (output == null || output.isBlank()) return List.of();
+    if (Strings.isBlank(output)) return List.of();
     var prefix = workspaceDir + "/";
     return output
         .lines()

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddRepoCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddRepoCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.SailYamlUpdater;
 import ai.singlr.sail.config.YamlUtil;
@@ -106,7 +107,7 @@ public final class ProjectAddRepoCommand implements Runnable {
     }
 
     var sshUser = config.sshUser();
-    var token = gitToken != null && !gitToken.isBlank() ? gitToken : null;
+    var token = Strings.isNotBlank(gitToken) ? gitToken : null;
     var applier = new ProjectApplier(shell, out);
     var result =
         applier.applyRepos(
@@ -153,14 +154,14 @@ public final class ProjectAddRepoCommand implements Runnable {
 
   private static String promptWithDefault(
       java.io.PrintStream out, Ansi ansi, String label, String def) {
-    if (def != null && !def.isEmpty()) {
+    if (!Strings.isEmpty(def)) {
       out.print(ansi.string("  @|bold " + label + "|@ @|faint [" + def + "]|@: "));
     } else {
       out.print(ansi.string("  @|bold " + label + "|@: "));
     }
     out.flush();
     var line = ConsoleHelper.readLine();
-    if (line == null || line.isBlank()) {
+    if (Strings.isBlank(line)) {
       return Objects.requireNonNullElse(def, "");
     }
     return line.strip();
@@ -171,7 +172,7 @@ public final class ProjectAddRepoCommand implements Runnable {
       out.print(ansi.string("  @|bold " + label + "|@: "));
       out.flush();
       var line = ConsoleHelper.readLine();
-      if (line != null && !line.isBlank()) {
+      if (Strings.isNotBlank(line)) {
         return line.strip();
       }
       out.println(ansi.string("    @|yellow Required field. Please enter a value.|@"));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddRepoCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddRepoCommand.java
@@ -17,6 +17,7 @@ import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ProjectApplier;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -136,7 +137,7 @@ public final class ProjectAddRepoCommand implements Runnable {
                 + " and sail.yaml updated"));
   }
 
-  private SailYaml.Repo collectRepoInteractively(java.io.PrintStream out, Ansi ansi) {
+  private SailYaml.Repo collectRepoInteractively(PrintStream out, Ansi ansi) {
     var repoUrl = promptRequired(out, ansi, "Repo URL");
     var pathDefault = guessRepoPath(repoUrl);
     var path = promptWithDefault(out, ansi, "Local path", pathDefault);
@@ -152,8 +153,7 @@ public final class ProjectAddRepoCommand implements Runnable {
     return repoName;
   }
 
-  private static String promptWithDefault(
-      java.io.PrintStream out, Ansi ansi, String label, String def) {
+  private static String promptWithDefault(PrintStream out, Ansi ansi, String label, String def) {
     if (!Strings.isEmpty(def)) {
       out.print(ansi.string("  @|bold " + label + "|@ @|faint [" + def + "]|@: "));
     } else {
@@ -167,7 +167,7 @@ public final class ProjectAddRepoCommand implements Runnable {
     return line.strip();
   }
 
-  private static String promptRequired(java.io.PrintStream out, Ansi ansi, String label) {
+  private static String promptRequired(PrintStream out, Ansi ansi, String label) {
     while (true) {
       out.print(ansi.string("  @|bold " + label + "|@: "));
       out.flush();

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddServiceCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddServiceCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.SailYamlUpdater;
 import ai.singlr.sail.config.YamlUtil;
@@ -273,14 +274,14 @@ public final class ProjectAddServiceCommand implements Runnable {
 
   private static String promptWithDefault(
       java.io.PrintStream out, Ansi ansi, String label, String def) {
-    if (def != null && !def.isEmpty()) {
+    if (!Strings.isEmpty(def)) {
       out.print(ansi.string("  @|bold " + label + "|@ @|faint [" + def + "]|@: "));
     } else {
       out.print(ansi.string("  @|bold " + label + "|@: "));
     }
     out.flush();
     var line = ConsoleHelper.readLine();
-    if (line == null || line.isBlank()) {
+    if (Strings.isBlank(line)) {
       return Objects.requireNonNullElse(def, "");
     }
     return line.strip();
@@ -291,7 +292,7 @@ public final class ProjectAddServiceCommand implements Runnable {
       out.print(ansi.string("  @|bold " + label + "|@: "));
       out.flush();
       var line = ConsoleHelper.readLine();
-      if (line != null && !line.isBlank()) {
+      if (Strings.isNotBlank(line)) {
         return line.strip();
       }
       out.println(ansi.string("    @|yellow Required field. Please enter a value.|@"));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddServiceCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddServiceCommand.java
@@ -17,10 +17,12 @@ import ai.singlr.sail.engine.ProjectApplier;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.gen.ServicePresets;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
@@ -110,7 +112,7 @@ public final class ProjectAddServiceCommand implements Runnable {
     }
 
     var applier = new ProjectApplier(shell, out);
-    var result = applier.applyServices(name, java.util.Map.of(svcName, service));
+    var result = applier.applyServices(name, Map.of(svcName, service));
 
     SailYamlUpdater.addService(singYamlPath, svcName, service);
 
@@ -136,7 +138,7 @@ public final class ProjectAddServiceCommand implements Runnable {
   }
 
   private SailYaml.Service buildServiceFromFlags() {
-    java.util.Map<String, String> env = null;
+    Map<String, String> env = null;
     if (envPairs != null && !envPairs.isEmpty()) {
       env = new LinkedHashMap<>();
       for (var pair : envPairs) {
@@ -151,7 +153,7 @@ public final class ProjectAddServiceCommand implements Runnable {
 
   private record ServiceSelection(String name, SailYaml.Service service) {}
 
-  private ServiceSelection collectServiceInteractively(java.io.PrintStream out, Ansi ansi) {
+  private ServiceSelection collectServiceInteractively(PrintStream out, Ansi ansi) {
     var presets = ServicePresets.all();
 
     out.println(ansi.string("  @|bold Choose a service (runs as a Podman container):|@"));
@@ -200,7 +202,7 @@ public final class ProjectAddServiceCommand implements Runnable {
   }
 
   private SailYaml.Service customizePresetEnv(
-      SailYaml.Service service, java.io.PrintStream out, Ansi ansi) {
+      SailYaml.Service service, PrintStream out, Ansi ansi) {
     var defaultEnv = service.environment();
     var env = new LinkedHashMap<String, String>();
     if (defaultEnv != null && !defaultEnv.isEmpty()) {
@@ -228,7 +230,7 @@ public final class ProjectAddServiceCommand implements Runnable {
         service.volumes());
   }
 
-  private ServiceSelection collectCustomService(java.io.PrintStream out, Ansi ansi) {
+  private ServiceSelection collectCustomService(PrintStream out, Ansi ansi) {
     out.println();
     out.println(ansi.string("  @|bold Custom Podman service|@"));
     var svcName =
@@ -249,7 +251,7 @@ public final class ProjectAddServiceCommand implements Runnable {
       }
       if (customPorts.isEmpty()) customPorts = null;
     }
-    java.util.Map<String, String> env = null;
+    Map<String, String> env = null;
     if (ConsoleHelper.confirmNo("Add environment variables?")) {
       env = new LinkedHashMap<>();
       do {
@@ -272,8 +274,7 @@ public final class ProjectAddServiceCommand implements Runnable {
         svcName, new SailYaml.Service(img, customPorts, env, null, customVolumes));
   }
 
-  private static String promptWithDefault(
-      java.io.PrintStream out, Ansi ansi, String label, String def) {
+  private static String promptWithDefault(PrintStream out, Ansi ansi, String label, String def) {
     if (!Strings.isEmpty(def)) {
       out.print(ansi.string("  @|bold " + label + "|@ @|faint [" + def + "]|@: "));
     } else {
@@ -287,7 +288,7 @@ public final class ProjectAddServiceCommand implements Runnable {
     return line.strip();
   }
 
-  private static String promptRequired(java.io.PrintStream out, Ansi ansi, String label) {
+  private static String promptRequired(PrintStream out, Ansi ansi, String label) {
     while (true) {
       out.print(ansi.string("  @|bold " + label + "|@: "));
       out.flush();

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectApplyCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectApplyCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
@@ -110,7 +111,7 @@ public final class ProjectApplyCommand implements Runnable {
 
     var applier = new ProjectApplier(shell, System.out);
     var sshUser = config.sshUser();
-    var token = gitToken != null && !gitToken.isBlank() ? gitToken : null;
+    var token = Strings.isNotBlank(gitToken) ? gitToken : null;
 
     var totalAdded = 0;
     var totalRemoved = 0;

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCreateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCreateCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlUtil;
@@ -222,7 +223,7 @@ public final class ProjectCreateCommand implements Runnable {
       return Map.of();
     }
 
-    if (gitToken != null && !gitToken.isBlank()) {
+    if (Strings.isNotBlank(gitToken)) {
       return GitCredentials.singleTokenMap(gitToken);
     }
 
@@ -234,7 +235,7 @@ public final class ProjectCreateCommand implements Runnable {
     var tokens = new LinkedHashMap<String, String>();
     for (var host : hosts) {
       var envToken = GitCredentials.resolveTokenForHost(host, null);
-      if (envToken != null && !envToken.isBlank()) {
+      if (Strings.isNotBlank(envToken)) {
         tokens.put(host, envToken);
       }
     }
@@ -248,7 +249,7 @@ public final class ProjectCreateCommand implements Runnable {
       try {
         var prompted =
             ConsoleHelper.readPassword("  Git access token for " + host + " (blank to skip): ");
-        if (prompted != null && !prompted.isBlank()) {
+        if (Strings.isNotBlank(prompted)) {
           tokens.put(host, prompted);
         }
       } catch (EchoDisabledUnavailableException e) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCreateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCreateCommand.java
@@ -24,6 +24,8 @@ import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import picocli.CommandLine.Command;
@@ -329,8 +331,8 @@ public final class ProjectCreateCommand implements Runnable {
       Files.copy(
           sourceYaml,
           targetYaml,
-          java.nio.file.StandardCopyOption.REPLACE_EXISTING,
-          java.nio.file.StandardCopyOption.COPY_ATTRIBUTES);
+          StandardCopyOption.REPLACE_EXISTING,
+          StandardCopyOption.COPY_ATTRIBUTES);
     }
     syncFilesDirectory(
         sourceYaml.getParent().resolve("files"), targetYaml.getParent().resolve("files"));
@@ -360,8 +362,8 @@ public final class ProjectCreateCommand implements Runnable {
           Files.copy(
               path,
               destination,
-              java.nio.file.StandardCopyOption.REPLACE_EXISTING,
-              java.nio.file.StandardCopyOption.COPY_ATTRIBUTES);
+              StandardCopyOption.REPLACE_EXISTING,
+              StandardCopyOption.COPY_ATTRIBUTES);
         }
       }
     }
@@ -372,7 +374,7 @@ public final class ProjectCreateCommand implements Runnable {
       return;
     }
     try (var walk = Files.walk(dir)) {
-      for (var path : walk.sorted(java.util.Comparator.reverseOrder()).toList()) {
+      for (var path : walk.sorted(Comparator.reverseOrder()).toList()) {
         Files.deleteIfExists(path);
       }
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectDemoCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectDemoCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlUtil;
@@ -256,7 +257,7 @@ public final class ProjectDemoCommand implements Runnable {
       out.print(ansi.string("  @|bold Git name (for commits)|@: "));
       out.flush();
       gitName = ConsoleHelper.readLine();
-      if (gitName == null || gitName.isBlank()) {
+      if (Strings.isBlank(gitName)) {
         throw new IllegalArgumentException(
             "Git name is required."
                 + "\n  Set it with: git config --global user.name \"Your Name\"");
@@ -267,7 +268,7 @@ public final class ProjectDemoCommand implements Runnable {
       out.print(ansi.string("  @|bold Git email|@: "));
       out.flush();
       gitEmail = ConsoleHelper.readLine();
-      if (gitEmail == null || gitEmail.isBlank()) {
+      if (Strings.isBlank(gitEmail)) {
         throw new IllegalArgumentException(
             "Git email is required."
                 + "\n  Set it with: git config --global user.email you@example.com");
@@ -298,7 +299,7 @@ public final class ProjectDemoCommand implements Runnable {
     try {
       var sudoUser = System.getenv("SUDO_USER");
       var pb =
-          sudoUser != null && !sudoUser.isBlank()
+          Strings.isNotBlank(sudoUser)
               ? new ProcessBuilder("su", "-", sudoUser, "-c", "git config --global " + key)
               : new ProcessBuilder("git", "config", "--global", key);
       pb.redirectErrorStream(true);
@@ -315,7 +316,7 @@ public final class ProjectDemoCommand implements Runnable {
   static String detectSshPublicKey() {
     var sudoUser = System.getenv("SUDO_USER");
     Path sshDir;
-    if (sudoUser != null && !sudoUser.isBlank()) {
+    if (Strings.isNotBlank(sudoUser)) {
       sshDir = Path.of("/home", sudoUser, ".ssh");
     } else {
       sshDir = Path.of(System.getProperty("user.home"), ".ssh");

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectDestroyCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectDestroyCommand.java
@@ -13,6 +13,7 @@ import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
@@ -144,7 +145,7 @@ public final class ProjectDestroyCommand implements Runnable {
                 try {
                   Files.delete(path);
                 } catch (IOException e) {
-                  throw new java.io.UncheckedIOException(e);
+                  throw new UncheckedIOException(e);
                 }
               });
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.FileMaterializer;
@@ -94,7 +95,7 @@ public final class ProjectFilesCommand implements Runnable {
      */
     static String share(FileStore files, Path projectsDir, String project, Path source, String as)
         throws IOException {
-      var path = as != null && !as.isBlank() ? as : source.getFileName().toString();
+      var path = Strings.isNotBlank(as) ? as : source.getFileName().toString();
       NameValidator.requireSafePath(path, "path");
       files.put(project, path, Base64.getEncoder().encodeToString(Files.readAllBytes(source)));
       new FileMaterializer(files, projectsDir).materialize(project);
@@ -241,7 +242,7 @@ public final class ProjectFilesCommand implements Runnable {
 
     @Override
     public Integer call() throws Exception {
-      if (all == (project != null && !project.isBlank())) {
+      if (all == (Strings.isNotBlank(project))) {
         System.err.println(Banner.errorLine("Pass a project name OR --all, not both.", Ansi.AUTO));
         return 1;
       }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectInitCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectInitCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
@@ -271,14 +272,14 @@ public final class ProjectInitCommand implements Runnable {
 
   private static String promptWithDefault(
       java.io.PrintStream out, Ansi ansi, String label, String def) {
-    if (def != null && !def.isEmpty()) {
+    if (!Strings.isEmpty(def)) {
       out.print(ansi.string("  @|bold " + label + "|@ @|faint [" + def + "]|@: "));
     } else {
       out.print(ansi.string("  @|bold " + label + "|@: "));
     }
     out.flush();
     var line = ConsoleHelper.readLine();
-    if (line == null || line.isBlank()) {
+    if (Strings.isBlank(line)) {
       return Objects.requireNonNullElse(def, "");
     }
     return line.strip();
@@ -289,7 +290,7 @@ public final class ProjectInitCommand implements Runnable {
       out.print(ansi.string("  @|bold " + label + "|@: "));
       out.flush();
       var line = ConsoleHelper.readLine();
-      if (line != null && !line.isBlank()) {
+      if (Strings.isNotBlank(line)) {
         return line.strip();
       }
       out.println(ansi.string("    @|yellow Required field. Please enter a value.|@"));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectInitCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectInitCommand.java
@@ -13,11 +13,13 @@ import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.gen.SailYamlGenerator;
 import ai.singlr.sail.gen.ServicePresets;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
@@ -103,7 +105,7 @@ public final class ProjectInitCommand implements Runnable {
     return "sail project create " + name + " -f " + outputPath;
   }
 
-  private SailYaml collectInputs(java.io.PrintStream out, Ansi ansi) {
+  private SailYaml collectInputs(PrintStream out, Ansi ansi) {
     var dirName = sanitizeProjectName(Path.of("").toAbsolutePath().getFileName().toString());
     var name = promptWithDefault(out, ansi, "Project name", dirName);
     NameValidator.requireValidProjectName(name);
@@ -170,7 +172,7 @@ public final class ProjectInitCommand implements Runnable {
 
     out.println();
     out.println(ansi.string("  @|bold Infrastructure services (Podman containers)|@"));
-    java.util.Map<String, SailYaml.Service> services = new LinkedHashMap<>();
+    Map<String, SailYaml.Service> services = new LinkedHashMap<>();
     for (var preset : ServicePresets.all()) {
       var ports =
           preset.service().ports().stream()
@@ -242,7 +244,7 @@ public final class ProjectInitCommand implements Runnable {
   }
 
   private static SailYaml.Service customizePresetEnv(
-      SailYaml.Service service, java.io.PrintStream out, Ansi ansi) {
+      SailYaml.Service service, PrintStream out, Ansi ansi) {
     var defaultEnv = service.environment();
     var env = new LinkedHashMap<String, String>();
     if (defaultEnv != null && !defaultEnv.isEmpty()) {
@@ -270,8 +272,7 @@ public final class ProjectInitCommand implements Runnable {
         service.volumes());
   }
 
-  private static String promptWithDefault(
-      java.io.PrintStream out, Ansi ansi, String label, String def) {
+  private static String promptWithDefault(PrintStream out, Ansi ansi, String label, String def) {
     if (!Strings.isEmpty(def)) {
       out.print(ansi.string("  @|bold " + label + "|@ @|faint [" + def + "]|@: "));
     } else {
@@ -285,7 +286,7 @@ public final class ProjectInitCommand implements Runnable {
     return line.strip();
   }
 
-  private static String promptRequired(java.io.PrintStream out, Ansi ansi, String label) {
+  private static String promptRequired(PrintStream out, Ansi ansi, String label) {
     while (true) {
       out.print(ansi.string("  @|bold " + label + "|@: "));
       out.flush();
@@ -297,7 +298,7 @@ public final class ProjectInitCommand implements Runnable {
     }
   }
 
-  private static int promptInt(java.io.PrintStream out, Ansi ansi, String label, int def) {
+  private static int promptInt(PrintStream out, Ansi ansi, String label, int def) {
     var raw = promptWithDefault(out, ansi, label, String.valueOf(def));
     try {
       return Integer.parseInt(raw);
@@ -341,7 +342,7 @@ public final class ProjectInitCommand implements Runnable {
    * services map.
    */
   private static void collectCustomServices(
-      java.io.PrintStream out, Ansi ansi, java.util.Map<String, SailYaml.Service> services) {
+      PrintStream out, Ansi ansi, Map<String, SailYaml.Service> services) {
     do {
       out.println();
       out.println(ansi.string("  @|bold Custom Podman service|@"));
@@ -363,7 +364,7 @@ public final class ProjectInitCommand implements Runnable {
         }
         if (ports.isEmpty()) ports = null;
       }
-      java.util.Map<String, String> env = null;
+      Map<String, String> env = null;
       if (ConsoleHelper.confirmNo("Add environment variables?")) {
         env = new LinkedHashMap<>();
         do {
@@ -417,7 +418,7 @@ public final class ProjectInitCommand implements Runnable {
     }
 
     if (config.repos() != null && !config.repos().isEmpty()) {
-      var reposList = new ArrayList<java.util.Map<String, Object>>();
+      var reposList = new ArrayList<Map<String, Object>>();
       for (var repo : config.repos()) {
         var r = new LinkedHashMap<String, Object>();
         r.put("url", repo.url());

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectListCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectListCommand.java
@@ -13,6 +13,7 @@ import ai.singlr.sail.engine.ShellExecutor;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -60,7 +61,7 @@ public final class ProjectListCommand implements Runnable {
   }
 
   private void printJson(List<ContainerManager.ContainerInfo> containers) {
-    var list = new ArrayList<java.util.Map<String, Object>>();
+    var list = new ArrayList<Map<String, Object>>();
     for (var c : containers) {
       var map = new LinkedHashMap<String, Object>();
       map.put("name", c.name());

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectMigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectMigrateCommand.java
@@ -1,5 +1,6 @@
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
@@ -106,10 +107,10 @@ public final class ProjectMigrateCommand implements Runnable {
   }
 
   private List<String> selectedProjects() throws Exception {
-    if (all == (name != null && !name.isBlank())) {
+    if (all == (Strings.isNotBlank(name))) {
       throw new IllegalArgumentException("Specify exactly one project name or --all.");
     }
-    if (name != null && !name.isBlank()) {
+    if (Strings.isNotBlank(name)) {
       NameValidator.requireValidProjectName(name);
       importLegacyState(List.of(name));
       return List.of(name);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectMigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectMigrateCommand.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
@@ -239,7 +240,7 @@ public final class ProjectMigrateCommand implements Runnable {
     return all ? SailPaths.resolveSailYaml(project, file).toString() : file;
   }
 
-  private static java.util.Map<String, Object> summary(List<ProjectResult> results) {
+  private static Map<String, Object> summary(List<ProjectResult> results) {
     var map = new LinkedHashMap<String, Object>();
     map.put("total", results.size());
     map.put("ok", results.stream().filter(result -> "ok".equals(result.status())).count());
@@ -432,7 +433,7 @@ public final class ProjectMigrateCommand implements Runnable {
       return new ProjectResult(name, "failed", false, 0, 0, 0, false, "unknown", List.of(), error);
     }
 
-    private java.util.Map<String, Object> toMap() {
+    private Map<String, Object> toMap() {
       var map = new LinkedHashMap<String, Object>();
       map.put("name", name);
       map.put("status", status);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectPullCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectPullCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.PlaceholderResolver;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlMerger;
@@ -78,7 +79,7 @@ public final class ProjectPullCommand implements Runnable {
   private void execute() throws Exception {
     NameValidator.requireValidProjectName(name);
 
-    if (repo == null || repo.isBlank()) {
+    if (Strings.isBlank(repo)) {
       throw new IllegalArgumentException(
           "--repo is required. Specify the GitHub repository that holds your project descriptors"
               + " (e.g. --repo your-org/projects).");
@@ -112,7 +113,7 @@ public final class ProjectPullCommand implements Runnable {
     var projectContent = GitHubFetcher.fetchRawFile(repo, projectPath, token, ref);
     if (projectContent == null) {
       var hint =
-          (token == null || token.isBlank())
+          (Strings.isBlank(token))
               ? "\n  If the repository is private, provide a token with --github-token or GITHUB_TOKEN."
               : "\n  Check that the file exists and your token has 'repo' scope.";
       throw new IllegalStateException(
@@ -290,17 +291,17 @@ public final class ProjectPullCommand implements Runnable {
   }
 
   private String resolveToken() {
-    if (githubToken != null && !githubToken.isBlank()) {
+    if (Strings.isNotBlank(githubToken)) {
       return githubToken;
     }
     var envToken = System.getenv("GITHUB_TOKEN");
-    if (envToken != null && !envToken.isBlank()) {
+    if (Strings.isNotBlank(envToken)) {
       return envToken;
     }
     try {
       var prompted =
           ConsoleHelper.readPassword("  GitHub personal access token (needs 'repo' scope): ");
-      if (prompted == null || prompted.isBlank()) {
+      if (Strings.isBlank(prompted)) {
         throw new IllegalArgumentException(
             "GitHub token required. Pass --github-token, set GITHUB_TOKEN, or enter interactively.");
       }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectPullCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectPullCommand.java
@@ -13,6 +13,7 @@ import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.GitHubFetcher;
 import ai.singlr.sail.engine.NameValidator;
+import ai.singlr.sail.engine.ProjectCatalog;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.WorkspaceFiles;
 import ai.singlr.sail.gen.SailYamlGenerator;
@@ -168,7 +169,7 @@ public final class ProjectPullCommand implements Runnable {
       Files.createDirectories(outputPath.getParent());
     }
     Files.writeString(outputPath, resolvedYaml);
-    ai.singlr.sail.engine.ProjectCatalog.record(name, resolvedYaml, null);
+    ProjectCatalog.record(name, resolvedYaml, null);
 
     var outputDir = outputPath.getParent() != null ? outputPath.getParent() : Path.of(".");
     var filesPulled = pullFilesDirectory(token, name, outputDir);
@@ -261,7 +262,7 @@ public final class ProjectPullCommand implements Runnable {
     if (Files.exists(outputPath)) {
       var existingContent = Files.readString(outputPath);
       var existingConfig = SailYaml.fromMap(YamlUtil.parseMap(existingContent));
-      var replacements = new java.util.LinkedHashMap<String, String>();
+      var replacements = new LinkedHashMap<String, String>();
       if (existingConfig.git() != null) {
         if (existingConfig.git().name() != null) {
           replacements.put("${GIT_NAME}", existingConfig.git().name());

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectPushCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectPushCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
@@ -81,7 +82,7 @@ public final class ProjectPushCommand implements Runnable {
   private void execute() throws Exception {
     NameValidator.requireValidProjectName(name);
 
-    if (repo == null || repo.isBlank()) {
+    if (Strings.isBlank(repo)) {
       throw new IllegalArgumentException(
           "--repo is required. Specify the GitHub repository that holds your project descriptors"
               + " (e.g. --repo your-org/projects).");
@@ -225,17 +226,17 @@ public final class ProjectPushCommand implements Runnable {
   }
 
   private String resolveToken() {
-    if (githubToken != null && !githubToken.isBlank()) {
+    if (Strings.isNotBlank(githubToken)) {
       return githubToken;
     }
     var envToken = System.getenv("GITHUB_TOKEN");
-    if (envToken != null && !envToken.isBlank()) {
+    if (Strings.isNotBlank(envToken)) {
       return envToken;
     }
     try {
       var prompted =
           ConsoleHelper.readPassword("  GitHub personal access token (needs 'repo' scope): ");
-      if (prompted == null || prompted.isBlank()) {
+      if (Strings.isBlank(prompted)) {
         throw new IllegalArgumentException(
             "GitHub token required. Pass --github-token, set GITHUB_TOKEN, or enter interactively.");
       }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectSyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectSyncCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ClaudeCodeHookConfig;
@@ -53,11 +54,11 @@ public final class ProjectSyncCommand implements Runnable {
   }
 
   private void execute() throws Exception {
-    if (!all && (name == null || name.isBlank())) {
+    if (!all && (Strings.isBlank(name))) {
       throw new IllegalArgumentException(
           "Provide a project name or pass --all to sync every project.");
     }
-    if (all && name != null && !name.isBlank()) {
+    if (all && Strings.isNotBlank(name)) {
       throw new IllegalArgumentException("Pass a project name OR --all, not both.");
     }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.SpecDirectory;
 import ai.singlr.sail.config.YamlUtil;
@@ -357,7 +358,7 @@ public final class RunCommand implements Runnable {
   private void autoRollback(ShellExecutor shell, String snapshotLabel, int exitCode) {
     try {
       var rollbackMap = new LinkedHashMap<String, Object>();
-      rollbackMap.put("rolled_back_at", java.time.Instant.now().toString());
+      rollbackMap.put("rolled_back_at", DateTimeUtils.now().toString());
       rollbackMap.put("exit_code", exitCode);
       rollbackMap.put("snapshot_restored", snapshotLabel);
       rollbackMap.put("task", task);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerTokenCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerTokenCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.Sqlite;
@@ -102,7 +103,7 @@ public final class ServerTokenCommand implements Runnable {
     }
 
     private String resolveFdeId(Sqlite db) {
-      if (fde == null || fde.isBlank()) {
+      if (Strings.isBlank(fde)) {
         return null;
       }
       return new FdeStore(db)

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerTokenCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerTokenCommand.java
@@ -10,6 +10,7 @@ import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.TokenStore;
+import java.time.Duration;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -86,7 +87,7 @@ public final class ServerTokenCommand implements Runnable {
     }
 
     /** Resolves the requested lifetime; {@code null} never expires. Visible for tests. */
-    static java.time.Duration resolveTtl(boolean noExpiry, Integer ttlDays) {
+    static Duration resolveTtl(boolean noExpiry, Integer ttlDays) {
       if (noExpiry && ttlDays != null) {
         throw new IllegalArgumentException("Pass --ttl-days or --no-expiry, not both.");
       }
@@ -99,7 +100,7 @@ public final class ServerTokenCommand implements Runnable {
       if (ttlDays <= 0) {
         throw new IllegalArgumentException("--ttl-days must be a positive number of days.");
       }
-      return java.time.Duration.ofDays(ttlDays);
+      return Duration.ofDays(ttlDays);
     }
 
     private String resolveFdeId(Sqlite db) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SnapsPruneCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SnapsPruneCommand.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.commands;
 
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerManager;
@@ -244,7 +245,7 @@ public final class SnapsPruneCommand implements Runnable {
   }
 
   static Instant parseSnapshotTime(String iso) {
-    if (iso == null || iso.isBlank()) {
+    if (Strings.isBlank(iso)) {
       return null;
     }
     try {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SnapsPruneCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SnapsPruneCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerManager;
@@ -80,7 +81,7 @@ public final class SnapsPruneCommand implements Runnable {
       throw new IllegalArgumentException("--keep must be 0 or greater.");
     }
     Duration maxAge = olderThan != null ? parseAge(olderThan) : null;
-    Instant cutoff = maxAge != null ? Instant.now().minus(maxAge) : null;
+    Instant cutoff = maxAge != null ? DateTimeUtils.now().minus(maxAge) : null;
     var shell = new ShellExecutor(dryRun);
     var mgr = new ContainerManager(shell);
     var snapMgr = new SnapshotManager(shell);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.Event;
 import ai.singlr.sail.api.SailEventPublisher;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SyncConfig;
 import ai.singlr.sail.config.YamlUtil;
@@ -114,7 +115,7 @@ public final class SyncCommand implements Callable<Integer> {
 
   /** The main target: the {@code --main} flag if given, else the configured one. */
   static String resolveMain(String flag, SyncConfig sync) {
-    if (flag != null && !flag.isBlank()) {
+    if (Strings.isNotBlank(flag)) {
       return flag;
     }
     if (sync.isMain()) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.Capability;
 import ai.singlr.sail.api.Role;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.engine.HostInfo;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.store.AuthSessionStore;
@@ -85,7 +86,7 @@ public final class SyncServerCommand implements Callable<Integer> {
   }
 
   private static boolean canWrite(Sqlite db, String token) {
-    if (token == null || token.isBlank()) {
+    if (Strings.isBlank(token)) {
       return false;
     }
     return new AuthSessionStore(db)

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/UpgradeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/UpgradeCommand.java
@@ -24,9 +24,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
+import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -367,7 +369,7 @@ public final class UpgradeCommand implements Runnable {
    * was introduced, so the OLD binary is safe to do this. Everything else (new schema migrations,
    * new data migrations) is handled by the sub-process that runs the NEW binary.
    */
-  private void bootstrapAdminToken(java.nio.file.Path dbPath) {
+  private void bootstrapAdminToken(Path dbPath) {
     try {
       SailPaths.ensureDataDir(dbPath.getParent());
       try (var db = Sqlite.open(dbPath)) {
@@ -395,13 +397,13 @@ public final class UpgradeCommand implements Runnable {
    * NEW code — that's the whole point. Inherits stdio so the operator sees what migrated. Tolerates
    * non-zero exits; the {@code sail-api} restart afterwards is a second chance.
    */
-  private void runNewBinaryMigrate(java.nio.file.Path binaryPath) {
+  private void runNewBinaryMigrate(Path binaryPath) {
     try {
       var process =
           new ProcessBuilder(binaryPath.toString(), "migrate", "--non-interactive")
               .inheritIO()
               .start();
-      var finished = process.waitFor(2, java.util.concurrent.TimeUnit.MINUTES);
+      var finished = process.waitFor(2, TimeUnit.MINUTES);
       if (!finished) {
         process.destroyForcibly();
         if (!json) {
@@ -484,7 +486,7 @@ public final class UpgradeCommand implements Runnable {
 
   /** Re-executes the current command with sudo, inheriting stdin/stdout/stderr. */
   private void reExecWithSudo() throws IOException, InterruptedException {
-    var args = new java.util.ArrayList<String>();
+    var args = new ArrayList<String>();
     args.add("sudo");
     args.add(SailPaths.binaryPath().toString());
     args.add("upgrade");

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.engine;
 
 import ai.singlr.sail.SailVersion;
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.SpecStatus;
@@ -814,7 +815,7 @@ public final class Banner {
    * an empty string when the timestamp is missing or unparseable. Visible for tests.
    */
   static String formatElapsed(String startedAtIso, Instant now) {
-    if (startedAtIso == null || startedAtIso.isBlank() || now == null) {
+    if (Strings.isBlank(startedAtIso) || now == null) {
       return "";
     }
     Instant start;
@@ -976,7 +977,7 @@ public final class Banner {
     if (task != null) {
       out.println(amber(ansi, "    @|bold Task:|@    " + prettifyTask(task)));
     }
-    if (branch != null && !branch.isBlank()) {
+    if (Strings.isNotBlank(branch)) {
       out.println(amber(ansi, "    @|bold Branch:|@  " + branch));
     }
     out.println(amber(ansi, "    @|bold Log:|@     sail agent log " + name + " --follow"));

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.engine;
 
 import ai.singlr.sail.SailVersion;
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.SpecStatus;
@@ -922,7 +923,7 @@ public final class Banner {
     }
     if (!info.startedAt().isBlank()) {
       out.println(amber(ansi, "    @|bold Started:|@    " + formatTimestamp(info.startedAt())));
-      var elapsed = formatElapsed(info.startedAt(), Instant.now());
+      var elapsed = formatElapsed(info.startedAt(), DateTimeUtils.now());
       if (!elapsed.isEmpty()) {
         out.println(amber(ansi, "    @|bold Elapsed:|@    " + elapsed));
       }

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
@@ -10,6 +10,7 @@ import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;
 import java.io.PrintStream;
 import java.text.NumberFormat;
@@ -1047,8 +1048,8 @@ public final class Banner {
           var doneIds =
               report.specs().stream()
                   .filter(s -> s.status() == SpecStatus.DONE)
-                  .map(ai.singlr.sail.config.Spec::id)
-                  .collect(java.util.stream.Collectors.toSet());
+                  .map(Spec::id)
+                  .collect(Collectors.toSet());
           var blocked = spec.dependsOn().stream().filter(d -> !doneIds.contains(d)).toList();
           if (!blocked.isEmpty()) {
             out.println(

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/GitCredentials.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/GitCredentials.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SailYaml;
 import java.nio.file.Path;
 import java.util.LinkedHashSet;
@@ -36,7 +37,7 @@ public final class GitCredentials {
     var sb = new StringBuilder();
     for (var host : hosts) {
       var resolved = resolveTokenForHost(host, tokens);
-      if (resolved != null && !resolved.isBlank()) {
+      if (Strings.isNotBlank(resolved)) {
         sb.append("https://oauth2:").append(resolved).append('@').append(host).append('\n');
       }
     }
@@ -70,11 +71,11 @@ public final class GitCredentials {
   public static String resolveTokenForHost(String host, Map<String, String> tokens) {
     if (tokens != null) {
       var explicit = tokens.get(host);
-      if (explicit != null && !explicit.isBlank()) {
+      if (Strings.isNotBlank(explicit)) {
         return explicit;
       }
       var wildcard = tokens.get("*");
-      if (wildcard != null && !wildcard.isBlank()) {
+      if (Strings.isNotBlank(wildcard)) {
         return wildcard;
       }
     }
@@ -96,7 +97,7 @@ public final class GitCredentials {
 
   /** Wraps a single token string into a wildcard token map. Returns empty map if null/blank. */
   public static Map<String, String> singleTokenMap(String token) {
-    if (token == null || token.isBlank()) return Map.of();
+    if (Strings.isBlank(token)) return Map.of();
     return Map.of("*", token);
   }
 
@@ -162,7 +163,7 @@ public final class GitCredentials {
   public static Path resolveHostPath(String path) {
     if (path.startsWith("~/")) {
       var sudoUser = System.getenv("SUDO_USER");
-      if (sudoUser != null && !sudoUser.isBlank()) {
+      if (Strings.isNotBlank(sudoUser)) {
         return Path.of("/home", sudoUser, path.substring(2));
       }
       return Path.of(System.getProperty("user.home"), path.substring(2));

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/HostInfo.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/HostInfo.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.Strings;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
@@ -20,14 +21,14 @@ public final class HostInfo {
   public static String hostname() {
     try {
       var name = InetAddress.getLocalHost().getHostName();
-      if (name != null && !name.isBlank()) {
+      if (Strings.isNotBlank(name)) {
         return name;
       }
     } catch (UnknownHostException ignored) {
       // fall through to env/unknown
     }
     var envName = System.getenv("HOSTNAME");
-    if (envName != null && !envName.isBlank()) {
+    if (Strings.isNotBlank(envName)) {
       return envName;
     }
     return "unknown";

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/HostProvisioner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/HostProvisioner.java
@@ -5,13 +5,13 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.YamlUtil;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
@@ -78,7 +78,7 @@ public final class HostProvisioner {
             HostYaml.DEFAULT_IMAGE,
             incusVersion,
             serverIp,
-            Instant.now().toString());
+            DateTimeUtils.now().toString());
 
     writeHostYaml(hostYaml, hostYamlPath);
     return hostYaml;

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/NetworkDetector.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/NetworkDetector.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.Strings;
 import java.net.Inet4Address;
 import java.net.NetworkInterface;
 import java.net.SocketException;
@@ -71,7 +72,7 @@ public final class NetworkDetector {
    * @return true if the string is a valid dotted-quad IPv4 address
    */
   public static boolean isValidIpv4(String ip) {
-    if (ip == null || ip.isBlank()) {
+    if (Strings.isBlank(ip)) {
       return false;
     }
     var parts = ip.split("\\.");

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectApplier.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectApplier.java
@@ -177,7 +177,7 @@ public final class ProjectApplier {
   }
 
   private static List<String> rootExec(String containerName, List<String> args) {
-    var full = new java.util.ArrayList<>(List.of("incus", "exec", containerName, "--"));
+    var full = new ArrayList<>(List.of("incus", "exec", containerName, "--"));
     full.addAll(args);
     return List.copyOf(full);
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectProvisioner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectProvisioner.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.gen.AgentAuditFiles;
@@ -13,7 +14,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -1162,7 +1162,7 @@ public final class ProjectProvisioner {
             name: %s
             created_at: %s
             """
-            .formatted(name, Instant.now());
+            .formatted(name, DateTimeUtils.now());
     pushFileToContainer(name, "/etc/sail/project.yaml", yaml);
 
     tracker.advance(currentPhase);

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProvisionTracker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProvisionTracker.java
@@ -5,12 +5,12 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.YamlUtil;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.time.Instant;
 import java.util.Optional;
 
 /**
@@ -95,7 +95,7 @@ public final class ProvisionTracker<P extends Enum<P>> {
         throw new IllegalStateException("Cannot regress from " + current + " to " + completedPhase);
       }
     }
-    var now = Instant.now().toString();
+    var now = DateTimeUtils.now().toString();
     this.state =
         new ProvisionState(
             completedPhase.name(), state.startedAt() != null ? state.startedAt() : now, now, null);
@@ -107,7 +107,7 @@ public final class ProvisionTracker<P extends Enum<P>> {
    * field is NOT updated — it still reflects the last successfully completed phase.
    */
   public void recordFailure(P failedPhase, String message) throws IOException {
-    var now = Instant.now().toString();
+    var now = DateTimeUtils.now().toString();
     this.state =
         new ProvisionState(
             state.completedPhase(),

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ResourceChecker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ResourceChecker.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.Strings;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -44,7 +45,7 @@ public final class ResourceChecker {
    * null, blank, or unparseable values.
    */
   public static long parseMemoryMb(String memory) {
-    if (memory == null || memory.isBlank()) {
+    if (Strings.isBlank(memory)) {
       return 0;
     }
     var matcher = MEMORY_PATTERN.matcher(memory.trim());

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/SnapshotManager.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/SnapshotManager.java
@@ -5,10 +5,11 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.YamlUtil;
 import java.io.IOException;
 import java.time.Duration;
-import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +28,7 @@ import java.util.concurrent.TimeoutException;
 public final class SnapshotManager {
 
   private static final DateTimeFormatter LABEL_FORMAT =
-      DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
+      DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").withZone(ZoneOffset.UTC);
 
   /** Default timeout for snapshot mutations (create/restore/delete). */
   public static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(10);
@@ -122,7 +123,7 @@ public final class SnapshotManager {
 
   /** Generates a default snapshot label from the current timestamp. */
   public static String defaultLabel() {
-    return "snap-" + LocalDateTime.now().format(LABEL_FORMAT);
+    return "snap-" + LABEL_FORMAT.format(DateTimeUtils.now());
   }
 
   private ShellExec.Result execMutation(List<String> cmd, Duration timeout, String description)

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/SpecAudit.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/SpecAudit.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SpecAuditEvent;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,7 +37,7 @@ public final class SpecAudit {
   public SpecAudit(ShellExec shell, String containerName, String specsDir) {
     this.shell = Objects.requireNonNull(shell, "shell");
     NameValidator.requireValidProjectName(containerName);
-    if (specsDir == null || specsDir.isBlank()) {
+    if (Strings.isBlank(specsDir)) {
       throw new IllegalArgumentException("specsDir is required.");
     }
     this.containerName = containerName;

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/SpecWorkspace.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/SpecWorkspace.java
@@ -1,5 +1,6 @@
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecDirectory;
 import ai.singlr.sail.config.SpecStatus;
@@ -20,7 +21,7 @@ public final class SpecWorkspace {
   public SpecWorkspace(ShellExec shell, String containerName, String specsDir) {
     this.shell = Objects.requireNonNull(shell);
     NameValidator.requireValidProjectName(containerName);
-    if (specsDir == null || specsDir.isBlank()) {
+    if (Strings.isBlank(specsDir)) {
       throw new IllegalArgumentException("specsDir is required.");
     }
     this.containerName = containerName;

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/SystemdServiceInstaller.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/SystemdServiceInstaller.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.Strings;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -88,13 +89,13 @@ public final class SystemdServiceInstaller {
       this.systemdLinkPath = home.resolve(".config/systemd/user").resolve(UNIT_FILENAME);
     }
     this.sailBinary = Objects.requireNonNull(sailBinary, "sailBinary");
-    if (bindAddress == null || bindAddress.isBlank()) {
+    if (Strings.isBlank(bindAddress)) {
       throw new IllegalArgumentException("bindAddress is required");
     }
     if (bindPort <= 0 || bindPort > 65535) {
       throw new IllegalArgumentException("bindPort must be 1..65535, got " + bindPort);
     }
-    if (username == null || username.isBlank()) {
+    if (Strings.isBlank(username)) {
       throw new IllegalArgumentException("username is required");
     }
     this.bindAddress = bindAddress;
@@ -350,7 +351,7 @@ public final class SystemdServiceInstaller {
   }
 
   private static Integer parsePid(String raw) {
-    if (raw == null || raw.isBlank()) {
+    if (Strings.isBlank(raw)) {
       return null;
     }
     try {

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/SystemdServiceInstaller.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/SystemdServiceInstaller.java
@@ -8,8 +8,10 @@ package ai.singlr.sail.engine;
 import ai.singlr.sail.common.Strings;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -201,7 +203,7 @@ public final class SystemdServiceInstaller {
     String onDisk;
     try {
       onDisk = Files.readString(serviceFilePath);
-    } catch (java.nio.file.NoSuchFileException nsf) {
+    } catch (NoSuchFileException nsf) {
       install();
       return true;
     }
@@ -336,7 +338,7 @@ public final class SystemdServiceInstaller {
   }
 
   private static Map<String, String> parseShowOutput(String output) {
-    var map = new java.util.LinkedHashMap<String, String>();
+    var map = new LinkedHashMap<String, String>();
     if (output == null) {
       return map;
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/UpdateChecker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/UpdateChecker.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.YamlUtil;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -39,7 +40,7 @@ public final class UpdateChecker {
     var cached = readCache(cacheFile);
     if (cached != null) {
       var lastChecked = Instant.ofEpochMilli((Long) cached.get("last_checked"));
-      if (Instant.now().minus(CHECK_INTERVAL).isBefore(lastChecked)) {
+      if (DateTimeUtils.now().minus(CHECK_INTERVAL).isBefore(lastChecked)) {
         return (String) cached.get("latest_version");
       }
     }
@@ -66,7 +67,7 @@ public final class UpdateChecker {
     try {
       Files.createDirectories(cacheFile.getParent());
       var map = new LinkedHashMap<String, Object>();
-      map.put("last_checked", Instant.now().toEpochMilli());
+      map.put("last_checked", DateTimeUtils.now().toEpochMilli());
       map.put("latest_version", latestVersion);
       var tmpFile = cacheFile.resolveSibling("update-check.yaml.tmp");
       YamlUtil.dumpToFile(map, tmpFile);


### PR DESCRIPTION
The agreed follow-up sweep: adopt the JDK-25 conventions across the codebase. All mechanical, semantics-preserving, verified by the full suite after each phase.

## Phases
1. **Time seam** — `Instant.now()` → `DateTimeUtils.now()` across main (31 files), so all wall-clock time flows through one stubbable UTC seam. Fixed the two timestamp exceptions: snapshot labels (`LocalDateTime.now()` → UTC) and SSE/agent-log heartbeats (`currentTimeMillis()` → monotonic `nanoTime()`).
2. **Strings** — inline same-variable null/blank/empty guards → `Strings.isBlank/isNotBlank/isEmpty` (134 sites, ~70 files). `isBlank` is String-only so it's safe to sweep; `isEmpty` was applied only to verified `String` types (Collection/Map `.isEmpty()` deliberately left).
3. **No inline FQ names** — stripped inline fully-qualified `java.*` and `ai.singlr.*` class references (41 files), adding imports, collision-safe (a simple name bound elsewhere keeps its qualifier). Text-embedding generators skipped.
4. **Coverage ratchet** — raised the JaCoCo BUNDLE floors to just under current actuals (line 0.44→0.53, branch 0.36→0.45, method 0.67→0.72, class 0.86→0.88) so the bar is locked in. Per-class 100% gates unchanged.

## Release
Cuts **0.13.74**, which also ships the previously-merged-but-unreleased security backlog + foundation (PR #56): WebAuthn userHandle binding, token-file/rate-limiting, cosign signing, SHA-pinned Actions, and `Ids`/`Strings`/`DateTimeUtils` (UUID v7).

`mvn verify` green throughout: **1625 infra tests**, api.* still 100%, all ratcheted gates pass.