### PR TITLE
Forbid wildcard imports (PATTERNS.md compliance)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Forbid wildcard imports
+        run: |
+          if grep -rEn 'import +(static +)?[a-zA-Z0-9_.]+\.\*;' --include='*.java' sail-core sail-infra sail-harness; then
+            echo "::error::Wildcard imports are forbidden. Import each symbol explicitly."
+            exit 1
+          fi
+
       - name: Verify quality gates
         run: mvn clean verify
 

--- a/sail-core/src/test/java/ai/singlr/sail/auth/EnrollmentServiceTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/auth/EnrollmentServiceTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.auth;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.EnrollmentTicketStore;
 import ai.singlr.sail.store.FdeStore;

--- a/sail-core/src/test/java/ai/singlr/sail/auth/PasskeyServiceTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/auth/PasskeyServiceTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.auth;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.AuthSessionStore;
 import ai.singlr.sail.store.FdeStore;

--- a/sail-core/src/test/java/ai/singlr/sail/common/DateTimeUtilsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/common/DateTimeUtilsTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.common;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.time.Instant;

--- a/sail-core/src/test/java/ai/singlr/sail/common/IdsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/common/IdsTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.common;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import org.junit.jupiter.api.Test;

--- a/sail-core/src/test/java/ai/singlr/sail/common/StringsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/common/StringsTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.common;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-core/src/test/java/ai/singlr/sail/config/BranchPolicyTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/BranchPolicyTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/sail-core/src/test/java/ai/singlr/sail/config/ClientConfigTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/ClientConfigTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/sail-core/src/test/java/ai/singlr/sail/config/CodeReviewTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/CodeReviewTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;

--- a/sail-core/src/test/java/ai/singlr/sail/config/GuardrailsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/GuardrailsTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.Map;

--- a/sail-core/src/test/java/ai/singlr/sail/config/HostYamlTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/HostYamlTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-core/src/test/java/ai/singlr/sail/config/NotificationsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/NotificationsTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;

--- a/sail-core/src/test/java/ai/singlr/sail/config/PlaceholderResolverTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/PlaceholderResolverTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.StringReader;

--- a/sail-core/src/test/java/ai/singlr/sail/config/ReviewPipelineConfigTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/ReviewPipelineConfigTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.ReviewPipelineConfig.Gate;
 import ai.singlr.sail.config.ReviewPipelineConfig.StageType;

--- a/sail-core/src/test/java/ai/singlr/sail/config/SailYamlTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/SailYamlTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-core/src/test/java/ai/singlr/sail/config/SailYamlUpdaterTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/SailYamlUpdaterTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.util.List;

--- a/sail-core/src/test/java/ai/singlr/sail/config/SecurityAuditTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/SecurityAuditTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;

--- a/sail-core/src/test/java/ai/singlr/sail/config/SpecAuditEventTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/SpecAuditEventTest.java
@@ -5,7 +5,13 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.util.LinkedHashMap;

--- a/sail-core/src/test/java/ai/singlr/sail/config/SpecDirectoryTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/SpecDirectoryTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;

--- a/sail-core/src/test/java/ai/singlr/sail/config/SpecScaffoldTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/SpecScaffoldTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-core/src/test/java/ai/singlr/sail/config/SpecTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/SpecTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.List;

--- a/sail-core/src/test/java/ai/singlr/sail/config/SyncConfigTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/SyncConfigTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;

--- a/sail-core/src/test/java/ai/singlr/sail/config/WebauthnConfigTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/WebauthnConfigTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;

--- a/sail-core/src/test/java/ai/singlr/sail/config/WebhookUrlSafetyTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/WebhookUrlSafetyTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-core/src/test/java/ai/singlr/sail/config/YamlMergerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/YamlMergerTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;

--- a/sail-core/src/test/java/ai/singlr/sail/config/YamlUtilTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/YamlUtilTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/sail-core/src/test/java/ai/singlr/sail/engine/AgentCliTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/AgentCliTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-core/src/test/java/ai/singlr/sail/engine/ContainerExecTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/ContainerExecTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.Finding;
 import org.junit.jupiter.api.Test;

