### PR TITLE
fix(files): height-bounded scrolling picker + sorted, junk-filtered listing

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/engine/CheckboxPicker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/CheckboxPicker.java
@@ -151,26 +151,56 @@ public final class CheckboxPicker {
     return new Move(s, Outcome.BROWSING, null);
   }
 
-  /** Renders the screen as display lines: a header, the checkbox rows, and the key legend. */
-  public static List<String> render(Screen s) {
+  /**
+   * Renders the screen to at most {@code terminalRows} display lines: a header, a scrolling window
+   * of checkbox rows that always keeps the cursor visible, and the key legend. Capping to the
+   * terminal height is what keeps the in-place redraw honest — a listing taller than the screen
+   * would scroll the terminal and strand the cursor off-screen, which is exactly what makes the
+   * arrows feel dead.
+   */
+  public static List<String> render(Screen s, int terminalRows) {
     var here = s.root().relativize(s.cwd()).toString();
+    var total = s.entries().size();
+    var listRows = Math.max(1, terminalRows - 2);
+    var offset = scrollOffset(s.cursor(), total, listRows);
+    var end = Math.min(offset + listRows, total);
+
     var lines = new ArrayList<String>();
-    lines.add("  " + (here.isEmpty() ? "." : here) + "  —  check files to share");
-    if (s.entries().isEmpty()) {
+    var position = total == 0 ? "0/0" : (s.cursor() + 1) + "/" + total;
+    lines.add(
+        "  " + (here.isEmpty() ? "." : here) + "  —  check files to share   (" + position + ")");
+    if (total == 0) {
       lines.add("    (empty folder)");
     }
-    for (var i = 0; i < s.entries().size(); i++) {
-      var e = s.entries().get(i);
-      var pointer = i == s.cursor() ? "›" : " ";
-      var box = s.picked().contains(e.path()) ? "[x]" : "[ ]";
-      var name = e.path().getFileName() + (e.directory() ? "/" : "");
-      var detail = e.directory() ? "" : "  " + FilePicker.humanSize(e.size());
-      lines.add(String.format("  %s %s %-28s%s", pointer, box, name, detail));
+    for (var i = offset; i < end; i++) {
+      lines.add(row(s, i));
     }
-    lines.add(
-        "  ↑↓ move · space check · → open · ← up · a all · enter/s share · q quit  ("
-            + s.picked().size()
-            + " checked)");
+    lines.add(legend(s.picked().size(), offset > 0, end < total));
     return lines;
+  }
+
+  static int scrollOffset(int cursor, int total, int listRows) {
+    if (total <= listRows) {
+      return 0;
+    }
+    var centered = cursor - listRows / 2;
+    return Math.max(0, Math.min(centered, total - listRows));
+  }
+
+  private static String row(Screen s, int i) {
+    var e = s.entries().get(i);
+    var pointer = i == s.cursor() ? "›" : " ";
+    var box = s.picked().contains(e.path()) ? "[x]" : "[ ]";
+    var name = e.path().getFileName() + (e.directory() ? "/" : "");
+    var detail = e.directory() ? "" : "  " + FilePicker.humanSize(e.size());
+    return String.format("  %s %s %-28s%s", pointer, box, name, detail);
+  }
+
+  private static String legend(int checked, boolean moreAbove, boolean moreBelow) {
+    var scroll = (moreAbove ? "↑" : " ") + (moreBelow ? "↓" : " ");
+    return "  ↑↓ move · space check · → open · ← up · a all · enter/s share · q quit  ("
+        + checked
+        + " checked) "
+        + scroll;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/FilePicker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/FilePicker.java
@@ -81,7 +81,8 @@ public final class FilePicker {
         .sorted(
             Comparator.comparing(Entry::directory)
                 .reversed()
-                .thenComparing(e -> e.path().getFileName().toString()))
+                .thenComparing(
+                    e -> e.path().getFileName().toString(), String.CASE_INSENSITIVE_ORDER))
         .toList();
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/TerminalFilePicker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/TerminalFilePicker.java
@@ -15,9 +15,11 @@ import java.util.Optional;
 
 /**
  * Drives a real terminal against the pure {@link CheckboxPicker}: puts the TTY in raw mode so arrow
- * keys and the space bar are read a keystroke at a time, redraws the checkbox list in place, and
- * always restores the terminal — on confirm, cancel, exception, or Ctrl-C. Reads the directory tree
- * through a {@link FileSource}, so it browses a host path or a container workspace identically.
+ * keys and the space bar are read a keystroke at a time, renders into the alternate screen buffer
+ * (so a big listing scrolls within a fixed, height-bounded window instead of flooding the
+ * scrollback), and always restores the terminal — on confirm, cancel, exception, or Ctrl-C. Reads
+ * the directory tree through a {@link FileSource}, so it browses a host path or a container
+ * workspace identically.
  *
  * <p>Raw mode needs an interactive terminal and the {@code stty} utility; callers gate on {@link
  * #isAvailable()} and fall back to the typed {@link FilePicker} when it returns false.
@@ -26,6 +28,8 @@ public final class TerminalFilePicker {
 
   private static final String ESC = String.valueOf((char) 27);
   private static final int IGNORED_KEY = -99;
+  private static final int FALLBACK_ROWS = 24;
+  private static final int FALLBACK_COLS = 80;
 
   private final FileSource source;
   private final Path root;
@@ -61,7 +65,7 @@ public final class TerminalFilePicker {
     Runtime.getRuntime().addShutdownHook(restore);
     try {
       stty("raw -echo");
-      out.print(ESC + "[?25l");
+      out.print(ESC + "[?1049h" + ESC + "[?25l");
       out.flush();
       return drive();
     } finally {
@@ -73,10 +77,9 @@ public final class TerminalFilePicker {
   /** The key/redraw loop, with no terminal-mode side effects, so it is testable without a TTY. */
   Optional<LinkedHashSet<Path>> drive() throws IOException {
     var picked = new LinkedHashSet<Path>();
-    var screen = CheckboxPicker.Screen.of(root, root, source.children(root), picked);
-    var previousLines = 0;
+    var screen = CheckboxPicker.Screen.of(root, root, FilePicker.list(source, root), picked);
     while (true) {
-      previousLines = draw(screen, previousLines);
+      draw(screen);
       var move = CheckboxPicker.apply(screen, CheckboxPicker.key(readKey()));
       screen = move.screen();
       switch (move.outcome()) {
@@ -94,25 +97,44 @@ public final class TerminalFilePicker {
 
   private CheckboxPicker.Screen navigate(CheckboxPicker.Screen screen, Path target) {
     try {
-      return CheckboxPicker.Screen.of(root, target, source.children(target), screen.picked());
+      return CheckboxPicker.Screen.of(
+          root, target, FilePicker.list(source, target), screen.picked());
     } catch (IOException unreadable) {
       return screen;
     }
   }
 
-  private int draw(CheckboxPicker.Screen screen, int previousLines) {
-    var lines = CheckboxPicker.render(screen);
-    var sb = new StringBuilder();
-    if (previousLines > 0) {
-      sb.append(ESC).append('[').append(previousLines).append('A');
+  private void draw(CheckboxPicker.Screen screen) {
+    var size = terminalSize();
+    var lines = CheckboxPicker.render(screen, size[0]);
+    var sb = new StringBuilder(ESC + "[H");
+    for (var i = 0; i < lines.size(); i++) {
+      sb.append(fit(lines.get(i), size[1])).append(ESC).append("[K");
+      if (i < lines.size() - 1) {
+        sb.append("\r\n");
+      }
     }
-    sb.append('\r').append(ESC).append("[0J");
-    for (var line : lines) {
-      sb.append(line).append("\r\n");
-    }
+    sb.append(ESC).append("[0J");
     out.print(sb);
     out.flush();
-    return lines.size();
+  }
+
+  static String fit(String line, int cols) {
+    return line.length() <= cols ? line : line.substring(0, Math.max(0, cols - 1)) + "…";
+  }
+
+  private int[] terminalSize() {
+    var size = stty("size").strip().split("\\s+");
+    if (size.length == 2) {
+      try {
+        return new int[] {
+          Math.max(4, Integer.parseInt(size[0])), Math.max(20, Integer.parseInt(size[1]))
+        };
+      } catch (NumberFormatException ignored) {
+        return new int[] {FALLBACK_ROWS, FALLBACK_COLS};
+      }
+    }
+    return new int[] {FALLBACK_ROWS, FALLBACK_COLS};
   }
 
   private int readKey() throws IOException {
@@ -136,7 +158,7 @@ public final class TerminalFilePicker {
   }
 
   private void restore(String saved) {
-    out.print(ESC + "[?25h");
+    out.print(ESC + "[?25h" + ESC + "[?1049l");
     out.flush();
     stty(saved);
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/CheckboxPickerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/CheckboxPickerTest.java
@@ -122,10 +122,11 @@ class CheckboxPickerTest {
   @Test
   void renderShowsCursorCheckboxesCountAndLegend() {
     var checked = CheckboxPicker.apply(screen(), CheckboxPicker.Key.TOGGLE).screen();
-    var lines = CheckboxPicker.render(checked);
+    var lines = CheckboxPicker.render(checked, 24);
     var text = String.join("\n", lines);
 
     assertTrue(text.contains("check files to share"));
+    assertTrue(text.contains("(1/2)"), "shows cursor position");
     assertTrue(text.contains("[x] a.txt"));
     assertTrue(text.contains("[ ] src/"));
     assertTrue(lines.get(1).contains("›"), "cursor points at the first row");
@@ -136,6 +137,33 @@ class CheckboxPickerTest {
   @Test
   void renderMarksAnEmptyFolder() {
     var empty = CheckboxPicker.Screen.of(ROOT, ROOT, List.of(), new LinkedHashSet<>());
-    assertTrue(String.join("\n", CheckboxPicker.render(empty)).contains("(empty folder)"));
+    assertTrue(String.join("\n", CheckboxPicker.render(empty, 24)).contains("(empty folder)"));
+  }
+
+  @Test
+  void renderNeverExceedsTheTerminalHeightAndWindowsAroundTheCursor() {
+    var entries = new java.util.ArrayList<FilePicker.Entry>();
+    for (var i = 0; i < 100; i++) {
+      entries.add(new FilePicker.Entry(ROOT.resolve("f" + i + ".txt"), false, i));
+    }
+    var deep =
+        new CheckboxPicker.Screen(ROOT, ROOT, List.copyOf(entries), 60, new LinkedHashSet<>());
+
+    var lines = CheckboxPicker.render(deep, 12);
+
+    assertTrue(lines.size() <= 12, "fits the terminal: " + lines.size());
+    var text = String.join("\n", lines);
+    assertTrue(text.contains("› [ ] f60.txt"), "the cursor row is visible");
+    assertFalse(text.contains("f0.txt"), "rows above the window are not drawn");
+    assertTrue(text.contains("(61/100)"));
+  }
+
+  @Test
+  void scrollOffsetKeepsTheCursorInViewAtBothEnds() {
+    assertEquals(0, CheckboxPicker.scrollOffset(0, 100, 10));
+    assertEquals(0, CheckboxPicker.scrollOffset(3, 100, 10));
+    assertEquals(90, CheckboxPicker.scrollOffset(99, 100, 10));
+    assertEquals(0, CheckboxPicker.scrollOffset(5, 8, 10), "no scroll when it all fits");
+    assertEquals(45, CheckboxPicker.scrollOffset(50, 100, 10), "centers mid-list");
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/TerminalFilePickerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/TerminalFilePickerTest.java
@@ -44,7 +44,7 @@ class TerminalFilePickerTest {
 
   @Test
   void checkingAFileThenConfirmingReturnsIt() throws IOException {
-    var result = picker(' ', 's').drive();
+    var result = picker(27, '[', 'B', ' ', 's').drive();
     assertTrue(result.isPresent());
     assertEquals(List.of(ROOT.resolve("a.txt")), List.copyOf(result.orElseThrow()));
   }
@@ -61,7 +61,7 @@ class TerminalFilePickerTest {
 
   @Test
   void arrowsNavigateIntoAFolderAndBackOut() throws IOException {
-    var result = picker(27, '[', 'B', 27, '[', 'C', ' ', 27, '[', 'D', 's').drive();
+    var result = picker(27, '[', 'C', ' ', 27, '[', 'D', 's').drive();
     assertTrue(result.isPresent());
     assertEquals(List.of(ROOT.resolve("src/b.txt")), List.copyOf(result.orElseThrow()));
   }
@@ -83,6 +83,14 @@ class TerminalFilePickerTest {
   @Test
   void notAvailableWithoutAnInteractiveConsole() {
     assertFalse(TerminalFilePicker.isAvailable());
+  }
+
+  @Test
+  void fitTruncatesOverlongLinesToTheTerminalWidth() {
+    assertEquals("short", TerminalFilePicker.fit("short", 80));
+    var fitted = TerminalFilePicker.fit("x".repeat(120), 40);
+    assertEquals(40, fitted.length());
+    assertTrue(fitted.endsWith("…"));
   }
 
   private record MapSource(Map<Path, List<FilePicker.Entry>> tree) implements FileSource {


### PR DESCRIPTION
## What

Makes the checkbox picker usable on a **real workspace**: a big listing no longer overflows the terminal and strands the cursor off-screen (which made the arrow keys look dead). Plus the listing is now properly **sorted and junk-filtered**.

## The bugs

1. **No viewport.** `render` emitted *every* entry every frame. When the list was taller than the terminal, the screen scrolled and the in-place redraw ("move up N lines") couldn't reach the top — the cursor moved but you couldn't see it.
2. **No sorting / no junk filter.** The picker called `source.children()` directly instead of `FilePicker.list()`, so entries came back in raw filesystem order and `.git`/`node_modules`/`target`/… were shown.

## The fix

- **Alternate screen buffer** (`ESC[?1049h`) — the picker takes over a fixed region and restores your scrollback on exit, like `less`/`vim`. No more move-up math.
- **Height-aware viewport** — `render(screen, terminalRows)` caps output to the terminal height with a scroll window that keeps the cursor centered and visible. A position indicator (`12/240`) and `↑/↓` scroll hints make movement obvious. Each line is clamped to terminal width so nothing wraps. Terminal size is re-read each frame, so it's resize-safe.
- **Listing via `FilePicker.list`** — folders first, then alphabetical (**case-insensitive**, the standard), junk dirs hidden — consistent with the typed picker.

## Tests

Pure `CheckboxPicker.render`/`scrollOffset` unit-tested for the window math, the height cap (never exceeds rows), and the position indicator; the driver's `fit` (width clamp) and scripted-keystroke navigation are covered. Full `mvn verify`: **1632 sail-infra tests green, coverage gates pass.**
