### PR TITLE
Onboarding DX: stop the API-service nag + fix sail join identity/target

### DIFF
--- a/docs/E2E_JOIN_RUNBOOK.md
+++ b/docs/E2E_JOIN_RUNBOOK.md
@@ -41,10 +41,15 @@ If the box **already runs sail** (it has a `~/.sail` / control plane from prior 
 `sail join` is the *only* step — do **not** re-run `host init`:
 
 ```bash
-# NODE (existing sail box)
-sail join sail@<main-ip>             # generates the sync key, points this box at main,
-                                     # and prints the exact line for MAIN to authorize
+# NODE (existing sail box) — bare host is fine; the sail@ user is implied
+sail join <main-ip>                  # generates the sync key, points this box at main,
+                                     # then prompts: "Authorise this node as which handle
+                                     # on main? [mady]" — type the FDE handle you created
+                                     # on MAIN. It prints the exact line for MAIN to run.
 ```
+
+`sail join` never assumes `root`: the prompt defaults to this box's own FDE or
+`$SUDO_USER`. Use `--handle mady` to skip the prompt (required with `--json`).
 
 Only a **brand-new** box needs the one-time control plane first (a node syncs outbound
 to main, so it does **not** need `host ssh-identity`):
@@ -52,7 +57,7 @@ to main, so it does **not** need `host ssh-identity`):
 ```bash
 # NODE (brand-new box only)
 sudo sail host init
-sail join sail@<main-ip>
+sail join <main-ip> --handle mady
 ```
 
 `sail join` prints something like:

--- a/docs/E2E_JOIN_RUNBOOK.md
+++ b/docs/E2E_JOIN_RUNBOOK.md
@@ -37,12 +37,22 @@ sail host sync                       # verify: "This box is main."
 
 ## 2. NODE — one-command join
 
+If the box **already runs sail** (it has a `~/.sail` / control plane from prior use),
+`sail join` is the *only* step — do **not** re-run `host init`:
+
 ```bash
-# NODE
-sudo sail host init                  # one-time control plane (no ssh-identity needed —
-                                     # a node only syncs outbound to main)
+# NODE (existing sail box)
 sail join sail@<main-ip>             # generates the sync key, points this box at main,
                                      # and prints the exact line for MAIN to authorize
+```
+
+Only a **brand-new** box needs the one-time control plane first (a node syncs outbound
+to main, so it does **not** need `host ssh-identity`):
+
+```bash
+# NODE (brand-new box only)
+sudo sail host init
+sail join sail@<main-ip>
 ```
 
 `sail join` prints something like:

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostInitCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostInitCommand.java
@@ -18,7 +18,9 @@ import ai.singlr.sail.engine.ProvisionListener;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.engine.SystemdServiceInstaller;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -213,6 +215,13 @@ public final class HostInitCommand implements Runnable {
   private void printApiServiceNextSteps(ShellExec shell) {
     var sudoUser = System.getenv("SUDO_USER");
     System.out.println();
+    if (apiServiceInstalled(targetHome(sudoUser))) {
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|green ✓|@ sail API service already installed — nothing to do here;"
+                  + " 'sail upgrade' keeps it current."));
+      return;
+    }
     System.out.println(Ansi.AUTO.string("  @|bold Next step:|@ enable the sail API service."));
     if (Strings.isNotBlank(sudoUser) && !"root".equals(sudoUser)) {
       enableLingerForUser(shell, sudoUser);
@@ -221,6 +230,37 @@ public final class HostInitCommand implements Runnable {
       System.out.println("    Run as your dev user (without sudo):");
     }
     System.out.println(Ansi.AUTO.string("      @|bold sail host service install|@"));
+  }
+
+  /**
+   * Resolves the home of the engineer who will own the user-level API service: the {@code
+   * SUDO_USER} when {@code init} runs under sudo, otherwise the current user's home.
+   */
+  private static Path targetHome(String sudoUser) {
+    if (Strings.isNotBlank(sudoUser) && !"root".equals(sudoUser)) {
+      return Path.of("/home/" + sudoUser);
+    }
+    return Path.of(System.getProperty("user.home"));
+  }
+
+  /**
+   * True when the per-user {@code sail-api} unit already exists under {@code userHome}. Lets {@code
+   * init} skip the install prompt on a box that was set up before (an idempotent re-init), since
+   * the service is purely file-state that root can read for any user.
+   */
+  static boolean apiServiceInstalled(Path userHome) {
+    if (userHome == null) {
+      return false;
+    }
+    return new SystemdServiceInstaller(
+            new ShellExecutor(false),
+            SystemdServiceInstaller.Mode.USER,
+            userHome,
+            SailPaths.binaryPath(),
+            "127.0.0.1",
+            7070,
+            "sail")
+        .isInstalled();
   }
 
   private void enableLingerForUser(ShellExec shell, String user) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/JoinCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/JoinCommand.java