--- a/sail-core/src/test/java/ai/singlr/sail/engine/FixTaskBuilderTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/FixTaskBuilderTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.Finding;
 import java.util.List;

--- a/sail-core/src/test/java/ai/singlr/sail/engine/GitSpecSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/GitSpecSyncTest.java
@@ -1,6 +1,11 @@
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.file.Path;
 import java.time.Duration;

--- a/sail-core/src/test/java/ai/singlr/sail/engine/NameValidatorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/NameValidatorTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/sail-core/src/test/java/ai/singlr/sail/engine/PlatformDetectorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/PlatformDetectorTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-core/src/test/java/ai/singlr/sail/engine/ReviewPromptBuilderTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/ReviewPromptBuilderTest.java
@@ -5,7 +5,7 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/sail-core/src/test/java/ai/singlr/sail/engine/RuntimeModeTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/RuntimeModeTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/sail-core/src/test/java/ai/singlr/sail/engine/SailPathsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/SailPathsTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/sail-core/src/test/java/ai/singlr/sail/engine/SemVerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/SemVerTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-core/src/test/java/ai/singlr/sail/engine/ShellExecutorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/ShellExecutorTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.time.Duration;

--- a/sail-core/src/test/java/ai/singlr/sail/engine/SpecIndexMigratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/SpecIndexMigratorTest.java
@@ -1,6 +1,8 @@
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.time.Duration;

--- a/sail-core/src/test/java/ai/singlr/sail/gen/AgentContextGeneratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/gen/AgentContextGeneratorTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.gen;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SailYaml;
 import java.util.LinkedHashMap;

--- a/sail-core/src/test/java/ai/singlr/sail/gen/CodeReviewGeneratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/gen/CodeReviewGeneratorTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.gen;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.CodeReview;
 import ai.singlr.sail.config.SailYaml;

--- a/sail-core/src/test/java/ai/singlr/sail/gen/GeneratedFileTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/gen/GeneratedFileTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.gen;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-core/src/test/java/ai/singlr/sail/gen/PostTaskHooksGeneratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/gen/PostTaskHooksGeneratorTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.gen;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.CodeReview;
 import ai.singlr.sail.config.SailYaml;

--- a/sail-core/src/test/java/ai/singlr/sail/gen/SailYamlGeneratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/gen/SailYamlGeneratorTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.gen;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlUtil;

--- a/sail-core/src/test/java/ai/singlr/sail/gen/SecurityAuditGeneratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/gen/SecurityAuditGeneratorTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.gen;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.SecurityAudit;

--- a/sail-core/src/test/java/ai/singlr/sail/gen/ServicePresetsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/gen/ServicePresetsTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.gen;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/sail-core/src/test/java/ai/singlr/sail/gen/SpecSkillGeneratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/gen/SpecSkillGeneratorTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.gen;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.engine.AgentCli;
 import org.junit.jupiter.api.Test;

--- a/sail-core/src/test/java/ai/singlr/sail/ssh/CommandTokenizerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/ssh/CommandTokenizerTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.ssh;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/sail-core/src/test/java/ai/singlr/sail/ssh/SshGatewayTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/ssh/SshGatewayTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.ssh;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.AuthSessionStore;
 import ai.singlr.sail.store.FdeStore;

--- a/sail-core/src/test/java/ai/singlr/sail/ssh/SshPublicKeyTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/ssh/SshPublicKeyTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.ssh;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/AuthSessionStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/AuthSessionStoreTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.time.Duration;

--- a/sail-core/src/test/java/ai/singlr/sail/store/ChangeLogTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ChangeLogTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;

--- a/sail-core/src/test/java/ai/singlr/sail/store/ConflictDetectorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ConflictDetectorTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/sail-core/src/test/java/ai/singlr/sail/store/EnrollmentTicketStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/EnrollmentTicketStoreTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.time.Duration;

