### PR TITLE
fix(sync): surface why a one-shot sail sync failed (was silent)

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
@@ -145,11 +145,26 @@ public final class SyncCommand implements Callable<Integer> {
         "Single devbox — nothing to sync. Add a second box with: sail host sync --main <user@host>.");
   }
 
-  private int runOnce(Boxes boxes, String target) throws Exception {
-    var report = reconcile(boxes, target);
-    System.out.println(render(report, json));
-    notifyBoardUpdated(report);
-    return 0;
+  private int runOnce(Boxes boxes, String target) {
+    try {
+      var report = reconcile(boxes, target);
+      System.out.println(render(report, json));
+      notifyBoardUpdated(report);
+      return 0;
+    } catch (Exception e) {
+      System.err.println(
+          Banner.errorLine("Sync with " + target + " failed: " + reason(e), Ansi.AUTO));
+      return 1;
+    }
+  }
+
+  /** A human-readable reason for a failed round, falling back to the exception type. */
+  static String reason(Exception e) {
+    var message = e.getMessage();
+    if (message == null || message.isBlank()) {
+      return e.getClass().getSimpleName();
+    }
+    return message;
   }
 
   private int watchLoop(Boxes boxes, String target) throws InterruptedException {
@@ -163,7 +178,7 @@ public final class SyncCommand implements Callable<Integer> {
       } catch (Exception e) {
         System.err.println(
             Banner.errorLine(
-                "Sync round failed (" + e.getMessage() + "); retrying in " + intervalSeconds + "s.",
+                "Sync round failed (" + reason(e) + "); retrying in " + intervalSeconds + "s.",
                 Ansi.AUTO));
       }
       Thread.sleep(intervalSeconds * 1000L);

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SyncCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SyncCommandTest.java
@@ -117,4 +117,11 @@ class SyncCommandTest {
     assertEquals(2, event.data().get("merged"));
     assertEquals(4, event.data().get("conflicts"));
   }
+
+  @Test
+  void reasonUsesTheMessageOrFallsBackToTheExceptionType() {
+    assertEquals("boom", SyncCommand.reason(new IllegalStateException("boom")));
+    assertEquals("RuntimeException", SyncCommand.reason(new RuntimeException()));
+    assertEquals("IllegalStateException", SyncCommand.reason(new IllegalStateException("  ")));
+  }
 }


### PR DESCRIPTION
`sail sync` (a Callable) let its exceptions hit Main's global `setExecutionExceptionHandler`, which returns 1 and prints nothing — so a failed sync was a silent empty response with no reason. The `--watch` loop already reported failures; the one-shot path didn't. `runOnce` now catches and prints `Sync with <target> failed: <reason>` and returns exit 1. New `reason()` test. Follow-up noted: the global handler swallowing any escaped Callable exception is a broader latent issue. Full verify green: 1216 / 120 / 1620.