### PR TITLE
sail fde update + join captures name/email

### DIFF
--- a/docs/E2E_JOIN_RUNBOOK.md
+++ b/docs/E2E_JOIN_RUNBOOK.md
@@ -150,22 +150,43 @@ sail conflicts                       # expect push-demo listed; resolve it (take
 sail sync                            # expect convergence; conflicts = 0 afterward
 ```
 
-### 5. Files materialize; local edits are kept
+### 5. Projects and files sync from main; local edits are kept
+
+**5a — a project definition created on main lands on the node ("pull a project from main" = sync):**
+```bash
+# MAIN — create a project; this catalogs its definition (and provisions a container on main)
+sail project create testsync --yes
+# NODE
+sail sync                                      # expect "1 new project(s) synced from main: testsync"
+cat ~/.sail/projects/testsync/sail.yaml        # expect the descriptor, materialized from the catalog
+sail project config testsync                   # reads the catalog (DB-authoritative) — same definition
+sudo sail project create testsync              # (optional) provision the synced definition locally
+```
+
+**5b — a definition edited on main propagates (the DB is the source of truth):**
+```bash
+# MAIN
+sail project edit testsync                     # change e.g. the description; saves to the catalog
+# NODE
+sail sync && sail project config testsync      # expect the edited definition (not a stale local file)
+```
+
+**5c — shared files materialize, and a local edit is kept, not overwritten:**
 ```bash
 # MAIN
 echo "shared config v1" > /tmp/shared.env
-sail project files add --project <proj> /tmp/shared.env --as config/shared.env
+sail project files add --project testsync /tmp/shared.env --as config/shared.env
 # NODE
 sail sync
-sail project files ls --project <proj>          # expect config/shared.env
-cat ~/.sail/projects/<proj>/config/shared.env   # expect "shared config v1"
+sail project files ls --project testsync            # expect config/shared.env (in the bordered table)
+cat ~/.sail/projects/testsync/files/config/shared.env   # expect "shared config v1"
 
-# Now prove a local edit is preserved, not overwritten:
+# now prove a local edit survives:
 # NODE
-echo "node local change" >> ~/.sail/projects/<proj>/config/shared.env
+echo "node local change" >> ~/.sail/projects/testsync/files/config/shared.env
 # MAIN
 echo "shared config v2" > /tmp/shared.env
