### PR TITLE
Interactive file-share DX + consolidate file commands

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddCommand.java
@@ -9,12 +9,11 @@ import picocli.CommandLine.Command;
 
 @Command(
     name = "add",
-    description = "Add services, repos, or files to a running project.",
+    description = "Add services or repos to a running project.",
     mixinStandardHelpOptions = true,
     subcommands = {
       ProjectAddServiceCommand.class,
       ProjectAddRepoCommand.class,
-      ProjectAddFileCommand.class,
     })
 public final class ProjectAddCommand implements Runnable {
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddFileCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddFileCommand.java
@@ -33,8 +33,8 @@ import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Spec;
 
 @Command(
-    name = "file",
-    description = "Capture workspace files from a running project for sharing.",
+    name = "capture",
+    description = "Capture workspace files from a running project container into the shared set.",
     mixinStandardHelpOptions = true)
 public final class ProjectAddFileCommand implements Runnable {
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
@@ -9,6 +9,7 @@ import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.FileMaterializer;
+import ai.singlr.sail.engine.FilePicker;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.store.FileStore;
@@ -37,7 +38,7 @@ import picocli.CommandLine.Parameters;
  */
 @Command(
     name = "files",
-    description = "Share project files across FDEs (add, ls, cat, rm, export).",
+    description = "Share project files across FDEs (add, ls, cat, rm, pull).",
     mixinStandardHelpOptions = true,
     subcommands = {
       ProjectFilesCommand.Add.class,
@@ -55,14 +56,18 @@ public final class ProjectFilesCommand implements Runnable {
 
   @Command(
       name = "add",
-      description = "Share a local file with every FDE on the project.",
+      description =
+          "Share files with every FDE on the project. Give a file, or omit it to browse and pick.",
       mixinStandardHelpOptions = true)
   static final class Add implements Callable<Integer> {
 
     @Parameters(index = "0", description = "Project name.")
     private String project;
 
-    @Parameters(index = "1", description = "Local file to share.")
+    @Parameters(
+        index = "1",
+        arity = "0..1",
+        description = "Local file to share. Omit to browse and pick interactively.")
     private Path source;
 
     @Option(
@@ -70,15 +75,35 @@ public final class ProjectFilesCommand implements Runnable {
         description = "Relative path to store it under (default: the file's name).")
     private String as;
 
+    @Option(
+        names = "--from",
+        description = "Directory to browse when picking (default: the current directory).")
+    private Path from;
+
     @Override
     public Integer call() throws Exception {
       NameValidator.requireValidProjectName(project);
+      if (source != null) {
+        return addOne();
+      }
+      if (System.console() == null) {
+        System.err.println(
+            Banner.errorLine(
+                "Give a file to share, or run in a terminal to browse and pick.", Ansi.AUTO));
+        return 1;
+      }
+      return pick();
+    }
+
+    private Integer addOne() throws Exception {
       if (!Files.isRegularFile(source)) {
         System.err.println(Banner.errorLine("Not a file: " + source, Ansi.AUTO));
         return 1;
       }
       try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
-        var path = share(new FileStore(db), SailPaths.projectsDir(), project, source, as);
+        var files = new FileStore(db);
+        var path = store(files, project, source, as);
+        new FileMaterializer(files, SailPaths.projectsDir()).materialize(project);
         System.out.println(
             Ansi.AUTO.string(
                 "  @|green ✓|@ Shared @|bold "
@@ -90,15 +115,63 @@ public final class ProjectFilesCommand implements Runnable {
       return 0;
     }
 
-    /**
-     * Stores {@code source} under its relative path and materializes it locally; returns the path.
-     */
-    static String share(FileStore files, Path projectsDir, String project, Path source, String as)
+    private Integer pick() throws Exception {
+      var root = (from != null ? from : Path.of("")).toAbsolutePath().normalize();
+      if (!Files.isDirectory(root)) {
+        System.err.println(Banner.errorLine("Not a directory: " + root, Ansi.AUTO));
+        return 1;
+      }
+      var state = FilePicker.State.at(root);
+      while (true) {
+        var entries = FilePicker.list(state.cwd());
+        System.out.println(FilePicker.render(state, entries));
+        System.out.print("  > ");
+        System.out.flush();
+        var line = ConsoleHelper.readLine();
+        var step = FilePicker.step(state, entries, line == null ? "q" : line);
+        state = step.state();
+        if (Strings.isNotBlank(step.message())) {
+          System.out.println("  " + step.message());
+        }
+        if (step.status() == FilePicker.Status.CANCELLED) {
+          System.out.println(Ansi.AUTO.string("  @|faint Nothing shared.|@"));
+          return 0;
+        }
+        if (step.status() == FilePicker.Status.CONFIRMED) {
+          break;
+        }
+      }
+      return shareSelected(root, FilePicker.selectedFiles(state));
+    }
+
+    private Integer shareSelected(Path root, List<Path> selected) throws Exception {
+      if (selected.isEmpty()) {
+        System.out.println(Ansi.AUTO.string("  @|faint Nothing selected.|@"));
+        return 0;
+      }
+      try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+        var files = new FileStore(db);
+        for (var file : selected) {
+          store(files, project, file, root.relativize(file).toString());
+        }
+        new FileMaterializer(files, SailPaths.projectsDir()).materialize(project);
+      }
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|green ✓|@ Shared @|bold "
+                  + selected.size()
+                  + "|@ file(s) on @|bold "
+                  + project
+                  + "|@. Run @|bold sail sync|@ to propagate."));
+      return 0;
+    }
+
+    /** Stores {@code source} under its relative path (no materialization); returns the path. */
+    static String store(FileStore files, String project, Path source, String as)
         throws IOException {
       var path = Strings.isNotBlank(as) ? as : source.getFileName().toString();
       NameValidator.requireSafePath(path, "path");
       files.put(project, path, Base64.getEncoder().encodeToString(Files.readAllBytes(source)));
-      new FileMaterializer(files, projectsDir).materialize(project);
       return path;
     }
   }
@@ -229,15 +302,16 @@ public final class ProjectFilesCommand implements Runnable {
   }
 
   @Command(
-      name = "export",
-      description = "Write shared files to disk now (for the main box, which never runs sync).",
+      name = "pull",
+      aliases = "export",
+      description = "Write the shared files for a project to disk (materialize what's synced).",
       mixinStandardHelpOptions = true)
   static final class Export implements Callable<Integer> {
 
     @Parameters(index = "0", arity = "0..1", description = "Project name. Omit with --all.")
     private String project;
 
-    @Option(names = "--all", description = "Export every project that has shared files.")
+    @Option(names = "--all", description = "Pull every project that has shared files.")
     private boolean all;
 
     @Override
@@ -256,7 +330,7 @@ public final class ProjectFilesCommand implements Runnable {
         }
         System.out.println(
             Ansi.AUTO.string(
-                "  @|green ✓|@ Exported: "
+                "  @|green ✓|@ Pulled: "
                     + report.written()
                     + " written, "
                     + report.deleted()

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
@@ -42,6 +42,7 @@ import picocli.CommandLine.Parameters;
     mixinStandardHelpOptions = true,
     subcommands = {
       ProjectFilesCommand.Add.class,
+      ProjectAddFileCommand.class,
       ProjectFilesCommand.Ls.class,
       ProjectFilesCommand.Cat.class,
       ProjectFilesCommand.Rm.class,

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/FilePicker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/FilePicker.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Pure navigation engine for the interactive "pick files to share" prompt. It holds no I/O: the
+ * command reads a directory listing and a line of input, asks {@link #step} for the next {@link
+ * State}, and renders it — so every transition (descend, go up, toggle a file, select a whole
+ * folder, confirm, cancel) is deterministically testable without a terminal.
+ *
+ * <p>Navigation is fenced to the chosen {@code root}: {@code ..} never climbs above it, so a shared
+ * file's path is always meaningful relative to that root.
+ */
+public final class FilePicker {
+
+  private FilePicker() {}
+
+  /** One row in a directory listing. */
+  public record Entry(Path path, boolean directory, long size) {}
+
+  public enum Status {
+    BROWSING,
+    CONFIRMED,
+    CANCELLED
+  }
+
+  /** The current location and the set of files/folders picked so far. */
+  public record State(Path root, Path cwd, LinkedHashSet<Path> picked) {
+    public static State at(Path root) {
+      return new State(root, root, new LinkedHashSet<>());
+    }
+  }
+
+  /** The outcome of applying one line of input: the next state, the status, and a message. */
+  public record Step(State state, Status status, String message) {}
+
+  /** Lists a directory: sub-folders first, then files, each alphabetical. */
+  public static List<Entry> list(Path dir) throws IOException {
+    try (Stream<Path> entries = Files.list(dir)) {
+      return entries
+          .map(FilePicker::toEntry)
+          .sorted(
+              Comparator.comparing(Entry::directory)
+                  .reversed()
+                  .thenComparing(e -> e.path().getFileName().toString()))
+          .toList();
+    }
+  }
+
+  private static Entry toEntry(Path p) {
+    var dir = Files.isDirectory(p);
+    long size = 0;
+    if (!dir) {
+      try {
+        size = Files.size(p);
+      } catch (IOException ignored) {
+        size = 0;
+      }
+    }
+    return new Entry(p, dir, size);
+  }
+
+  /**
+   * Applies one line of input against the {@code entries} of the current directory. A lone
+   * directory number descends; any other number(s) toggle the referenced files/folders; {@code a}
+   * picks the whole current folder; {@code ..} goes up; {@code done} confirms; {@code q} cancels.
+   */
+  public static Step step(State state, List<Entry> entries, String input) {
+    var in = input == null ? "" : input.strip();
+    if (in.isEmpty()) {
+      return browsing(state, "");
+    }
+    return switch (in) {
+      case "q" -> new Step(state, Status.CANCELLED, "");
+      case "done", "d" -> new Step(state, Status.CONFIRMED, "");
+      case ".." -> up(state);
+      case "a" -> pick(state, List.of(state.cwd()), "Selected this folder.");
+      default -> numbers(state, entries, in);
+    };
+  }
+
+  private static Step up(State state) {
+    if (state.cwd().equals(state.root())) {
+      return browsing(state, "Already at the top.");
+    }
+    return browsing(new State(state.root(), state.cwd().getParent(), state.picked()), "");
+  }
+
+  private static Step numbers(State state, List<Entry> entries, String in) {
+    var tokens = in.split("\\s+");
+    var chosen = new ArrayList<Entry>();
+    for (var token : tokens) {
+      var index = parseIndex(token, entries.size());
+      if (index < 0) {
+        return browsing(state, "Not a choice: " + token);
+      }
+      chosen.add(entries.get(index));
+    }
+    if (chosen.size() == 1 && chosen.get(0).directory()) {
+      return browsing(new State(state.root(), chosen.get(0).path(), state.picked()), "");
+    }
+    return pick(state, chosen.stream().map(Entry::path).toList(), null);
+  }
+
+  private static Step pick(State state, List<Path> paths, String message) {
+    var picked = new LinkedHashSet<>(state.picked());
+    for (var path : paths) {
+      if (!picked.remove(path)) {
+        picked.add(path);
+      }
+    }
+    var note = message != null ? message : picked.size() + " selected.";
+    return browsing(new State(state.root(), state.cwd(), picked), note);
+  }
+
+  private static Step browsing(State state, String message) {
+    return new Step(state, Status.BROWSING, message);
+  }
+
+  private static int parseIndex(String token, int size) {
+    try {
+      var n = Integer.parseInt(token) - 1;
+      return n >= 0 && n < size ? n : -1;
+    } catch (NumberFormatException e) {
+      return -1;
+    }
+  }
+
+  /** Renders the current folder as a numbered listing with picked entries marked. */
+  public static String render(State state, List<Entry> entries) {
+    var here = state.root().relativize(state.cwd()).toString();
+    var out = new StringBuilder();
+    out.append("  ").append(here.isEmpty() ? "." : here).append("  —  pick files to share\n");
+    for (var i = 0; i < entries.size(); i++) {
+      var e = entries.get(i);
+      var mark = state.picked().contains(e.path()) ? "*" : " ";
+      var name = e.path().getFileName() + (e.directory() ? "/" : "");
+      var detail = e.directory() ? "" : "  " + humanSize(e.size());
+      out.append(String.format("  %s [%d] %-28s%s%n", mark, i + 1, name, detail));
+    }
+    out.append("    number(s) toggle · a = this folder · .. up · done · q quit");
+    if (!state.picked().isEmpty()) {
+      out.append("   (").append(state.picked().size()).append(" picked)");
+    }
+    return out.toString();
+  }
+
+  private static String humanSize(long bytes) {
+    if (bytes < 1024) {
+      return bytes + " B";
+    }
+    if (bytes < 1024 * 1024) {
+      return bytes / 1024 + " KB";
+    }
+    return bytes / (1024 * 1024) + " MB";
+  }
+
+  /**
+   * Expands the picked set to concrete regular files (folders walked recursively), de-duplicated.
+   */
+  public static List<Path> selectedFiles(State state) throws IOException {
+    var files = new LinkedHashSet<Path>();
+    for (var picked : state.picked()) {
+      if (Files.isDirectory(picked)) {
+        try (Stream<Path> walk = Files.walk(picked)) {
+          walk.filter(Files::isRegularFile).forEach(files::add);
+        }
+      } else if (Files.isRegularFile(picked)) {
+        files.add(picked);
+      }
+    }
+    return files.stream().sorted().toList();
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectFilesCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectFilesCommandTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.singlr.sail.engine.FileMaterializer;
 import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.Sqlite;
@@ -59,7 +60,7 @@ class ProjectFilesCommandTest {
     assertTrue(usage.contains("ls"));
     assertTrue(usage.contains("cat"));
     assertTrue(usage.contains("rm"));
-    assertTrue(usage.contains("export"));
+    assertTrue(usage.contains("pull"));
   }
 
   @Test
@@ -72,8 +73,8 @@ class ProjectFilesCommandTest {
     var source = tempDir.resolve("deploy.sh");
     Files.writeString(source, "echo hi");
 
-    var path =
-        ProjectFilesCommand.Add.share(files, projectsDir, "acme", source, "scripts/deploy.sh");
+    var path = ProjectFilesCommand.Add.store(files, "acme", source, "scripts/deploy.sh");
+    new FileMaterializer(files, projectsDir).materialize("acme");
 
     assertEquals("scripts/deploy.sh", path);
     assertEquals(b64("echo hi"), files.find("acme", "scripts/deploy.sh").orElseThrow().content());
@@ -85,7 +86,7 @@ class ProjectFilesCommandTest {
     var source = tempDir.resolve("notes.md");
     Files.writeString(source, "hello");
 
-    var path = ProjectFilesCommand.Add.share(files, projectsDir, "acme", source, null);
+    var path = ProjectFilesCommand.Add.store(files, "acme", source, null);
 
     assertEquals("notes.md", path);
   }
@@ -97,7 +98,7 @@ class ProjectFilesCommandTest {
 
     assertThrows(
         IllegalArgumentException.class,
-        () -> ProjectFilesCommand.Add.share(files, projectsDir, "acme", source, "../escape"));
+        () -> ProjectFilesCommand.Add.store(files, "acme", source, "../escape"));
   }
 
   @Test
@@ -139,7 +140,8 @@ class ProjectFilesCommandTest {
   void rmTombstonesAndRemovesTheLocalCopy() throws Exception {
     var source = tempDir.resolve("a.txt");
     Files.writeString(source, "data");
-    ProjectFilesCommand.Add.share(files, projectsDir, "acme", source, "a.txt");
+    ProjectFilesCommand.Add.store(files, "acme", source, "a.txt");
+    new FileMaterializer(files, projectsDir).materialize("acme");
     assertTrue(Files.exists(filesDir("acme").resolve("a.txt")));
 
     var removed = ProjectFilesCommand.Rm.unshare(files, projectsDir, "acme", "a.txt");

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/FilePickerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/FilePickerTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FilePickerTest {
+
+  @TempDir Path root;
+
+  @BeforeEach
+  void tree() throws Exception {
+    Files.createDirectories(root.resolve("src/api"));
+    Files.createDirectories(root.resolve("scripts"));
+    Files.writeString(root.resolve("README.md"), "readme");
+    Files.writeString(root.resolve("src/Main.java"), "class Main {}");
+    Files.writeString(root.resolve("src/api/Handler.java"), "class Handler {}");
+    Files.writeString(root.resolve("scripts/deploy.sh"), "echo deploy");
+  }
+
+  private FilePicker.State start() {
+    return FilePicker.State.at(root);
+  }
+
+  @Test
+  void listsFoldersFirstThenFilesAlphabetical() throws Exception {
+    var names = FilePicker.list(root).stream().map(e -> e.path().getFileName().toString()).toList();
+    assertEquals(java.util.List.of("scripts", "src", "README.md"), names);
+  }
+
+  @Test
+  void aLoneDirectoryNumberDescendsAndDotDotReturns() throws Exception {
+    var s0 = start();
+    var entries = FilePicker.list(s0.cwd());
+
+    var descended = FilePicker.step(s0, entries, "2");
+    assertEquals(FilePicker.Status.BROWSING, descended.status());
+    assertEquals(root.resolve("src"), descended.state().cwd());
+
+    var up = FilePicker.step(descended.state(), FilePicker.list(descended.state().cwd()), "..");
+    assertEquals(root, up.state().cwd());
+  }
+
+  @Test
+  void dotDotIsFencedAtTheRoot() throws Exception {
+    var step = FilePicker.step(start(), FilePicker.list(root), "..");
+    assertEquals(root, step.state().cwd());
+    assertTrue(step.message().contains("top"));
+  }
+
+  @Test
+  void numbersToggleFilesOnAndOff() throws Exception {
+    var s0 = start();
+    var entries = FilePicker.list(s0.cwd());
+
+    var picked = FilePicker.step(s0, entries, "3");
+    assertTrue(picked.state().picked().contains(root.resolve("README.md")));
+
+    var unpicked = FilePicker.step(picked.state(), entries, "3");
+    assertFalse(unpicked.state().picked().contains(root.resolve("README.md")));
+  }
+
+  @Test
+  void aSelectsTheWholeCurrentFolder() throws Exception {
+    var inSrc = FilePicker.step(start(), FilePicker.list(root), "2").state();
+    var step = FilePicker.step(inSrc, FilePicker.list(inSrc.cwd()), "a");
+    assertTrue(step.state().picked().contains(root.resolve("src")));
+  }
+
+  @Test
+  void selectedFilesExpandsFoldersRecursively() throws Exception {
+    var picked = new java.util.LinkedHashSet<Path>();
+    picked.add(root.resolve("src"));
+    picked.add(root.resolve("README.md"));
+    var state = new FilePicker.State(root, root, picked);
+
+    var files = FilePicker.selectedFiles(state);
+
+    assertEquals(
+        java.util.List.of(
+            root.resolve("README.md"),
+            root.resolve("src/Main.java"),
+            root.resolve("src/api/Handler.java")),
+        files);
+  }
+
+  @Test
+  void doneConfirmsAndQuitCancels() throws Exception {
+    var entries = FilePicker.list(root);
+    assertEquals(FilePicker.Status.CONFIRMED, FilePicker.step(start(), entries, "done").status());
+    assertEquals(FilePicker.Status.CONFIRMED, FilePicker.step(start(), entries, "d").status());
+    assertEquals(FilePicker.Status.CANCELLED, FilePicker.step(start(), entries, "q").status());
+  }
+
+  @Test
+  void unknownChoiceIsRejectedWithoutChangingState() throws Exception {
+    var entries = FilePicker.list(root);
+    var step = FilePicker.step(start(), entries, "99");
+    assertEquals(FilePicker.Status.BROWSING, step.status());
+    assertTrue(step.state().picked().isEmpty());
+    assertTrue(step.message().contains("Not a choice"));
+  }
+
+  @Test
+  void emptyInputJustRedraws() throws Exception {
+    var step = FilePicker.step(start(), FilePicker.list(root), "  ");
+    assertEquals(FilePicker.Status.BROWSING, step.status());
+  }
+
+  @Test
+  void renderNumbersEntriesAndMarksPicks() throws Exception {
+    var picked = new java.util.LinkedHashSet<Path>();
+    picked.add(root.resolve("README.md"));
+    var rendered =
+        FilePicker.render(new FilePicker.State(root, root, picked), FilePicker.list(root));
+
+    assertTrue(rendered.contains("[1] scripts/"));
+    assertTrue(rendered.contains("[3] README.md"));
+    assertTrue(rendered.contains("* [3]"), "the picked file is marked");
+    assertTrue(rendered.contains("1 picked"));
+  }
+}


### PR DESCRIPTION
World-class DX for sharing files across FDEs, plus a file-command consolidation.

## Interactive picker
`sail project files add <project>` with no file opens a **numbered browser**:
```
  .  —  pick files to share
    [1] scripts/
    [2] src/
  * [3] README.md      1.2 KB
    number(s) toggle · a = this folder · .. up · done · q quit   (1 picked)
```
Descend into folders by number, `..` up (fenced to the browse root), toggle files, `a` to take the whole current folder, `done` to share / `q` to quit. Selected folders share recursively; each file is keyed by its path relative to the root (`--from`, default CWD). Non-interactive stdin still needs an explicit path. The navigation is a **pure `FilePicker` engine** (list/step/render/selectedFiles) — fully unit-tested without a terminal; the command is a thin I/O loop.

## Other FDEs pull
`files export` → **`files pull`** (FDE mental model: get the shared files onto my disk), `export` kept as an alias.

## Consolidation
All file operations now live under `project files`: **add** (pick local), **capture** (from a running container — moved from `project add file`), **ls**, **cat**, **rm**, **pull**. `project add` is now just services and repos.

> Note: `project pull`/`push` are the **descriptor-onboarding** mechanism (CLAUDE.md), *not* legacy git sync — deliberately left as-is.

`mvn verify` green: 1635 tests, api.* 100%, ratcheted gates hold. Test + production only — no version bump.

### Remaining reorg (your call, not in this PR)
Noun-first `project service add/remove` + `project repo add/remove` would mean deprecating the verb-first `project add service` (picocli can't alias across parents without duplicate classes). Lower value now that files are unified — happy to do it if you want the noun grouping.