### PR TITLE
ci: make OWASP dependency scan resilient to NVD outages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
           -DskipTestScope=true
           -DnvdApiKey=${{ secrets.NVD_API_KEY }}
           -DdataDirectory=${{ runner.temp }}/dependency-check-data
+          -DnvdValidForHours=168
+          -DnvdApiDelay=4000
+          -DnvdMaxRetryCount=30
 
       - name: Upload dependency check reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
**Symptom:** CI's `Scan dependencies` step started failing with `NvdApiException: NVD Returned Status Code: 524` (a Cloudflare origin timeout from the National Vulnerability Database API). Our actual build is fine — `Verify quality gates` (tests + coverage) and the native build pass, and Release 0.13.87 published normally. The scan just couldn't pull the NVD CVE feed.

**Root cause:** OWASP Dependency-Check's default `nvdValidForHours` is 4 hours, so a cached CVE database older than that gets "refreshed" on every run — forcing a call to the frequently-flaky NVD API. When NVD returned 524, the scan aborted ("No documents exist").

**Fix:** reuse the cached database for a week (`nvdValidForHours=168`) so routine PR/main runs never contact NVD; add `nvdApiDelay=4000` + `nvdMaxRetryCount=30` so the weekly refresh tolerates transient NVD slowness. The `failBuildOnCVSS=7` gate is unchanged — this only stops NVD's uptime from gating merges.