### PR TITLE
One-command node join over SSH keys (sail join)

### DIFF
--- a/docs/E2E_JOIN_RUNBOOK.md
+++ b/docs/E2E_JOIN_RUNBOOK.md
@@ -1,0 +1,239 @@
+# E2E Runbook — Main ↔ Node Join & Sync
+
+A hand-driven test of the db-sync star: one **main** devbox (the sync authority) and
+one **node** that joins it, reconciles specs and files, and survives conflicts and
+outages. Drive it once by hand to feel the flow before we automate it.
+
+> **Why two boxes.** There is exactly one `/var/lib/sail` and one `sail` OS user per
+> machine, so you cannot fake two mains on one host. Use two real boxes: two Incus
+> containers on the bare-metal host, or two VMs. Anything with its own `~/.sail`,
+> its own `/var/lib/sail`, and SSH reachability to the other works.
+
+Throughout: **MAIN** = the authority, **NODE** = the joiner. Run each block on the
+box named in its heading. Replace `<main-ip>` with MAIN's address and `bob` with the
+node engineer's handle.
+
+> **Security model — it's SSH keys, end to end.** A node syncs by running `ssh
+> sail@<main> sail _sync` over the locked `sail` user's forced-command gateway
+> (`command="sail _gateway --fde <handle>",restrict` — no shell, no port-forward).
+> `sail join` generates a dedicated, sail-managed key (`~/.sail/sync_ed25519`) and the
+> sync lane pins it with `ssh -i … -o IdentitiesOnly=yes`. The **only** thing that
+> crosses out of band is a *public* key — never a secret — so there is no network
+> enrolment surface to attack.
+
+---
+
+## 1. MAIN — become the authority
+
+```bash
+# MAIN
+sudo sail host init                  # one-time: control plane + container host
+sudo sail host ssh-identity          # provision the locked `sail` user + /var/lib/sail
+sudo sail host sync --as-main        # role = main (the sync authority)
+sail host sync                       # verify: "This box is main."
+```
+
+---
+
+## 2. NODE — one-command join
+
+```bash
+# NODE
+sudo sail host init                  # one-time control plane (no ssh-identity needed —
+                                     # a node only syncs outbound to main)
+sail join sail@<main-ip>             # generates the sync key, points this box at main,
+                                     # and prints the exact line for MAIN to authorize
+```
+
+`sail join` prints something like:
+
+```
+✓ This box is now a node syncing to sail@<main-ip>.
+
+  Send this to the operator of sail@<main-ip> — they run it once:
+
+    sail fde add bob --role member --key "ssh-ed25519 AAAA… sail-sync@node"
+
+  Once they have, finish here with sail sync. Only a public key leaves this box.
+```
+
+(`--handle <name>` overrides the suggested handle; `--json` emits `public_key` +
+`authorize_command` for scripting.)
+
+## 3. MAIN — authorize the node (one command)
+
+Paste the line `sail join` printed. `fde add --key` registers the key **and** refreshes
+`authorized_keys` in one step (`member`+ can push; a `viewer` can only pull):
+
+```bash
+# MAIN
+sail fde add bob --role member --key "ssh-ed25519 AAAA… sail-sync@node"
+sail fde list                        # verify: bob, role member, status active
+```
+
+## 4. NODE — prove the transport, then reconcile
+
+```bash
+# NODE — gate: should authenticate as `sail` and start the RPC server (it hangs
+# waiting for bytes; Ctrl-C is fine). Must NOT see a password prompt,
+# "Permission denied (publickey)", or a shell.
+ssh -o PasswordAuthentication=no -o IdentitiesOnly=yes -i ~/.sail/sync_ed25519 \
+    sail@<main-ip> sail _sync
+# Ctrl-C to exit.
+
+sail sync                            # first reconcile
+# expect: "Synced with main: N pulled, 0 pushed, 0 merged." (N = specs already on main)
+sail sync                            # run again
+# expect: "Already in sync with main."   ← idempotency (assertion 8)
+```
+
+---
+
+## 5. The assertion matrix
+
+Each row is a distinct code path. Run the action on the box named, then `sail sync`
+**on NODE**, then check. `sail sync --json` prints `{pulled, pushed, merged, conflicts}`
+if you'd rather assert on numbers.
+
+### 1. Pull (main → node)
+```bash
+# MAIN
+sail spec create pull-demo --title "Pull works"
+# NODE
+sail sync                            # expect pulled ≥ 1
+sail spec list                       # expect pull-demo present
+```
+
+### 2. Push (node → main), member can write
+```bash
+# NODE
+sail spec create push-demo --title "Push works"
+sail sync                            # expect pushed ≥ 1
+# MAIN
+sail spec list                       # expect push-demo present
+```
+
+### 3. Auto-merge (disjoint fields)
+```bash
+# MAIN
+sail spec edit pull-demo --assignee alice
+# NODE  (edit a DIFFERENT field on the same spec, before syncing)
+sail spec edit pull-demo --title "Pull works (node-edited)"
+sail sync                            # expect merged ≥ 1, conflicts = 0
+sail spec show pull-demo             # expect BOTH: assignee=alice AND the node title
+```
+
+### 4. Conflict (same field), node row not clobbered
+```bash
+# MAIN
+sail spec edit push-demo --title "Main's title"
+# NODE  (same field, different value, before syncing)
+sail spec edit push-demo --title "Node's title"
+sail sync                            # expect conflicts ≥ 1
+sail spec show push-demo             # expect STILL "Node's title" — local not clobbered
+sail conflicts                       # expect push-demo listed; resolve it (take main or local)
+sail sync                            # expect convergence; conflicts = 0 afterward
+```
+
+### 5. Files materialize; local edits are kept
+```bash
+# MAIN
+echo "shared config v1" > /tmp/shared.env
+sail project files add --project <proj> /tmp/shared.env --as config/shared.env
+# NODE
+sail sync
+sail project files ls --project <proj>          # expect config/shared.env
+cat ~/.sail/projects/<proj>/config/shared.env   # expect "shared config v1"
+
+# Now prove a local edit is preserved, not overwritten:
+# NODE
+echo "node local change" >> ~/.sail/projects/<proj>/config/shared.env
+# MAIN
+echo "shared config v2" > /tmp/shared.env
+sail project files add --project <proj> /tmp/shared.env --as config/shared.env
+# NODE
+sail sync     # expect a "Kept 1 locally-modified file(s)" warning; your edit survives
+```
+
+### 6. FDE roster replication
+```bash
+# NODE
+sail fde list                        # expect main's FDEs (incl. bob) mirrored here
+```
+
+### 7. Role enforcement (viewer is pull-only)
+```bash
+# MAIN
+sail fde add viewer1 --role viewer --email v@example.com
+sail fde key add viewer1 "<a second NODE key, or a throwaway box's key>"
+sudo sail host keys sync
+# From the box holding viewer1's key:
+sail spec create blocked --title "should not push"
+sail sync                            # expect: pull works, but the push is REFUSED
+```
+
+### 8. Idempotency — already verified in §4 ("Already in sync").
+
+### 9. Resilience across a main outage
+```bash
+# NODE
+sail sync --watch --interval 10      # leave running
+# MAIN — take it offline (stop sshd, or pause the container)
+# MAIN — meanwhile create a spec:  sail spec create after-outage --title "post outage"
+# MAIN — bring it back
+# NODE — watch loop should retry, resume from checkpoint, pull after-outage, no dupes
+#        (Ctrl-C the watch when satisfied)
+sail spec list                       # expect after-outage present exactly once
+```
+
+### 10. Attribution
+```bash
+# After any pull, on NODE:
+sail spec history pull-demo          # expect updates attributed to the real author,
+                                     # NOT to "sync"
+```
+
+### 11. board_updated notification
+```bash
+# NODE — in a second shell, before a pull that brings remote work:
+sail events stream                   # leave running
+# Trigger a pull (do assertion 1 again with a new spec). Expect a board_updated
+# event on the stream, and the CLI to surface an "updates available" hint.
+```
+
+---
+
+## Reset between runs
+
+```bash
+# On EACH box, to start clean (DESTRUCTIVE — wipes the control-plane DB):
+sail spec list                       # note what exists first if you care
+rm -f /var/lib/sail/sail.db          # or ~/.sail/sail.db on a non-provisioned box
+# Re-run host init / host sync / sail join as in sections 1–4.
+```
+
+To change a box's role without wiping: `sudo sail host sync --as-main` makes it the
+authority, `sail join sail@<other>` (or `sudo sail host sync --main sail@<other>`)
+re-points it at a main; `sail host sync` with no flags prints the current role.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `Permission denied (publickey)` on the gate (§4) | The operator hasn't run the `sail fde add … --key` line `sail join` printed (or ran it against a different handle). `fde add --key` auto-syncs `authorized_keys`, so no separate step is needed. |
+| Gate gives a password prompt | The `sail` user isn't the one answering — check `sudo sail host ssh-identity` ran on MAIN and `authorized_keys` has the `command="sail _gateway --fde …"` line. |
+| `sail sync` says "Single devbox — nothing to sync" | `sail join …` wasn't run on the node (no main configured). |
+| Push silently does nothing on a node | The FDE's role is `viewer`. Bump it: re-run the authorize line with `--role member`. |
+| Conflicts never clear | Resolve them: `sail conflicts` then re-`sail sync`. A round only converges once same-field disputes are decided. |
+
+---
+
+## What "exceptional" looks like before we announce
+
+- All 11 rows pass on two real boxes, twice (cold join + reset-and-rejoin).
+- The gate (§4) and the role-refusal (§7) fail **loudly and clearly** — those are the
+  two errors a new community node-runner will hit first.
+- Then we codify §5 as an automated harness (provision two throwaway boxes → run matrix
+  → assert → tear down) so it becomes a release gate and a demo.

--- a/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
@@ -122,6 +122,21 @@ public final class SailPaths {
   }
 
   /**
+   * Private SSH key this box presents when syncing to main: {@code ~/.sail/sync_ed25519}. A
+   * sail-managed identity distinct from the engineer's personal keys, used only for the {@code ssh
+   * sail@main sail _sync} lane so its public half is deterministic at join time and {@code sail
+   * sync --watch} authenticates without a forwarded agent.
+   */
+  public static Path syncKeyPath() {
+    return SAIL_DIR.resolve("sync_ed25519");
+  }
+
+  /** Public half of {@link #syncKeyPath()}: {@code ~/.sail/sync_ed25519.pub}. */
+  public static Path syncPublicKeyPath() {
+    return SAIL_DIR.resolve("sync_ed25519.pub");
+  }
+
+  /**
    * Resolves the project descriptor path for a project. Checks in order:
    *
    * <ol>

--- a/sail-core/src/main/java/ai/singlr/sail/engine/SyncIdentity.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/SyncIdentity.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * The node's dedicated SSH identity for syncing to main: a single ed25519 keypair under {@code
+ * ~/.sail/}, separate from the engineer's personal keys and used only for the {@code ssh sail@main
+ * sail _sync} lane. Keeping it sail-managed makes the public key deterministic and printable at
+ * join time, and lets {@code sail sync --watch} authenticate non-interactively without depending on
+ * a forwarded agent.
+ */
+public final class SyncIdentity {
+
+  private final ShellExec shell;
+  private final Path privateKey;
+  private final Path publicKey;
+
+  public SyncIdentity(ShellExec shell) {
+    this(shell, SailPaths.syncKeyPath(), SailPaths.syncPublicKeyPath());
+  }
+
+  public SyncIdentity(ShellExec shell, Path privateKey, Path publicKey) {
+    this.shell = shell;
+    this.privateKey = privateKey;
+    this.publicKey = publicKey;
+  }
+
+  /**
+   * Resolves the managed sync key to pass to {@code ssh -i}, or empty when none has been generated
+   * yet. Empty keeps the sync lane on its default-key behaviour, so boxes that never ran {@code
+   * sail join} are unaffected.
+   */
+  public static Optional<Path> resolve() {
+    return resolve(SailPaths.syncKeyPath());
+  }
+
+  /** Pure resolver; visible for tests so the present/absent decision needs no real home dir. */
+  static Optional<Path> resolve(Path keyPath) {
+    return Files.isRegularFile(keyPath) ? Optional.of(keyPath) : Optional.empty();
+  }
+
+  /** True once the keypair exists on disk. */
+  public boolean exists() {
+    return Files.isRegularFile(privateKey) && Files.isRegularFile(publicKey);
+  }
+
+  /**
+   * Generates the keypair if absent and returns its public-key line. Idempotent: an existing
+   * keypair is reused untouched, so the public key a node hands its operator is stable across
+   * re-runs of {@code sail join}.
+   */
+  public String ensure(String comment) throws IOException, InterruptedException, TimeoutException {
+    if (!exists()) {
+      SailPaths.ensureDataDir(privateKey.getParent());
+      Files.deleteIfExists(privateKey);
+      Files.deleteIfExists(publicKey);
+      var result =
+          shell.exec(
+              List.of(
+                  "ssh-keygen",
+                  "-t",
+                  "ed25519",
+                  "-N",
+                  "",
+                  "-C",
+                  comment,
+                  "-f",
+                  privateKey.toString()));
+      if (!result.ok()) {
+        throw new IOException("ssh-keygen failed: " + result.stderr().strip());
+      }
+    }
+    return publicKeyLine();
+  }
+
+  /** Reads the public-key line, e.g. {@code ssh-ed25519 AAAA... sail-sync@host}. */
+  public String publicKeyLine() throws IOException {
+    return Files.readString(publicKey).strip();
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/engine/SyncIdentityTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/SyncIdentityTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SyncIdentityTest {
+
+  private static final String PUB =
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEYBLOB sail-sync@node";
+
+  @TempDir Path dir;
+
+  private SyncIdentity identity(ShellExec shell) {
+    return new SyncIdentity(shell, dir.resolve("sync_ed25519"), dir.resolve("sync_ed25519.pub"));
+  }
+
+  @Test
+  void ensureGeneratesTheKeypairAndReturnsItsPublicLine() throws Exception {
+    var keygen = new FakeKeygen(0);
+    var pub = identity(keygen).ensure("sail-sync@node");
+
+    assertEquals(PUB, pub);
+    assertTrue(keygen.ran, "ssh-keygen should run when no key exists");
+    assertTrue(Files.isRegularFile(dir.resolve("sync_ed25519")));
+    assertTrue(Files.isRegularFile(dir.resolve("sync_ed25519.pub")));
+  }
+
+  @Test
+  void ensureIsIdempotentAndReusesAnExistingKey() throws Exception {
+    Files.writeString(dir.resolve("sync_ed25519"), "PRIVATE");
+    Files.writeString(dir.resolve("sync_ed25519.pub"), PUB + "\n");
+
+    var keygen = new FakeKeygen(0);
+    var pub = identity(keygen).ensure("sail-sync@node");
+
+    assertEquals(PUB, pub);
+    assertFalse(keygen.ran, "an existing keypair must be reused untouched");
+  }
+
+  @Test
+  void ensureSurfacesAKeygenFailure() {
+    var failing = new FakeKeygen(1);
+
+    var error = assertThrows(IOException.class, () -> identity(failing).ensure("sail-sync@node"));
+    assertTrue(error.getMessage().contains("ssh-keygen failed"));
+  }
+
+  @Test
+  void existsTracksBothHalvesOfTheKeypair() throws Exception {
+    var identity = identity(new FakeKeygen(0));
+    assertFalse(identity.exists());
+
+    Files.writeString(dir.resolve("sync_ed25519"), "PRIVATE");
+    assertFalse(identity.exists(), "private half alone is not a usable identity");
+
+    Files.writeString(dir.resolve("sync_ed25519.pub"), PUB);
+    assertTrue(identity.exists());
+  }
+
+  @Test
+  void resolveReturnsTheKeyOnlyOnceItExists() throws Exception {
+    var key = dir.resolve("sync_ed25519");
+    assertTrue(SyncIdentity.resolve(key).isEmpty(), "no managed key yet → default-key behaviour");
+
+    Files.writeString(key, "PRIVATE");
+    assertEquals(key, SyncIdentity.resolve(key).orElseThrow());
+  }
+
+  @Test
+  void publicKeyLineIsTrimmed() throws Exception {
+    Files.writeString(dir.resolve("sync_ed25519.pub"), "  " + PUB + "  \n");
+    assertEquals(PUB, identity(new FakeKeygen(0)).publicKeyLine());
+  }
+
+  private final class FakeKeygen implements ShellExec {
+
+    private final int exitCode;
+    private boolean ran;
+
+    private FakeKeygen(int exitCode) {
+      this.exitCode = exitCode;
+    }
+
+    @Override
+    public Result exec(List<String> command) throws IOException {
+      ran = true;
+      if (exitCode != 0) {
+        return new Result(exitCode, "", "boom");
+      }
+      var target = Path.of(command.get(command.indexOf("-f") + 1));
+      Files.writeString(target, "PRIVATE");
+      Files.writeString(Path.of(target + ".pub"), PUB + "\n");
+      return new Result(0, "", "");
+    }
+
+    @Override
+    public Result exec(List<String> command, Path workDir, Duration timeout) throws IOException {
+      return exec(command);
+    }
+
+    @Override
+    public boolean isDryRun() {
+      return false;
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/Sail.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/Sail.java
@@ -12,6 +12,7 @@ import ai.singlr.sail.commands.EventsCommand;
 import ai.singlr.sail.commands.FdeCommand;
 import ai.singlr.sail.commands.GatewayCommand;
 import ai.singlr.sail.commands.HostCommand;
+import ai.singlr.sail.commands.JoinCommand;
 import ai.singlr.sail.commands.LoginCommand;
 import ai.singlr.sail.commands.MigrateCommand;
 import ai.singlr.sail.commands.ProjectCommand;
@@ -46,6 +47,7 @@ import picocli.CommandLine.Help.Ansi;
       SyncCommand.class,
       SyncServerCommand.class,
       ConflictsCommand.class,
+      JoinCommand.class,
     })
 public final class Sail implements Runnable {
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/JoinCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/JoinCommand.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.config.HostYaml;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.HostInfo;
+import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.engine.SyncIdentity;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+/**
+ * Joins this box to a main devbox as a sync node in one step: generates the sail-managed sync key
+ * if absent, points the box's config at main ({@code role=node}, {@code main=<target>}), and prints
+ * the public key together with the exact {@code sail fde add} line for main's operator to run.
+ *
+ * <p>The handshake stays pure SSH keys end to end. The only thing that crosses out of band is a
+ * public key — never a secret — so there is no network enrolment surface to secure. Once the
+ * operator authorises the key, {@code sail sync} reconciles against main.
+ */
+@Command(
+    name = "join",
+    description = "Join this box to a main devbox as a sync node (prints the key to authorise).",
+    mixinStandardHelpOptions = true)
+public final class JoinCommand implements Runnable {
+
+  @Parameters(
+      index = "0",
+      paramLabel = "TARGET",
+      description = "SSH target of the main devbox, e.g. sail@maindevbox.")
+  private String target;
+
+  @Option(
+      names = "--handle",
+      description = "FDE handle to suggest in the authorise line (default: your local username).")
+  private String handle;
+
+  @Option(names = "--json", description = "Output in JSON format.")
+  private boolean json;
+
+  @Spec private CommandSpec spec;
+
+  @Override
+  public void run() {
+    CliCommand.run(spec, this::execute);
+  }
+
+  private void execute() throws Exception {
+    var resolvedHandle = handle == null || handle.isBlank() ? defaultHandle() : handle;
+    var identity = new SyncIdentity(new ShellExecutor(false));
+    var plan = plan(SailPaths.hostConfigPath(), identity, target, resolvedHandle);
+    print(plan);
+  }
+
+  /**
+   * Generates the sync key if needed and points the local host config at {@code target} as a node.
+   * Pure of any stdout so it can be exercised directly in tests with a {@code @TempDir} config and
+   * a stub identity.
+   */
+  static Plan plan(Path hostConfig, SyncIdentity identity, String target, String handle)
+      throws Exception {
+    if (!Files.exists(hostConfig)) {
+      throw new IllegalStateException("Server not initialized. Run 'sail host init' first.");
+    }
+    HostConfigSetCommand.validate("sync-main", target);
+    var publicKey = identity.ensure("sail-sync@" + HostInfo.hostname());
+    var host = HostYaml.fromMap(YamlUtil.parseFile(hostConfig));
+    var updated = HostSyncCommand.configure(host, false, target);
+    requireWritable(hostConfig, target);
+    YamlUtil.dumpToFile(updated.toMap(), hostConfig);
+    return new Plan(target, handle, publicKey);
+  }
+
+  private static void requireWritable(Path hostConfig, String target) {
+    var probe = Files.exists(hostConfig) ? hostConfig : hostConfig.getParent();
+    if (probe != null && !Files.isWritable(probe)) {
+      throw new IllegalStateException(
+          "Writing " + hostConfig + " needs root. Re-run: sudo sail join " + target);
+    }
+  }
+
+  static String defaultHandle() {
+    var user = System.getProperty("user.name");
+    return user == null || user.isBlank() ? "your-handle" : user;
+  }
+
+  /** The {@code sail fde add} line main's operator runs to authorise this node. */
+  static String authorizeLine(String handle, String publicKey) {
+    return "sail fde add " + handle + " --role member --key \"" + publicKey + "\"";
+  }
+
+  private void print(Plan plan) {
+    if (json) {
+      var map = new LinkedHashMap<String, Object>();
+      map.put("target", plan.target());
+      map.put("suggested_handle", plan.handle());
+      map.put("public_key", plan.publicKey());
+      map.put("authorize_command", authorizeLine(plan.handle(), plan.publicKey()));
+      System.out.println(YamlUtil.dumpJson(map));
+      return;
+    }
+    var out = System.out;
+    out.println(
+        Ansi.AUTO.string(
+            "  @|bold,green ✓|@ This box is now a @|bold node|@ syncing to @|bold "
+                + plan.target()
+                + "|@."));
+    out.println();
+    out.println("  Send this to the operator of " + plan.target() + " — they run it once:");
+    out.println();
+    out.println(
+        Ansi.AUTO.string("    @|cyan " + authorizeLine(plan.handle(), plan.publicKey()) + "|@"));
+    out.println();
+    out.println(
+        Ansi.AUTO.string(
+            "  Once they have, finish here with @|bold sail sync|@. Only a public key leaves this"
+                + " box — never a secret."));
+  }
+
+  /** Result of a join: the target, the suggested handle, and this node's public sync key. */
+  record Plan(String target, String handle, String publicKey) {}
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/SshSyncChannel.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/SshSyncChannel.java
@@ -11,6 +11,8 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -35,7 +37,7 @@ public final class SshSyncChannel implements AutoCloseable {
 
   /** Opens a sync channel to {@code target} (e.g. {@code sail@maindevbox}). */
   public static SshSyncChannel open(String target) throws IOException {
-    var builder = new ProcessBuilder(sshCommand(target));
+    var builder = new ProcessBuilder(sshCommand(target, SyncIdentity.resolve().orElse(null)));
     builder.redirectError(ProcessBuilder.Redirect.INHERIT);
     return new SshSyncChannel(builder.start());
   }
@@ -43,18 +45,25 @@ public final class SshSyncChannel implements AutoCloseable {
   /**
    * The {@code ssh} argument vector for a sync session. Like the rest of the gateway lane it
    * forbids password and keyboard-interactive auth, so a missing key fails fast rather than
-   * dangling a prompt for the locked {@code sail} account.
+   * dangling a prompt for the locked {@code sail} account. When {@code identity} is non-null the
+   * lane pins {@code sail join}'s managed key with {@code IdentitiesOnly} so it never silently
+   * falls back to an unrelated agent key.
    */
-  static List<String> sshCommand(String target) {
-    return List.of(
-        "ssh",
-        "-o",
-        "PasswordAuthentication=no",
-        "-o",
-        "KbdInteractiveAuthentication=no",
-        target,
-        "sail",
-        "_sync");
+  static List<String> sshCommand(String target, Path identity) {
+    var command =
+        new ArrayList<>(
+            List.of(
+                "ssh", "-o", "PasswordAuthentication=no", "-o", "KbdInteractiveAuthentication=no"));
+    if (identity != null) {
+      command.add("-o");
+      command.add("IdentitiesOnly=yes");
+      command.add("-i");
+      command.add(identity.toString());
+    }
+    command.add(target);
+    command.add("sail");
+    command.add("_sync");
+    return List.copyOf(command);
   }
 
   public BufferedReader reader() {

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
@@ -39,7 +39,8 @@ class CommandTaxonomyTest {
             "migrate",
             "upgrade",
             "sync",
-            "conflicts"),
+            "conflicts",
+            "join"),
         userFacing);
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/JoinCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/JoinCommandTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.HostYaml;
+import ai.singlr.sail.config.SyncConfig;
+import ai.singlr.sail.config.WebauthnConfig;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.SyncIdentity;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JoinCommandTest {
+
+  private static final String PUB =
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEYBLOB sail-sync@node";
+
+  private static final HostYaml BASE =
+      new HostYaml(
+          "dir",
+          "devpool",
+          null,
+          "incusbr0",
+          "singlr-base",
+          "ubuntu/24.04",
+          "6.21",
+          "10.0.0.1",
+          "2026-02-18T01:00:00Z",
+          WebauthnConfig.disabled());
+
+  @TempDir Path dir;
+
+  private Path writeHostConfig() throws IOException {
+    var path = dir.resolve("host.yaml");
+    YamlUtil.dumpToFile(BASE.toMap(), path);
+    return path;
+  }
+
+  private SyncIdentity identity() {
+    return new SyncIdentity(
+        new StubKeygen(), dir.resolve("sync_ed25519"), dir.resolve("sync_ed25519.pub"));
+  }
+
+  @Test
+  void planPointsTheBoxAtMainAndReturnsItsPublicKey() throws Exception {
+    var hostConfig = writeHostConfig();
+
+    var plan = JoinCommand.plan(hostConfig, identity(), "sail@maindevbox", "mady");
+
+    assertEquals("sail@maindevbox", plan.target());
+    assertEquals("mady", plan.handle());
+    assertEquals(PUB, plan.publicKey());
+
+    var written = HostYaml.fromMap(YamlUtil.parseFile(hostConfig));
+    assertEquals(SyncConfig.ROLE_NODE, written.sync().role());
+    assertEquals("sail@maindevbox", written.sync().main());
+    assertEquals("10.0.0.1", written.serverIp(), "unrelated host config is preserved");
+  }
+
+  @Test
+  void planRequiresAnInitializedHost() {
+    var missing = dir.resolve("absent.yaml");
+
+    var error =
+        assertThrows(
+            IllegalStateException.class,
+            () -> JoinCommand.plan(missing, identity(), "sail@main", "mady"));
+    assertTrue(error.getMessage().contains("host init"));
+  }
+
+  @Test
+  void planRejectsAMalformedTarget() throws Exception {
+    var hostConfig = writeHostConfig();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> JoinCommand.plan(hostConfig, identity(), "not a target!", "mady"));
+  }
+
+  @Test
+  void authorizeLineIsACopyPasteFdeAddCommand() {
+    assertEquals(
+        "sail fde add mady --role member --key \"" + PUB + "\"",
+        JoinCommand.authorizeLine("mady", PUB));
+  }
+
+  @Test
+  void defaultHandleFallsBackWhenUsernameIsAbsent() {
+    var original = System.getProperty("user.name");
+    try {
+      System.setProperty("user.name", "");
+      assertEquals("your-handle", JoinCommand.defaultHandle());
+      System.setProperty("user.name", "mady");
+      assertEquals("mady", JoinCommand.defaultHandle());
+    } finally {
+      System.setProperty("user.name", original);
+    }
+  }
+
+  private final class StubKeygen implements ShellExec {
+    @Override
+    public Result exec(List<String> command) throws IOException {
+      var target = Path.of(command.get(command.indexOf("-f") + 1));
+      Files.writeString(target, "PRIVATE");
+      Files.writeString(Path.of(target + ".pub"), PUB + "\n");
+      return new Result(0, "", "");
+    }
+
+    @Override
+    public Result exec(List<String> command, Path workDir, Duration timeout) throws IOException {
+      return exec(command);
+    }
+
+    @Override
+    public boolean isDryRun() {
+      return false;
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/SshSyncChannelTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/SshSyncChannelTest.java
@@ -6,8 +6,10 @@
 package ai.singlr.sail.engine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +17,7 @@ class SshSyncChannelTest {
 
   @Test
   void sshCommandTargetsTheGatewayAndRunsTheSyncServer() {
-    var command = SshSyncChannel.sshCommand("sail@maindevbox");
+    var command = SshSyncChannel.sshCommand("sail@maindevbox", null);
 
     assertEquals("ssh", command.getFirst());
     assertEquals(List.of("sail", "_sync"), command.subList(command.size() - 2, command.size()));
@@ -24,9 +26,29 @@ class SshSyncChannelTest {
 
   @Test
   void sshCommandForbidsPasswordAndKeyboardInteractiveAuth() {
-    var command = SshSyncChannel.sshCommand("sail@host");
+    var command = SshSyncChannel.sshCommand("sail@host", null);
 
     assertTrue(command.contains("PasswordAuthentication=no"));
     assertTrue(command.contains("KbdInteractiveAuthentication=no"));
+  }
+
+  @Test
+  void sshCommandWithoutAnIdentityOmitsTheKeyFlags() {
+    var command = SshSyncChannel.sshCommand("sail@host", null);
+
+    assertFalse(command.contains("-i"));
+    assertFalse(command.contains("IdentitiesOnly=yes"));
+  }
+
+  @Test
+  void sshCommandPinsTheManagedKeyWhenAnIdentityIsGiven() {
+    var command = SshSyncChannel.sshCommand("sail@host", Path.of("/home/dev/.sail/sync_ed25519"));
+
+    assertTrue(command.contains("IdentitiesOnly=yes"));
+    var i = command.indexOf("-i");
+    assertTrue(i > 0);
+    assertEquals("/home/dev/.sail/sync_ed25519", command.get(i + 1));
+    assertEquals(List.of("sail", "_sync"), command.subList(command.size() - 2, command.size()));
+    assertTrue(command.indexOf("sail@host") < command.indexOf("sail"));
   }
 }


### PR DESCRIPTION
Collapses node onboarding to **one command per side** while keeping the handshake **pure SSH keys** — no network enrolment endpoint, no plaintext-HTTP key submission. The only thing that crosses out of band is a *public* key.

## Why not a ticket/HTTP enroll flow
Investigation confirmed the cold-start constraint: the SSH gateway is key-only (an unregistered key can't authenticate — no keyless bootstrap), and the control-plane HTTP API is loopback + plaintext + full-access-token by design. Auto-registering a node's key over the network would mean exposing that surface on `0.0.0.0` over plaintext HTTP. We deliberately **don't** do that. Public keys aren't secret, so the secure path is an automated public-key handoff, not a new trust endpoint.

## What's here
- **`SyncIdentity`** — a sail-managed ed25519 keypair at `~/.sail/sync_ed25519`, generated on demand, separate from the engineer's personal keys. The sync lane pins it with `ssh -i … -o IdentitiesOnly=yes` (`SshSyncChannel`), so `sail sync --watch` authenticates without a forwarded agent. Boxes that never ran `sail join` keep their prior default-key behaviour (`resolve()` returns empty → zero-touch).
- **`sail join sail@<main>`** — generates the key, points the box at main (`role=node`), and prints the exact `sail fde add … --key` line for main's operator. The `plan()` core is a pure, fully unit-tested seam.
- **Main side** was already one command: `sail fde add <h> --role member --key "<line>"` registers the key **and** refreshes `authorized_keys`.
- `SailPaths.syncKeyPath`/`syncPublicKeyPath`; `JoinCommand` registered; command-taxonomy test updated.
- **`docs/E2E_JOIN_RUNBOOK.md`** — hand-driven main↔node test, now leading with the `sail join` flow, plus the 11-row sync assertion matrix (pull/push/merge/conflict/files/roster/role/idempotency/outage/attribution/notify).

## Flow
**Node:** `sail join sail@<main>` → prints the authorize line.
**Main:** paste `sail fde add bob --role member --key "ssh-ed25519 … sail-sync@node"`.
**Node:** `sail sync`. Done. Still the `command="sail _gateway --fde bob",restrict` forced-command lockdown — no shell, no port-forward.

## Verification
Full reactor `mvn verify` green: **1197** core, **130** harness, **1592** infra. Coverage gates pass (api.* 100%, bundle floors). New `SyncIdentityTest`, `JoinCommandTest`, and expanded `SshSyncChannelTest`.