--- a/sail-core/src/test/java/ai/singlr/sail/store/EventStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/EventStoreTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;

--- a/sail-core/src/test/java/ai/singlr/sail/store/ExpiredRowSweeperTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ExpiredRowSweeperTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.time.Duration;

--- a/sail-core/src/test/java/ai/singlr/sail/store/FdeReplicateTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FdeReplicateTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;

--- a/sail-core/src/test/java/ai/singlr/sail/store/FdeSshKeyStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FdeSshKeyStoreTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.ssh.SshPublicKey;
 import ai.singlr.sail.ssh.TestSshKeys;

--- a/sail-core/src/test/java/ai/singlr/sail/store/FdeStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FdeStoreTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.ssh.SshPublicKey;
 import java.nio.file.Path;

--- a/sail-core/src/test/java/ai/singlr/sail/store/FileStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FileStoreTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;

--- a/sail-core/src/test/java/ai/singlr/sail/store/FindingTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FindingTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/sail-core/src/test/java/ai/singlr/sail/store/PendingChallengeStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/PendingChallengeStoreTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.time.Duration;

--- a/sail-core/src/test/java/ai/singlr/sail/store/ProjectStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ProjectStoreTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;

--- a/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SpecStatus;
 import java.nio.file.Path;

--- a/sail-core/src/test/java/ai/singlr/sail/store/RevisionsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RevisionsTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;

--- a/sail-core/src/test/java/ai/singlr/sail/store/SessionStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SessionStoreTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecJournalTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecJournalTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SpecStatus;
 import java.nio.file.Path;

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecMigratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecMigratorTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SpecStatus;
 import java.nio.file.Path;

--- a/sail-core/src/test/java/ai/singlr/sail/store/SqliteTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SqliteTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/sail-core/src/test/java/ai/singlr/sail/store/SyncConflictsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SyncConflictsTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;

--- a/sail-core/src/test/java/ai/singlr/sail/store/SyncStateTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SyncStateTest.java
@@ -5,7 +5,7 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;

--- a/sail-core/src/test/java/ai/singlr/sail/store/TokenStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/TokenStoreTest.java
@@ -5,7 +5,13 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;

--- a/sail-core/src/test/java/ai/singlr/sail/store/WebauthnCredentialStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/WebauthnCredentialStoreTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.store;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.webauthn.CoseKey;
 import ai.singlr.sail.webauthn.RegisteredCredential;

--- a/sail-core/src/test/java/ai/singlr/sail/sync/CommitCasTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/CommitCasTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.sync;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.LinkedHashMap;

--- a/sail-core/src/test/java/ai/singlr/sail/sync/ConcurrentReconcileTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/ConcurrentReconcileTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.sync;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.ArrayDeque;

--- a/sail-core/src/test/java/ai/singlr/sail/sync/ConflictMergeTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/ConflictMergeTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.sync;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/sail-core/src/test/java/ai/singlr/sail/sync/ConflictResolutionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/ConflictResolutionTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.sync;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.store.SpecStore;

--- a/sail-core/src/test/java/ai/singlr/sail/sync/FileSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/FileSyncTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.sync;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.ChangeLog;
 import ai.singlr.sail.store.FileStore;

--- a/sail-core/src/test/java/ai/singlr/sail/sync/RemoteMainReplicaTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/RemoteMainReplicaTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.sync;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.StringReader;

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.sync;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.io.StringReader;
 import java.io.StringWriter;

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncSessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncSessionTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.sync;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.io.StringReader;

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncTransportTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncTransportTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.sync;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.store.ChangeLog;

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncWireTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncWireTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.sync;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringReader;
 import java.util.LinkedHashMap;

--- a/sail-core/src/test/java/ai/singlr/sail/sync/TwoNodeSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/TwoNodeSyncTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.sync;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.store.SpecStore;

