### PR TITLE
Harden file sharing for real project trees

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
@@ -62,6 +62,18 @@ public final class ProjectFilesCommand implements Runnable {
       mixinStandardHelpOptions = true)
   static final class Add implements Callable<Integer> {
 
+    /**
+     * Cap on a single shared file. Shared files are configs, scripts, and docs replicated through
+     * SQLite as base64 — large binaries belong in a real artifact store, and bulk-grabbing one
+     * would bloat every FDE's synced database. 5 MiB is far above any legitimate workspace file.
+     */
+    static final long MAX_SHARE_BYTES = 5L * 1024 * 1024;
+
+    /**
+     * A bulk share above this many files asks for confirmation — a guard against a stray folder.
+     */
+    static final int CONFIRM_OVER = 100;
+
     @Parameters(index = "0", description = "Project name.")
     private String project;
 
@@ -97,13 +109,15 @@ public final class ProjectFilesCommand implements Runnable {
     }
 
     private Integer addOne() throws Exception {
-      if (!Files.isRegularFile(source)) {
-        System.err.println(Banner.errorLine("Not a file: " + source, Ansi.AUTO));
+      var path = Strings.isNotBlank(as) ? as : source.getFileName().toString();
+      var problem = shareProblem(source, path);
+      if (problem != null) {
+        System.err.println(Banner.errorLine("Cannot share " + source + ": " + problem, Ansi.AUTO));
         return 1;
       }
       try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
         var files = new FileStore(db);
-        var path = store(files, project, source, as);
+        store(files, project, source, path);
         new FileMaterializer(files, SailPaths.projectsDir()).materialize(project);
         System.out.println(
             Ansi.AUTO.string(
@@ -124,7 +138,15 @@ public final class ProjectFilesCommand implements Runnable {
       }
       var state = FilePicker.State.at(root);
       while (true) {
-        var entries = FilePicker.list(state.cwd());
+        List<FilePicker.Entry> entries;
+        try {
+          entries = FilePicker.list(state.cwd());
+        } catch (IOException unreadable) {
+          System.out.println(
+              Ansi.AUTO.string("  @|yellow ⚠|@ Can't read that folder; returning to the top."));
+          state = FilePicker.State.at(root);
+          continue;
+        }
         System.out.println(FilePicker.render(state, entries));
         System.out.print("  > ");
         System.out.flush();
@@ -150,28 +172,80 @@ public final class ProjectFilesCommand implements Runnable {
         System.out.println(Ansi.AUTO.string("  @|faint Nothing selected.|@"));
         return 0;
       }
+      if (selected.size() > CONFIRM_OVER
+          && !ConsoleHelper.confirmNo("Share " + selected.size() + " files?")) {
+        System.out.println(Ansi.AUTO.string("  @|faint Nothing shared.|@"));
+        return 0;
+      }
+      var skipped = new ArrayList<String>();
+      var shared = 0;
       try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
         var files = new FileStore(db);
         for (var file : selected) {
-          store(files, project, file, root.relativize(file).toString());
+          var path = root.relativize(file).toString();
+          var problem = shareProblem(file, path);
+          if (problem != null) {
+            skipped.add(path + " (" + problem + ")");
+            continue;
+          }
+          try {
+            store(files, project, file, path);
+            shared++;
+          } catch (IOException vanished) {
+            skipped.add(path + " (" + vanished.getMessage() + ")");
+          }
         }
-        new FileMaterializer(files, SailPaths.projectsDir()).materialize(project);
+        if (shared > 0) {
+          new FileMaterializer(files, SailPaths.projectsDir()).materialize(project);
+        }
+      }
+      for (var skip : skipped) {
+        System.err.println(Ansi.AUTO.string("  @|yellow ⚠|@ skipped " + skip));
       }
       System.out.println(
           Ansi.AUTO.string(
               "  @|green ✓|@ Shared @|bold "
-                  + selected.size()
+                  + shared
                   + "|@ file(s) on @|bold "
                   + project
                   + "|@. Run @|bold sail sync|@ to propagate."));
       return 0;
     }
 
-    /** Stores {@code source} under its relative path (no materialization); returns the path. */
-    static String store(FileStore files, String project, Path source, String as)
+    /**
+     * Why {@code file} cannot be shared at {@code relPath}, or {@code null} if it can: a guard for
+     * the things real project trees throw at us — non-regular files, oversized blobs, unreadable
+     * entries, and paths that would escape the project's files directory.
+     */
+    static String shareProblem(Path file, String relPath) {
+      if (!Files.isRegularFile(file)) {
+        return "not a regular file";
+      }
+      if (!FilePicker.isShareablePath(relPath)) {
+        return "unsafe path";
+      }
+      try {
+        if (Files.size(file) > MAX_SHARE_BYTES) {
+          return "larger than " + (MAX_SHARE_BYTES / (1024 * 1024)) + " MiB";
+        }
+      } catch (IOException e) {
+        return "unreadable";
+      }
+      return null;
+    }
+
+    /**
+     * Stores {@code source} at {@code path} (no materialization). Caller validates with {@link
+     * #shareProblem}; this re-checks defensively. Returns the path.
+     */
+    static String store(FileStore files, String project, Path source, String path)
         throws IOException {
-      var path = Strings.isNotBlank(as) ? as : source.getFileName().toString();
-      NameValidator.requireSafePath(path, "path");
+      if (!FilePicker.isShareablePath(path)) {
+        throw new IllegalArgumentException("Unsafe share path: '" + path + "'.");
+      }
+      if (Files.size(source) > MAX_SHARE_BYTES) {
+        throw new IllegalArgumentException("File exceeds the " + MAX_SHARE_BYTES + "-byte limit.");
+      }
       files.put(project, path, Base64.getEncoder().encodeToString(Files.readAllBytes(source)));
       return path;
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/FilePicker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/FilePicker.java
@@ -6,12 +6,16 @@
 package ai.singlr.sail.engine;
 
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -24,6 +28,35 @@ import java.util.stream.Stream;
  * file's path is always meaningful relative to that root.
  */
 public final class FilePicker {
+
+  /**
+   * Build outputs, dependency caches, and VCS metadata are never the workspace files an FDE means
+   * to share, and recursively walking them (a {@code .git} or {@code node_modules}) would bloat the
+   * synced database. They are hidden from the listing and skipped when a folder is expanded.
+   */
+  static final Set<String> IGNORED_DIRS =
+      Set.of(
+          ".git",
+          ".hg",
+          ".svn",
+          "node_modules",
+          "target",
+          "build",
+          "dist",
+          "out",
+          "bin",
+          ".gradle",
+          ".mvn",
+          ".idea",
+          ".vscode",
+          ".venv",
+          "venv",
+          "__pycache__",
+          ".next",
+          ".nuxt",
+          "coverage",
+          "vendor",
+          ".terraform");
 
   private FilePicker() {}
 
@@ -46,10 +79,11 @@ public final class FilePicker {
   /** The outcome of applying one line of input: the next state, the status, and a message. */
   public record Step(State state, Status status, String message) {}
 
-  /** Lists a directory: sub-folders first, then files, each alphabetical. */
+  /** Lists a directory: sub-folders first, then files, each alphabetical; junk folders hidden. */
   public static List<Entry> list(Path dir) throws IOException {
     try (Stream<Path> entries = Files.list(dir)) {
       return entries
+          .filter(p -> !isIgnoredDir(p))
           .map(FilePicker::toEntry)
           .sorted(
               Comparator.comparing(Entry::directory)
@@ -57,6 +91,10 @@ public final class FilePicker {
                   .thenComparing(e -> e.path().getFileName().toString()))
           .toList();
     }
+  }
+
+  private static boolean isIgnoredDir(Path p) {
+    return Files.isDirectory(p) && IGNORED_DIRS.contains(p.getFileName().toString());
   }
 
   private static Entry toEntry(Path p) {
@@ -168,19 +206,64 @@ public final class FilePicker {
   }
 
   /**
-   * Expands the picked set to concrete regular files (folders walked recursively), de-duplicated.
+   * Expands the picked set to concrete regular files, de-duplicated and sorted. A picked folder is
+   * walked recursively, skipping {@link #IGNORED_DIRS} and tolerating unreadable subtrees (skipped,
+   * never fatal) so one permission error cannot abort a whole selection.
    */
   public static List<Path> selectedFiles(State state) throws IOException {
     var files = new LinkedHashSet<Path>();
     for (var picked : state.picked()) {
       if (Files.isDirectory(picked)) {
-        try (Stream<Path> walk = Files.walk(picked)) {
-          walk.filter(Files::isRegularFile).forEach(files::add);
-        }
+        Files.walkFileTree(picked, new CollectingVisitor(files));
       } else if (Files.isRegularFile(picked)) {
         files.add(picked);
       }
     }
     return files.stream().sorted().toList();
+  }
+
+  private record CollectingVisitor(Set<Path> files) implements FileVisitor<Path> {
+    @Override
+    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+      return IGNORED_DIRS.contains(dir.getFileName().toString())
+          ? FileVisitResult.SKIP_SUBTREE
+          : FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+      if (attrs.isRegularFile()) {
+        files.add(file);
+      }
+      return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFileFailed(Path file, IOException exc) {
+      return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
+      return FileVisitResult.CONTINUE;
+    }
+  }
+
+  /**
+   * Whether a relative path is safe to share: not blank, not absolute, with no {@code ..} segment
+   * and no control characters. Deliberately permits spaces and Unicode — real filenames have them —
+   * since traversal, not the character set, is the security boundary (the materializer additionally
+   * fences every write to the project's files directory).
+   */
+  public static boolean isShareablePath(String path) {
+    if (path == null || path.isBlank() || path.startsWith("/")) {
+      return false;
+    }
+    for (var segment : path.split("/")) {
+      if (segment.equals("..")) {
+        return false;
+      }
+    }
+    return path.chars().noneMatch(c -> c < 0x20);
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectFilesCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectFilesCommandTest.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.commands;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -82,13 +83,14 @@ class ProjectFilesCommandTest {
   }
 
   @Test
-  void addDefaultsTheStoredPathToTheSourceFileName() throws Exception {
+  void storeUsesTheGivenRelativePath() throws Exception {
     var source = tempDir.resolve("notes.md");
     Files.writeString(source, "hello");
 
-    var path = ProjectFilesCommand.Add.store(files, "acme", source, null);
+    var path = ProjectFilesCommand.Add.store(files, "acme", source, "docs/notes.md");
 
-    assertEquals("notes.md", path);
+    assertEquals("docs/notes.md", path);
+    assertTrue(files.find("acme", "docs/notes.md").isPresent());
   }
 
   @Test
@@ -99,6 +101,32 @@ class ProjectFilesCommandTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> ProjectFilesCommand.Add.store(files, "acme", source, "../escape"));
+  }
+
+  @Test
+  void shareProblemAcceptsRealFilesAndFlagsTheRest() throws Exception {
+    var ok = tempDir.resolve("ok.txt");
+    Files.writeString(ok, "hi");
+    assertNull(ProjectFilesCommand.Add.shareProblem(ok, "ok.txt"));
+
+    assertEquals("unsafe path", ProjectFilesCommand.Add.shareProblem(ok, "../escape"));
+    assertEquals("not a regular file", ProjectFilesCommand.Add.shareProblem(tempDir, "dir"));
+    assertEquals(
+        "not a regular file",
+        ProjectFilesCommand.Add.shareProblem(tempDir.resolve("gone"), "gone"));
+  }
+
+  @Test
+  void shareProblemRejectsAnOversizedFile() throws Exception {
+    var big = tempDir.resolve("big.bin");
+    try (var raf = new java.io.RandomAccessFile(big.toFile(), "rw")) {
+      raf.setLength(ProjectFilesCommand.Add.MAX_SHARE_BYTES + 1);
+    }
+
+    assertTrue(ProjectFilesCommand.Add.shareProblem(big, "big.bin").contains("larger than"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ProjectFilesCommand.Add.store(files, "acme", big, "big.bin"));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/FilePickerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/FilePickerTest.java
@@ -119,6 +119,45 @@ class FilePickerTest {
   }
 
   @Test
+  void junkDirectoriesAreHiddenFromTheListing() throws Exception {
+    Files.createDirectories(root.resolve("node_modules/pkg"));
+    Files.createDirectories(root.resolve(".git"));
+    Files.writeString(root.resolve("node_modules/pkg/index.js"), "junk");
+    Files.writeString(root.resolve(".git/config"), "[core]");
+
+    var names = FilePicker.list(root).stream().map(e -> e.path().getFileName().toString()).toList();
+
+    assertFalse(names.contains("node_modules"));
+    assertFalse(names.contains(".git"));
+    assertTrue(names.contains("src"));
+  }
+
+  @Test
+  void selectedFilesSkipsJunkDirectoriesWhenExpandingAFolder() throws Exception {
+    Files.createDirectories(root.resolve("node_modules/pkg"));
+    Files.writeString(root.resolve("node_modules/pkg/index.js"), "junk");
+    var picked = new java.util.LinkedHashSet<Path>();
+    picked.add(root);
+
+    var files = FilePicker.selectedFiles(new FilePicker.State(root, root, picked));
+
+    assertTrue(files.contains(root.resolve("README.md")));
+    assertFalse(
+        files.contains(root.resolve("node_modules/pkg/index.js")), "node_modules is not walked");
+  }
+
+  @Test
+  void isShareablePathAllowsRealNamesButBlocksTraversal() {
+    assertTrue(FilePicker.isShareablePath("scripts/My Deploy (final).sh"));
+    assertTrue(FilePicker.isShareablePath("docs/café.md"));
+    assertFalse(FilePicker.isShareablePath("../escape"));
+    assertFalse(FilePicker.isShareablePath("a/../../b"));
+    assertFalse(FilePicker.isShareablePath("/etc/passwd"));
+    assertFalse(FilePicker.isShareablePath(""));
+    assertFalse(FilePicker.isShareablePath("with\ttab"), "control characters are rejected");
+  }
+
+  @Test
   void renderNumbersEntriesAndMarksPicks() throws Exception {
     var picked = new java.util.LinkedHashSet<Path>();
     picked.add(root.resolve("README.md"));


### PR DESCRIPTION
Production hardening before pointing the picker at real client repos. Each item is a thing a real tree throws at the naive version:

- **Size cap (5 MiB/file)** — base64-in-SQLite is for configs/scripts/docs; oversized files are skipped in a bulk share and rejected with a clear error for an explicit add, so a stray binary can't bloat every FDE's synced DB.
- **Skip junk folders** (`.git`, `node_modules`, `target`, `build`, `.venv`, `__pycache__`, …) in the listing *and* when expanding a picked folder — a recursive add can't vacuum up a VCS dir or dependency cache.
- **Permissive-but-safe paths** — real filenames (spaces, Unicode) now share fine; traversal (`..`), absolute paths, and control characters are still blocked. The materializer's directory fence stays the hard security boundary.
- **Never abort a batch** — a non-regular / oversized / unsafe / unreadable file (or one that vanishes mid-share) is skipped and reported, not fatal; an unreadable folder during browse returns to the top; the recursive walk tolerates unreadable subtrees.
- **Confirm a bulk share over 100 files** — guard against a stray folder selection.

New tests cover junk-skipping, the shareable-path matrix, and the size/regular-file guards. `mvn verify` green: **1644 tests**, api.* 100%, ratcheted gates hold.