@@ -5,15 +5,22 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.YamlUtil;
-import ai.singlr.sail.engine.HostInfo;
+import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SyncIdentity;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.Sqlite;
+import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -29,6 +36,11 @@ import picocli.CommandLine.Spec;
  * <p>The handshake stays pure SSH keys end to end. The only thing that crosses out of band is a
  * public key — never a secret — so there is no network enrolment surface to secure. Once the
  * operator authorises the key, {@code sail sync} reconciles against main.
+ *
+ * <p>The handle is an FDE identity that lives on <em>main</em>, which this box cannot see, so it is
+ * never guessed from the local OS user (which is {@code root} under sudo). It is prompted for, with
+ * a sensible default drawn from this box's own FDE roster or {@code $SUDO_USER} — never {@code
+ * root}. The {@code sail@} gateway user is implied, so a bare host like {@code maindevbox} works.
  */
 @Command(
     name = "join",
@@ -39,12 +51,12 @@ public final class JoinCommand implements Runnable {
   @Parameters(
       index = "0",
       paramLabel = "TARGET",
-      description = "SSH target of the main devbox, e.g. sail@maindevbox.")
+      description = "Main devbox host (e.g. maindevbox or 10.0.0.1); the sail@ user is implied.")
   private String target;
 
   @Option(
       names = "--handle",
-      description = "FDE handle to suggest in the authorise line (default: your local username).")
+      description = "FDE handle main will authorise (skips the prompt; required with --json).")
   private String handle;
 
   @Option(names = "--json", description = "Output in JSON format.")
@@ -58,16 +70,20 @@ public final class JoinCommand implements Runnable {
   }
 
   private void execute() throws Exception {
-    var resolvedHandle = handle == null || handle.isBlank() ? defaultHandle() : handle;
+    var normalized = normalizeTarget(target);
+    nonSailUserWarning(target)
+        .ifPresent(warning -> System.err.println(Banner.errorLine(warning, Ansi.AUTO)));
+    var resolvedHandle = resolveHandle();
     var identity = new SyncIdentity(new ShellExecutor(false));
-    var plan = plan(SailPaths.hostConfigPath(), identity, target, resolvedHandle);
+    var plan = plan(SailPaths.hostConfigPath(), identity, normalized, resolvedHandle);
+    probeReachability(normalized);
     print(plan);
   }
 
   /**
    * Generates the sync key if needed and points the local host config at {@code target} as a node.
-   * Pure of any stdout so it can be exercised directly in tests with a {@code @TempDir} config and
-   * a stub identity.
+   * Pure of any prompting or stdout so it can be exercised directly in tests with a
+   * {@code @TempDir} config and a stub identity.
    */
   static Plan plan(Path hostConfig, SyncIdentity identity, String target, String handle)
       throws Exception {
@@ -75,7 +91,7 @@ public final class JoinCommand implements Runnable {
       throw new IllegalStateException("Server not initialized. Run 'sail host init' first.");
     }
     HostConfigSetCommand.validate("sync-main", target);
-    var publicKey = identity.ensure("sail-sync@" + HostInfo.hostname());
+    var publicKey = identity.ensure("sail-sync:" + handle);
     var host = HostYaml.fromMap(YamlUtil.parseFile(hostConfig));
     var updated = HostSyncCommand.configure(host, false, target);
     requireWritable(hostConfig, target);
@@ -91,9 +107,159 @@ public final class JoinCommand implements Runnable {
     }
   }
 