--- a/sail-core/src/test/java/ai/singlr/sail/webauthn/AuthenticatorDataTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/webauthn/AuthenticatorDataTest.java
@@ -5,7 +5,13 @@
 
 package ai.singlr.sail.webauthn;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;

--- a/sail-core/src/test/java/ai/singlr/sail/webauthn/CborTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/webauthn/CborTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.webauthn;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HexFormat;
 import java.util.List;

--- a/sail-core/src/test/java/ai/singlr/sail/webauthn/ClientDataTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/webauthn/ClientDataTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.webauthn;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;

--- a/sail-core/src/test/java/ai/singlr/sail/webauthn/CoseKeyTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/webauthn/CoseKeyTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.webauthn;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigInteger;
 import java.security.KeyPairGenerator;

--- a/sail-core/src/test/java/ai/singlr/sail/webauthn/HashesTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/webauthn/HashesTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.webauthn;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;

--- a/sail-core/src/test/java/ai/singlr/sail/webauthn/RelyingPartyTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/webauthn/RelyingPartyTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.webauthn;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentReporterTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentReporterTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.SpecStatus;

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SailYaml;
 import java.util.List;

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/ClaudeCodeHookConfigTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/ClaudeCodeHookConfigTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.YamlUtil;
 import java.io.IOException;

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/CodexHookConfigTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/CodexHookConfigTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.YamlUtil;
 import java.io.IOException;

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/GitHubFetcherTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/GitHubFetcherTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/GitHubPusherTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/GitHubPusherTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/GuardrailCheckerTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/GuardrailCheckerTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.Guardrails;
 import java.time.Duration;

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/ReleaseFetcherTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/ReleaseFetcherTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/SailEventHelperTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/SailEventHelperTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import org.junit.jupiter.api.Test;

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/WebhookNotifierTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/WebhookNotifierTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;

--- a/sail-infra/src/test/java/ai/singlr/sail/SailVersionTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/SailVersionTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AgentLogStreamerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AgentLogStreamerTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiCoverageEdgesTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiCoverageEdgesTest.java
@@ -5,7 +5,13 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiJsonMappableGuardTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiJsonMappableGuardTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.net.URI;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiJsonTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiJsonTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiResponseTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiResponseTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiResultIntegrationTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiResultIntegrationTest.java
@@ -5,7 +5,7 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterRateLimitTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterRateLimitTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpContext;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterSelfFilterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterSelfFilterTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.URI;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AuditPersisterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AuditPersisterTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AuthorizationTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AuthorizationTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AuthorizerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AuthorizerTest.java
@@ -5,7 +5,7 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/BoundedVirtualExecutorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/BoundedVirtualExecutorTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EventBusTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EventBusTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EventStreamClientTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EventStreamClientTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EventTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EventTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Instant;
 import java.util.LinkedHashMap;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/OptimisticConcurrencyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/OptimisticConcurrencyTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.engine.ShellExecutor;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RateLimiterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RateLimiterTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ResultTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ResultTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewOperationsTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.store.Finding;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.ReviewPipelineConfig;
 import ai.singlr.sail.config.SpecStatus;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoleTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoleTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailApiClientTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailApiClientTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.engine.ShellExec;
 import java.io.IOException;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailEventPublisherTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailEventPublisherTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.engine.ShellExecutor;
 import java.io.IOException;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailYamlNotificationsResolverTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailYamlNotificationsResolverTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ServerConnectionConfigTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ServerConnectionConfigTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SessionAwareAuthTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SessionAwareAuthTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import ai.singlr.sail.store.AuthSessionStore;
 import ai.singlr.sail.store.FdeStore;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SessionTrackerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SessionTrackerTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SessionStore;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SpecLifecycleReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SpecLifecycleReactorTest.java
