### PR TITLE
feat(files): arrow-key checkbox picker for sharing files

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
@@ -16,6 +16,7 @@ import ai.singlr.sail.engine.HostFileSource;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.engine.TerminalFilePicker;
 import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.Sqlite;
 import java.io.IOException;
@@ -25,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -98,6 +100,11 @@ public final class ProjectFilesCommand implements Runnable {
         description = "Directory to browse when picking (default: the current directory).")
     private Path from;
 
+    @Option(
+        names = "--plain",
+        description = "Use the typed picker instead of the arrow-key checkbox UI.")
+    private boolean plain;
+
     @Override
     public Integer call() throws Exception {
       project = CurrentProject.require(project);
@@ -146,24 +153,44 @@ public final class ProjectFilesCommand implements Runnable {
       return 0;
     }
 
+    private record Browse(FileSource source, Path root) {}
+
     private Integer pick() throws Exception {
-      FileSource fileSource;
-      Path root;
+      var browse = resolveBrowse();
+      if (browse == null) {
+        return 1;
+      }
+      var picked =
+          TerminalFilePicker.isAvailable() && !plain
+              ? new TerminalFilePicker(browse.source(), browse.root()).run()
+              : typedPick(browse.source(), browse.root());
+      if (picked.isEmpty()) {
+        System.out.println(Ansi.AUTO.string("  @|faint Nothing shared.|@"));
+        return 0;
+      }
+      var state = new FilePicker.State(browse.root(), browse.root(), picked.get());
+      return shareSelected(
+          browse.source(), browse.root(), FilePicker.selectedFiles(browse.source(), state));
+    }
+
+    private Browse resolveBrowse() {
       if (from != null) {
-        fileSource = new HostFileSource();
-        root = from.toAbsolutePath().normalize();
+        var root = from.toAbsolutePath().normalize();
         if (!Files.isDirectory(root)) {
           System.err.println(Banner.errorLine("Not a directory: " + root, Ansi.AUTO));
-          return 1;
+          return null;
         }
-      } else {
-        var workspace = ContainerWorkspace.resolve(project);
-        if (workspace.isEmpty()) {
-          return 1;
-        }
-        fileSource = new ContainerFileSource(new ShellExecutor(false), project);
-        root = workspace.get();
+        return new Browse(new HostFileSource(), root);
       }
+      var workspace = ContainerWorkspace.resolve(project);
+      if (workspace.isEmpty()) {
+        return null;
+      }
+      return new Browse(
+          new ContainerFileSource(new ShellExecutor(false), project), workspace.get());
+    }
+
+    private Optional<LinkedHashSet<Path>> typedPick(FileSource fileSource, Path root) {
       var state = FilePicker.State.at(root);
       while (true) {
         List<FilePicker.Entry> entries;
@@ -185,14 +212,12 @@ public final class ProjectFilesCommand implements Runnable {
           System.out.println("  " + step.message());
         }
         if (step.status() == FilePicker.Status.CANCELLED) {
-          System.out.println(Ansi.AUTO.string("  @|faint Nothing shared.|@"));
-          return 0;
+          return Optional.empty();
         }
         if (step.status() == FilePicker.Status.CONFIRMED) {
-          break;
+          return Optional.of(state.picked());
         }
       }
-      return shareSelected(fileSource, root, FilePicker.selectedFiles(fileSource, state));
     }
 
     private Integer shareSelected(FileSource fileSource, Path root, List<Path> selected)

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
@@ -176,7 +176,7 @@ public final class ProjectFilesCommand implements Runnable {
           continue;
         }
         System.out.println(FilePicker.render(state, entries));
-        System.out.print("  > ");
+        System.out.print("  type a command > ");
         System.out.flush();
         var line = ConsoleHelper.readLine();
         var step = FilePicker.step(state, entries, line == null ? "q" : line);

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/CheckboxPicker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/CheckboxPicker.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Pure state engine for the raw-mode checkbox file picker: cursor movement, checking/unchecking,
+ * and the intent to open a folder or go up. It holds no I/O — {@link TerminalFilePicker} drives a
+ * real terminal against it — so every transition is deterministically testable without a TTY.
+ *
+ * <p>Keys arrive as integer codes: printable bytes as-is, arrows as the negative {@code ARROW_*}
+ * constants the driver substitutes for escape sequences. {@link #key} maps a code to a {@link Key};
+ * {@link #apply} maps a {@code (Screen, Key)} to a {@link Move} whose {@link Outcome} tells the
+ * driver whether to redraw, navigate, share, or cancel.
+ */
+public final class CheckboxPicker {
+
+  public static final int ARROW_UP = -1;
+  public static final int ARROW_DOWN = -2;
+  public static final int ARROW_RIGHT = -3;
+  public static final int ARROW_LEFT = -4;
+
+  private static final int ESC = 27;
+  private static final int CTRL_C = 3;
+
+  private CheckboxPicker() {}
+
+  public enum Key {
+    UP,
+    DOWN,
+    OPEN,
+    PARENT,
+    TOGGLE,
+    ALL,
+    CONFIRM,
+    CANCEL,
+    NONE
+  }
+
+  public enum Outcome {
+    BROWSING,
+    OPEN,
+    PARENT,
+    CONFIRMED,
+    CANCELLED
+  }
+
+  /** The current folder, its listing, the highlighted row, and everything checked so far. */
+  public record Screen(
+      Path root, Path cwd, List<FilePicker.Entry> entries, int cursor, LinkedHashSet<Path> picked) {
+
+    public static Screen of(
+        Path root, Path cwd, List<FilePicker.Entry> entries, LinkedHashSet<Path> picked) {
+      return new Screen(root, cwd, entries, 0, picked);
+    }
+
+    FilePicker.Entry current() {
+      return entries.isEmpty() ? null : entries.get(cursor);
+    }
+  }
+
+  /**
+   * The result of one key: the next screen, what the driver should do, and any navigation target.
+   */
+  public record Move(Screen screen, Outcome outcome, Path target) {}
+
+  /** Maps a raw key code (or synthetic {@code ARROW_*}) to a {@link Key}. */
+  public static Key key(int code) {
+    return switch (code) {
+      case ARROW_UP -> Key.UP;
+      case ARROW_DOWN -> Key.DOWN;
+      case ARROW_RIGHT -> Key.OPEN;
+      case ARROW_LEFT -> Key.PARENT;
+      case ' ' -> Key.TOGGLE;
+      case '\r', '\n', 's', 'S' -> Key.CONFIRM;
+      case 'q', 'Q', ESC, CTRL_C -> Key.CANCEL;
+      case 'a', 'A' -> Key.ALL;
+      case 'k', 'K' -> Key.UP;
+      case 'j', 'J' -> Key.DOWN;
+      case 'l', 'L' -> Key.OPEN;
+      case 'h', 'H' -> Key.PARENT;
+      default -> Key.NONE;
+    };
+  }
+
+  /** Applies a key to the screen, returning the next screen and what the driver should do next. */
+  public static Move apply(Screen s, Key key) {
+    return switch (key) {
+      case UP -> browsing(withCursor(s, s.cursor() - 1));
+      case DOWN -> browsing(withCursor(s, s.cursor() + 1));
+      case TOGGLE -> browsing(toggle(s, current(s)));
+      case ALL -> browsing(toggleAll(s));
+      case CONFIRM -> new Move(s, Outcome.CONFIRMED, null);
+      case CANCEL -> new Move(s, Outcome.CANCELLED, null);
+      case PARENT ->
+          s.cwd().equals(s.root()) ? browsing(s) : new Move(s, Outcome.PARENT, s.cwd().getParent());
+      case OPEN -> open(s);
+      case NONE -> browsing(s);
+    };
+  }
+
+  private static Move open(Screen s) {
+    var entry = s.current();
+    if (entry == null) {
+      return browsing(s);
+    }
+    return entry.directory() ? new Move(s, Outcome.OPEN, entry.path()) : browsing(toggle(s, entry));
+  }
+
+  private static Screen toggle(Screen s, FilePicker.Entry entry) {
+    if (entry == null) {
+      return s;
+    }
+    var picked = new LinkedHashSet<>(s.picked());
+    if (!picked.remove(entry.path())) {
+      picked.add(entry.path());
+    }
+    return new Screen(s.root(), s.cwd(), s.entries(), s.cursor(), picked);
+  }
+
+  private static Screen toggleAll(Screen s) {
+    var picked = new LinkedHashSet<>(s.picked());
+    for (var entry : s.entries()) {
+      if (!picked.remove(entry.path())) {
+        picked.add(entry.path());
+      }
+    }
+    return new Screen(s.root(), s.cwd(), s.entries(), s.cursor(), picked);
+  }
+
+  private static FilePicker.Entry current(Screen s) {
+    return s.current();
+  }
+
+  private static Screen withCursor(Screen s, int cursor) {
+    if (s.entries().isEmpty()) {
+      return s;
+    }
+    var clamped = Math.max(0, Math.min(cursor, s.entries().size() - 1));
+    return new Screen(s.root(), s.cwd(), s.entries(), clamped, s.picked());
+  }
+
+  private static Move browsing(Screen s) {
+    return new Move(s, Outcome.BROWSING, null);
+  }
+
+  /** Renders the screen as display lines: a header, the checkbox rows, and the key legend. */
+  public static List<String> render(Screen s) {
+    var here = s.root().relativize(s.cwd()).toString();
+    var lines = new ArrayList<String>();
+    lines.add("  " + (here.isEmpty() ? "." : here) + "  —  check files to share");
+    if (s.entries().isEmpty()) {
+      lines.add("    (empty folder)");
+    }
+    for (var i = 0; i < s.entries().size(); i++) {
+      var e = s.entries().get(i);
+      var pointer = i == s.cursor() ? "›" : " ";
+      var box = s.picked().contains(e.path()) ? "[x]" : "[ ]";
+      var name = e.path().getFileName() + (e.directory() ? "/" : "");
+      var detail = e.directory() ? "" : "  " + FilePicker.humanSize(e.size());
+      lines.add(String.format("  %s %s %-28s%s", pointer, box, name, detail));
+    }
+    lines.add(
+        "  ↑↓ move · space check · → open · ← up · a all · enter/s share · q quit  ("
+            + s.picked().size()
+            + " checked)");
+    return lines;
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/FilePicker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/FilePicker.java
@@ -180,7 +180,7 @@ public final class FilePicker {
     return out.toString();
   }
 
-  private static String humanSize(long bytes) {
+  static String humanSize(long bytes) {
     if (bytes < 1024) {
       return bytes + " B";
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/FilePicker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/FilePicker.java
@@ -93,15 +93,16 @@ public final class FilePicker {
    * Applies one line of input against the {@code entries} of the current directory. A lone
    * directory number descends; any other number(s) toggle the referenced files/folders; {@code a}
    * picks the whole current folder; {@code ..} goes up; {@code done} confirms; {@code q} cancels.
+   * Confirm and cancel accept common synonyms so a guessed word still does the obvious thing.
    */
   public static Step step(State state, List<Entry> entries, String input) {
-    var in = input == null ? "" : input.strip();
+    var in = input == null ? "" : input.strip().toLowerCase();
     if (in.isEmpty()) {
       return browsing(state, "");
     }
     return switch (in) {
-      case "q" -> new Step(state, Status.CANCELLED, "");
-      case "done", "d" -> new Step(state, Status.CONFIRMED, "");
+      case "q", "quit", "cancel", "exit" -> new Step(state, Status.CANCELLED, "");
+      case "done", "d", "share", "ok" -> new Step(state, Status.CONFIRMED, "");
       case ".." -> up(state);
       case "a" -> pick(state, List.of(state.cwd()), "Selected this folder.");
       default -> numbers(state, entries, in);
@@ -158,6 +159,7 @@ public final class FilePicker {
   /** Renders the current folder as a numbered listing with picked entries marked. */
   public static String render(State state, List<Entry> entries) {
     var here = state.root().relativize(state.cwd()).toString();
+    var count = state.picked().size();
     var out = new StringBuilder();
     out.append("  ").append(here.isEmpty() ? "." : here).append("  —  pick files to share\n");
     for (var i = 0; i < entries.size(); i++) {
@@ -167,10 +169,14 @@ public final class FilePicker {
       var detail = e.directory() ? "" : "  " + humanSize(e.size());
       out.append(String.format("  %s [%d] %-28s%s%n", mark, i + 1, name, detail));
     }
-    out.append("    number(s) toggle · a = this folder · .. up · done · q quit");
-    if (!state.picked().isEmpty()) {
-      out.append("   (").append(state.picked().size()).append(" picked)");
-    }
+    out.append("  Type a command, then Enter (arrow keys don't work here):\n");
+    out.append(
+        "    a number  pick a file, or open a folder   ·   a  pick everything here   ·   ..  go up\n");
+    var finish =
+        count == 0
+            ? "done  finish (nothing picked yet)"
+            : "done  share the " + count + " picked file(s)";
+    out.append("    ").append(finish).append("   ·   q  cancel");
     return out.toString();
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/TerminalFilePicker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/TerminalFilePicker.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+
+/**
+ * Drives a real terminal against the pure {@link CheckboxPicker}: puts the TTY in raw mode so arrow
+ * keys and the space bar are read a keystroke at a time, redraws the checkbox list in place, and
+ * always restores the terminal — on confirm, cancel, exception, or Ctrl-C. Reads the directory tree
+ * through a {@link FileSource}, so it browses a host path or a container workspace identically.
+ *
+ * <p>Raw mode needs an interactive terminal and the {@code stty} utility; callers gate on {@link
+ * #isAvailable()} and fall back to the typed {@link FilePicker} when it returns false.
+ */
+public final class TerminalFilePicker {
+
+  private static final String ESC = String.valueOf((char) 27);
+  private static final int IGNORED_KEY = -99;
+
+  private final FileSource source;
+  private final Path root;
+  private final InputStream in;
+  private final PrintStream out;
+
+  public TerminalFilePicker(FileSource source, Path root) {
+    this(source, root, System.in, System.out);
+  }
+
+  TerminalFilePicker(FileSource source, Path root, InputStream in, PrintStream out) {
+    this.source = source;
+    this.root = root;
+    this.in = in;
+    this.out = out;
+  }
+
+  /** Whether a raw-mode picker can run here: an interactive console with a working {@code stty}. */
+  public static boolean isAvailable() {
+    return System.console() != null && sttyState().isPresent();
+  }
+
+  /**
+   * Runs the picker, returning the checked paths (files and whole folders) the user confirmed, or
+   * empty if they cancelled. The returned set feeds {@link FilePicker#selectedFiles} for expansion.
+   */
+  public Optional<LinkedHashSet<Path>> run() throws IOException {
+    var saved = sttyState().orElse(null);
+    if (saved == null) {
+      return Optional.empty();
+    }
+    var restore = new Thread(() -> restore(saved));
+    Runtime.getRuntime().addShutdownHook(restore);
+    try {
+      stty("raw -echo");
+      out.print(ESC + "[?25l");
+      out.flush();
+      return drive();
+    } finally {
+      restore(saved);
+      Runtime.getRuntime().removeShutdownHook(restore);
+    }
+  }
+
+  /** The key/redraw loop, with no terminal-mode side effects, so it is testable without a TTY. */
+  Optional<LinkedHashSet<Path>> drive() throws IOException {
+    var picked = new LinkedHashSet<Path>();
+    var screen = CheckboxPicker.Screen.of(root, root, source.children(root), picked);
+    var previousLines = 0;
+    while (true) {
+      previousLines = draw(screen, previousLines);
+      var move = CheckboxPicker.apply(screen, CheckboxPicker.key(readKey()));
+      screen = move.screen();
+      switch (move.outcome()) {
+        case CONFIRMED -> {
+          return Optional.of(screen.picked());
+        }
+        case CANCELLED -> {
+          return Optional.empty();
+        }
+        case OPEN, PARENT -> screen = navigate(screen, move.target());
+        case BROWSING -> {}
+      }
+    }
+  }
+
+  private CheckboxPicker.Screen navigate(CheckboxPicker.Screen screen, Path target) {
+    try {
+      return CheckboxPicker.Screen.of(root, target, source.children(target), screen.picked());
+    } catch (IOException unreadable) {
+      return screen;
+    }
+  }
+
+  private int draw(CheckboxPicker.Screen screen, int previousLines) {
+    var lines = CheckboxPicker.render(screen);
+    var sb = new StringBuilder();
+    if (previousLines > 0) {
+      sb.append(ESC).append('[').append(previousLines).append('A');
+    }
+    sb.append('\r').append(ESC).append("[0J");
+    for (var line : lines) {
+      sb.append(line).append("\r\n");
+    }
+    out.print(sb);
+    out.flush();
+    return lines.size();
+  }
+
+  private int readKey() throws IOException {
+    var b = in.read();
+    if (b == -1) {
+      return 27;
+    }
+    if (b != 27) {
+      return b;
+    }
+    if (in.available() == 0 || in.read() != '[') {
+      return 27;
+    }
+    return switch (in.read()) {
+      case 'A' -> CheckboxPicker.ARROW_UP;
+      case 'B' -> CheckboxPicker.ARROW_DOWN;
+      case 'C' -> CheckboxPicker.ARROW_RIGHT;
+      case 'D' -> CheckboxPicker.ARROW_LEFT;
+      default -> IGNORED_KEY;
+    };
+  }
+
+  private void restore(String saved) {
+    out.print(ESC + "[?25h");
+    out.flush();
+    stty(saved);
+  }
+
+  private static Optional<String> sttyState() {
+    var result = stty("-g");
+    return result.isBlank() ? Optional.empty() : Optional.of(result.strip());
+  }
+
+  private static String stty(String args) {
+    try {
+      var process =
+          new ProcessBuilder("sh", "-c", "stty " + args + " </dev/tty")
+              .redirectErrorStream(false)
+              .start();
+      var output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+      process.waitFor();
+      return output;
+    } catch (IOException e) {
+      return "";
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return "";
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/CheckboxPickerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/CheckboxPickerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CheckboxPickerTest {
+
+  private static final Path ROOT = Path.of("/home/dev/workspace");
+  private static final FilePicker.Entry FILE =
+      new FilePicker.Entry(ROOT.resolve("a.txt"), false, 12);
+  private static final FilePicker.Entry DIR = new FilePicker.Entry(ROOT.resolve("src"), true, 0);
+
+  private static CheckboxPicker.Screen screen() {
+    return CheckboxPicker.Screen.of(ROOT, ROOT, List.of(FILE, DIR), new LinkedHashSet<>());
+  }
+
+  @Test
+  void mapsArrowsSpaceAndConfirmCancelKeys() {
+    assertEquals(CheckboxPicker.Key.UP, CheckboxPicker.key(CheckboxPicker.ARROW_UP));
+    assertEquals(CheckboxPicker.Key.DOWN, CheckboxPicker.key(CheckboxPicker.ARROW_DOWN));
+    assertEquals(CheckboxPicker.Key.OPEN, CheckboxPicker.key(CheckboxPicker.ARROW_RIGHT));
+    assertEquals(CheckboxPicker.Key.PARENT, CheckboxPicker.key(CheckboxPicker.ARROW_LEFT));
+    assertEquals(CheckboxPicker.Key.TOGGLE, CheckboxPicker.key(' '));
+    assertEquals(CheckboxPicker.Key.CONFIRM, CheckboxPicker.key('\r'));
+    assertEquals(CheckboxPicker.Key.CONFIRM, CheckboxPicker.key('s'));
+    assertEquals(CheckboxPicker.Key.CANCEL, CheckboxPicker.key('q'));
+    assertEquals(CheckboxPicker.Key.CANCEL, CheckboxPicker.key(27));
+    assertEquals(CheckboxPicker.Key.CANCEL, CheckboxPicker.key(3));
+    assertEquals(CheckboxPicker.Key.ALL, CheckboxPicker.key('a'));
+    assertEquals(CheckboxPicker.Key.UP, CheckboxPicker.key('k'));
+    assertEquals(CheckboxPicker.Key.DOWN, CheckboxPicker.key('j'));
+    assertEquals(CheckboxPicker.Key.NONE, CheckboxPicker.key('z'));
+  }
+
+  @Test
+  void cursorMovesAndClampsAtBothEnds() {
+    var atTop = CheckboxPicker.apply(screen(), CheckboxPicker.Key.UP);
+    assertEquals(0, atTop.screen().cursor());
+
+    var down = CheckboxPicker.apply(screen(), CheckboxPicker.Key.DOWN);
+    assertEquals(1, down.screen().cursor());
+
+    var clampedBottom = CheckboxPicker.apply(down.screen(), CheckboxPicker.Key.DOWN);
+    assertEquals(1, clampedBottom.screen().cursor());
+  }
+
+  @Test
+  void spaceTogglesTheHighlightedEntry() {
+    var checked = CheckboxPicker.apply(screen(), CheckboxPicker.Key.TOGGLE);
+    assertTrue(checked.screen().picked().contains(FILE.path()));
+
+    var unchecked = CheckboxPicker.apply(checked.screen(), CheckboxPicker.Key.TOGGLE);
+    assertFalse(unchecked.screen().picked().contains(FILE.path()));
+  }
+
+  @Test
+  void toggleAllFlipsEveryEntry() {
+    var all = CheckboxPicker.apply(screen(), CheckboxPicker.Key.ALL);
+    assertTrue(all.screen().picked().contains(FILE.path()));
+    assertTrue(all.screen().picked().contains(DIR.path()));
+  }
+
+  @Test
+  void openOnAFolderRequestsNavigationOpenOnAFileChecksIt() {
+    var onFolder = CheckboxPicker.apply(screen(), CheckboxPicker.Key.DOWN);
+    var open = CheckboxPicker.apply(onFolder.screen(), CheckboxPicker.Key.OPEN);
+    assertEquals(CheckboxPicker.Outcome.OPEN, open.outcome());
+    assertEquals(DIR.path(), open.target());
+
+    var openFile = CheckboxPicker.apply(screen(), CheckboxPicker.Key.OPEN);
+    assertEquals(CheckboxPicker.Outcome.BROWSING, openFile.outcome());
+    assertTrue(openFile.screen().picked().contains(FILE.path()));
+  }
+
+  @Test
+  void parentStaysPutAtRootAndNavigatesUpBelowIt() {
+    var atRoot = CheckboxPicker.apply(screen(), CheckboxPicker.Key.PARENT);
+    assertEquals(CheckboxPicker.Outcome.BROWSING, atRoot.outcome());
+
+    var deeper =
+        CheckboxPicker.Screen.of(ROOT, ROOT.resolve("src"), List.of(FILE), new LinkedHashSet<>());
+    var up = CheckboxPicker.apply(deeper, CheckboxPicker.Key.PARENT);
+    assertEquals(CheckboxPicker.Outcome.PARENT, up.outcome());
+    assertEquals(ROOT, up.target());
+  }
+
+  @Test
+  void confirmAndCancelReportOutcomes() {
+    assertEquals(
+        CheckboxPicker.Outcome.CONFIRMED,
+        CheckboxPicker.apply(screen(), CheckboxPicker.Key.CONFIRM).outcome());
+    assertEquals(
+        CheckboxPicker.Outcome.CANCELLED,
+        CheckboxPicker.apply(screen(), CheckboxPicker.Key.CANCEL).outcome());
+  }
+
+  @Test
+  void noneAndEmptyFolderKeysLeaveTheScreenUntouched() {
+    var s = screen();
+    assertSame(s, CheckboxPicker.apply(s, CheckboxPicker.Key.NONE).screen());
+
+    var empty = CheckboxPicker.Screen.of(ROOT, ROOT, List.of(), new LinkedHashSet<>());
+    assertSame(empty, CheckboxPicker.apply(empty, CheckboxPicker.Key.TOGGLE).screen());
+    assertSame(empty, CheckboxPicker.apply(empty, CheckboxPicker.Key.DOWN).screen());
+    assertEquals(
+        CheckboxPicker.Outcome.BROWSING,
+        CheckboxPicker.apply(empty, CheckboxPicker.Key.OPEN).outcome());
+  }
+
+  @Test
+  void renderShowsCursorCheckboxesCountAndLegend() {
+    var checked = CheckboxPicker.apply(screen(), CheckboxPicker.Key.TOGGLE).screen();
+    var lines = CheckboxPicker.render(checked);
+    var text = String.join("\n", lines);
+
+    assertTrue(text.contains("check files to share"));
+    assertTrue(text.contains("[x] a.txt"));
+    assertTrue(text.contains("[ ] src/"));
+    assertTrue(lines.get(1).contains("›"), "cursor points at the first row");
+    assertTrue(text.contains("(1 checked)"));
+    assertTrue(text.contains("space check"));
+  }
+
+  @Test
+  void renderMarksAnEmptyFolder() {
+    var empty = CheckboxPicker.Screen.of(ROOT, ROOT, List.of(), new LinkedHashSet<>());
+    assertTrue(String.join("\n", CheckboxPicker.render(empty)).contains("(empty folder)"));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/FilePickerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/FilePickerTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -104,6 +105,36 @@ class FilePickerTest {
     assertEquals(FilePicker.Status.CONFIRMED, FilePicker.step(start(), entries, "done").status());
     assertEquals(FilePicker.Status.CONFIRMED, FilePicker.step(start(), entries, "d").status());
     assertEquals(FilePicker.Status.CANCELLED, FilePicker.step(start(), entries, "q").status());
+  }
+
+  @Test
+  void confirmAndCancelAcceptSynonymsAndAnyCase() throws Exception {
+    var entries = FilePicker.list(source, root);
+    for (var confirm : List.of("share", "ok", "DONE", "Done")) {
+      assertEquals(
+          FilePicker.Status.CONFIRMED,
+          FilePicker.step(start(), entries, confirm).status(),
+          confirm + " should confirm");
+    }
+    for (var cancel : List.of("quit", "cancel", "exit", "Q")) {
+      assertEquals(
+          FilePicker.Status.CANCELLED,
+          FilePicker.step(start(), entries, cancel).status(),
+          cancel + " should cancel");
+    }
+  }
+
+  @Test
+  void footerShowsHowToConfirmAndThePickedCount() throws Exception {
+    var entries = FilePicker.list(source, root);
+    var empty = FilePicker.render(start(), entries);
+    assertTrue(empty.contains("Type a command"));
+    assertTrue(empty.contains("nothing picked yet"));
+    assertTrue(empty.contains("q  cancel"));
+
+    var withOne = FilePicker.step(start(), entries, "3");
+    var rendered = FilePicker.render(withOne.state(), entries);
+    assertTrue(rendered.contains("share the 1 picked file(s)"));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/TerminalFilePickerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/TerminalFilePickerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TerminalFilePickerTest {
+
+  private static final Path ROOT = Path.of("/ws");
+
+  private static final FileSource TREE =
+      new MapSource(
+          Map.of(
+              ROOT,
+              List.of(
+                  new FilePicker.Entry(ROOT.resolve("a.txt"), false, 3),
+                  new FilePicker.Entry(ROOT.resolve("src"), true, 0)),
+              ROOT.resolve("src"),
+              List.of(new FilePicker.Entry(ROOT.resolve("src/b.txt"), false, 5))));
+
+  private TerminalFilePicker picker(int... keys) {
+    var bytes = new byte[keys.length];
+    for (var i = 0; i < keys.length; i++) {
+      bytes[i] = (byte) keys[i];
+    }
+    return new TerminalFilePicker(
+        TREE, ROOT, new ByteArrayInputStream(bytes), new PrintStream(new ByteArrayOutputStream()));
+  }
+
+  @Test
+  void checkingAFileThenConfirmingReturnsIt() throws IOException {
+    var result = picker(' ', 's').drive();
+    assertTrue(result.isPresent());
+    assertEquals(List.of(ROOT.resolve("a.txt")), List.copyOf(result.orElseThrow()));
+  }
+
+  @Test
+  void quittingReturnsEmpty() throws IOException {
+    assertTrue(picker('q').drive().isEmpty());
+  }
+
+  @Test
+  void closedInputCancelsInsteadOfSpinning() throws IOException {
+    assertTrue(picker().drive().isEmpty());
+  }
+
+  @Test
+  void arrowsNavigateIntoAFolderAndBackOut() throws IOException {
+    var result = picker(27, '[', 'B', 27, '[', 'C', ' ', 27, '[', 'D', 's').drive();
+    assertTrue(result.isPresent());
+    assertEquals(List.of(ROOT.resolve("src/b.txt")), List.copyOf(result.orElseThrow()));
+  }
+
+  @Test
+  void redrawEmitsCursorAndClearSequences() throws IOException {
+    var captured = new ByteArrayOutputStream();
+    var p =
+        new TerminalFilePicker(
+            TREE,
+            ROOT,
+            new ByteArrayInputStream(new byte[] {'q'}),
+            new PrintStream(captured, true, StandardCharsets.UTF_8));
+    p.drive();
+    var esc = (char) 27;
+    assertTrue(captured.toString(StandardCharsets.UTF_8).contains(esc + "[0J"));
+  }
+
+  @Test
+  void notAvailableWithoutAnInteractiveConsole() {
+    assertFalse(TerminalFilePicker.isAvailable());
+  }
+
+  private record MapSource(Map<Path, List<FilePicker.Entry>> tree) implements FileSource {
+    @Override
+    public List<FilePicker.Entry> children(Path dir) {
+      return tree.getOrDefault(dir, List.of());
+    }
+
+    @Override
+    public boolean isDirectory(Path path) {
+      return tree.containsKey(path);
+    }
+
+    @Override
+    public long size(Path file) {
+      return 0;
+    }
+
+    @Override
+    public List<Path> walkFiles(Path dir) {
+      return List.of();
+    }
+
+    @Override
+    public byte[] read(Path file) {
+      return new byte[0];
+    }
+  }
+}


### PR DESCRIPTION
## What

A real **arrow-key + checkbox** picker for `sail project files add`, replacing the typed-only prompt that confused (arrow keys did nothing; a stray `q` discarded picks).

```
  manatee/workspace  —  check files to share
  › [x] deploy.sh        2 KB
    [ ] config/
    [x] .env.example     312 B
    [ ] src/
  ↑↓ move · space check · → open · ← up · a all · enter/s share · q quit  (2 checked)
```

**Bindings:** `↑/↓` (or `j/k`) move · `space` check/uncheck · `→` (or Enter on a folder) open · `←` up · `a` toggle-all · `Enter`/`s` share · `q`/`Esc` cancel.

## How

- **`CheckboxPicker` (pure engine):** cursor movement, check/uncheck, open/parent intents, key-code mapping, and render — no I/O, fully unit-tested (`CheckboxPickerTest`, 10 tests).
- **`TerminalFilePicker` (I/O shell):** raw mode via `stty` (**no new dependencies**), escape-sequence decoding, in-place redraw, and guaranteed terminal restore — `finally` **and** a shutdown hook so Ctrl-C never leaves your shell wedged. The key/redraw loop is a package-private `drive()` tested with scripted keystrokes + a fake `FileSource` (`TerminalFilePickerTest`, 6 tests).
- **Same `FileSource` seam** → browses a host dir (`--from`) or the container workspace identically. Checked folders expand via the existing `FilePicker.selectedFiles`.

## Fallback

Uses the checkbox UI only when `isAvailable()` (interactive console + working `stty`). Otherwise — pipes, no TTY, or `--plain` — it falls back to the **typed picker**, which this PR also makes clearer (explicit "type a command", live picked count, `done`/`share`/`ok` + `q`/`quit`/`cancel` synonyms).

## Tests

Full `mvn verify`: **1629 sail-infra tests green, all coverage gates pass.** The terminal driver's pure logic is covered via `drive()`; only the thin `stty`/raw-mode wrapper is left uncovered (it can't run without a real TTY).