-  static String defaultHandle() {
-    var user = System.getProperty("user.name");
-    return user == null || user.isBlank() ? "your-handle" : user;
+  /** Prepends the implied {@code sail@} gateway user to a bare host; respects an explicit user. */
+  static String normalizeTarget(String raw) {
+    var trimmed = raw.strip();
+    return trimmed.contains("@") ? trimmed : "sail@" + trimmed;
+  }
+
+  /**
+   * Warns when the target names a user other than {@code sail}: the forced-command gateway only
+   * authorises the {@code sail} account, so {@code someone@host} would be rejected.
+   */
+  static Optional<String> nonSailUserWarning(String raw) {
+    var trimmed = raw.strip();
+    var at = trimmed.indexOf('@');
+    if (at <= 0) {
+      return Optional.empty();
+    }
+    var user = trimmed.substring(0, at);
+    if ("sail".equals(user)) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        "The sync gateway only accepts the 'sail' user; '"
+            + user
+            + "@…' will be rejected. Use sail@"
+            + trimmed.substring(at + 1)
+            + " (or just the host).");
+  }
+
+  /**
+   * Bare host for a reachability probe: strips any {@code user@} prefix and {@code :port} suffix.
+   */
+  static String hostForProbe(String target) {
+    var trimmed = target.strip();
+    var at = trimmed.indexOf('@');
+    var host = at >= 0 ? trimmed.substring(at + 1) : trimmed;
+    var colon = host.indexOf(':');
+    return colon >= 0 ? host.substring(0, colon) : host;
+  }
+
+  /**
+   * Default handle to offer, never {@code root}: this box's sole FDE if it has exactly one,
+   * otherwise {@code $SUDO_USER}, otherwise the local part of {@code git config user.email}, else
+   * {@code null} (caller must ask).
+   */
+  static String defaultHandle(List<String> nodeFdeHandles, String sudoUser, String gitLocalPart) {
+    if (nodeFdeHandles.size() == 1) {
+      return nodeFdeHandles.getFirst();
+    }
+    if (Strings.isNotBlank(sudoUser) && !"root".equals(sudoUser)) {
+      return sudoUser;
+    }
+    if (Strings.isNotBlank(gitLocalPart) && !"root".equals(gitLocalPart)) {
+      return gitLocalPart;
+    }
+    return null;
+  }
+
+  private String resolveHandle() {
+    var fallback = defaultHandle(nodeFdeHandles(), System.getenv("SUDO_USER"), gitEmailLocalPart());
+    return switch (handleChoice(handle, json, System.console() != null, fallback)) {
+      case HandleChoice.Resolved resolved -> resolved.handle();
+      case HandleChoice.NeedsPrompt prompt -> promptHandle(prompt.fallback());
+    };
+  }
+
+  /**
+   * Decides how to obtain the handle without doing any I/O: an explicit {@code --handle} wins; a
+   * non-interactive run ({@code --json} or no console) resolves from the fallback or fails with an
+   * actionable message; otherwise the caller must prompt. Pure so every branch is unit-tested.
+   */
+  static HandleChoice handleChoice(String flag, boolean json, boolean hasConsole, String fallback) {
+    if (Strings.isNotBlank(flag)) {
+      return new HandleChoice.Resolved(flag.strip());
+    }
+    if (json) {
+      throw new IllegalArgumentException("--json requires --handle (the FDE main will authorise).");
+    }
+    if (!hasConsole) {
+      if (fallback == null) {
+        throw new IllegalArgumentException(
+            "No terminal to prompt on. Pass --handle <the FDE main will authorise>.");
+      }
+      return new HandleChoice.Resolved(fallback);
+    }
+    return new HandleChoice.NeedsPrompt(fallback);
+  }
+
+  /** Reconciles a prompt's typed line with its default, rejecting an empty result. */
+  static String chosenHandle(String typedLine, String fallback) {
+    var chosen = typedLine == null || typedLine.isBlank() ? fallback : typedLine.strip();
+    if (Strings.isBlank(chosen)) {
+      throw new IllegalArgumentException(
+          "A handle is required — it is the FDE main will authorise.");
+    }
+    return chosen;
+  }
+
+  private String promptHandle(String fallback) {
+    var suffix = fallback != null ? " @|faint [" + fallback + "]|@" : "";
+    System.out.print(
+        Ansi.AUTO.string("  Authorise this node as which handle on main?" + suffix + " "));
+    return chosenHandle(ConsoleHelper.readLine(), fallback);
+  }
+
+  /** How {@link #resolveHandle()} should obtain the handle, decided without I/O. */
+  sealed interface HandleChoice {
+    /** A handle is already determined (explicit flag, or a fallback in non-interactive mode). */
+    record Resolved(String handle) implements HandleChoice {}
+
+    /** The caller must prompt, offering {@code fallback} (may be {@code null}) as the default. */
+    record NeedsPrompt(String fallback) implements HandleChoice {}
+  }
+
+  private static List<String> nodeFdeHandles() {
+    try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+      return new FdeStore(db)
+          .list().stream()
+              .filter(fde -> "active".equals(fde.status()))
+              .map(FdeStore.Fde::handle)
+              .toList();
+    } catch (Exception ignored) {
+      return List.of();
+    }
+  }
+
+  private static String gitEmailLocalPart() {
+    try {
+      var result = new ShellExecutor(false).exec(List.of("git", "config", "--get", "user.email"));
+      if (result.ok()) {
+        var email = result.stdout().strip();
+        var at = email.indexOf('@');
+        if (at > 0) {
+          return email.substring(0, at);
+        }
+      }
+    } catch (Exception ignored) {
+    }
+    return null;
+  }
+
+  private static void probeReachability(String target) {
+    var host = hostForProbe(target);
+    try (var socket = new Socket()) {
+      socket.connect(new InetSocketAddress(host, 22), 5000);
+    } catch (Exception e) {
+      System.err.println(
+          Banner.errorLine(
+              "Heads up: couldn't reach "
+                  + host
+                  + ":22 right now. Check the address and firewall — you can still hand the"
+                  + " operator the line below and run 'sail sync' once it's reachable.",
+              Ansi.AUTO));
+    }
   }
 
   /** The {@code sail fde add} line main's operator runs to authorise this node. */