@@ -5,7 +5,13 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.engine.ScriptedShellExecutor;
 import ai.singlr.sail.engine.ShellExec;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SpecStoreAuditPersisterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SpecStoreAuditPersisterTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.EventStore;
 import ai.singlr.sail.store.SchemaManager;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SseHandlerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SseHandlerTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.sun.net.httpserver.HttpServer;
 import java.io.BufferedReader;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TokenAuthTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TokenAuthTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.Sqlite;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/UnixSocketEventsListenerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/UnixSocketEventsListenerTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WebauthnAuthHandlerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WebauthnAuthHandlerTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.auth.EnrollmentService;
 import ai.singlr.sail.auth.EnrollmentTickets;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WebauthnPageHandlerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WebauthnPageHandlerTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.Sqlite;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WebhookMessageTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WebhookMessageTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WebhookReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WebhookReactorTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.api;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.Notifications;
 import java.util.ArrayList;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentAttachCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentAttachCommandTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.engine.AgentCli;
 import org.junit.jupiter.api.Test;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentReportCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentReportCommandTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentStatusCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentStatusCommandTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentSweepCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentSweepCommandTest.java
@@ -5,7 +5,7 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentWatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentWatchCommandTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.api.Event;
 import java.time.Instant;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ApiSpecCommandsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ApiSpecCommandsTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import ai.singlr.sail.api.EventBus;
 import ai.singlr.sail.api.SailApiOperations;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CliCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CliCommandTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CliEntryPointTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CliEntryPointTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.Sail;
 import java.io.ByteArrayOutputStream;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CliJsonTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CliJsonTest.java
@@ -5,7 +5,7 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ClientInitCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ClientInitCommandTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.ClientConfig;
 import java.nio.file.Files;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.Sail;
 import java.util.Set;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ConflictsCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ConflictsCommandTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.config.YamlUtil;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ConsoleHelperTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ConsoleHelperTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandResolveSpecTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandResolveSpecTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.Sail;
 import ai.singlr.sail.config.SailYaml;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/EventRendererTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/EventRendererTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.api.Event;
 import java.time.Instant;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/EventsCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/EventsCommandTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.Sail;
 import java.io.PrintWriter;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/HostConfigSetCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/HostConfigSetCommandTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.Sail;
 import ai.singlr.sail.config.HostYaml;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/HostServiceCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/HostServiceCommandTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.Sail;
 import java.io.PrintWriter;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/HostSyncCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/HostSyncCommandTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.WebauthnConfig;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/LifecycleCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/LifecycleCommandTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.Sail;
 import java.io.ByteArrayOutputStream;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/LoopbackCallbackServerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/LoopbackCallbackServerTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.net.http.HttpClient;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.engine.ContainerSpecImporter;
 import ai.singlr.sail.store.DataMigration;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/NodeDependencyCheckTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/NodeDependencyCheckTest.java
@@ -5,7 +5,13 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlUtil;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectAddFileCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectAddFileCommandTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.junit.jupiter.api.Nested;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectDemoCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectDemoCommandTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectDescriptorPathsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectDescriptorPathsTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.engine.SailPaths;
 import java.nio.file.Files;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectFilesCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectFilesCommandTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.SchemaManager;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectMigrateCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectMigrateCommandTest.java
