### PR TITLE
Consistent bordered tables for fde list, fde key list, project files ls, agent sessions

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentSessionsCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentSessionsCommand.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.SailApiClient;
 import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.Banner;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,26 +57,7 @@ public final class AgentSessionsCommand implements Runnable {
         return;
       }
 
-      System.out.println(Ansi.AUTO.string("  @|bold Agent Sessions:|@ " + project));
-      System.out.println();
-      for (var session : sessions) {
-        var status = (String) session.get("status");
-        var agent = (String) session.get("agent");
-        var specId = session.get("spec_id");
-        var startedAt = (String) session.get("started_at");
-        var color = "running".equals(status) ? "green" : "faint";
-        System.out.println(
-            Ansi.AUTO.string(
-                "  @|"
-                    + color
-                    + " "
-                    + status
-                    + "|@  "
-                    + agent
-                    + (specId != null ? "  spec=" + specId : "")
-                    + "  "
-                    + startedAt));
-      }
+      Banner.printAgentSessionsTable(sessions, project, System.out, Ansi.AUTO);
     }
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
@@ -9,6 +9,7 @@ import ai.singlr.sail.auth.EnrollmentService;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.AuthorizedKeysSync;
+import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.ssh.SshPublicKey;
 import ai.singlr.sail.store.EnrollmentTicketStore;
@@ -219,14 +220,7 @@ public final class FdeCommand implements Runnable {
                 System.out.println("  No FDEs. Add one with 'sail fde add <handle>'.");
                 return;
               }
-              for (var fde : fdes) {
-                System.out.printf(
-                    "  %-16s  %-20s  %-8s  %s%n",
-                    fde.handle(),
-                    fde.displayName() == null ? "" : fde.displayName(),
-                    fde.role(),
-                    fde.status());
-              }
+              Banner.printFdeTable(fdes, System.out, Ansi.AUTO);
             }
           });
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
@@ -363,13 +363,7 @@ public final class FdeCommand implements Runnable {
                   System.out.println("  No SSH keys. Register one with 'sail fde key add'.");
                   return;
                 }
-                for (var key : keys) {
-                  System.out.printf(
-                      "  %-16s  %-12s  %s%n",
-                      key.fdeHandle(),
-                      key.comment() == null ? "" : key.comment(),
-                      key.fingerprint());
-                }
+                Banner.printFdeKeyTable(keys, System.out, Ansi.AUTO);
               }
             });
       }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectFilesCommand.java
@@ -315,11 +315,17 @@ public final class ProjectFilesCommand implements Runnable {
       project = CurrentProject.require(project);
       NameValidator.requireValidProjectName(project);
       try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
-        System.out.println(render(new FileStore(db).list(project), project, json));
+        var rows = new FileStore(db).list(project);
+        if (json || rows.isEmpty()) {
+          System.out.println(render(rows, project, json));
+        } else {
+          Banner.printProjectFilesTable(rows, project, System.out, Ansi.AUTO);
+        }
         return 0;
       }
     }
 