@@ -102,33 +268,34 @@ public final class JoinCommand implements Runnable {
   }
 
   private void print(Plan plan) {
+    System.out.println(render(plan, json));
+  }
+
+  /** Renders the join result — machine JSON or the human next-steps block. Pure for testing. */
+  static String render(Plan plan, boolean json) {
+    var authorize = authorizeLine(plan.handle(), plan.publicKey());
     if (json) {
       var map = new LinkedHashMap<String, Object>();
       map.put("target", plan.target());
       map.put("suggested_handle", plan.handle());
       map.put("public_key", plan.publicKey());
-      map.put("authorize_command", authorizeLine(plan.handle(), plan.publicKey()));
-      System.out.println(YamlUtil.dumpJson(map));
-      return;
+      map.put("authorize_command", authorize);
+      return YamlUtil.dumpJson(map);
     }
-    var out = System.out;
-    out.println(
-        Ansi.AUTO.string(
-            "  @|bold,green ✓|@ This box is now a @|bold node|@ syncing to @|bold "
-                + plan.target()
-                + "|@."));
-    out.println();
-    out.println("  Send this to the operator of " + plan.target() + " — they run it once:");
-    out.println();
-    out.println(
-        Ansi.AUTO.string("    @|cyan " + authorizeLine(plan.handle(), plan.publicKey()) + "|@"));
-    out.println();
-    out.println(
-        Ansi.AUTO.string(
-            "  Once they have, finish here with @|bold sail sync|@. Only a public key leaves this"
-                + " box — never a secret."));
+    return Ansi.AUTO.string(
+        """
+
+            @|bold,green ✓|@ This box is now a @|bold node|@ syncing to @|bold %s|@.
+
+            Send this to the operator of %s — they run it once:
+
+              @|cyan %s|@
+
+            Once they have, finish here with @|bold sail sync|@. Only a public key leaves \
+        this box — never a secret."""
+            .formatted(plan.target(), plan.target(), authorize));
   }
 