@@ -1,6 +1,9 @@
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.Sail;
 import java.io.PrintWriter;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectPushCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectPushCommandTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlUtil;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectRemoveCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectRemoveCommandTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectRemoveServiceCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectRemoveServiceCommandTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectResourcesSetCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectResourcesSetCommandTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlUtil;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectSyncCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectSyncCommandTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.Sail;
 import java.io.PrintWriter;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/RunCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/RunCommandTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.Sail;
 import java.io.ByteArrayOutputStream;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ServerTokenCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ServerTokenCommandTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.TokenStore;
 import java.time.Duration;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ShellCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ShellCommandTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SnapsPruneCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SnapsPruneCommandTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.Sail;
 import java.io.PrintWriter;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SnapshotDecisionTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SnapshotDecisionTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SailYaml;
 import java.io.ByteArrayInputStream;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SpecListCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SpecListCommandTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.Sail;
 import java.io.PrintWriter;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SyncCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SyncCommandTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.api.Event;
 import ai.singlr.sail.config.SyncConfig;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SyncServerCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SyncServerCommandTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.store.AuthSessionStore;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/UpgradeCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/UpgradeCommandTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.commands;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.SailVersion;
 import java.nio.file.Files;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/AuthorizedKeysRendererTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/AuthorizedKeysRendererTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.FdeSshKeyStore;
 import java.util.List;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/AuthorizedKeysSyncTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/AuthorizedKeysSyncTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.ssh.SshPublicKey;
 import ai.singlr.sail.ssh.TestSshKeys;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/BannerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/BannerTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SailYaml;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/CleanupScriptsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/CleanupScriptsTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerFilePushTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerFilePushTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerManagerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerManagerTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import org.junit.jupiter.api.Test;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerSailSetupTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerSailSetupTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import org.junit.jupiter.api.Test;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerStateGuardTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerStateGuardTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/DirQueryTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/DirQueryTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/DiskDetectorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/DiskDetectorTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/DispatchReposTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/DispatchReposTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/FileImporterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/FileImporterTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.SchemaManager;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/FileMaterializerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/FileMaterializerTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.SchemaManager;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/GitCredentialsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/GitCredentialsTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SailYaml;
 import java.nio.file.Path;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/HostDetectorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/HostDetectorTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/HostInfoTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/HostInfoTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
 

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/HostProvisionerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/HostProvisionerTest.java
@@ -5,7 +5,13 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/IncusDeviceManagerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/IncusDeviceManagerTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/NetworkDetectorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/NetworkDetectorTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/PodmanCommandsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/PodmanCommandsTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SailYaml;
 import java.util.LinkedHashMap;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/PrerequisiteCheckerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/PrerequisiteCheckerTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectApplierTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectApplierTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.SecurityAudit;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectImporterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectImporterTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.SchemaManager;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectProvisionerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectProvisionerTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SailYaml;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ProvisionTrackerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ProvisionTrackerTest.java
@@ -5,7 +5,13 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/RemoteCommandRunnerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/RemoteCommandRunnerTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.ClientConfig;
 import java.util.List;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ResourceCheckerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ResourceCheckerTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/SnapshotManagerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/SnapshotManagerTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import org.junit.jupiter.api.Test;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/SpecAuditTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/SpecAuditTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SpecAuditEvent;
 import java.io.IOException;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/SpecWorkspaceTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/SpecWorkspaceTest.java
@@ -1,6 +1,9 @@
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/SshIdentityProvisionerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/SshIdentityProvisionerTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/SshSyncChannelTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/SshSyncChannelTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/SystemdServiceInstallerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/SystemdServiceInstallerTest.java
@@ -5,7 +5,11 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.engine.SystemdServiceInstaller.Mode;
 import java.io.IOException;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/TableFormatterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/TableFormatterTest.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/UpdateCheckerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/UpdateCheckerTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.YamlUtil;
 import java.nio.file.Files;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/WorkspaceFilesTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/WorkspaceFilesTest.java
@@ -5,7 +5,12 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ZfsQueryTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ZfsQueryTest.java
@@ -5,7 +5,10 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
PATTERNS.md bans wildcard imports outright — including the ubiquitous test `import static org.junit.jupiter.api.Assertions.*`.

- Expanded all **221** wildcard static imports to explicit per-method imports (only the assertion methods each test actually uses; main source was already wildcard-free).
- Added a zero-dependency CI step that fails the build on any `.*;` import, so it can never regress.

Test + CI only — no production code changed, so the binary is identical to v0.13.74 (no new release needed). `mvn verify` green: 1625 infra tests, all gates hold.

Deferred PATTERNS.md gaps (scheduled, not in this PR): split the 1130-line `ProjectProvisioner` God class, drive coverage to the 100% bar, and retrofit value records with static Builders + `with` accessors.