### PR TITLE
fix(sync): drop spec_dependencies.depends_on FK (was aborting sync)

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -294,7 +294,17 @@ public final class SchemaManager {
           )""",
           "ALTER TABLE api_tokens ADD COLUMN expires_at TEXT",
           "ALTER TABLE projects ADD COLUMN rev TEXT",
-          "ALTER TABLE projects ADD COLUMN base_rev TEXT");
+          "ALTER TABLE projects ADD COLUMN base_rev TEXT",
+          """
+          CREATE TABLE spec_dependencies_v2 (
+              spec_id TEXT NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
+              depends_on TEXT NOT NULL,
+              PRIMARY KEY (spec_id, depends_on)
+          )""",
+          "INSERT INTO spec_dependencies_v2 (spec_id, depends_on)"
+              + " SELECT spec_id, depends_on FROM spec_dependencies",
+          "DROP TABLE spec_dependencies",
+          "ALTER TABLE spec_dependencies_v2 RENAME TO spec_dependencies");
 
   private final Sqlite db;
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
@@ -364,4 +364,31 @@ class SpecStoreTest {
     assertTrue(store.findById("child").isEmpty());
     assertTrue(store.getContent("child").isEmpty());
   }
+
+  @Test
+  void aSpecCanDependOnOneThatHasNotArrivedYet() {
+    var billing =
+        new SpecStore.SpecRow(
+            "billing",
+            "test-project",
+            "Billing",
+            SpecStatus.PENDING,
+            null,
+            null,
+            null,
+            null,
+            null,
+            0,
+            null,
+            "",
+            "",
+            null,
+            List.of("auth"),
+            List.of());
+
+    store.create(billing);
+
+    assertEquals(List.of("auth"), store.findById("billing").orElseThrow().dependsOn());
+    assertTrue(store.findById("auth").isEmpty(), "the dependency need not exist");
+  }
 }


### PR DESCRIPTION
**The sync failure** `FOREIGN KEY constraint failed (sqlite error 19)` was `spec_dependencies.depends_on REFERENCES specs(id)`. The sync engine applies specs one entity at a time in arbitrary order, so a spec that depends on one that hasn't synced yet (or was deleted) violates the FK — aborting the whole round before the FDE roster pulls (hence "No FDEs" on the node). The constraint is incompatible with order-independent replication; `depends_on` is a soft reference. Migration recreates the table keeping `spec_id`'s cascade FK + the PK, dropping only the `depends_on` FK. Regression test added. Both main and node need it (main hits the same FK on a pushed dependent spec). Full verify green: 1217 / 120 / 1620.