-  /** Result of a join: the target, the suggested handle, and this node's public sync key. */
+  /** Result of a join: the target, the chosen handle, and this node's public sync key. */
   record Plan(String target, String handle, String publicKey) {}
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/HostInitCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/HostInitCommandTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class HostInitCommandTest {
+
+  @TempDir Path home;
+
+  @Test
+  void apiServiceIsNotInstalledOnAFreshHome() {
+    assertFalse(HostInitCommand.apiServiceInstalled(home));
+  }
+
+  @Test
+  void apiServiceIsNotInstalledForANullHome() {
+    assertFalse(HostInitCommand.apiServiceInstalled(null));
+  }
+
+  @Test
+  void apiServiceIsInstalledWhenBothUnitFilesExist() throws Exception {
+    var unit = home.resolve(".sail/services/sail-api.service");
+    var link = home.resolve(".config/systemd/user/sail-api.service");
+    Files.createDirectories(unit.getParent());
+    Files.createDirectories(link.getParent());
+    Files.writeString(unit, "[Unit]\n");
+    Files.writeString(link, "[Unit]\n");
+
+    assertTrue(HostInitCommand.apiServiceInstalled(home));
+  }
+
+  @Test
+  void apiServiceIsNotInstalledWhenOnlyTheUnitFileExistsWithoutTheUserLink() throws Exception {
+    var unit = home.resolve(".sail/services/sail-api.service");
+    Files.createDirectories(unit.getParent());
+    Files.writeString(unit, "[Unit]\n");
+
+    assertFalse(HostInitCommand.apiServiceInstalled(home));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/JoinCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/JoinCommandTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.io.TempDir;
 class JoinCommandTest {
 
   private static final String PUB =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEYBLOB sail-sync@node";
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEYBLOB sail-sync:mady";
 
   private static final HostYaml BASE =
       new HostYaml(
@@ -98,16 +98,125 @@ class JoinCommandTest {
   }
 
   @Test
-  void defaultHandleFallsBackWhenUsernameIsAbsent() {
-    var original = System.getProperty("user.name");
-    try {
-      System.setProperty("user.name", "");
-      assertEquals("your-handle", JoinCommand.defaultHandle());
-      System.setProperty("user.name", "mady");
-      assertEquals("mady", JoinCommand.defaultHandle());
-    } finally {
-      System.setProperty("user.name", original);
-    }
+  void normalizeTargetPrependsTheImpliedSailUserForABareHost() {
+    assertEquals("sail@maindevbox", JoinCommand.normalizeTarget("maindevbox"));
+    assertEquals("sail@10.0.0.1", JoinCommand.normalizeTarget("  10.0.0.1 "));
+  }
+
+  @Test
+  void normalizeTargetRespectsAnExplicitUser() {
+    assertEquals("sail@host", JoinCommand.normalizeTarget("sail@host"));
+    assertEquals("mady@host", JoinCommand.normalizeTarget("mady@host"));
+  }
+
+  @Test
+  void nonSailUserWarningFiresOnlyForANonSailUser() {
+    assertTrue(JoinCommand.nonSailUserWarning("mady@host").isPresent());
+    assertTrue(JoinCommand.nonSailUserWarning("root@host").get().contains("sail@host"));
+    assertTrue(JoinCommand.nonSailUserWarning("sail@host").isEmpty());
+    assertTrue(JoinCommand.nonSailUserWarning("maindevbox").isEmpty());
+  }
+
+  @Test
+  void hostForProbeStripsTheUserAndPort() {
+    assertEquals("host", JoinCommand.hostForProbe("sail@host"));
+    assertEquals("10.0.0.1", JoinCommand.hostForProbe("sail@10.0.0.1:2222"));
+    assertEquals("maindevbox", JoinCommand.hostForProbe("maindevbox"));
+  }
+
+  @Test
+  void defaultHandlePrefersThisBoxesSoleFde() {
+    assertEquals("mady", JoinCommand.defaultHandle(List.of("mady"), "ignored", "ignored"));
+  }
+
+  @Test
+  void defaultHandleFallsBackToSudoUserButNeverRoot() {
+    assertEquals("mady", JoinCommand.defaultHandle(List.of(), "mady", null));
+    assertEquals("alice", JoinCommand.defaultHandle(List.of("a", "b"), "alice", null));
+  }
+
+  @Test
+  void defaultHandleUsesGitLocalPartWhenThereIsNoUsableSudoUser() {
+    assertEquals("mady", JoinCommand.defaultHandle(List.of(), "root", "mady"));
+    assertEquals("mady", JoinCommand.defaultHandle(List.of(), null, "mady"));
+  }
+
+  @Test
+  void defaultHandleIsNullWhenNothingUsableAndNeverRoot() {
+    assertEquals(null, JoinCommand.defaultHandle(List.of(), "root", "root"));
+    assertEquals(null, JoinCommand.defaultHandle(List.of("a", "b"), null, null));
+    assertEquals(null, JoinCommand.defaultHandle(List.of(), "", "  "));
+  }
+
+  @Test
+  void handleChoiceUsesAnExplicitFlagAboveEverything() {
+    var choice = JoinCommand.handleChoice("mady", false, true, "ignored");
+    assertEquals(new JoinCommand.HandleChoice.Resolved("mady"), choice);
+  }
+
+  @Test
+  void handleChoiceFailsWhenJsonHasNoHandle() {
+    var error =
+        assertThrows(
+            IllegalArgumentException.class, () -> JoinCommand.handleChoice(null, true, true, "x"));
+    assertTrue(error.getMessage().contains("--json requires --handle"));
+  }
+
+  @Test
+  void handleChoiceUsesTheFallbackWhenThereIsNoConsole() {
+    assertEquals(
+        new JoinCommand.HandleChoice.Resolved("mady"),
+        JoinCommand.handleChoice(null, false, false, "mady"));
+  }
+
+  @Test
+  void handleChoiceFailsWithoutAConsoleOrFallback() {
+    var error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> JoinCommand.handleChoice(null, false, false, null));
+    assertTrue(error.getMessage().contains("No terminal to prompt"));
+  }
+
+  @Test
+  void handleChoiceAsksToPromptWhenInteractive() {
+    assertEquals(
+        new JoinCommand.HandleChoice.NeedsPrompt("mady"),
+        JoinCommand.handleChoice(null, false, true, "mady"));
+  }
+
+  @Test
+  void chosenHandleTakesTheTypedLineOverTheFallback() {
+    assertEquals("alice", JoinCommand.chosenHandle("  alice ", "mady"));
+  }
+
+  @Test
+  void chosenHandleFallsBackOnAnEmptyLine() {
+    assertEquals("mady", JoinCommand.chosenHandle("", "mady"));
+    assertEquals("mady", JoinCommand.chosenHandle(null, "mady"));
+  }
+
+  @Test
+  void chosenHandleRejectsAnEmptyResult() {
+    assertThrows(IllegalArgumentException.class, () -> JoinCommand.chosenHandle("", null));
+  }
+
+  @Test
+  void renderJsonEmitsTheAuthorizeCommand() {
+    var out = JoinCommand.render(new JoinCommand.Plan("sail@host", "mady", PUB), true);
+
+    assertTrue(out.contains("\"target\""));
+    assertTrue(out.contains("\"authorize_command\""));
+    assertTrue(out.contains("sail fde add mady --role member --key"));
+  }
+
+  @Test
+  void renderHumanShowsTheTargetAndAuthorizeLine() {
+    var out = JoinCommand.render(new JoinCommand.Plan("sail@host", "mady", PUB), false);
+
+    assertTrue(out.contains("sail@host"));
+    assertTrue(out.contains("sail fde add mady --role member"));
+    assertTrue(out.contains("sail sync"));
   }
 
   private final class StubKeygen implements ShellExec {


### PR DESCRIPTION
Two onboarding papercuts found while testing the main↔node join with a second engineer.

## 1. `sail host init` nagged to install an already-present service
`host init` printed "Next step: enable the sail API service → `sail host service install`" on **every** run — including a re-init of a box that already runs sail (which already has it). A node engineer who re-ran init got told to install something they had.

Fix: `init` checks the per-user `sail-api` unit (file-state root can read for `$SUDO_USER`) and, when present, prints "✓ already installed — nothing to do; 'sail upgrade' keeps it current" instead. `sail upgrade` already reconciles/restarts an installed service; it correctly does *not* freshly install a user-level unit (that needs the dev user + linger), so the bug was purely the unconditional message.

## 2. `sail join` suggested `sail fde add root …` and a generic key comment
The handle defaulted to the local OS username — which is **`root`** under sudo — and the handle is an FDE that lives on *main*, which the node can't see. The key comment used the box's base-image hostname (`sail-sync@Ubuntu-2404-noble-amd64-base`).

Fixes:
- **Handle is prompted for, never `root`.** Default resolves: this box's sole FDE → `$SUDO_USER` → `git config user.email` local part → else ask. `--handle` skips the prompt; `--json` requires it.
- **`sail@` gateway user is implied** — `sail join maindevbox` works; an explicit non-`sail` user is warned (the gateway only accepts `sail`).
- **Reachability probe** warns early if `main:22` is unreachable instead of failing later as a confusing sync error.
- **Key comment** is now `sail-sync:<handle>`, so `fde key list` on main reads cleanly.

## Rigor
Decision logic is extracted into pure, fully-tested seams (`handleChoice`, `chosenHandle`, `defaultHandle`, `normalizeTarget`, `nonSailUserWarning`, `hostForProbe`, `render`) — all ~100% covered; the picocli shell stays thin (SRP). New `HostInitCommandTest` + expanded `JoinCommandTest` (22 cases). Runbook updated to the bare-host + prompt flow and to stop telling existing boxes to re-run `host init`.

Full reactor `mvn verify` green: **1197** core, **130** harness, **1613** infra. Coverage gates pass (api.* 100%, bundle floors).