### PR TITLE
feat(specs): DB-authoritative specs — dispatch + agent + gated import + single-box DX

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
@@ -439,78 +439,45 @@ public final class AgentContextGenerator {
         """;
   }
 
-  /** Appends the spec-driven development section when a specs directory is configured. */
+  /** Appends the spec-driven development section when specs are enabled for the project. */
   private static void appendSpecSection(StringBuilder sb, SailYaml config) {
     if (config.agent() == null || config.agent().specsDir() == null) {
       return;
     }
-    var specsDir = "~/workspace/" + config.agent().specsDir();
     sb.append("\n## Spec-Driven Development\n\n");
-    sb.append("This project uses spec-driven development. ");
-    sb.append("Specs live in `").append(specsDir).append("/` (absolute path — ");
-    sb.append("not inside any repo).\n");
     sb.append(
         """
+        This project uses spec-driven development. Specs live in the **Sail database** — the shared,
+        synced source of truth — and you manage them with the `sail spec` CLI, never by editing
+        files. What you create syncs to every devbox on the project.
 
-        ### Directory Structure
-        ```
-        %s/
-        ├── oauth-flow/
-        │   ├── spec.yaml        # Metadata: id, title, status, assignee, depends_on, repo/repos, agent, branch
-        │   ├── spec.md          # Detailed specification
-        │   └── plan.md          # Optional implementation plan
-        └── search-api/
-            ├── spec.yaml
-            └── spec.md
-        ```
+        ### Working with specs
+        - `sail spec board` — kanban summary; `sail spec list [--status pending] [--assignee me]`
+        - `sail spec show <id>` — metadata, dependencies, and the full body
+        - `sail spec create --id <id> --title "<title>" --body-file <file>` — create one; add
+          `--depends-on a,b`, `--repos api,web`, `--agent codex|claude-code`, `--model <id>`,
+          `--reasoning-effort none|low|medium|high|xhigh` as the work warrants
+        - `sail spec edit <id> --status <status>` — change metadata;
+          `sail spec content <id> --set --body-file <file>` — revise the body
 
-        **Important:** Specs are managed separately from source repos. Never create a `specs/`
-        directory inside a repo. Always use the absolute path `%1$s/` for all spec operations.
-
-        ### spec.yaml Format
-        ```yaml
-        id: oauth-flow
-        title: OAuth 2.0 authorization code flow
-        status: in_progress
-        assignee: claude-code
-        depends_on: []
-        repo: app
-        agent: codex
-        model: gpt-5.5
-        reasoning_effort: high
-        branch: feat/oauth-flow
-        ```
-
-        Use `repo: <path>` for a single target repository and `repos: [api, web]` for cross-repo
-        work. The values must match `repos[].path` in `sail.yaml`. If a multi-repository
-        project omits repo targeting, `sail spec dispatch` will not auto-create a branch.
-
-        Use `agent: codex` or `agent: claude-code` when a spec should run on a specific
-        installed agent. If omitted, `sail spec dispatch` uses `agent.type` from `sail.yaml`.
-
-        Use `model` and `reasoning_effort` when the selected agent supports those controls. Codex
-        supports both; unsupported combinations fail during dispatch instead of silently falling
-        back.
+        Repo, agent, and model values must match `sail.yaml` (`repos[].path`, installed agents). In
+        a multi-repo project, set `--repos` before dispatch or `sail spec dispatch` will not
+        auto-create a branch.
 
         ### Status Lifecycle
         `pending` → `in_progress` → `review` → `done`
-        Spec status is managed by `sail`, not by you. Do not modify spec status directly during autonomous execution.
-
-        ### Interactive Mode
-        When the engineer asks you to brainstorm or write a spec:
-        1. Create a directory under `%1$s/` named after the spec id
-        2. Write `%1$s/<id>/spec.yaml` with metadata, repo targeting, and status `pending`
-        3. Write `%1$s/<id>/spec.md` with the detailed specification
+        Status is managed by `sail`, not by you. Do not change a spec's status during autonomous
+        execution.
 
         ### Dependencies
-        The `depends_on` field lists spec ids that must be `done` before this spec can start.
-        Never start a spec whose dependencies are not all `done`.
+        `--depends-on` lists spec ids that must be `done` before a spec can start. Never start a
+        spec whose dependencies are not all `done`; `sail spec dispatch` enforces this when it picks
+        the next ready spec.
 
-        ### Assignee Filtering
-        Only pick up specs where `assignee` matches your agent type.
-        Leave unassigned specs (`assignee: null`) for the engineer to assign.
-        """
-            .formatted(specsDir));
+        ### Interactive Mode
+        When the engineer asks you to brainstorm or write specs, draft each body to a temporary
+        markdown file and run `sail spec create ...`. There is no `specs/` directory to edit.
+        """);
   }
 
   /** Appends the autonomous operation section when guardrails or a task file are configured. */

--- a/sail-core/src/main/java/ai/singlr/sail/gen/SpecSkillGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/SpecSkillGenerator.java
@@ -10,12 +10,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Generates spec management skills for AI coding agents. When {@code agent.specs_dir} is
- * configured, produces agent-native skill files that teach the agent to create, list, update, and
- * display specs without manual YAML editing.
+ * Generates the spec-board skill for AI coding agents. Specs live in the Sail database — the
+ * shared, synced source of truth — so the skill teaches the agent to manage them through the {@code
+ * sail spec} CLI ({@code create}/{@code list}/{@code board}/{@code show}/{@code edit}), never by
+ * editing YAML files on disk. The CLI reaches the control-plane API over the socket already mounted
+ * in the container, so what the agent creates here syncs to every other box.
  *
  * <ul>
