### PR TITLE
fix(sync): backfill revisions so pre-existing projects replicate

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
@@ -126,6 +126,22 @@ public final class ProjectStore implements ConflictResolver {
   }
 
   /**
+   * Records a baseline revision for every catalogued project that has none yet. A project written
+   * before this store journaled its mutations has a row but no change-log entry, so it is invisible
+   * to sync until journaled. Idempotent — a project already in the change log is left untouched.
+   * Returns how many were backfilled.
+   */
+  public int backfillRevisions() {
+    var journaled = syncEntityIds();
+    var pending = list().stream().filter(row -> !journaled.contains(row.name())).toList();
+    for (var row : pending) {
+      db.transaction(
+          () -> recordRevision(row.name(), row.definition(), null, "local", false, false));
+    }
+    return pending.size();
+  }
+
+  /**
    * Adopts main's authoritative state at its exact rev (no minting), as the new synced ancestor.
    */
   public void applyRevision(String id, Map<String, Object> snapshot, String rev) {

--- a/sail-core/src/test/java/ai/singlr/sail/store/ProjectStoreSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ProjectStoreSyncTest.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -126,6 +127,26 @@ class ProjectStoreSyncTest {
     store.resolveConflict("acme", def("theirs"), def("theirs"));
 
     assertEquals(def("theirs"), store.comparableSnapshot("acme"));
+  }
+
+  @Test
+  void backfillMakesACataloguedButUnjournaledProjectSyncable() {
+    db.execute(
+        "INSERT INTO projects (name, definition, created_at, updated_at)"
+            + " VALUES ('legacy', 'name: legacy\n', '2026-01-01', '2026-01-01')");
+    assertFalse(store.syncEntityIds().contains("legacy"), "no change-log entry yet");
+
+    assertEquals(1, store.backfillRevisions());
+
+    assertTrue(store.syncEntityIds().contains("legacy"), "now visible to sync");
+    assertEquals(def("name: legacy\n"), store.comparableSnapshot("legacy"));
+  }
+
+  @Test
+  void backfillIsIdempotentAndSkipsAlreadyJournaledProjects() {
+    store.upsert("acme", "v1", "uday");
+
+    assertEquals(0, store.backfillRevisions(), "an already-journaled project is left untouched");
   }
 
   @Test

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -87,6 +87,7 @@ public final class MigrateCommand implements Runnable {
       var animate = !jsonOutput && System.console() != null;
       var runs = applyMigrations(db, dbPath.toString(), prompter, animate, jsonOutput);
       importProjects(db, jsonOutput);
+      backfillProjectRevisions(db, jsonOutput);
       importFiles(db, jsonOutput);
       seedDemo(db, jsonOutput);
       relocateHostConfig(jsonOutput);
@@ -105,6 +106,19 @@ public final class MigrateCommand implements Runnable {
     if (!jsonOutput && report.imported() > 0) {
       System.out.println(
           Ansi.AUTO.string("  @|green ✓|@ project catalog: " + report.imported() + " imported"));
+    }
+  }
+
+  /**
+   * Journals a baseline revision for catalogued projects that predate the sync machinery, so a
+   * project sitting in the catalog without a change-log entry becomes visible to {@code sail sync}.
+   * Quiet when nothing needed it.
+   */
+  private static void backfillProjectRevisions(Sqlite db, boolean jsonOutput) {
+    var backfilled = new ProjectStore(db).backfillRevisions();
+    if (!jsonOutput && backfilled > 0) {
+      System.out.println(
+          Ansi.AUTO.string("  @|green ✓|@ project catalog: " + backfilled + " made syncable"));
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
@@ -317,13 +317,11 @@ public final class SyncCommand implements Callable<Integer> {
       publisher.publish(boardUpdatedEvent(HostInfo.hostname(), report));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-    } catch (Exception e) {
+    } catch (Exception ignored) {
       System.err.println(
-          Banner.errorLine(
-              "Could not publish board_updated event ("
-                  + e.getMessage()
-                  + "). sail-api may be unreachable; the sync itself is unaffected.",
-              Ansi.AUTO));
+          Ansi.AUTO.string(
+              "  @|faint Board notification skipped — sail-api isn't running here; the sync is"
+                  + " unaffected.|@"));
     }
   }
 


### PR DESCRIPTION
A main with several projects synced only `demo` to a node. Root cause: Brick B added `change_log` journaling to `ProjectStore.upsert` for new mutations but never backfilled existing rows, and sync only replicates entities with a change_log entry (`syncEntityIds()`). Projects catalogued by an older `sail` were invisible to sync. `ProjectStore.backfillRevisions()` journals a baseline for each unjournaled catalogued project (idempotent), run by `sail migrate`. Also quiets the `board_updated (null)` notification on a node (no local sail-api → expected). Regression tests added. Full verify green: 1219 / 120 / 1620.