+    /** Renders the JSON list, or the empty-state message for the human path. */
     static String render(List<FileStore.FileRow> rows, String project, boolean json) {
       if (json) {
         var list =
@@ -334,19 +340,7 @@ public final class ProjectFilesCommand implements Runnable {
                 .toList();
         return YamlUtil.dumpJson(list);
       }
-      if (rows.isEmpty()) {
-        return Ansi.AUTO.string(
-            "  @|faint No shared files on |@@|bold " + project + "|@@|faint .|@");
-      }
-      var out = new StringBuilder();
-      out.append(
-          Ansi.AUTO.string("  @|bold " + rows.size() + "|@ shared file(s) on " + project + ":\n"));
-      for (var r : rows) {
-        out.append(
-            Ansi.AUTO.string(
-                "    @|green " + r.path() + "|@ @|faint (" + decodedSize(r.content()) + " B)|@\n"));
-      }
-      return out.toString().stripTrailing();
+      return Ansi.AUTO.string("  @|faint No shared files on |@@|bold " + project + "|@@|faint .|@");
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
@@ -12,11 +12,14 @@ import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.store.FdeSshKeyStore;
 import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.FileStore;
 import java.io.PrintStream;
 import java.text.NumberFormat;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -627,6 +630,42 @@ public final class Banner {
 
   private static String orDash(String value) {
     return value == null || value.isBlank() ? "-" : value;
+  }
+
+  /** Prints a bordered table of an FDE's registered SSH keys. */
+  public static void printFdeKeyTable(
+      List<FdeSshKeyStore.SshKeyInfo> keys, PrintStream out, Ansi ansi) {
+    var table = new TableFormatter(" SSH Keys ", List.of("HANDLE", "COMMENT", "FINGERPRINT"));
+    for (var key : keys) {
+      table.addRow(key.fdeHandle(), orDash(key.comment()), key.fingerprint());
+    }
+    table.render(out, ansi);
+  }
+
+  /** Prints a bordered table of a project's shared files. */
+  public static void printProjectFilesTable(
+      List<FileStore.FileRow> rows, String project, PrintStream out, Ansi ansi) {
+    var table = new TableFormatter(" Files: " + project + " ", List.of("PATH", "SIZE"));
+    for (var row : rows) {
+      table.addRow(row.path(), Base64.getDecoder().decode(row.content()).length + " B");
+    }
+    table.render(out, ansi);
+  }
+
+  /** Prints a bordered table of a project's agent sessions. */
+  public static void printAgentSessionsTable(
+      List<Map<String, Object>> sessions, String project, PrintStream out, Ansi ansi) {
+    var table =
+        new TableFormatter(
+            " Agent Sessions: " + project + " ", List.of("STATUS", "AGENT", "SPEC", "STARTED"));
+    for (var session : sessions) {
+      table.addRow(
+          Objects.toString(session.get("status"), "-"),
+          Objects.toString(session.get("agent"), "-"),
+          Objects.toString(session.get("spec_id"), "-"),
+          Objects.toString(session.get("started_at"), "-"));
+    }
+    table.render(out, ansi);
   }
 
   /** Prints a success line for container destruction. */

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
@@ -12,6 +12,7 @@ import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.store.FdeStore;
 import java.io.PrintStream;
 import java.text.NumberFormat;
 import java.time.Duration;
@@ -612,6 +613,20 @@ public final class Banner {
       table.addRow(c.name(), status, ip, cpu, mem);
     }
     table.render(out, ansi);
+  }
+
+  /** Prints a bordered FDE list table. */
+  public static void printFdeTable(List<FdeStore.Fde> fdes, PrintStream out, Ansi ansi) {
+    var table = new TableFormatter(" FDEs ", List.of("HANDLE", "NAME", "EMAIL", "ROLE", "STATUS"));
+    for (var fde : fdes) {
+      table.addRow(
+          fde.handle(), orDash(fde.displayName()), orDash(fde.email()), fde.role(), fde.status());
+    }
+    table.render(out, ansi);
+  }
+
+  private static String orDash(String value) {
+    return value == null || value.isBlank() ? "-" : value;
   }
 
   /** Prints a success line for container destruction. */

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectFilesCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectFilesCommandTest.java
@@ -12,10 +12,14 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.FileMaterializer;
 import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.Sqlite;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
@@ -25,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
+import picocli.CommandLine.Help.Ansi;
 
 class ProjectFilesCommandTest {
 
@@ -142,11 +147,18 @@ class ProjectFilesCommandTest {
   }
 
   @Test
-  void lsRendersHumanAndJson() {
+  void lsRendersHumanTableAndJson() {
     files.put("acme", "a.txt", b64("AAAA"));
     files.put("acme", "b.txt", b64("B"));
 
-    var human = ProjectFilesCommand.Ls.render(files.list("acme"), "acme", false);
+    var captured = new ByteArrayOutputStream();
+    Banner.printProjectFilesTable(
+        files.list("acme"),
+        "acme",
+        new PrintStream(captured, true, StandardCharsets.UTF_8),
+        Ansi.OFF);
+    var human = captured.toString(StandardCharsets.UTF_8);
+    assertTrue(human.contains("PATH"));
     assertTrue(human.contains("a.txt"));
     assertTrue(human.contains("4 B"));
 

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/BannerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/BannerTest.java
@@ -13,6 +13,7 @@ import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.store.FdeSshKeyStore;
 import ai.singlr.sail.store.FdeStore;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -63,6 +64,47 @@ class BannerTest {
     assertTrue(text.contains("admin"));
     assertTrue(text.contains("mady"));
     assertTrue(text.contains("-"), "missing name/email render as a dash");
+  }
+
+  @Test
+  void fdeKeyTableShowsHandleCommentAndFingerprint() {
+    var out = new ByteArrayOutputStream();
+    var keys =
+        List.of(
+            new FdeSshKeyStore.SshKeyInfo(
+                "SHA256:abc", "id1", "uday", "ssh-ed25519 AAAA", "laptop", "t"),
+            new FdeSshKeyStore.SshKeyInfo(
+                "SHA256:xyz", "id2", "mady", "ssh-ed25519 BBBB", null, "t"));
+
+    Banner.printFdeKeyTable(keys, new PrintStream(out, true, StandardCharsets.UTF_8), Ansi.OFF);
+    var text = out.toString(StandardCharsets.UTF_8);
+
+    assertTrue(text.contains("HANDLE"));
+    assertTrue(text.contains("FINGERPRINT"));
+    assertTrue(text.contains("uday"));
+    assertTrue(text.contains("laptop"));
+    assertTrue(text.contains("SHA256:abc"));
+    assertTrue(text.contains("-"), "a missing comment renders as a dash");
+  }
+
+  @Test
+  void agentSessionsTableShowsStatusAgentSpecAndStarted() {
+    var out = new ByteArrayOutputStream();
+    var sessions =
+        List.<Map<String, Object>>of(
+            Map.of("status", "running", "agent", "claude-code", "spec_id", "auth"),
+            Map.of("status", "stopped", "agent", "codex", "started_at", "2026-06-16T00:00:00Z"));
+
+    Banner.printAgentSessionsTable(
+        sessions, "acme", new PrintStream(out, true, StandardCharsets.UTF_8), Ansi.OFF);
+    var text = out.toString(StandardCharsets.UTF_8);
+
+    assertTrue(text.contains("Agent Sessions: acme"));
+    assertTrue(text.contains("STATUS"));
+    assertTrue(text.contains("running"));
+    assertTrue(text.contains("claude-code"));
+    assertTrue(text.contains("auth"));
+    assertTrue(text.contains("-"), "a missing field renders as a dash");
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/BannerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/BannerTest.java
@@ -13,6 +13,7 @@ import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.store.FdeStore;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
@@ -40,6 +41,28 @@ class BannerTest {
     assertTrue(output.contains("6 cores / 12 threads"));
     assertTrue(output.contains("31,868 MB"));
     assertTrue(output.contains("Host Detection"));
+  }
+
+  @Test
+  void fdeTableShowsHeadersDataAndDashesForMissingFields() {
+    var out = new ByteArrayOutputStream();
+    var fdes =
+        List.of(
+            new FdeStore.Fde("id1", "uday", "Uday Chandra", "uday@x.ai", "admin", "active", "t"),
+            new FdeStore.Fde("id2", "mady", null, null, "member", "active", "t"));
+
+    Banner.printFdeTable(fdes, new PrintStream(out, true, StandardCharsets.UTF_8), Ansi.OFF);
+    var text = out.toString(StandardCharsets.UTF_8);
+
+    assertTrue(text.contains("FDEs"));
+    assertTrue(text.contains("HANDLE"));
+    assertTrue(text.contains("EMAIL"));
+    assertTrue(text.contains("STATUS"));
+    assertTrue(text.contains("uday"));
+    assertTrue(text.contains("Uday Chandra"));
+    assertTrue(text.contains("admin"));
+    assertTrue(text.contains("mady"));
+    assertTrue(text.contains("-"), "missing name/email render as a dash");
   }
 
   @Test


### PR DESCRIPTION
`sail fde list` printed plain `printf` rows while `project list`, snapshots, and `agent status` all use the branded bordered `TableFormatter`. This brings every flat list command to the same presentation:

- `fde list` → `Banner.printFdeTable` (HANDLE, NAME, EMAIL, ROLE, STATUS)
- `fde key list` → `Banner.printFdeKeyTable` (HANDLE, COMMENT, FINGERPRINT)
- `project files ls` → `Banner.printProjectFilesTable` (PATH, SIZE) — JSON path unchanged, empty-state message preserved
- `agent sessions` → `Banner.printAgentSessionsTable` (STATUS, AGENT, SPEC, STARTED)

Missing fields render as a dash. `spec list` keeps its intentional grouped-by-project board view; `conflicts` keeps its richer multi-field layout (a flat row would lose detail).

New `BannerTest` cases for the FDE, key, and sessions tables; `ProjectFilesCommandTest` asserts the human table. Full verify green: 1212 core / 120 harness / 1618 infra, coverage gates pass.