-sail project files add --project <proj> /tmp/shared.env --as config/shared.env
+sail project files add --project testsync /tmp/shared.env --as config/shared.env
 # NODE
 sail sync     # expect a "Kept 1 locally-modified file(s)" warning; your edit survives
 ```

--- a/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
@@ -125,6 +125,39 @@ public final class FdeStore {
     return db.queryOne(SELECT + " WHERE id = ?", FdeStore::map, id);
   }
 
+  /**
+   * Amends an existing FDE in place — only the non-null arguments change; the rest are left as they
+   * are, and the surrogate id (and the keys, tokens, and sessions that reference it) is preserved.
+   * Returns the updated FDE, or empty if the handle is unknown. The change propagates to every node
+   * on its next roster pull.
+   */
+  public Optional<Fde> update(String handle, String displayName, String email, String role) {
+    var existing = byHandle(handle).orElse(null);
+    if (existing == null) {
+      return Optional.empty();
+    }
+    if (role != null && !ROLES.contains(role)) {
+      throw new IllegalArgumentException(
+          "Invalid role: " + role + ". Must be one of " + ROLES + ".");
+    }
+    var updated =
+        new Fde(
+            existing.id(),
+            existing.handle(),
+            displayName != null ? displayName : existing.displayName(),
+            email != null ? email : existing.email(),
+            role != null ? role : existing.role(),
+            existing.status(),
+            existing.createdAt());
+    db.execute(
+        "UPDATE fdes SET display_name = ?, email = ?, role = ? WHERE handle = ?",
+        updated.displayName(),
+        updated.email(),
+        updated.role(),
+        handle);
+    return Optional.of(updated);
+  }
+
   public List<Fde> list() {
     return db.query(SELECT + " ORDER BY handle", FdeStore::map);
   }

--- a/sail-core/src/test/java/ai/singlr/sail/store/FdeStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FdeStoreTest.java
@@ -207,4 +207,36 @@ class FdeStoreTest {
     store.add("dup", null, null);
     assertThrows(SqliteException.class, () -> store.add("dup", null, null));
   }
+
+  @Test
+  void updateAmendsOnlyTheGivenFieldsAndPreservesTheId() {
+    var added = store.add("mady", null, null, "member");
+
+    var updated = store.update("mady", "Mady M", "mady@example.com", null).orElseThrow();
+
+    assertEquals(added.id(), updated.id(), "the surrogate id is preserved");
+    assertEquals("Mady M", updated.displayName());
+    assertEquals("mady@example.com", updated.email());
+    assertEquals("member", updated.role(), "an unspecified field is left as it was");
+    assertEquals("Mady M", store.byHandle("mady").orElseThrow().displayName());
+  }
+
+  @Test
+  void updateCanChangeTheRole() {
+    store.add("mady", "Mady M", "mady@example.com", "member");
+    assertEquals("admin", store.update("mady", null, null, "admin").orElseThrow().role());
+    assertEquals("Mady M", store.byHandle("mady").orElseThrow().displayName());
+  }
+
+  @Test
+  void updateIsEmptyForAnUnknownHandle() {
+    assertTrue(store.update("ghost", "X", null, null).isEmpty());
+  }
+
+  @Test
+  void updateRejectsAnInvalidRole() {
+    store.add("mady", null, null, "member");
+    assertThrows(
+        IllegalArgumentException.class, () -> store.update("mady", null, null, "superuser"));
+  }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
@@ -38,6 +38,7 @@ import picocli.CommandLine.Spec;
     subcommands = {
       FdeCommand.Add.class,
       FdeCommand.ListFdes.class,
+      FdeCommand.Update.class,
       FdeCommand.Remove.class,
       FdeCommand.Enroll.class,
       FdeCommand.Key.class
@@ -118,7 +119,12 @@ public final class FdeCommand implements Runnable {
             try (var db = Sqlite.open(dbPath())) {
               var fdeStore = new FdeStore(db);
               if (fdeStore.byHandle(handle).isPresent()) {
-                throw new IllegalArgumentException("FDE '" + handle + "' already exists.");
+                throw new IllegalArgumentException(
+                    "FDE '"
+                        + handle
+                        + "' already exists. Change it with 'sail fde update "
+                        + handle
+                        + "'.");
               }
               var fde =
                   key == null
@@ -147,6 +153,49 @@ public final class FdeCommand implements Runnable {
         throw new IllegalArgumentException(
             "That key (" + key.fingerprint() + ") is already registered.");
       }
+    }
+  }
+
+  @Command(
+      name = "update",
+      description = "Update an FDE's display name, email, or role.",
+      mixinStandardHelpOptions = true)
+  static final class Update implements Runnable {
+
+    @Parameters(index = "0", description = "FDE handle.")
+    private String handle;
+
+    @Option(names = "--name", description = "New display name.")
+    private String displayName;
+
+    @Option(names = "--email", description = "New email address.")
+    private String email;
+
+    @Option(names = "--role", description = "New role: admin, member, or viewer.")
+    private String role;
+
+    @Spec private CommandSpec spec;
+
+    @Override
+    public void run() {
+      CliCommand.run(
+          spec,
+          () -> {
+            if (displayName == null && email == null && role == null) {
+              throw new IllegalArgumentException(
+                  "Nothing to update. Pass --name, --email, and/or --role.");
+            }
+            try (var db = Sqlite.open(dbPath())) {
+              var updated =
+                  new FdeStore(db)
+                      .update(handle, displayName, email, role)
+                      .orElseThrow(
+                          () -> new IllegalArgumentException("Unknown FDE '" + handle + "'."));
+              System.out.println(
+                  Ansi.AUTO.string(
+                      "  @|green ✓|@ Updated " + updated.handle() + " (" + updated.role() + ")"));
+            }
+          });
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/JoinCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/JoinCommand.java
@@ -59,6 +59,16 @@ public final class JoinCommand implements Runnable {
       description = "FDE handle main will authorise (skips the prompt; required with --json).")
   private String handle;
 
+  @Option(
+      names = "--name",
+      description = "Your full name for the team roster (default: git user.name).")
+  private String fullName;
+
+  @Option(
+      names = "--email",
+      description = "Your email for the team roster (default: git user.email).")
+  private String email;
+
   @Option(names = "--json", description = "Output in JSON format.")
   private boolean json;
 
@@ -74,8 +84,17 @@ public final class JoinCommand implements Runnable {
     nonSailUserWarning(target)
         .ifPresent(warning -> System.err.println(Banner.errorLine(warning, Ansi.AUTO)));
     var resolvedHandle = resolveHandle();
+    var resolvedName = resolveOptional(fullName, gitConfig("user.name"), "Your full name");
+    var resolvedEmail = resolveOptional(email, gitConfig("user.email"), "Your email");
     var identity = new SyncIdentity(new ShellExecutor(false));
-    var plan = plan(SailPaths.hostConfigPath(), identity, normalized, resolvedHandle);
+    var plan =
+        plan(
+            SailPaths.hostConfigPath(),
+            identity,
+            normalized,
+            resolvedHandle,
+            resolvedName,
+            resolvedEmail);
     probeReachability(normalized);
     print(plan);
   }
@@ -85,7 +104,13 @@ public final class JoinCommand implements Runnable {
    * Pure of any prompting or stdout so it can be exercised directly in tests with a
    * {@code @TempDir} config and a stub identity.
    */
-  static Plan plan(Path hostConfig, SyncIdentity identity, String target, String handle)
+  static Plan plan(
+      Path hostConfig,
+      SyncIdentity identity,
+      String target,
+      String handle,
+      String name,
+      String email)
       throws Exception {
     if (!Files.exists(hostConfig)) {
       throw new IllegalStateException("Server not initialized. Run 'sail host init' first.");
@@ -96,7 +121,7 @@ public final class JoinCommand implements Runnable {
     var updated = HostSyncCommand.configure(host, false, target);
     requireWritable(hostConfig, target);
     YamlUtil.dumpToFile(updated.toMap(), hostConfig);
-    return new Plan(target, handle, publicKey);
+    return new Plan(target, handle, name, email, publicKey);
   }
 
   private static void requireWritable(Path hostConfig, String target) {
@@ -233,18 +258,42 @@ public final class JoinCommand implements Runnable {
   }
 
   private static String gitEmailLocalPart() {
+    var email = gitConfig("user.email");
+    if (email == null) {
+      return null;
+    }
+    var at = email.indexOf('@');
+    return at > 0 ? email.substring(0, at) : null;
+  }
+
+  private static String gitConfig(String key) {
     try {
-      var result = new ShellExecutor(false).exec(List.of("git", "config", "--get", "user.email"));
+      var result = new ShellExecutor(false).exec(List.of("git", "config", "--get", key));
       if (result.ok()) {
-        var email = result.stdout().strip();
-        var at = email.indexOf('@');
-        if (at > 0) {
-          return email.substring(0, at);
-        }
+        var value = result.stdout().strip();
+        return value.isBlank() ? null : value;
       }
     } catch (Exception ignored) {
     }
     return null;
+  }
+
+  /**
+   * Resolves an optional roster field (name/email): an explicit flag wins, a non-interactive run
+   * uses the git default, and an interactive run prompts with the git default. May be blank — the
+   * FDE works without it, so the printed line just omits the flag.
+   */
+  private String resolveOptional(String flag, String gitDefault, String label) {
+    if (Strings.isNotBlank(flag)) {
+      return flag.strip();
+    }
+    if (json || System.console() == null) {
+      return gitDefault;
+    }
+    var suffix = Strings.isNotBlank(gitDefault) ? " @|faint [" + gitDefault + "]|@" : "";
+    System.out.print(Ansi.AUTO.string("  " + label + "?" + suffix + " "));
+    var line = ConsoleHelper.readLine();
+    return line == null || line.isBlank() ? gitDefault : line.strip();
   }
 
   private static void probeReachability(String target) {
@@ -263,8 +312,16 @@ public final class JoinCommand implements Runnable {
   }
 
   /** The {@code sail fde add} line main's operator runs to authorise this node. */
-  static String authorizeLine(String handle, String publicKey) {
-    return "sail fde add " + handle + " --role member --key \"" + publicKey + "\"";
+  static String authorizeLine(String handle, String name, String email, String publicKey) {
+    var line = new StringBuilder("sail fde add " + handle + " --role member");
+    if (Strings.isNotBlank(name)) {
+      line.append(" --name \"").append(name).append('"');
+    }
+    if (Strings.isNotBlank(email)) {
+      line.append(" --email \"").append(email).append('"');
+    }
+    line.append(" --key \"").append(publicKey).append('"');
+    return line.toString();
   }
 
   private void print(Plan plan) {
@@ -273,11 +330,13 @@ public final class JoinCommand implements Runnable {
 
   /** Renders the join result — machine JSON or the human next-steps block. Pure for testing. */
   static String render(Plan plan, boolean json) {
-    var authorize = authorizeLine(plan.handle(), plan.publicKey());
+    var authorize = authorizeLine(plan.handle(), plan.name(), plan.email(), plan.publicKey());
     if (json) {
       var map = new LinkedHashMap<String, Object>();
       map.put("target", plan.target());
       map.put("suggested_handle", plan.handle());
+      map.put("suggested_name", plan.name());
+      map.put("suggested_email", plan.email());
       map.put("public_key", plan.publicKey());
       map.put("authorize_command", authorize);
       return YamlUtil.dumpJson(map);
@@ -297,5 +356,5 @@ public final class JoinCommand implements Runnable {
   }
 
   /** Result of a join: the target, the chosen handle, and this node's public sync key. */
-  record Plan(String target, String handle, String publicKey) {}
+  record Plan(String target, String handle, String name, String email, String publicKey) {}
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/JoinCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/JoinCommandTest.java
@@ -58,10 +58,14 @@ class JoinCommandTest {
   void planPointsTheBoxAtMainAndReturnsItsPublicKey() throws Exception {
     var hostConfig = writeHostConfig();
 
-    var plan = JoinCommand.plan(hostConfig, identity(), "sail@maindevbox", "mady");
+    var plan =
+        JoinCommand.plan(
+            hostConfig, identity(), "sail@maindevbox", "mady", "Mady M", "mady@example.com");
 
     assertEquals("sail@maindevbox", plan.target());
     assertEquals("mady", plan.handle());
+    assertEquals("Mady M", plan.name());
+    assertEquals("mady@example.com", plan.email());
     assertEquals(PUB, plan.publicKey());
 
     var written = HostYaml.fromMap(YamlUtil.parseFile(hostConfig));
@@ -77,7 +81,7 @@ class JoinCommandTest {
     var error =
         assertThrows(
             IllegalStateException.class,
-            () -> JoinCommand.plan(missing, identity(), "sail@main", "mady"));
+            () -> JoinCommand.plan(missing, identity(), "sail@main", "mady", null, null));
     assertTrue(error.getMessage().contains("host init"));
   }
 
@@ -87,14 +91,23 @@ class JoinCommandTest {
 
     assertThrows(
         IllegalArgumentException.class,
-        () -> JoinCommand.plan(hostConfig, identity(), "not a target!", "mady"));
+        () -> JoinCommand.plan(hostConfig, identity(), "not a target!", "mady", null, null));
   }
 
   @Test
-  void authorizeLineIsACopyPasteFdeAddCommand() {
+  void authorizeLineCarriesNameAndEmailWhenPresent() {
+    assertEquals(
+        "sail fde add mady --role member --name \"Mady M\" --email \"mady@example.com\" --key \""
+            + PUB
+            + "\"",
+        JoinCommand.authorizeLine("mady", "Mady M", "mady@example.com", PUB));
+  }
+
+  @Test
+  void authorizeLineOmitsBlankNameAndEmail() {
     assertEquals(
         "sail fde add mady --role member --key \"" + PUB + "\"",
-        JoinCommand.authorizeLine("mady", PUB));
+        JoinCommand.authorizeLine("mady", null, "  ", PUB));
   }
 
   @Test
@@ -203,16 +216,20 @@ class JoinCommandTest {
 
   @Test
   void renderJsonEmitsTheAuthorizeCommand() {
-    var out = JoinCommand.render(new JoinCommand.Plan("sail@host", "mady", PUB), true);
+    var out =
+        JoinCommand.render(
+            new JoinCommand.Plan("sail@host", "mady", "Mady M", "mady@example.com", PUB), true);
 
     assertTrue(out.contains("\"target\""));
     assertTrue(out.contains("\"authorize_command\""));
-    assertTrue(out.contains("sail fde add mady --role member --key"));
+    assertTrue(out.contains("\"suggested_name\""));
+    assertTrue(out.contains("Mady M"));
+    assertTrue(out.contains("sail fde add mady --role member --name"));
   }
 
   @Test
   void renderHumanShowsTheTargetAndAuthorizeLine() {
-    var out = JoinCommand.render(new JoinCommand.Plan("sail@host", "mady", PUB), false);
+    var out = JoinCommand.render(new JoinCommand.Plan("sail@host", "mady", null, null, PUB), false);
 
     assertTrue(out.contains("sail@host"));
     assertTrue(out.contains("sail fde add mady --role member"));


### PR DESCRIPTION
Two onboarding gaps found adding a second engineer to a main:

**1. No way to amend an FDE.** An FDE added from the `sail join` line had only handle/role/key — no name or email — and the only fix was a destructive `fde rm` + re-add. New **`sail fde update <handle> [--name] [--email] [--role]`**: `FdeStore.update` amends only the supplied fields, preserves the surrogate id (and the keys/tokens/sessions that reference it), and the change replicates to nodes on the next roster pull. `fde add` on an existing handle now points you at `fde update`.

**2. `sail join` didn't capture identity.** It now asks for full name and email — defaulting from `git config user.name`/`user.email`, prompting when interactive, or via `--name`/`--email` — and folds them into the printed `sail fde add … --name … --email …` line, so the roster is populated from the start. Blank values are omitted.

New `FdeStore.update` tests (amend-subset, role change, unknown handle, invalid role) and `JoinCommand` coverage (authorize line with/without name+email, plan, render). Full verify green: **1216 core / 120 harness / 1619 infra**, coverage gates pass.