### PR TITLE
Noun-first project groups + de-overload sync/migrate

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddCommand.java
@@ -5,20 +5,33 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.engine.Banner;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Unmatched;
 
+/**
+ * Deprecated shim. Service and repo management moved to the noun-first {@code project service} and
+ * {@code project repo} groups; this points there and otherwise does nothing.
+ */
 @Command(
     name = "add",
-    description = "Add services or repos to a running project.",
-    mixinStandardHelpOptions = true,
-    subcommands = {
-      ProjectAddServiceCommand.class,
-      ProjectAddRepoCommand.class,
-    })
-public final class ProjectAddCommand implements Runnable {
+    hidden = true,
+    description = "(deprecated) Use 'project service add' or 'project repo add'.")
+public final class ProjectAddCommand implements Callable<Integer> {
+
+  @Unmatched private List<String> ignored = new ArrayList<>();
 
   @Override
-  public void run() {
-    new picocli.CommandLine(this).usage(System.out);
+  public Integer call() {
+    System.err.println(
+        Banner.errorLine(
+            "'sail project add' has moved. Use 'sail project service add' or"
+                + " 'sail project repo add'.",
+            Ansi.AUTO));
+    return 2;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddRepoCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddRepoCommand.java
@@ -30,7 +30,7 @@ import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Spec;
 
 @Command(
-    name = "repo",
+    name = "add",
     description = "Add a git repository to a running project.",
     mixinStandardHelpOptions = true)
 public final class ProjectAddRepoCommand implements Runnable {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddServiceCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddServiceCommand.java
@@ -32,7 +32,7 @@ import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Spec;
 
 @Command(
-    name = "service",
+    name = "add",
     description = "Add an infrastructure service to a running project.",
     mixinStandardHelpOptions = true)
 public final class ProjectAddServiceCommand implements Runnable {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCommand.java
@@ -27,6 +27,8 @@ import picocli.CommandLine.Command;
       ShellCommand.class,
       ConnectCommand.class,
       ProjectSnapshotCommand.class,
+      ProjectServiceCommand.class,
+      ProjectRepoCommand.class,
       ProjectAddCommand.class,
       ProjectRemoveCommand.class,
       ProjectResourcesCommand.class,

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectMigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectMigrateCommand.java
@@ -34,7 +34,8 @@ import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Spec;
 
 @Command(
-    name = "migrate",
+    name = "relayout",
+    aliases = "migrate",
     description = "Bring existing project containers up to the current SAIL layout.",
     mixinStandardHelpOptions = true)
 public final class ProjectMigrateCommand implements Runnable {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectRemoveCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectRemoveCommand.java
@@ -5,19 +5,28 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.engine.Banner;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Unmatched;
 
-@Command(
-    name = "remove",
-    description = "Remove services or repos from a running project.",
-    mixinStandardHelpOptions = true,
-    subcommands = {
-      ProjectRemoveServiceCommand.class,
-    })
-public final class ProjectRemoveCommand implements Runnable {
+/**
+ * Deprecated shim. Service removal moved to the noun-first {@code project service remove} group;
+ * this points there and otherwise does nothing.
+ */
+@Command(name = "remove", hidden = true, description = "(deprecated) Use 'project service remove'.")
+public final class ProjectRemoveCommand implements Callable<Integer> {
+
+  @Unmatched private List<String> ignored = new ArrayList<>();
 
   @Override
-  public void run() {
-    new picocli.CommandLine(this).usage(System.out);
+  public Integer call() {
+    System.err.println(
+        Banner.errorLine(
+            "'sail project remove' has moved. Use 'sail project service remove'.", Ansi.AUTO));
+    return 2;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectRemoveServiceCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectRemoveServiceCommand.java
@@ -25,7 +25,7 @@ import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Spec;
 
 @Command(
-    name = "service",
+    name = "remove",
     description = "Remove an infrastructure service from a running project.",
     mixinStandardHelpOptions = true)
 public final class ProjectRemoveServiceCommand implements Runnable {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectRepoCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectRepoCommand.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import picocli.CommandLine.Command;
+
+@Command(
+    name = "repo",
+    description = "Manage git repositories on a running project.",
+    mixinStandardHelpOptions = true,
+    subcommands = {
+      ProjectAddRepoCommand.class,
+    })
+public final class ProjectRepoCommand implements Runnable {
+
+  @Override
+  public void run() {
+    new picocli.CommandLine(this).usage(System.out);
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectServiceCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectServiceCommand.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import picocli.CommandLine.Command;
+
+@Command(
+    name = "service",
+    description = "Manage infrastructure services on a running project.",
+    mixinStandardHelpOptions = true,
+    subcommands = {
+      ProjectAddServiceCommand.class,
+      ProjectRemoveServiceCommand.class,
+    })
+public final class ProjectServiceCommand implements Runnable {
+
+  @Override
+  public void run() {
+    new picocli.CommandLine(this).usage(System.out);
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectSyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectSyncCommand.java
@@ -27,7 +27,8 @@ import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Spec;
 
 @Command(
-    name = "sync",
+    name = "reconfigure",
+    aliases = "sync",
     description =
         "Backfill host-side configuration (currently: sail-api event socket) onto existing"
             + " project containers. Idempotent.",

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectAddCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectAddCommandTest.java
@@ -14,22 +14,23 @@ import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
-class ProjectRemoveCommandTest {
+class ProjectAddCommandTest {
 
   @Test
-  void deprecatedShimPointsToTheServiceGroup() {
+  void deprecatedShimPointsToTheServiceAndRepoGroups() {
     var captured = new ByteArrayOutputStream();
     var original = System.err;
     System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
     int exit;
     try {
-      exit = new CommandLine(new ProjectRemoveCommand()).execute("service", "redpanda");
+      exit = new CommandLine(new ProjectAddCommand()).execute("service", "redpanda");
     } finally {
       System.setErr(original);
     }
 
     var err = captured.toString(StandardCharsets.UTF_8);
     assertEquals(2, exit, "deprecated path signals it did not run");
-    assertTrue(err.contains("project service remove"), err);
+    assertTrue(err.contains("project service add"), err);
+    assertTrue(err.contains("project repo add"), err);
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectRepoCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectRepoCommandTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class ProjectRepoCommandTest {
+
+  @Test
+  void groupsAdd() {
+    var usage = new CommandLine(new ProjectRepoCommand()).getUsageMessage();
+    assertTrue(usage.contains("add"));
+  }
+
+  @Test
+  void printsUsageWithoutError() {
+    assertEquals(0, new CommandLine(new ProjectRepoCommand()).execute());
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectServiceCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectServiceCommandTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class ProjectServiceCommandTest {
+
+  @Test
+  void groupsAddAndRemove() {
+    var usage = new CommandLine(new ProjectServiceCommand()).getUsageMessage();
+    assertTrue(usage.contains("add"));
+    assertTrue(usage.contains("remove"));
+  }
+
+  @Test
+  void printsUsageWithoutError() {
+    assertEquals(0, new CommandLine(new ProjectServiceCommand()).execute());
+  }
+}


### PR DESCRIPTION
Completes the project-command consolidation (your "also rename sync/migrate" choice).

## Noun-first groups
- **`project service add|remove`** and **`project repo add`** are the canonical paths (new `ProjectServiceCommand` / `ProjectRepoCommand` groups; the leaf commands renamed to `add`/`remove`).
- **`project add` / `project remove`** become **hidden deprecated shims** that print a pointer to the new groups and exit non-zero — old muscle memory gets a clear redirect instead of a silent break.

## De-overloaded verbs
- **`project sync` → `project reconfigure`** (host-side config backfill — no longer collides with the db-sync `sail sync`). `sync` kept as an alias.
- **`project migrate` → `project relayout`** (container layout — no longer collides with the control-plane `sail migrate`). `migrate` kept as an alias.

## Result — the `project` surface now reads cleanly
`files` (add/capture/ls/cat/rm/pull) · `service` (add/remove) · `repo` (add) · `snapshot` · `resources` · plus the flat lifecycle/access verbs.

`mvn verify` green: 1639 tests, api.* 100%, ratcheted gates hold. Production + tests only — no version bump.