### PR TITLE
Current-project context: no name arg, no cwd sail.yaml

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/CurrentProject.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/CurrentProject.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.engine.SailPaths;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * The current project — the one {@code sail switch} last selected — so project commands need
+ * neither a name argument nor a {@code cd} into a descriptor directory. It is a single line under
+ * {@code ~/.sail}; the project catalog itself lives in the database, this is only the pointer.
+ */
+final class CurrentProject {
+
+  private CurrentProject() {}
+
+  static Path file() {
+    return SailPaths.sailDir().resolve("current-project");
+  }
+
+  /** The current project, or empty if none is set. */
+  static Optional<String> get() {
+    return get(file());
+  }
+
+  static Optional<String> get(Path stateFile) {
+    try {
+      if (!Files.exists(stateFile)) {
+        return Optional.empty();
+      }
+      var name = Files.readString(stateFile).strip();
+      return Strings.isBlank(name) ? Optional.empty() : Optional.of(name);
+    } catch (IOException unreadable) {
+      return Optional.empty();
+    }
+  }
+
+  /** Records {@code name} as the current project. */
+  static void set(String name) {
+    set(file(), name);
+  }
+
+  static void set(Path stateFile, String name) {
+    try {
+      Files.createDirectories(stateFile.getParent());
+      Files.writeString(stateFile, name + "\n");
+    } catch (IOException e) {
+      throw new UncheckedIOException("Could not record the current project", e);
+    }
+  }
+
+  /**
+   * Resolves the project a command should act on: the explicit name when given, otherwise the
+   * current project. Throws with actionable guidance when neither is available.
+   */
+  static String require(String explicit) {
+    return require(explicit, file());
+  }
+
+  static String require(String explicit, Path stateFile) {
+    if (Strings.isNotBlank(explicit)) {
+      return explicit;
+    }
+    return get(stateFile)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "No current project. Run 'sail switch <project>' or pass a project name."));
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
@@ -74,11 +74,13 @@ public final class ProjectFilesCommand implements Runnable {
      */
     static final int CONFIRM_OVER = 100;
 
-    @Parameters(index = "0", description = "Project name.")
+    @Option(
+        names = {"-p", "--project"},
+        description = "Project (default: the current project from 'sail switch').")
     private String project;
 
     @Parameters(
-        index = "1",
+        index = "0",
         arity = "0..1",
         description = "Local file to share. Omit to browse and pick interactively.")
     private Path source;
@@ -95,6 +97,7 @@ public final class ProjectFilesCommand implements Runnable {
 
     @Override
     public Integer call() throws Exception {
+      project = CurrentProject.require(project);
       NameValidator.requireValidProjectName(project);
       if (source != null) {
         return addOne();
@@ -257,7 +260,9 @@ public final class ProjectFilesCommand implements Runnable {
       mixinStandardHelpOptions = true)
   static final class Ls implements Callable<Integer> {
 
-    @Parameters(index = "0", description = "Project name.")
+    @Option(
+        names = {"-p", "--project"},
+        description = "Project (default: the current project from 'sail switch').")
     private String project;
 
     @Option(names = "--json", description = "Output as JSON.")
@@ -265,6 +270,7 @@ public final class ProjectFilesCommand implements Runnable {
 
     @Override
     public Integer call() {
+      project = CurrentProject.require(project);
       NameValidator.requireValidProjectName(project);
       try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
         System.out.println(render(new FileStore(db).list(project), project, json));
@@ -308,14 +314,17 @@ public final class ProjectFilesCommand implements Runnable {
       mixinStandardHelpOptions = true)
   static final class Cat implements Callable<Integer> {
 
-    @Parameters(index = "0", description = "Project name.")
+    @Option(
+        names = {"-p", "--project"},
+        description = "Project (default: the current project from 'sail switch').")
     private String project;
 
-    @Parameters(index = "1", description = "Relative path of the file.")
+    @Parameters(index = "0", description = "Relative path of the file.")
     private String path;
 
     @Override
     public Integer call() throws Exception {
+      project = CurrentProject.require(project);
       NameValidator.requireValidProjectName(project);
       try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
         var bytes = read(new FileStore(db), project, path).orElse(null);
@@ -341,14 +350,17 @@ public final class ProjectFilesCommand implements Runnable {
       mixinStandardHelpOptions = true)
   static final class Rm implements Callable<Integer> {
 
-    @Parameters(index = "0", description = "Project name.")
+    @Option(
+        names = {"-p", "--project"},
+        description = "Project (default: the current project from 'sail switch').")
     private String project;
 
-    @Parameters(index = "1", description = "Relative path of the file.")
+    @Parameters(index = "0", description = "Relative path of the file.")
     private String path;
 
     @Override
     public Integer call() throws Exception {
+      project = CurrentProject.require(project);
       NameValidator.requireValidProjectName(project);
       try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
         if (!unshare(new FileStore(db), SailPaths.projectsDir(), project, path)) {
@@ -383,7 +395,9 @@ public final class ProjectFilesCommand implements Runnable {
       mixinStandardHelpOptions = true)
   static final class Export implements Callable<Integer> {
 
-    @Parameters(index = "0", arity = "0..1", description = "Project name. Omit with --all.")
+    @Option(
+        names = {"-p", "--project"},
+        description = "Project (default: the current project from 'sail switch').")
     private String project;
 
     @Option(names = "--all", description = "Pull every project that has shared files.")
@@ -391,13 +405,13 @@ public final class ProjectFilesCommand implements Runnable {
 
     @Override
     public Integer call() throws Exception {
-      if (all == (Strings.isNotBlank(project))) {
-        System.err.println(Banner.errorLine("Pass a project name OR --all, not both.", Ansi.AUTO));
+      if (all && Strings.isNotBlank(project)) {
+        System.err.println(Banner.errorLine("Pass --project OR --all, not both.", Ansi.AUTO));
         return 1;
       }
       try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
         var files = new FileStore(db);
-        var targets = all ? files.projectsWithFiles() : List.of(project);
+        var targets = all ? files.projectsWithFiles() : List.of(CurrentProject.require(project));
         var report = export(files, SailPaths.projectsDir(), targets);
         for (var skip : report.skipped()) {
           System.err.println(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SwitchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SwitchCommand.java
@@ -23,8 +23,10 @@ import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Spec;
 
 @Command(
-    name = "restart",
-    description = "Restart or switch to a project, warning if resources overcommit.",
+    name = "switch",
+    aliases = "restart",
+    description =
+        "Switch to a project (start it, make it current), warning if resources overcommit.",
     mixinStandardHelpOptions = true)
 public final class SwitchCommand implements Runnable {
 
@@ -56,6 +58,10 @@ public final class SwitchCommand implements Runnable {
     }
     if (state instanceof ContainerState.Error e) {
       throw new IllegalStateException("Container error: " + e.message());
+    }
+
+    if (!dryRun) {
+      CurrentProject.set(name);
     }
 
     if (!json) {

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CurrentProjectTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CurrentProjectTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CurrentProjectTest {
+
+  @TempDir Path tempDir;
+
+  private Path state() {
+    return tempDir.resolve("current-project");
+  }
+
+  @Test
+  void setThenGetRoundTrips() {
+    CurrentProject.set(state(), "acme");
+    assertEquals("acme", CurrentProject.get(state()).orElseThrow());
+  }
+
+  @Test
+  void getIsEmptyWhenUnsetOrBlank() throws Exception {
+    assertTrue(CurrentProject.get(state()).isEmpty());
+    Files.writeString(state(), "   \n");
+    assertTrue(CurrentProject.get(state()).isEmpty());
+  }
+
+  @Test
+  void requireFavoursTheExplicitNameThenTheCurrent() {
+    CurrentProject.set(state(), "acme");
+    assertEquals("globex", CurrentProject.require("globex", state()), "explicit wins");
+    assertEquals("acme", CurrentProject.require(null, state()), "falls back to current");
+    assertEquals("acme", CurrentProject.require("  ", state()), "blank is not explicit");
+  }
+
+  @Test
+  void requireFailsWithGuidanceWhenNeitherIsAvailable() {
+    var e = assertThrows(IllegalStateException.class, () -> CurrentProject.require(null, state()));
+    assertTrue(e.getMessage().contains("sail switch"), e.getMessage());
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/LifecycleCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/LifecycleCommandTest.java
@@ -114,7 +114,7 @@ class LifecycleCommandTest {
     var output = sw.toString();
     assertTrue(output.contains("--dry-run"));
     assertTrue(output.contains("--json"));
-    assertTrue(output.contains("Restart or switch to a project"));
+    assertTrue(output.contains("Switch to a project"));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectFilesCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectFilesCommandTest.java
@@ -133,7 +133,7 @@ class ProjectFilesCommandTest {
   void addReportsExitOneWhenTheSourceIsMissing() {
     var cmd = new CommandLine(new ProjectFilesCommand.Add());
     cmd.setErr(new java.io.PrintWriter(new java.io.StringWriter()));
-    assertEquals(1, cmd.execute("acme", tempDir.resolve("nope").toString()));
+    assertEquals(1, cmd.execute("-p", "acme", tempDir.resolve("nope").toString()));
   }
 
   @Test
@@ -202,13 +202,6 @@ class ProjectFilesCommandTest {
   void exportRejectsBothProjectAndAll() {
     var cmd = new CommandLine(new ProjectFilesCommand.Export());
     cmd.setErr(new java.io.PrintWriter(new java.io.StringWriter()));
-    assertEquals(1, cmd.execute("acme", "--all"));
-  }
-
-  @Test
-  void exportRejectsNeitherProjectNorAll() {
-    var cmd = new CommandLine(new ProjectFilesCommand.Export());
-    cmd.setErr(new java.io.PrintWriter(new java.io.StringWriter()));
-    assertEquals(1, cmd.execute());
+    assertEquals(1, cmd.execute("-p", "acme", "--all"));
   }
 }


### PR DESCRIPTION
First slice of the file-share DX fix you pushed on: the project catalog is DB-backed, so commands shouldn't make you name the project or `cd` to a `sail.yaml`.

- **`sail project switch <name>`** (alias: `restart`) now records the **current project** under `~/.sail`. `CurrentProject.require` resolves explicit → current → a clear *"run sail switch"* error.
- The files subcommands take project as **`-p`/`--project` (default: current)**, not a leading positional — so `sail project files ls`, `files add`, `files cat <path>`, `files rm <path>`, `files pull` all act on the current project; `-p` overrides. No name, no `cd`.

Fully tested (`CurrentProject` get/set/require, hermetic via @TempDir). `mvn verify` green: **1647 tests**, gates hold.

### Still file-based (next slice, not in this PR)
The `files add` **picker still browses the host cwd**. The real fix — browsing the project's **container `~/workspace`** and unifying `add`+`capture` — is the next slice (a `FileSource` abstraction + container `incus exec` listing/pull). Holding it for a focused pass rather than rushing it.