- *   <li>Claude Code: {@code .claude/skills/spec-board/SKILL.md} + supporting files
+ *   <li>Claude Code: {@code .claude/skills/spec-board/SKILL.md} + a spec body template
  *   <li>Codex: instructions embedded in {@code AGENTS.md} via {@link #codexInstructions}
  * </ul>
  */
@@ -24,22 +26,23 @@ public final class SpecSkillGenerator {
   private SpecSkillGenerator() {}
 
   /**
-   * Generates spec skill files for the given agent when specs are configured.
+   * Generates spec skill files for the given agent when specs are enabled for the project.
    *
    * @param agent the target agent type
-   * @param specsDir the specs directory name (e.g., "specs")
+   * @param specsDir the configured specs directory name; when {@code null}, specs are disabled and
+   *     no skill is generated. (Retained as the project's "uses specs" switch even though specs are
+   *     now stored in the database rather than this directory.)
    * @param basePath the workspace base path (e.g., {@code /home/dev/workspace/})
-   * @return generated files, empty if agent is Codex (uses inline instructions instead)
+   * @return generated files, empty if specs are disabled or the agent is Codex (inline
+   *     instructions)
    */
   public static List<GeneratedFile> generateFiles(
       AgentCli agent, String specsDir, String basePath) {
     if (specsDir == null) {
       return List.of();
     }
-    var absSpecsDir = "~/workspace/" + specsDir;
-
     return switch (agent) {
-      case CLAUDE_CODE -> claudeSkillFiles(absSpecsDir, basePath);
+      case CLAUDE_CODE -> claudeSkillFiles(basePath);
       case CODEX -> List.of();
     };
   }
@@ -48,37 +51,35 @@ public final class SpecSkillGenerator {
    * Returns spec management instructions for Codex, which has no skill system. These are appended
    * to the generated AGENTS.md content.
    *
-   * @param specsDir the specs directory name
-   * @return markdown instructions, or empty string if specsDir is null
+   * @param specsDir the configured specs directory name; {@code null} disables specs (empty string)
+   * @return markdown instructions, or empty string when specs are disabled
    */
   public static String codexInstructions(String specsDir) {
     if (specsDir == null) {
       return "";
     }
-    var absSpecsDir = "~/workspace/" + specsDir;
     return """
 
         ## Spec Management
 
-        You are the spec manager for this project. When the engineer asks you to create, list, \
-        update, or show specs, follow these instructions exactly.
+        You are the spec manager for this project. Specs live in the Sail database, not in files. \
+        When the engineer asks you to create, list, update, or show specs, use the `sail spec` CLI \
+        exactly as described below.
 
         """
-        + coreInstructions(absSpecsDir)
+        + coreInstructions()
         + specTemplate();
   }
 
-  private static List<GeneratedFile> claudeSkillFiles(String specsDir, String basePath) {
+  private static List<GeneratedFile> claudeSkillFiles(String basePath) {
     var files = new ArrayList<GeneratedFile>();
     var skillDir = basePath + ".claude/skills/spec-board/";
-
-    files.add(new GeneratedFile(skillDir + "SKILL.md", claudeSkillMd(specsDir), false));
+    files.add(new GeneratedFile(skillDir + "SKILL.md", claudeSkillMd(), false));
     files.add(new GeneratedFile(skillDir + "spec-template.md", specTemplateMd(), false));
-
     return List.copyOf(files);
   }
 
-  private static String claudeSkillMd(String specsDir) {
+  private static String claudeSkillMd() {
     return """
         ---
         name: spec-board
@@ -89,51 +90,53 @@ public final class SpecSkillGenerator {
         disable-model-invocation: true
         ---
 
-        You are the spec manager for this project. The engineer interacts with you to plan and
-        track work instead of editing YAML by hand.
+        You are the spec manager for this project. Specs live in the Sail database — the shared,
+        synced source of truth — so you manage them with the `sail spec` CLI, never by editing
+        files. Anything you create here syncs to every other devbox on the project.
 
         ## Commands
 
         ### `/spec-board list` or "show me the board"
         """
-        + listInstructions(specsDir)
+        + listInstructions()
         + """
 
         ### `/spec-board create <id> <title>` or "create a spec for ..."
         """
-        + createInstructions(specsDir)
+        + createInstructions()
         + """
 
         ### `/spec-board show <id>` or "show me the auth spec"
         """
-        + showInstructions(specsDir)
+        + showInstructions()
         + """
 
         ### `/spec-board update <id> <status>` or "move auth to in_progress"
         """
-        + updateInstructions(specsDir)
+        + updateInstructions()
         + """
 
         ### Bulk creation — "turn these into specs" or "create specs for all of these"
         """
-        + bulkCreateInstructions(specsDir)
+        + bulkCreateInstructions()
         + """
 
         ## Reference
 
         """
-        + coreReference(specsDir)
+        + coreReference()
         + """
 
-        ## Spec Template
+        ## Spec Body Template
 
-        When creating `spec.md`, use the template in [spec-template.md](spec-template.md).
+        When writing a spec body, use the template in [spec-template.md](spec-template.md).
         """;
   }
 
-  private static String listInstructions(String specsDir) {
+  private static String listInstructions() {
     return """
-        Scan `%s/*/spec.yaml` and display specs grouped by status columns:
+        Run `sail spec board` for the kanban summary, or `sail spec list` for the full set (add
+        `--status pending` or `--assignee me` to filter). Render the result as status columns:
 
         ```
         ┌─────────────┬─────────────────┬──────────────┬──────────────┐
@@ -147,158 +150,116 @@ public final class SpecSkillGenerator {
         └─────────────┴─────────────────┴──────────────┴──────────────┘
         ```
 
-        Show the title under each id. Mark specs whose dependencies are not yet met with \
-        a lock icon or note.
-        """
-        .formatted(specsDir);
+        Show the title under each id. The board marks the next ready spec; flag specs whose \
+        dependencies are not yet done as blocked.
+        """;
   }
 
-  private static String createInstructions(String specsDir) {
+  private static String createInstructions() {
     return """
-        1. Derive an id from the title (lowercase, hyphens, e.g., "OAuth Flow" → `oauth-flow`)
-        2. Create directory `%1$s/<id>/`
-        3. Write `%1$s/<id>/spec.yaml`:
-           ```yaml
-           id: <id>
-           title: "<title>"
-           status: pending
-           depends_on: []
-           repo: <repo-path>
-           agent: <claude-code|codex>
-           model: <model-id>
-           reasoning_effort: <none|low|medium|high|xhigh>
+        1. Derive an id from the title (lowercase, hyphens, e.g., "OAuth Flow" → `oauth-flow`).
+        2. Write the spec body to a temporary markdown file using the spec template, e.g. \
+        `/tmp/<id>.md`.
+        3. Create the spec in the database:
+           ```sh
+           sail spec create --id <id> --title "<title>" --body-file /tmp/<id>.md
            ```
-        4. Write `%1$s/<id>/spec.md` using the spec template
-        5. Confirm: "Created spec `<id>` — fill in the details in `%1$s/<id>/spec.md`"
+           Add options as the conversation warrants:
+           - `--depends-on a,b` — spec ids that must be `done` first
+           - `--repos repo-a,repo-b` — target repos (must match `repos[].path` in `sail.yaml`)
+           - `--agent codex|claude-code` — overrides the project default
+           - `--model <id>` `--reasoning-effort none|low|medium|high|xhigh` — for agents that \
+        support them
+        4. Confirm: "Created spec `<id>`."
 
-        If the engineer provided detailed requirements during the conversation, fill in the \
-        spec.md with those details instead of leaving placeholders.
-
-        Ask the engineer if this spec depends on any existing specs, and set `depends_on` \
-        accordingly.
-
-        Ask which repository the spec targets when the project has multiple repos. Use \
-        `repo: <path>` for one repo and `repos: [repo-a, repo-b]` for cross-repo work. \
-        Values must match `repos[].path` in `sail.yaml`.
-
-        Ask which agent should execute the spec when the project has multiple installed agents. \
-        Use `agent: codex` or `agent: claude-code`. If omitted, Sail uses `agent.type` from \
-        `sail.yaml`.
-
-        Ask which model and reasoning effort to use when the selected agent supports them. \
-        For Codex, use `model: gpt-5.5` and `reasoning_effort: high` when the engineer wants \
-        GPT-5.5 with high reasoning.
-        """
-        .formatted(specsDir);
+        If the engineer gave detailed requirements in the conversation, write them into the body \
+        file instead of leaving placeholders. Ask which repo, agent, model, and dependencies apply \
+        when the project's configuration makes them relevant.
+        """;
   }
 
-  private static String showInstructions(String specsDir) {
+  private static String showInstructions() {
     return """
-        1. Read `%s/<id>/spec.yaml`
-        2. Read `%s/<id>/spec.md`
-        3. Display metadata, dependencies, and the full markdown content
-        """
-        .formatted(specsDir, specsDir);
+        Run `sail spec show <id>` — it prints the metadata, dependencies, and the full body. Use
+        `--json` if you need to parse fields.
+        """;
   }
 
-  private static String updateInstructions(String specsDir) {
+  private static String updateInstructions() {
     return """
-        Valid statuses: `pending`, `in_progress`, `review`, `done`
+        Valid statuses: `pending`, `in_progress`, `review`, `done`.
 
-        1. Read `%1$s/<id>/spec.yaml`
-        2. Update the `status` field
-        3. Write the updated `%1$s/<id>/spec.yaml`
-        4. Confirm: "Updated `<id>` → `<new-status>`"
-        """
-        .formatted(specsDir);
+        ```sh
+        sail spec edit <id> --status <new-status>
+        ```
+
+        Confirm: "Updated `<id>` → `<new-status>`". To revise the body, write the new markdown to a
+        temp file and run `sail spec content <id> --set --body-file /tmp/<id>.md`.
+        """;
   }
 
-  private static String bulkCreateInstructions(String specsDir) {
+  private static String bulkCreateInstructions() {
     return """
         When the engineer has brainstormed multiple features or tasks and wants to turn them \
         into specs:
 
-        1. Extract each distinct unit of work from the conversation
-        2. For each, derive an id and title
-        3. Infer dependencies from the natural ordering and relationships discussed
-        4. Create each `%s/<id>/spec.yaml` and `%s/<id>/spec.md`
-        5. Show the resulting board view
+        1. Extract each distinct unit of work from the conversation.
+        2. For each, derive an id and title and write a body file.
+        3. Infer dependencies from the natural ordering discussed and pass them via `--depends-on`.
+        4. Run one `sail spec create` per unit.
+        5. Show the resulting board with `sail spec board`.
 
         This is the primary daytime workflow: brainstorm with the engineer, then materialize \
         the plan into specs with one confirmation.
-        """
-        .formatted(specsDir, specsDir);
+        """;
   }
 
-  private static String coreReference(String specsDir) {
+  private static String coreReference() {
     return """
-        ### spec.yaml Format
-        ```yaml
-        id: oauth-flow
-        title: OAuth 2.0 authorization code flow
-        status: in_progress
-        assignee: claude-code
-        depends_on: []
-        repo: app
-        agent: codex
-        model: gpt-5.5
-        reasoning_effort: high
-        branch: feat/oauth-flow
+        ### Creating a spec
+        ```sh
+        sail spec create --id oauth-flow --title "OAuth 2.0 authorization code flow" \\
+          --body-file /tmp/oauth-flow.md --depends-on data-model --repos app --agent codex \\
+          --model gpt-5.5 --reasoning-effort high
         ```
 
         ### Status Lifecycle
         `pending` → `in_progress` → `review` → `done`
         - **pending**: ready to be picked up
-        - **in_progress**: agent is actively working on it (set by `sail spec dispatch`)
+        - **in_progress**: an agent is actively working on it (set by `sail spec dispatch`)
         - **review**: PR created, waiting for human review (set by `sail`)
-        - **done**: PR merged, work complete (set by engineer via `sail`)
-        Status is managed by `sail`, not by the agent. Do not modify status directly during autonomous execution.
+        - **done**: PR merged, work complete (set by the engineer via `sail`)
 
-        ### Important
-        Specs live at `%1$s/` — an absolute path in the workspace root, NOT inside any repo.
-        Never create a `specs/` directory inside a source repository.
+        During autonomous execution Sail manages status itself — do not change it. The engineer's
+        `/spec-board update` is the exception, when they explicitly ask to move a spec.
 
-        ### Fields
-        - **id** (required): directory name, lowercase with hyphens
+        ### Fields (set at create or via `sail spec edit`)
+        - **id** (required): stable identifier, lowercase with hyphens
         - **title** (required): short human-readable description
-        - **status** (required): one of pending, in_progress, review, done
-        - **assignee** (optional): agent type or engineer name
-        - **depends_on** (optional): list of spec ids that must be done first
-        - **repo** (optional): single target repository path from `sail.yaml` `repos[].path`
-        - **repos** (optional): list of target repository paths for cross-repo work
-        - **agent** (optional): agent CLI for this spec (`claude-code` or `codex`)
-        - **model** (optional): model id for agents that support model selection
-        - **reasoning_effort** (optional): `none`, `low`, `medium`, `high`, or `xhigh`
-        - **branch** (optional): git branch name for this spec's work
+        - **status**: one of pending, in_progress, review, done
+        - **assignee**: agent type or engineer name
+        - **depends-on**: spec ids that must be done first
+        - **repos**: target repository paths from `sail.yaml` `repos[].path`
+        - **agent**: agent CLI for this spec (`claude-code` or `codex`)
+        - **model** / **reasoning-effort**: for agents that support them
+        - **branch**: git branch name for this spec's work
 
-        In multi-repo projects, always include `repo` or `repos` before dispatch so Sail can \
-        create the branch in the right repository. If omitted, dispatch only auto-branches when \
-        the project has exactly one configured repo.
-
-        In multi-agent projects, include `agent` when a spec should run on a non-default agent. \
-        If omitted, dispatch uses `agent.type` from `sail.yaml`.
-
-        Include `model` and `reasoning_effort` only for agents that support them. Sail passes \
-        these to Codex and rejects unsupported combinations for other agents.
-
-        ### Directory Structure
-        ```
-        %s/
-        └── <spec-id>/
-            ├── spec.yaml     # Metadata
-            ├── spec.md       # Detailed specification
-            └── plan.md       # Optional implementation plan
-        ```
+        In multi-repo projects, always set `--repos` before dispatch so Sail branches the right
+        repository. In multi-agent projects, set `--agent` when a spec should run on a non-default
+        agent; otherwise dispatch uses `agent.type` from `sail.yaml`.
 
         ### Dependency Rules
-        A spec cannot be started if any of its `depends_on` specs are not `done`.
-        When listing specs, visually indicate which pending specs are blocked.
-        """
-        .formatted(specsDir, specsDir);
+        A spec cannot be started until every id in its `depends-on` is `done`. When listing specs,
+        visually indicate which pending specs are blocked.
+
+        ### Where specs live
+        Specs are rows in the Sail database, replicated across devboxes by `sail sync`. There is no
+        `specs/` directory to edit — always go through `sail spec`.
+        """;
   }
 
   private static String specTemplate() {
-    return "When creating a new `spec.md`, use this structure:\n\n```markdown\n"
+    return "When writing a spec body, use this structure:\n\n```markdown\n"
         + specTemplateMd()
         + "```\n";
   }
@@ -335,12 +296,12 @@ public final class SpecSkillGenerator {
         """;
   }
 
-  private static String coreInstructions(String specsDir) {
-    return listInstructions(specsDir)
-        + createInstructions(specsDir)
-        + showInstructions(specsDir)
-        + updateInstructions(specsDir)
-        + bulkCreateInstructions(specsDir)
-        + coreReference(specsDir);
+  private static String coreInstructions() {
+    return listInstructions()
+        + createInstructions()
+        + showInstructions()
+        + updateInstructions()
+        + bulkCreateInstructions()
+        + coreReference();
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/gen/AgentContextGeneratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/gen/AgentContextGeneratorTest.java
@@ -1200,16 +1200,15 @@ class AgentContextGeneratorTest {
     var md = AgentContextGenerator.generateClaudeMd(config);
 
     assertTrue(md.contains("## Spec-Driven Development"));
-    assertTrue(md.contains("specs/"));
-    assertTrue(md.contains("spec.yaml"));
-    assertTrue(md.contains("spec.md"));
+    assertTrue(md.contains("Sail database"));
+    assertTrue(md.contains("sail spec create"));
+    assertTrue(md.contains("sail spec board"));
     assertTrue(md.contains("Status Lifecycle"));
     assertTrue(md.contains("pending"));
     assertTrue(md.contains("in_progress"));
-    assertTrue(md.contains("depends_on"));
-    assertTrue(md.contains("Assignee Filtering"));
+    assertTrue(md.contains("depends-on"));
     assertTrue(md.contains("Interactive Mode"));
-    assertTrue(md.contains("not inside any repo"));
+    assertFalse(md.contains("spec.yaml"), "specs are DB rows, not files");
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/gen/SpecSkillGeneratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/gen/SpecSkillGeneratorTest.java
@@ -44,12 +44,14 @@ class SpecSkillGeneratorTest {
   }
 
   @Test
-  void claudeSkillMdReferencesSpecsDir() {
+  void claudeSkillMdManagesSpecsThroughTheCliNotFiles() {
     var files = SpecSkillGenerator.generateFiles(AgentCli.CLAUDE_CODE, "my-specs", BASE);
     var content = files.get(0).content();
 
-    assertTrue(content.contains("my-specs/<id>/spec.yaml"));
-    assertTrue(content.contains("my-specs/<id>/spec.md"));
+    assertTrue(content.contains("sail spec create"));
+    assertTrue(content.contains("sail spec board"));
+    assertTrue(content.contains("sail spec edit"));
+    assertFalse(content.contains("spec.yaml"), "specs are DB rows, not files");
   }
 
   @Test
@@ -111,8 +113,8 @@ class SpecSkillGeneratorTest {
 
     assertFalse(instructions.isEmpty());
     assertTrue(instructions.contains("Spec Management"));
-    assertTrue(instructions.contains("specs/<id>/spec.yaml"));
-    assertTrue(instructions.contains("spec.md"));
+    assertTrue(instructions.contains("sail spec create"));
+    assertFalse(instructions.contains("spec.yaml"), "specs are DB rows, not files");
   }
 
   @Test
@@ -143,14 +145,14 @@ class SpecSkillGeneratorTest {
   }
 
   @Test
-  void customSpecsDirIsUsedInAllAgents() {
-    var customDir = "work-items";
+  void specsDirOnlyGatesGenerationItDoesNotLeakIntoContent() {
+    var claude = SpecSkillGenerator.generateFiles(AgentCli.CLAUDE_CODE, "work-items", BASE);
+    assertTrue(claude.get(0).content().contains("sail spec create"));
+    assertFalse(claude.get(0).content().contains("work-items"));
 
-    var claude = SpecSkillGenerator.generateFiles(AgentCli.CLAUDE_CODE, customDir, BASE);
-    assertTrue(claude.get(0).content().contains("work-items/<id>/spec.yaml"));
-
-    var codex = SpecSkillGenerator.codexInstructions(customDir);
-    assertTrue(codex.contains("work-items/<id>/spec.yaml"));
+    var codex = SpecSkillGenerator.codexInstructions("work-items");
+    assertTrue(codex.contains("sail spec create"));
+    assertFalse(codex.contains("work-items"));
   }
 
   @Test
@@ -166,7 +168,7 @@ class SpecSkillGeneratorTest {
     var files = SpecSkillGenerator.generateFiles(AgentCli.CLAUDE_CODE, "specs", BASE);
     var content = files.get(0).content();
 
-    assertTrue(content.contains("depends_on"));
+    assertTrue(content.contains("depends-on"));
     assertTrue(content.contains("blocked"));
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
@@ -11,7 +11,6 @@ import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.BranchPolicy;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
-import ai.singlr.sail.config.SpecAuditEvent;
 import ai.singlr.sail.config.SpecDirectory;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.config.YamlUtil;
@@ -30,8 +29,8 @@ import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SnapshotManager;
-import ai.singlr.sail.engine.SpecAudit;
-import ai.singlr.sail.engine.SpecWorkspace;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
@@ -45,9 +44,10 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 /**
- * Dispatches the next ready spec to an agent for autonomous execution. Reads per-spec metadata from
- * the container, finds the next pending spec, reads its {@code spec.md}, and launches the
- * configured agent.
+ * Dispatches the next ready spec to an agent for autonomous execution. Reads the project's specs
+ * from the control-plane database (the source of truth, replicated by sync), picks the next ready
+ * one, marks it {@code in_progress}, and launches the configured agent with its body — so a stopped
+ * or file-drifted container never blocks dispatch.
  */
 @Command(
     name = "dispatch",
@@ -90,7 +90,7 @@ public final class DispatchCommand implements Runnable {
       names = "--restart",
       description =
           "Re-dispatch a spec whose status is not 'pending'. Requires --spec. Resets status to"
-              + " pending and records a 'restarted' audit event before dispatching.")
+              + " pending and records a 'restarted' lifecycle event before dispatching.")
   private boolean restart;
 
   @Option(
@@ -132,22 +132,11 @@ public final class DispatchCommand implements Runnable {
     }
     var config = SailYaml.fromMap(YamlUtil.parseFile(singYamlPath));
 
-    if (config.agent() == null || config.agent().specsDir() == null) {
-      throw new IllegalStateException(
-          "No specs_dir configured in agent block. Add it to sail.yaml.");
+    if (config.agent() == null) {
+      throw new IllegalStateException("No agent configured in sail.yaml's agent block.");
     }
 
     var sshUser = config.sshUser();
-    var specsDir = "/home/" + sshUser + "/workspace/" + config.agent().specsDir();
-    var specWorkspace = new SpecWorkspace(shell, name, specsDir);
-    var specAudit = new SpecAudit(shell, name, specsDir);
-    var host = HostInfo.hostname();
-
-    var specs = specWorkspace.readSpecs();
-    if (specs.isEmpty()) {
-      printNoSpecs();
-      return;
-    }
 
     var agentSession = new AgentSession(shell);
     var existingSession = agentSession.queryStatus(name);
@@ -161,19 +150,19 @@ public final class DispatchCommand implements Runnable {
               + name);
     }
 
-    var resolution = resolveSpec(specId, restart, specs, specWorkspace, specAudit, host);
-    var nextSpec = resolution.spec();
-    if (nextSpec == null) {
+    var prepared = prepareDispatch(name, specId, restart);
+    if (prepared == null) {
       printNoSpecs();
       return;
     }
+    var resolution = prepared.resolution();
+    var nextSpec = resolution.spec();
+    var specBody = prepared.body();
 
     var agentType = nextSpec.agent() != null ? nextSpec.agent() : config.agent().type();
     var targetRepos = DispatchRepos.resolve(config, nextSpec, repoOverrides);
     var taskSpec = DispatchRepos.withTargetRepos(nextSpec, targetRepos);
     var branchName = BranchPolicy.branchName(config, nextSpec);
-    specWorkspace.updateStatus(nextSpec.id(), "in_progress");
-    specAudit.append(nextSpec.id(), SpecAuditEvent.dispatched(agentType, host, null));
 
     if (resolution.restarted()) {
       publishLifecycle(
@@ -186,7 +175,6 @@ public final class DispatchCommand implements Runnable {
         nextSpec.id(),
         dispatchedEventData(branchName, background));
 
-    var specBody = Objects.requireNonNullElse(specWorkspace.readSpecBody(nextSpec.id()), "");
     var description = !specBody.isBlank() ? specBody : nextSpec.title();
     var task = AgentTaskPrompt.build(taskSpec, description);
 
@@ -349,21 +337,64 @@ public final class DispatchCommand implements Runnable {
     }
   }
 
+  /** What {@link #prepareDispatch} produces: the resolved spec and its body, both from the DB. */
+  record Prepared(SpecResolution resolution, String body) {}
+
+  /**
+   * Reads the project's specs from the control-plane database — the source of truth — picks the one
+   * to dispatch, marks it {@code in_progress}, and returns it with its body. Returns {@code null}
+   * when the project has no specs or none are ready. The container is never read: a stopped or
+   * file-drifted project is irrelevant because the spec lives in the DB, replicated by sync.
+   */
+  private Prepared prepareDispatch(String project, String specId, boolean restart) {
+    try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+      var store = new SpecStore(db);
+      var specs = projectSpecs(store, project);
+      if (specs.isEmpty()) {
+        return null;
+      }
+      var resolution = resolveSpec(specId, restart, specs, store);
+      if (resolution.spec() == null) {
+        return null;
+      }
+      store.updateStatus(resolution.spec().id(), SpecStatus.IN_PROGRESS);
+      var body =
+          store.getContent(resolution.spec().id()).map(SpecStore.SpecContent::body).orElse("");
+      return new Prepared(resolution, body);
+    }
+  }
+
+  /** Every spec bucketed to this project, mapped from its stored row to the config value type. */
+  static List<Spec> projectSpecs(SpecStore store, String project) {
+    return store.list(new SpecStore.SpecFilter(project, null, null, null, null)).stream()
+        .map(DispatchCommand::toSpec)
+        .toList();
+  }
+
+  private static Spec toSpec(SpecStore.SpecRow row) {
+    return new Spec(
+        row.id(),
+        row.project(),
+        row.title(),
+        row.status(),
+        row.assignee(),
+        row.dependsOn(),
+        row.repos(),
+        row.agent(),
+        row.model(),
+        row.reasoningEffort(),
+        row.branch());
+  }
+
   /**
    * Picks the spec to dispatch. Enforces that {@code --spec} only targets pending specs unless
-   * {@code --restart} is set, in which case the spec's status is reset to {@code pending} and a
-   * {@code restarted} audit event is appended. Returns a {@link SpecResolution} so the caller can
-   * distinguish "picked next pending" from "reset a non-pending spec" without re-querying the
-   * workspace.
+   * {@code --restart} is set, in which case the spec's status is reset to {@code pending} in the
+   * DB. Returns a {@link SpecResolution} so the caller can distinguish "picked next pending" from
+   * "reset a non-pending spec" and publish the matching lifecycle event (which is the durable audit
+   * trail).
    */
   static SpecResolution resolveSpec(
-      String specId,
-      boolean restart,
-      List<Spec> specs,
-      SpecWorkspace workspace,
-      SpecAudit audit,
-      String host)
-      throws Exception {
+      String specId, boolean restart, List<Spec> specs, SpecStore store) {
     if (specId == null) {
       var next = SpecDirectory.nextReady(specs);
       return next == null ? SpecResolution.none() : SpecResolution.of(next);
@@ -382,13 +413,9 @@ public final class DispatchCommand implements Runnable {
               + "' is not pending (current status: "
               + found.status().wire()
               + "). A spec is dispatched only when pending. To dispatch it again, pass --restart"
-              + " (this resets status to pending and records the restart in audit.jsonl).");
+              + " (this resets status to pending and records the restart as a lifecycle event).");
     }
-    workspace.updateStatus(specId, "pending");
-    audit.append(
-        specId,
-        SpecAuditEvent.restarted(
-            SpecAuditEvent.SAIL_AGENT, host, "restarted from " + found.status().wire()));
+    store.updateStatus(specId, SpecStatus.PENDING);
     return SpecResolution.restarted(found, found.status().wire());
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostSync.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostSync.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.HostYaml;
+import ai.singlr.sail.config.SyncConfig;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.SailPaths;
+import java.io.IOException;
+import java.nio.file.Files;
+
+/**
+ * This box's sync role, read from {@code host.yaml}, and the questions the rest of the CLI asks of
+ * it: does it have a peer at all, and which suffix should a "shared/changed" message carry. Sync is
+ * opt-in, so a lone box answers "standalone" — no main to configure, nothing to propagate, and the
+ * commands that mention {@code sail sync} stay quiet rather than nagging about a step that does not
+ * apply.
+ */
+final class HostSync {
+
+  private HostSync() {}
+
+  /** This box's configured sync role, or {@link SyncConfig#unset()} when none is set. */
+  static SyncConfig config() {
+    var path = SailPaths.hostConfigPath();
+    if (!Files.exists(path)) {
+      return SyncConfig.unset();
+    }
+    try {
+      return HostYaml.fromMap(YamlUtil.parseFile(path)).sync();
+    } catch (IOException e) {
+      return SyncConfig.unset();
+    }
+  }
+
+  /** A box with a sync peer: it is the main hub, or it points at one. */
+  static boolean hasPeers(SyncConfig sync) {
+    return sync.isMain() || Strings.isNotBlank(sync.main());
+  }
+
+  /** A lone box — no role, no main; sync and propagation are meaningless here. */
+  static boolean isStandalone(SyncConfig sync) {
+    return !hasPeers(sync);
+  }
+
+  /** A box that initiates sync: a node points at a main and pushes to it. */
+  static boolean isNode(SyncConfig sync) {
+    return Strings.isNotBlank(sync.main());
+  }
+
+  /**
+   * The trailing hint after a "shared/changed" message: a node is told to run sync; a main is told
+   * peers will pull; a standalone box is told nothing.
+   */
+  static String propagationHint(SyncConfig sync) {
+    if (isNode(sync)) {
+      return "Run sail sync to propagate.";
+    }
+    if (sync.isMain()) {
+      return "Other boxes pull it on their next sync.";
+    }
+    return "";
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.commands;
 
 import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.SyncConfig;
 import ai.singlr.sail.engine.AuthorizedKeysSync;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerSpecImporter;
@@ -96,7 +97,12 @@ public final class MigrateCommand implements Runnable {
       var animate = !jsonOutput && System.console() != null;
       var runs =
           applyMigrations(
-              db, dbPath.toString(), importer::importAll, prompter, animate, jsonOutput);
+              db,
+              dbPath.toString(),
+              specImportStep(importer, dbPath.resolveSibling("spec-import.done")),
+              prompter,
+              animate,
+              jsonOutput);
       importProjects(db, jsonOutput);
       importFiles(db, jsonOutput);
       relocateHostConfig(jsonOutput);
@@ -215,6 +221,38 @@ public final class MigrateCommand implements Runnable {
           dbPath, result.schemaBefore(), result.schemaAfter(), importReport, result.dataRuns());
     }
     return result.dataRuns();
+  }
+
+  /**
+   * Gates the container spec scan: it runs only on a standalone box that has not run it before. A
+   * main or node never scans — its specs arrive over sync (node) or are authored in its own DB
+   * (main) — and the {@code spec-import.done} marker makes even a standalone box a one-time
+   * backfill, not a per-upgrade re-probe. The DB is the source of truth; this only rescues pre-DB
+   * file specs.
+   */
+  static Supplier<ContainerSpecImporter.Report> specImportStep(
+      ContainerSpecImporter importer, Path marker) {
+    return specImportStep(importer, marker, HostSync.config());
+  }
+
+  static Supplier<ContainerSpecImporter.Report> specImportStep(
+      ContainerSpecImporter importer, Path marker, SyncConfig sync) {
+    if (!HostSync.isStandalone(sync) || Files.exists(marker)) {
+      return ContainerSpecImporter.Report::empty;
+    }
+    return () -> {
+      var report = importer.importAll();
+      markImportDone(marker);
+      return report;
+    };
+  }
+
+  private static void markImportDone(Path marker) {
+    try {
+      Files.writeString(marker, "done");
+    } catch (Exception ignored) {
+      return;
+    }
   }
 
   private static <T> T phase(boolean animate, String message, Supplier<T> work) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
@@ -148,7 +148,8 @@ public final class ProjectFilesCommand implements Runnable {
                     + path
                     + "|@ on @|bold "
                     + project
-                    + "|@. Run @|bold sail sync|@ to propagate."));
+                    + "|@."
+                    + propagationSuffix()));
       }
       return 0;
     }
@@ -258,7 +259,8 @@ public final class ProjectFilesCommand implements Runnable {
                   + shared
                   + "|@ file(s) on @|bold "
                   + project
-                  + "|@. Run @|bold sail sync|@ to propagate."));
+                  + "|@."
+                  + propagationSuffix()));
       return 0;
     }
 
@@ -411,9 +413,7 @@ public final class ProjectFilesCommand implements Runnable {
       }
       System.out.println(
           Ansi.AUTO.string(
-              "  @|green ✓|@ Stopped sharing @|bold "
-                  + path
-                  + "|@. Run @|bold sail sync|@ to propagate."));
+              "  @|green ✓|@ Stopped sharing @|bold " + path + "|@." + propagationSuffix()));
       return 0;
     }
 
@@ -491,5 +491,11 @@ public final class ProjectFilesCommand implements Runnable {
 
   private static int decodedSize(String base64) {
     return Base64.getDecoder().decode(base64).length;
+  }
+
+  /** A leading-space propagation hint, or empty on a standalone box where sync does not apply. */
+  static String propagationSuffix() {
+    var hint = HostSync.propagationHint(HostSync.config());
+    return hint.isEmpty() ? "" : " " + hint;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
@@ -8,7 +8,6 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.api.Event;
 import ai.singlr.sail.api.SailEventPublisher;
 import ai.singlr.sail.common.Strings;
-import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SyncConfig;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
@@ -28,7 +27,6 @@ import ai.singlr.sail.sync.SpecReplica;
 import ai.singlr.sail.sync.SyncEngine;
 import ai.singlr.sail.sync.SyncSession;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -88,13 +86,12 @@ public final class SyncCommand implements Callable<Integer> {
           Banner.errorLine("--interval must be a positive number of seconds.", Ansi.AUTO));
       return 1;
     }
-    String target;
-    try {
-      target = resolveMain(main, hostSync());
-    } catch (IllegalStateException e) {
-      System.err.println(Banner.errorLine(e.getMessage(), Ansi.AUTO));
-      return 1;
+    var resolution = resolveMain(main, HostSync.config());
+    if (resolution.target() == null) {
+      System.out.println(Ansi.AUTO.string("  @|faint " + resolution.message() + "|@"));
+      return 0;
     }
+    var target = resolution.target();
     try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
       var host = HostInfo.hostname();
       var changeLog = new ChangeLog(db);
@@ -113,36 +110,27 @@ public final class SyncCommand implements Callable<Integer> {
 
   private record Boxes(SpecReplica spec, FileReplica file, FdeStore fdes, FileStore files) {}
 
-  /** The main target: the {@code --main} flag if given, else the configured one. */
-  static String resolveMain(String flag, SyncConfig sync) {
+  /**
+   * Where this box syncs to. A non-null {@link MainTarget#target()} means reconcile against it; a
+   * null target with a {@link MainTarget#message()} means there is nothing to sync — a single box,
+   * or the main hub itself — which the caller reports as friendly info, not an error.
+   */
+  record MainTarget(String target, String message) {}
+
+  static MainTarget resolveMain(String flag, SyncConfig sync) {
     if (Strings.isNotBlank(flag)) {
-      return flag;
+      return new MainTarget(flag, null);
+    }
+    if (Strings.isNotBlank(sync.main())) {
+      return new MainTarget(sync.main(), null);
     }
     if (sync.isMain()) {
-      return throwUnresolved("This box is the main devbox; it has nothing to sync to.");
+      return new MainTarget(
+          null, "This box is the main devbox — other boxes sync to it; it has nothing to sync to.");
     }
-    if (sync.main() != null) {
-      return sync.main();
-    }
-    return throwUnresolved(
-        "No main devbox configured. Set one with: sudo sail host sync --main <user@host>,"
-            + " or pass --main.");
-  }
-
-  private static String throwUnresolved(String message) {
-    throw new IllegalStateException(message);
-  }
-
-  private static SyncConfig hostSync() {
-    var path = SailPaths.hostConfigPath();
-    if (!Files.exists(path)) {
-      return SyncConfig.unset();
-    }
-    try {
-      return HostYaml.fromMap(YamlUtil.parseFile(path)).sync();
-    } catch (IOException e) {
-      return SyncConfig.unset();
-    }
+    return new MainTarget(
+        null,
+        "Single devbox — nothing to sync. Add a second box with: sail host sync --main <user@host>.");
   }
 
   private int runOnce(Boxes boxes, String target) throws Exception {

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandResolveSpecTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandResolveSpecTest.java
@@ -7,187 +7,158 @@ package ai.singlr.sail.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;
-import ai.singlr.sail.engine.ScriptedShellExecutor;
-import ai.singlr.sail.engine.ShellExec;
-import ai.singlr.sail.engine.SpecAudit;
-import ai.singlr.sail.engine.SpecWorkspace;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+/** Resolution now reads from the control-plane DB, so a stopped container never blocks dispatch. */
 class DispatchCommandResolveSpecTest {
 
   private static final String PROJECT = "acme-health";
-  private static final String SPECS_DIR = "/home/dev/workspace/specs";
-  private static final String HOST = "sail-host-01";
+
+  @TempDir Path dbDir;
+
+  private SpecStore store() {
+    var db = Sqlite.open(dbDir.resolve("sail.db"));
+    new SchemaManager(db).migrate();
+    return new SpecStore(db);
+  }
+
+  private static SpecStore.SpecRow row(String id, String status) {
+    return new SpecStore.SpecRow(
+        id,
+        PROJECT,
+        "Title for " + id,
+        SpecStatus.fromWire(status),
+        null,
+        null,
+        null,
+        null,
+        null,
+        0,
+        "me",
+        null,
+        null,
+        "me",
+        List.of(),
+        List.of());
+  }
+
+  private List<Spec> specsOf(SpecStore store) {
+    return DispatchCommand.projectSpecs(store, PROJECT);
+  }
 
   @Test
-  void autoSelectsNextPendingWhenNoSpecGiven() throws Exception {
-    var specs =
-        List.of(
-            specWith("done-spec", "done"),
-            specWith("oauth-flow", "pending"),
-            specWith("next-pending", "pending"));
-    var workspace = workspace(new ScriptedShellExecutor());
-    var audit = audit(new ScriptedShellExecutor());
+  void autoSelectsTheNextPendingWhenNoSpecGiven() {
+    var store = store();
+    store.create(row("done-spec", "done"));
+    store.create(row("oauth-flow", "pending"));
 
-    var resolution = DispatchCommand.resolveSpec(null, false, specs, workspace, audit, HOST);
+    var resolution = DispatchCommand.resolveSpec(null, false, specsOf(store), store);
 
-    assertNotNull(resolution.spec());
     assertEquals("oauth-flow", resolution.spec().id());
     assertFalse(resolution.restarted());
     assertNull(resolution.previousStatus());
   }
 
   @Test
-  void autoSelectReturnsNullSpecWhenNoPendingSpecs() throws Exception {
-    var specs = List.of(specWith("done-spec", "done"));
-    var workspace = workspace(new ScriptedShellExecutor());
-    var audit = audit(new ScriptedShellExecutor());
+  void autoSelectReturnsNullSpecWhenNothingIsPending() {
+    var store = store();
+    store.create(row("done-spec", "done"));
 
-    var resolution = DispatchCommand.resolveSpec(null, false, specs, workspace, audit, HOST);
+    var resolution = DispatchCommand.resolveSpec(null, false, specsOf(store), store);
 
     assertNull(resolution.spec());
     assertFalse(resolution.restarted());
   }
 
   @Test
-  void explicitSpecPassesWhenPending() throws Exception {
-    var specs = List.of(specWith("oauth-flow", "pending"));
-    var workspace = workspace(new ScriptedShellExecutor());
-    var audit = audit(new ScriptedShellExecutor());
+  void explicitSpecPassesWhenPending() {
+    var store = store();
+    store.create(row("oauth-flow", "pending"));
 
-    var resolution =
-        DispatchCommand.resolveSpec("oauth-flow", false, specs, workspace, audit, HOST);
+    var resolution = DispatchCommand.resolveSpec("oauth-flow", false, specsOf(store), store);
 
     assertEquals("oauth-flow", resolution.spec().id());
     assertFalse(resolution.restarted());
   }
 
   @Test
-  void explicitSpecPassesWithRestartFlagEvenWhenPendingWithoutSideEffects() throws Exception {
-    var specs = List.of(specWith("oauth-flow", "pending"));
-    var shell = new ScriptedShellExecutor();
+  void explicitPendingSpecWithRestartIsANoOp() {
+    var store = store();
+    store.create(row("oauth-flow", "pending"));
 
-    var resolution =
-        DispatchCommand.resolveSpec(
-            "oauth-flow", true, specs, workspace(shell), audit(shell), HOST);
+    var resolution = DispatchCommand.resolveSpec("oauth-flow", true, specsOf(store), store);
 
     assertEquals("oauth-flow", resolution.spec().id());
-    assertFalse(resolution.restarted(), "pending spec already pending — nothing to restart");
-    assertTrue(shell.invocations().isEmpty(), "pending spec + --restart should be a no-op");
+    assertFalse(resolution.restarted(), "already pending — nothing to restart");
+    assertEquals(SpecStatus.PENDING, store.findById("oauth-flow").orElseThrow().status());
   }
 
   @Test
   void unknownSpecThrowsIllegalArgument() {
-    var specs = List.of(specWith("oauth-flow", "pending"));
-    var workspace = workspace(new ScriptedShellExecutor());
-    var audit = audit(new ScriptedShellExecutor());
+    var store = store();
+    store.create(row("oauth-flow", "pending"));
 
     var ex =
         assertThrows(
             IllegalArgumentException.class,
-            () -> DispatchCommand.resolveSpec("nope", false, specs, workspace, audit, HOST));
+            () -> DispatchCommand.resolveSpec("nope", false, specsOf(store), store));
     assertTrue(ex.getMessage().contains("nope"));
   }
 
   @Test
   void nonPendingSpecWithoutRestartThrowsHelpfulError() {
-    var specs = List.of(specWith("oauth-flow", "in_progress"));
-    var workspace = workspace(new ScriptedShellExecutor());
-    var audit = audit(new ScriptedShellExecutor());
+    var store = store();
+    store.create(row("oauth-flow", "in_progress"));
 
     var ex =
         assertThrows(
             IllegalStateException.class,
-            () -> DispatchCommand.resolveSpec("oauth-flow", false, specs, workspace, audit, HOST));
+            () -> DispatchCommand.resolveSpec("oauth-flow", false, specsOf(store), store));
     assertTrue(ex.getMessage().contains("oauth-flow"));
     assertTrue(ex.getMessage().contains("in_progress"));
     assertTrue(ex.getMessage().contains("--restart"));
   }
 
   @Test
-  void doneSpecWithoutRestartThrows() {
-    var specs = List.of(specWith("oauth-flow", "done"));
-    var workspace = workspace(new ScriptedShellExecutor());
-    var audit = audit(new ScriptedShellExecutor());
+  void doneAndReviewSpecsWithoutRestartThrow() {
+    var store = store();
+    store.create(row("done-one", "done"));
+    store.create(row("review-one", "review"));
+    var specs = specsOf(store);
 
     assertThrows(
         IllegalStateException.class,
-        () -> DispatchCommand.resolveSpec("oauth-flow", false, specs, workspace, audit, HOST));
-  }
-
-  @Test
-  void reviewSpecWithoutRestartThrows() {
-    var specs = List.of(specWith("oauth-flow", "review"));
-    var workspace = workspace(new ScriptedShellExecutor());
-    var audit = audit(new ScriptedShellExecutor());
-
+        () -> DispatchCommand.resolveSpec("done-one", false, specs, store));
     assertThrows(
         IllegalStateException.class,
-        () -> DispatchCommand.resolveSpec("oauth-flow", false, specs, workspace, audit, HOST));
+        () -> DispatchCommand.resolveSpec("review-one", false, specs, store));
   }
 
   @Test
-  void restartResetsStatusAndAppendsRestartedAudit() throws Exception {
-    var specs = List.of(specWith("oauth-flow", "in_progress"));
-    var stored = "{id: oauth-flow, title: Implement OAuth, status: in_progress}";
-    var shell =
-        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
-            .onOk("cat " + SPECS_DIR + "/oauth-flow/spec.yaml", stored);
-    var workspace = workspace(shell);
-    var audit = audit(shell);
+  void restartResetsTheStatusToPendingInTheDb() {
+    var store = store();
+    store.create(row("oauth-flow", "in_progress"));
 
-    var resolution = DispatchCommand.resolveSpec("oauth-flow", true, specs, workspace, audit, HOST);
+    var resolution = DispatchCommand.resolveSpec("oauth-flow", true, specsOf(store), store);
 
     assertEquals("oauth-flow", resolution.spec().id());
     assertTrue(resolution.restarted(), "non-pending spec + --restart must mark restarted=true");
     assertEquals(
         "in_progress",
         resolution.previousStatus(),
-        "previousStatus must carry the pre-reset status so the caller can publish spec_restarted");
-    var cmds = shell.invocations();
-    var sawWriteMetadata =
-        cmds.stream().anyMatch(c -> c.contains("printf '%s' ") && c.contains("spec.yaml"));
-    var sawAuditAppend =
-        cmds.stream().anyMatch(c -> c.contains("printf '%s\\n'") && c.contains("audit.jsonl"));
-    assertTrue(sawWriteMetadata, "restart should write spec.yaml; saw: " + cmds);
-    assertTrue(sawAuditAppend, "restart should append audit.jsonl; saw: " + cmds);
-    var auditLine = cmds.stream().filter(c -> c.contains("audit.jsonl")).findFirst().orElseThrow();
-    assertTrue(auditLine.contains("\"event\": \"restarted\""));
-    assertTrue(auditLine.contains("\"agent\": \"sail\""));
-    assertTrue(auditLine.contains("\"note\": \"restarted from in_progress\""));
-  }
-
-  @Test
-  void restartPropagatesWorkspaceFailure() {
-    var specs = List.of(specWith("oauth-flow", "in_progress"));
-    var shell =
-        new ScriptedShellExecutor()
-            .onFail("cat " + SPECS_DIR + "/oauth-flow/spec.yaml", "permission denied");
-    var workspace = workspace(shell);
-    var audit = audit(shell);
-
-    assertThrows(
-        Exception.class,
-        () -> DispatchCommand.resolveSpec("oauth-flow", true, specs, workspace, audit, HOST));
-  }
-
-  private static Spec specWith(String id, String status) {
-    return new Spec(id, "Title for " + id, SpecStatus.fromWire(status), null, List.of(), null);
-  }
-
-  private static SpecWorkspace workspace(ShellExec shell) {
-    return new SpecWorkspace(shell, PROJECT, SPECS_DIR);
-  }
-
-  private static SpecAudit audit(ShellExec shell) {
-    return new SpecAudit(shell, PROJECT, SPECS_DIR);
+        "previousStatus carries the pre-reset status so the caller can publish spec_restarted");
+    assertEquals(SpecStatus.PENDING, store.findById("oauth-flow").orElseThrow().status());
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
@@ -15,6 +15,9 @@ import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.engine.AgentTaskPrompt;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
@@ -264,5 +267,40 @@ class DispatchCommandTest {
         DispatchCommand.branchRepoDir("/home/dev/workspace", List.of(sing, chorus), chorus);
 
     assertEquals("/home/dev/workspace/chorus", repoDir);
+  }
+
+  @TempDir Path dbDir;
+
+  @Test
+  void projectSpecsOnlyReturnsTheRequestedBucket() {
+    var db = Sqlite.open(dbDir.resolve("sail.db"));
+    new SchemaManager(db).migrate();
+    var store = new SpecStore(db);
+    store.create(row("mine", "acme", SpecStatus.PENDING));
+    store.create(row("other", "zenith", SpecStatus.PENDING));
+
+    var specs = DispatchCommand.projectSpecs(store, "acme");
+
+    assertEquals(List.of("mine"), specs.stream().map(Spec::id).toList());
+  }
+
+  private static SpecStore.SpecRow row(String id, String project, SpecStatus status) {
+    return new SpecStore.SpecRow(
+        id,
+        project,
+        id + " title",
+        status,
+        null,
+        null,
+        null,
+        null,
+        null,
+        0,
+        "me",
+        null,
+        null,
+        "me",
+        List.of(),
+        List.of());
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/HostSyncTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/HostSyncTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SyncConfig;
+import org.junit.jupiter.api.Test;
+
+class HostSyncTest {
+
+  private static final SyncConfig STANDALONE = SyncConfig.unset();
+  private static final SyncConfig MAIN = new SyncConfig(SyncConfig.ROLE_MAIN, null);
+  private static final SyncConfig NODE = new SyncConfig(SyncConfig.ROLE_NODE, "sail@maindevbox");
+
+  @Test
+  void standaloneHasNoPeerAndNoPropagationHint() {
+    assertTrue(HostSync.isStandalone(STANDALONE));
+    assertFalse(HostSync.hasPeers(STANDALONE));
+    assertFalse(HostSync.isNode(STANDALONE));
+    assertEquals("", HostSync.propagationHint(STANDALONE));
+  }
+
+  @Test
+  void aNodeHasPeersAndIsToldToSync() {
+    assertFalse(HostSync.isStandalone(NODE));
+    assertTrue(HostSync.hasPeers(NODE));
+    assertTrue(HostSync.isNode(NODE));
+    assertEquals("Run sail sync to propagate.", HostSync.propagationHint(NODE));
+  }
+
+  @Test
+  void theMainHubHasPeersButPropagatesPassively() {
+    assertFalse(HostSync.isStandalone(MAIN));
+    assertTrue(HostSync.hasPeers(MAIN));
+    assertFalse(HostSync.isNode(MAIN));
+    assertTrue(HostSync.propagationHint(MAIN).contains("pull"));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
@@ -7,12 +7,18 @@ package ai.singlr.sail.commands;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.singlr.sail.config.SyncConfig;
+import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerSpecImporter;
+import ai.singlr.sail.engine.ScriptedShellExecutor;
 import ai.singlr.sail.store.DataMigration;
 import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
@@ -56,6 +62,45 @@ class MigrateCommandTest {
         finalVersion,
         versionWhenImportRan.get(),
         "schema must be fully migrated before the spec import queries SpecStore");
+  }
+
+  private ContainerSpecImporter importerOverEmptyProjects() {
+    var shell = new ScriptedShellExecutor();
+    return new ContainerSpecImporter(
+        shell, new ContainerManager(shell), new SpecStore(db), tempDir.resolve("no-projects"));
+  }
+
+  @Test
+  void specImportIsGatedAwayWhenThisBoxIsAMainOrNode() throws Exception {
+    var marker = tempDir.resolve("spec-import.done");
+
+    var asMain =
+        MigrateCommand.specImportStep(
+            importerOverEmptyProjects(), marker, new SyncConfig(SyncConfig.ROLE_MAIN, null));
+    var asNode =
+        MigrateCommand.specImportStep(
+            importerOverEmptyProjects(),
+            marker,
+            new SyncConfig(SyncConfig.ROLE_NODE, "sail@maindevbox"));
+
+    assertEquals(0, asMain.get().imported());
+    assertEquals(0, asNode.get().imported());
+    assertFalse(Files.exists(marker), "a main/node never scans, so it never marks");
+  }
+
+  @Test
+  void specImportRunsOnceOnAStandaloneBoxThenStops() throws Exception {
+    var marker = tempDir.resolve("spec-import.done");
+
+    var first =
+        MigrateCommand.specImportStep(importerOverEmptyProjects(), marker, SyncConfig.unset());
+    first.get();
+    assertTrue(Files.exists(marker), "standalone backfill records that it ran");
+
+    var second =
+        MigrateCommand.specImportStep(importerOverEmptyProjects(), marker, SyncConfig.unset());
+    assertEquals(0, second.get().imported());
+    assertTrue(Files.exists(marker));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SyncCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SyncCommandTest.java
@@ -7,7 +7,7 @@ package ai.singlr.sail.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.api.Event;
@@ -26,33 +26,31 @@ class SyncCommandTest {
 
   @Test
   void resolveMainPrefersTheExplicitFlag() {
-    assertEquals(
-        "sail@override",
-        SyncCommand.resolveMain("sail@override", new SyncConfig(SyncConfig.ROLE_NODE, "sail@cfg")));
+    var resolved =
+        SyncCommand.resolveMain("sail@override", new SyncConfig(SyncConfig.ROLE_NODE, "sail@cfg"));
+    assertEquals("sail@override", resolved.target());
   }
 
   @Test
   void resolveMainFallsBackToTheConfiguredMain() {
-    assertEquals(
-        "sail@maindevbox",
-        SyncCommand.resolveMain(null, new SyncConfig(SyncConfig.ROLE_NODE, "sail@maindevbox")));
+    var resolved =
+        SyncCommand.resolveMain(null, new SyncConfig(SyncConfig.ROLE_NODE, "sail@maindevbox"));
+    assertEquals("sail@maindevbox", resolved.target());
   }
 
   @Test
-  void resolveMainRefusesWhenThisBoxIsMain() {
-    var error =
-        assertThrows(
-            IllegalStateException.class,
-            () -> SyncCommand.resolveMain(null, new SyncConfig(SyncConfig.ROLE_MAIN, null)));
-    assertTrue(error.getMessage().contains("main devbox"));
+  void resolveMainHasNoTargetWhenThisBoxIsMain() {
+    var resolved = SyncCommand.resolveMain(null, new SyncConfig(SyncConfig.ROLE_MAIN, null));
+    assertNull(resolved.target());
+    assertTrue(resolved.message().contains("main devbox"));
   }
 
   @Test
-  void resolveMainRefusesWhenNothingIsConfigured() {
-    var error =
-        assertThrows(
-            IllegalStateException.class, () -> SyncCommand.resolveMain("  ", SyncConfig.unset()));
-    assertTrue(error.getMessage().contains("No main devbox configured"));
+  void resolveMainHasNoTargetAndGuidesWhenStandalone() {
+    var resolved = SyncCommand.resolveMain("  ", SyncConfig.unset());
+    assertNull(resolved.target());
+    assertTrue(resolved.message().contains("Single devbox"));
+    assertTrue(resolved.message().contains("sail host sync --main"));
   }
 
   @Test


### PR DESCRIPTION
## Why

Three things Uday hit on his real box were one root cause: **specs were half-migrated** — the `sail spec` CLI was DB-backed, but `sail dispatch` and the in-container agent were still file-based, so the DB only learned of specs by re-scanning every container on every upgrade (skipping stopped ones). This makes the **database authoritative end-to-end**.

## Changes

**1. Peer-aware sync messaging** (`HostSync`)
- `files add` no longer says "Run sail sync to propagate" on a single box (the file is already DB-written + materialized locally). A node says it; a main says peers will pull; a standalone box says nothing.
- `sail sync` on a lone box prints a friendly "Single devbox — nothing to sync. Add a box with `sail host sync --main …`" instead of a "No main configured" **error**.

**2. Spec import gated** (`MigrateCommand`)
- The container spec scan runs **only on a standalone box, only once** (`spec-import.done` marker). A main or node never scans — its specs arrive via sync or are authored in its own DB. The per-upgrade "probing containers / skipped stopped project" noise is gone.

**3. Dispatch reads the DB** (`DispatchCommand`)
- Picks the next ready spec, marks it `in_progress`, and reads its body from `SpecStore` — never the container. A stopped/file-drifted container no longer blocks dispatch. `spec_dispatched`/`spec_restarted` events (persisted to `EventStore`) are the durable audit; the container-file `SpecAudit` is dropped.

**4. Agent authors via `sail spec`** (`SpecSkillGenerator`, `AgentContextGenerator`)
- The spec-board skill and the generated `CLAUDE.md`/`AGENTS.md` spec section now teach `sail spec create/list/board/show/edit` (the API socket is already mounted in every container, with a token) instead of writing `spec.yaml`/`spec.md`. No `specs/` directory to edit; what the agent creates syncs everywhere.

## Tests

New: `HostSyncTest`, gating tests in `MigrateCommandTest`, DB-backed `DispatchCommandResolveSpecTest` (rewritten) + `projectSpecs` bucket test, updated `SyncCommandTest`, and CLI-content assertions in `SpecSkillGeneratorTest`/`AgentContextGeneratorTest`. Full `mvn verify`: **all modules green (1636 sail-infra tests), coverage gates pass.**

## Note

Existing `CLAUDE.md`/skill files in already-provisioned containers regenerate on the next `sail agent context regen`; new code generates the DB-native instructions.
