### PR TITLE
Keep per-developer identity out of the synced project definition

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/config/PersonalFields.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/PersonalFields.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.config;
+
+import ai.singlr.sail.common.Strings;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The fields of a project definition that belong to whoever works a box, not to the project the
+ * fleet shares: the git identity commits are authored with, and the SSH key authorized into that
+ * box's containers. {@link #redact} rewrites these to {@code ${...}} placeholders so the
+ * catalogued, synced definition every box agrees on never carries one engineer's identity or — the
+ * part that matters for security — their keys. Each box fills them back in locally at provision
+ * time from its own identity (see {@link PlaceholderResolver}).
+ *
+ * <p>The transform is pure and idempotent: redacting an already-redacted definition returns it
+ * unchanged, and a definition with no personal fields is returned byte-for-byte so a sync sees no
+ * spurious change. Because it is deterministic, two boxes that redact the same concrete definition
+ * reach identical content and the sync engine converges them without a conflict.
+ */
+public final class PersonalFields {
+
+  private static final String GIT = "git";
+  private static final String NAME = "name";
+  private static final String EMAIL = "email";
+  private static final String SSH = "ssh";
+  private static final String AUTHORIZED_KEYS = "authorized_keys";
+
+  private static final List<String> SSH_KEY_PLACEHOLDER =
+      List.of(PlaceholderResolver.token(PlaceholderResolver.SSH_PUBLIC_KEY));
+
+  private PersonalFields() {}
+
+  /**
+   * Returns the definition with the developer's git identity and authorized SSH keys replaced by
+   * placeholders, or the input unchanged when there is nothing personal to redact.
+   */
+  public static String redact(String definition) {
+    if (Strings.isBlank(definition)) {
+      return definition;
+    }
+    var root = YamlUtil.parseMap(definition);
+    var changed = redactGit(root) | redactSsh(root);
+    return changed ? YamlUtil.dumpToString(root) : definition;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static boolean redactGit(Map<String, Object> root) {
+    if (!(root.get(GIT) instanceof Map<?, ?> git)) {
+      return false;
+    }
+    var fields = (Map<String, Object>) git;
+    var changed = placeholder(fields, NAME, PlaceholderResolver.GIT_NAME);
+    return placeholder(fields, EMAIL, PlaceholderResolver.GIT_EMAIL) || changed;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static boolean redactSsh(Map<String, Object> root) {
+    if (!(root.get(SSH) instanceof Map<?, ?> ssh)) {
+      return false;
+    }
+    var fields = (Map<String, Object>) ssh;
+    if (!fields.containsKey(AUTHORIZED_KEYS)
+        || SSH_KEY_PLACEHOLDER.equals(fields.get(AUTHORIZED_KEYS))) {
+      return false;
+    }
+    fields.put(AUTHORIZED_KEYS, SSH_KEY_PLACEHOLDER);
+    return true;
+  }
+
+  private static boolean placeholder(Map<String, Object> fields, String key, String name) {
+    var token = PlaceholderResolver.token(name);
+    if (!fields.containsKey(key) || token.equals(fields.get(key))) {
+      return false;
+    }
+    fields.put(key, token);
+    return true;
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/config/PlaceholderResolver.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/PlaceholderResolver.java
@@ -11,24 +11,67 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 
 /**
- * Resolves {@code ${PLACEHOLDER}} tokens in YAML content by prompting the user interactively. Only
- * a known set of placeholders is supported — unknown placeholders cause an error (safety against
- * injection).
+ * Resolves {@code ${PLACEHOLDER}} tokens in YAML content from a known, fixed set — a developer's
+ * git identity and SSH public key. Unknown placeholders are an error (safety against injection).
+ * Values come either from an interactive prompt or, on the provisioning path, from a supplied
+ * resolver that reads the local box's identity, so the synced definition stays identity-free until
+ * it lands on a box. The placeholder names are public so {@link PersonalFields} can mint them and a
+ * box-local identity provider can answer them.
  */
 public final class PlaceholderResolver {
+
+  public static final String GIT_NAME = "GIT_NAME";
+  public static final String GIT_EMAIL = "GIT_EMAIL";
+  public static final String SSH_PUBLIC_KEY = "SSH_PUBLIC_KEY";
 
   private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([A-Z_]+)\\}");
 
   private static final Map<String, String> KNOWN_PLACEHOLDERS =
       Map.of(
-          "GIT_NAME", "Your name (for git commits)",
-          "GIT_EMAIL", "Your email (for git commits)",
-          "SSH_PUBLIC_KEY", "Your SSH public key (for Zed remote access)");
+          GIT_NAME, "Your name (for git commits)",
+          GIT_EMAIL, "Your email (for git commits)",
+          SSH_PUBLIC_KEY, "Your SSH public key (for Zed remote access)");
 
   private PlaceholderResolver() {}
+
+  /** Returns the {@code ${NAME}} token for a placeholder, e.g. {@code ${GIT_NAME}}. */
+  public static String token(String name) {
+    return "${" + name + "}";
+  }
+
+  /**
+   * Resolves placeholders non-interactively: each unique {@code ${NAME}} is replaced with {@code
+   * values.apply(NAME)}. The resolver is consulted only for placeholders actually present, so
+   * content with none needs no identity at all. Unknown placeholders and blank values are errors.
+   */
+  public static String resolve(String content, UnaryOperator<String> values) {
+    var matcher = PLACEHOLDER_PATTERN.matcher(content);
+    var resolved = new LinkedHashMap<String, String>();
+    while (matcher.find()) {
+      var name = matcher.group(1);
+      if (resolved.containsKey(name)) {
+        continue;
+      }
+      if (!KNOWN_PLACEHOLDERS.containsKey(name)) {
+        throw new IllegalArgumentException(
+            "Unknown placeholder: ${"
+                + name
+                + "}. Known placeholders: "
+                + KNOWN_PLACEHOLDERS.keySet());
+      }
+      var value = values.apply(name);
+      if (Strings.isBlank(value)) {
+        throw new IllegalArgumentException(
+            "No value for ${" + name + "} (" + KNOWN_PLACEHOLDERS.get(name) + ")");
+      }
+      resolved.put(name, value.strip());
+    }
+    return substitute(content, resolved);
+  }
 
   /**
    * Scans the YAML content for {@code ${...}} placeholders, prompts the user for each unique one,
@@ -39,14 +82,14 @@ public final class PlaceholderResolver {
    * @throws IllegalArgumentException if an unknown placeholder is found
    */
   public static String resolve(String content) {
-    return resolve(content, null);
+    return resolveInteractively(content, null);
   }
 
   /**
-   * Scans the YAML content for placeholders and resolves them. If a {@code reader} is provided, it
-   * is used for input instead of stdin (for testing).
+   * Scans the YAML content for placeholders and resolves them by prompting. If a {@code reader} is
+   * provided, it is used for input instead of stdin (for testing).
    */
-  static String resolve(String content, BufferedReader reader) {
+  static String resolveInteractively(String content, BufferedReader reader) {
     var matcher = PLACEHOLDER_PATTERN.matcher(content);
     var found = new LinkedHashMap<String, String>();
 
@@ -80,9 +123,13 @@ public final class PlaceholderResolver {
       resolved.put(name, value.strip());
     }
 
+    return substitute(content, resolved);
+  }
+
+  private static String substitute(String content, Map<String, String> resolved) {
     var result = content;
     for (var entry : resolved.entrySet()) {
-      result = result.replace("${" + entry.getKey() + "}", entry.getValue());
+      result = result.replace(token(entry.getKey()), entry.getValue());
     }
     return result;
   }

--- a/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.store;
 
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.PersonalFields;
 import ai.singlr.sail.config.YamlUtil;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -53,12 +54,18 @@ public final class ProjectStore implements ConflictResolver {
    * Inserts the project or replaces its definition, preserving the original {@code
    * created_by}/{@code created_at}, and journals it as a local edit the next sync pushes.
    * Idempotent in effect; re-applying the same definition still records a revision that converges.
+   *
+   * <p>The definition is {@linkplain PersonalFields#redact redacted} first, so the catalogued,
+   * synced state never carries this box's git identity or SSH keys — each box resolves those
+   * locally at provision time. This is the one seam where a definition a human authored enters the
+   * catalog; revisions arriving over sync are already redacted at their origin.
    */
   public void upsert(String name, String definition, String actor) {
+    var canonical = PersonalFields.redact(definition);
     db.transaction(
         () -> {
-          writeRow(name, definition, actor);
-          recordRevision(name, definition, null, "local", false, false);
+          writeRow(name, canonical, actor);
+          recordRevision(name, canonical, null, "local", false, false);
         });
   }
 
@@ -139,6 +146,25 @@ public final class ProjectStore implements ConflictResolver {
           () -> recordRevision(row.name(), row.definition(), null, "local", false, false));
     }
     return pending.size();
+  }
+
+  /**
+   * Rewrites every catalogued definition to its {@linkplain PersonalFields#redact redacted} form,
+   * so a catalog written before this brick — carrying one box's git identity and SSH keys — is
+   * scrubbed and the placeholder form propagates on the next sync. A no-op for definitions already
+   * redacted; returns how many it changed. Because redaction is deterministic, a node that runs
+   * this against its main-derived rows reaches the same content main does and the two converge
+   * without conflict.
+   */
+  public int canonicalizeDefinitions() {
+    var changed = 0;
+    for (var row : list()) {
+      if (!PersonalFields.redact(row.definition()).equals(row.definition())) {
+        upsert(row.name(), row.definition(), row.updatedBy());
+        changed++;
+      }
+    }
+    return changed;
   }
 
   /**

--- a/sail-core/src/test/java/ai/singlr/sail/config/PersonalFieldsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/PersonalFieldsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PersonalFieldsTest {
+
+  @Test
+  void redactsGitIdentityToPlaceholders() {
+    var redacted = PersonalFields.redact("git:\n  name: Uday Chandra\n  email: uday@example.com\n");
+    var git = git(redacted);
+    assertEquals("${GIT_NAME}", git.get("name"));
+    assertEquals("${GIT_EMAIL}", git.get("email"));
+  }
+
+  @Test
+  void redactsAuthorizedKeysToASinglePlaceholder() {
+    var redacted =
+        PersonalFields.redact(
+            "ssh:\n  user: dev\n  authorized_keys:\n    - ssh-ed25519 AAAA main\n"
+                + "    - ssh-ed25519 BBBB laptop\n");
+    var ssh = ssh(redacted);
+    assertEquals(List.of("${SSH_PUBLIC_KEY}"), ssh.get("authorized_keys"));
+    assertEquals("dev", ssh.get("user"), "the shared ssh user is left alone");
+  }
+
+  @Test
+  void leavesSharedFieldsUntouched() {
+    var redacted =
+        PersonalFields.redact(
+            "name: acme\nimage: ubuntu/24.04\n"
+                + "resources:\n  cpu: 4\n  memory: 8GB\n  disk: 50GB\n"
+                + "git:\n  name: Uday\n  email: uday@example.com\n  auth: ssh\n");
+    var root = YamlUtil.parseMap(redacted);
+    assertEquals("acme", root.get("name"));
+    assertEquals("ubuntu/24.04", root.get("image"));
+    assertEquals("ssh", git(redacted).get("auth"), "git.auth is a project choice, not personal");
+  }
+
+  @Test
+  void returnsTheInputUnchangedWhenNothingIsPersonal() {
+    var definition = "name: acme\nimage: ubuntu/24.04\n";
+    assertSame(definition, PersonalFields.redact(definition), "no parse/dump churn when untouched");
+  }
+
+  @Test
+  void isIdempotent() {
+    var once = PersonalFields.redact("git:\n  name: Uday\n  email: uday@example.com\n");
+    assertEquals(once, PersonalFields.redact(once));
+  }
+
+  @Test
+  void redactingAnAlreadyRedactedDefinitionDoesNotReportAChange() {
+    var redacted = PersonalFields.redact("git:\n  name: Uday\n  email: uday@example.com\n");
+    assertSame(redacted, PersonalFields.redact(redacted), "second pass is a no-op, returns same");
+  }
+
+  @Test
+  void toleratesMissingGitAndSshBlocks() {
+    var definition = "name: acme\n";
+    assertSame(definition, PersonalFields.redact(definition));
+  }
+
+  @Test
+  void redactsGitEvenWhenSshIsAbsentAndViceVersa() {
+    assertTrue(
+        PersonalFields.redact("git:\n  name: U\n  email: u@e.com\n").contains("${GIT_NAME}"));
+    assertTrue(
+        PersonalFields.redact("ssh:\n  authorized_keys:\n    - key\n")
+            .contains("${SSH_PUBLIC_KEY}"));
+  }
+
+  @Test
+  void survivesBlankInput() {
+    assertSame("", PersonalFields.redact(""));
+    assertEquals("   ", PersonalFields.redact("   "));
+  }
+
+  @Test
+  void redactedDefinitionNoLongerCarriesTheOriginalIdentity() {
+    var redacted =
+        PersonalFields.redact(
+            "git:\n  name: Uday Chandra\n  email: uday@example.com\n"
+                + "ssh:\n  authorized_keys:\n    - ssh-ed25519 SECRETKEY main\n");
+    assertFalse(redacted.contains("Uday Chandra"));
+    assertFalse(redacted.contains("uday@example.com"));
+    assertFalse(redacted.contains("SECRETKEY"));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static java.util.Map<String, Object> git(String yaml) {
+    return (java.util.Map<String, Object>) YamlUtil.parseMap(yaml).get("git");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static java.util.Map<String, Object> ssh(String yaml) {
+    return (java.util.Map<String, Object>) YamlUtil.parseMap(yaml).get("ssh");
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/config/PlaceholderResolverTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/PlaceholderResolverTest.java
@@ -12,9 +12,55 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.StringReader;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class PlaceholderResolverTest {
+
+  @Test
+  void resolvesNonInteractivelyFromAProvider() {
+    var content = "git:\n  name: ${GIT_NAME}\n  email: ${GIT_EMAIL}\n";
+    var values = Map.of("GIT_NAME", "Mady M", "GIT_EMAIL", "mady@example.com");
+
+    var result = PlaceholderResolver.resolve(content, values::get);
+
+    assertEquals("git:\n  name: Mady M\n  email: mady@example.com\n", result);
+  }
+
+  @Test
+  void providerIsConsultedOnlyForPresentPlaceholders() {
+    var content = "name: acme\n";
+    var result =
+        PlaceholderResolver.resolve(
+            content,
+            name -> {
+              throw new AssertionError("provider must not be called: " + name);
+            });
+    assertEquals(content, result);
+  }
+
+  @Test
+  void providerResolveRejectsUnknownPlaceholders() {
+    var ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> PlaceholderResolver.resolve("x: ${NOPE}\n", name -> "v"));
+    assertTrue(ex.getMessage().contains("Unknown placeholder"));
+  }
+
+  @Test
+  void providerResolveRejectsBlankValues() {
+    var ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> PlaceholderResolver.resolve("x: ${GIT_NAME}\n", name -> "  "));
+    assertTrue(ex.getMessage().contains("GIT_NAME"));
+  }
+
+  @Test
+  void tokenWrapsAName() {
+    assertEquals("${GIT_NAME}", PlaceholderResolver.token(PlaceholderResolver.GIT_NAME));
+  }
 
   @Test
   void resolvesKnownPlaceholders() {
@@ -26,7 +72,7 @@ class PlaceholderResolverTest {
         """;
     var reader = new BufferedReader(new StringReader("Alice\nalice@example.com\n"));
 
-    var result = PlaceholderResolver.resolve(content, reader);
+    var result = PlaceholderResolver.resolveInteractively(content, reader);
 
     assertTrue(result.contains("Alice"));
     assertTrue(result.contains("alice@example.com"));
@@ -39,7 +85,7 @@ class PlaceholderResolverTest {
     var content = "name: ${GIT_NAME}\nauthor: ${GIT_NAME}\n";
     var reader = new BufferedReader(new StringReader("Bob\n"));
 
-    var result = PlaceholderResolver.resolve(content, reader);
+    var result = PlaceholderResolver.resolveInteractively(content, reader);
 
     assertEquals("name: Bob\nauthor: Bob\n", result);
   }
@@ -51,7 +97,8 @@ class PlaceholderResolverTest {
 
     var ex =
         assertThrows(
-            IllegalArgumentException.class, () -> PlaceholderResolver.resolve(content, reader));
+            IllegalArgumentException.class,
+            () -> PlaceholderResolver.resolveInteractively(content, reader));
     assertTrue(ex.getMessage().contains("Unknown placeholder"));
     assertTrue(ex.getMessage().contains("UNKNOWN_VAR"));
   }
@@ -60,7 +107,7 @@ class PlaceholderResolverTest {
   void noPlaceholdersReturnsUnchanged() {
     var content = "name: acme-health\nimage: ubuntu/24.04\n";
 
-    var result = PlaceholderResolver.resolve(content, null);
+    var result = PlaceholderResolver.resolveInteractively(content, null);
 
     assertEquals(content, result);
   }
@@ -76,7 +123,7 @@ class PlaceholderResolverTest {
         """;
     var reader = new BufferedReader(new StringReader("ssh-ed25519 AAAA... alice@laptop\n"));
 
-    var result = PlaceholderResolver.resolve(content, reader);
+    var result = PlaceholderResolver.resolveInteractively(content, reader);
 
     assertTrue(result.contains("ssh-ed25519 AAAA... alice@laptop"));
     assertFalse(result.contains("${SSH_PUBLIC_KEY}"));
@@ -89,7 +136,8 @@ class PlaceholderResolverTest {
 
     var ex =
         assertThrows(
-            IllegalArgumentException.class, () -> PlaceholderResolver.resolve(content, reader));
+            IllegalArgumentException.class,
+            () -> PlaceholderResolver.resolveInteractively(content, reader));
     assertTrue(ex.getMessage().contains("Value required"));
     assertTrue(ex.getMessage().contains("GIT_NAME"));
   }
@@ -107,7 +155,7 @@ class PlaceholderResolverTest {
         """;
     var reader = new BufferedReader(new StringReader("Carol\ncarol@co.com\nssh-ed25519 AAAA...\n"));
 
-    var result = PlaceholderResolver.resolve(content, reader);
+    var result = PlaceholderResolver.resolveInteractively(content, reader);
 
     assertTrue(result.contains("Carol"));
     assertTrue(result.contains("carol@co.com"));

--- a/sail-core/src/test/java/ai/singlr/sail/store/ProjectStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ProjectStoreTest.java
@@ -94,4 +94,47 @@ class ProjectStoreTest {
     assertNull(store.findByName("acme").orElseThrow().createdBy());
     assertThrows(SqliteException.class, () -> store.upsert("broken", null, null));
   }
+
+  @Test
+  void upsertRedactsPersonalFieldsBeforeStoring() {
+    store.upsert(
+        "acme",
+        "git:\n  name: Uday Chandra\n  email: uday@example.com\n"
+            + "ssh:\n  authorized_keys:\n    - ssh-ed25519 SECRETKEY main\n",
+        "uday");
+
+    var definition = store.findByName("acme").orElseThrow().definition();
+    assertTrue(definition.contains("${GIT_NAME}"));
+    assertTrue(definition.contains("${SSH_PUBLIC_KEY}"));
+    assertFalse(definition.contains("Uday Chandra"));
+    assertFalse(definition.contains("SECRETKEY"));
+  }
+
+  @Test
+  void theSyncedSnapshotCarriesPlaceholdersNotIdentity() {
+    store.upsert("acme", "git:\n  name: Uday\n  email: uday@example.com\n", "uday");
+
+    var snapshot = store.comparableSnapshot("acme");
+    assertTrue(snapshot.get("definition").toString().contains("${GIT_NAME}"));
+    assertFalse(snapshot.get("definition").toString().contains("uday@example.com"));
+  }
+
+  @Test
+  void canonicalizeScrubsAPreBrickRowAndCountsIt() {
+    db.execute(
+        "INSERT INTO projects (name, definition, created_at, updated_at)"
+            + " VALUES ('legacy', 'git:\n  name: Uday\n  email: uday@example.com\n', 'now', 'now')");
+
+    assertEquals(1, store.canonicalizeDefinitions());
+
+    var definition = store.findByName("legacy").orElseThrow().definition();
+    assertTrue(definition.contains("${GIT_NAME}"));
+    assertFalse(definition.contains("uday@example.com"));
+  }
+
+  @Test
+  void canonicalizeIsANoOpForAlreadyRedactedRows() {
+    store.upsert("acme", "git:\n  name: Uday\n  email: uday@example.com\n", "uday");
+    assertEquals(0, store.canonicalizeDefinitions(), "upsert already redacted it");
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/sync/FleetSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/FleetSyncTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.store.ChangeLog;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.FileStore;
+import ai.singlr.sail.store.ProjectStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import ai.singlr.sail.store.SyncConflicts;
+import ai.singlr.sail.store.SyncState;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * End-to-end fleet sync against realistic state — the integration coverage the unit tests lacked. A
+ * fresh node syncs every entity from a main seeded the way a real one is: specs that depend on each
+ * other, a project catalogued by an older sail (a {@code projects} row with no change-log entry,
+ * backfilled by {@code migrate}), shared files, and the FDE roster. Reproduces, as regressions, the
+ * three bugs that reached a real box: the {@code depends_on} foreign key that aborted the round,
+ * the un-journaled project invisible to sync, and the roster pull that those aborts skipped.
+ */
+class FleetSyncTest {
+
+  @TempDir Path dir;
+  private final SyncEngine engine = new SyncEngine();
+
+  private Box main;
+  private Box node;
+
+  private final class Box implements AutoCloseable {
+    final Sqlite db;
+    final SpecStore specs;
+    final FileStore files;
+    final ProjectStore projects;
+    final FdeStore fdes;
+    final SpecReplica specReplica;
+    final FileReplica fileReplica;
+    final ProjectReplica projectReplica;
+
+    Box(String id) {
+      this.db = Sqlite.open(dir.resolve(id + ".db"));
+      new SchemaManager(db).migrate();
+      var changeLog = new ChangeLog(db);
+      var conflicts = new SyncConflicts(db);
+      var syncState = new SyncState(db);
+      this.specs = new SpecStore(db);
+      this.files = new FileStore(db);
+      this.projects = new ProjectStore(db);
+      this.fdes = new FdeStore(db);
+      this.specReplica = new SpecReplica(id, specs, changeLog, conflicts, syncState);
+      this.fileReplica = new FileReplica(id, files, changeLog, conflicts, syncState);
+      this.projectReplica = new ProjectReplica(id, projects, changeLog, conflicts, syncState);
+    }
+
+    @Override
+    public void close() {
+      db.close();
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    main = new Box("main");
+    node = new Box("node");
+  }
+
+  @AfterEach
+  void tearDown() {
+    node.close();
+    main.close();
+  }
+
+  private void syncFromMain() {
+    engine.reconcile(node.specReplica, main.specReplica);
+    engine.reconcile(node.fileReplica, main.fileReplica);
+    engine.reconcile(node.projectReplica, main.projectReplica);
+    pullRoster();
+  }
+
+  private void pullRoster() {
+    for (var fde : main.fdes.list()) {
+      node.fdes.replicate(
+          fde.handle(), fde.displayName(), fde.email(), fde.role(), fde.status(), fde.createdAt());
+    }
+  }
+
+  private static SpecStore.SpecRow spec(String id, String title, String status, List<String> deps) {
+    return new SpecStore.SpecRow(
+        id,
+        "acme",
+        title,
+        SpecStatus.fromWire(status),
+        null,
+        null,
+        null,
+        null,
+        null,
+        0,
+        "uday",
+        "",
+        "",
+        "uday",
+        deps,
+        List.of());
+  }
+
+  private static String b64(String text) {
+    return Base64.getEncoder().encodeToString(text.getBytes());
+  }
+
+  private void seedRealisticMain() {
+    main.specs.create(spec("oauth", "OAuth flow", "done", List.of()));
+    main.specs.create(spec("billing", "Billing", "pending", List.of("oauth")));
+    main.files.put("acme", "scripts/deploy.sh", b64("deploy"));
+    main.projects.upsert("acme", "name: acme\nimage: ubuntu/24.04\n", "uday");
+    main.db.execute(
+        "INSERT INTO projects (name, definition, created_at, updated_at)"
+            + " VALUES ('outline', 'name: outline\n', '2026-01-01', '2026-01-01')");
+    main.fdes.add("uday", "Uday Chandra", "uday@example.com", "admin");
+    main.fdes.add("mady", "Mady M", "mady@example.com", "member");
+  }
+
+  @Test
+  void aFreshNodePullsEverythingFromARealisticMain() {
+    seedRealisticMain();
+    assertEquals(1, main.projects.backfillRevisions(), "the legacy project becomes syncable");
+
+    syncFromMain();
+
+    assertEquals("OAuth flow", node.specs.findById("oauth").orElseThrow().title());
+    assertEquals(
+        List.of("oauth"),
+        node.specs.findById("billing").orElseThrow().dependsOn(),
+        "a dependent spec replicates without a foreign-key abort");
+
+    assertEquals(
+        "name: acme\nimage: ubuntu/24.04\n",
+        node.projects.findByName("acme").orElseThrow().definition());
+    assertTrue(
+        node.projects.findByName("outline").isPresent(),
+        "a project catalogued by an older sail, made syncable by backfill, replicates");
+
+    assertEquals("deploy", decode(node.files.find("acme", "scripts/deploy.sh").orElseThrow()));
+
+    assertEquals(
+        2, node.fdes.list().size(), "the roster pulled — the step the aborts used to skip");
+    assertEquals("Mady M", node.fdes.byHandle("mady").orElseThrow().displayName());
+  }
+
+  @Test
+  void aSyncedProjectNeverCarriesMainsIdentityOrKeysToANode() {
+    main.projects.upsert(
+        "acme",
+        "name: acme\n"
+            + "git:\n  name: Uday Chandra\n  email: uday@example.com\n"
+            + "ssh:\n  authorized_keys:\n    - ssh-ed25519 UDAYKEY uday@main\n",
+        "uday");
+
+    syncFromMain();
+
+    var onNode = node.projects.findByName("acme").orElseThrow().definition();
+    assertTrue(onNode.contains("${GIT_NAME}"), "the node sees a placeholder, not Uday's name");
+    assertTrue(onNode.contains("${SSH_PUBLIC_KEY}"), "and a placeholder, not Uday's key");
+    assertFalse(onNode.contains("Uday Chandra"));
+    assertFalse(onNode.contains("uday@example.com"));
+    assertFalse(onNode.contains("UDAYKEY"), "main's SSH key never lands on the node");
+  }
+
+  @Test
+  void twoBoxesScrubbingTheSameLegacyProjectConvergeWithoutAConflict() {
+    var legacy = "name: outline\ngit:\n  name: Uday\n  email: uday@example.com\n";
+    insertLegacyProject(main, "outline", legacy);
+    insertLegacyProject(node, "outline", legacy);
+
+    assertEquals(1, main.projects.canonicalizeDefinitions());
+    assertEquals(1, node.projects.canonicalizeDefinitions());
+
+    var report = engine.reconcile(node.projectReplica, main.projectReplica);
+
+    assertEquals(0, report.conflicts(), "identical redacted content converges, never conflicts");
+    assertTrue(
+        node.projects.findByName("outline").orElseThrow().definition().contains("${GIT_NAME}"));
+  }
+
+  private static void insertLegacyProject(Box box, String name, String definition) {
+    box.db.execute(
+        "INSERT INTO projects (name, definition, created_at, updated_at) VALUES (?, ?, ?, ?)",
+        name,
+        definition,
+        "2026-01-01",
+        "2026-01-01");
+  }
+
+  @Test
+  void anUnjournaledProjectStaysInvisibleUntilBackfilled() {
+    main.db.execute(
+        "INSERT INTO projects (name, definition, created_at, updated_at)"
+            + " VALUES ('outline', 'name: outline\n', '2026-01-01', '2026-01-01')");
+
+    syncFromMain();
+    assertFalse(
+        node.projects.findByName("outline").isPresent(),
+        "without backfill, a catalogued-but-un-journaled project does not sync");
+
+    main.projects.backfillRevisions();
+    syncFromMain();
+
+    assertTrue(node.projects.findByName("outline").isPresent(), "backfill makes it replicate");
+  }
+
+  private static String decode(FileStore.FileRow row) {
+    return new String(Base64.getDecoder().decode(row.content()));
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -88,6 +88,7 @@ public final class MigrateCommand implements Runnable {
       var runs = applyMigrations(db, dbPath.toString(), prompter, animate, jsonOutput);
       importProjects(db, jsonOutput);
       backfillProjectRevisions(db, jsonOutput);
+      scrubProjectIdentity(db, jsonOutput);
       importFiles(db, jsonOutput);
       seedDemo(db, jsonOutput);
       relocateHostConfig(jsonOutput);
@@ -119,6 +120,23 @@ public final class MigrateCommand implements Runnable {
     if (!jsonOutput && backfilled > 0) {
       System.out.println(
           Ansi.AUTO.string("  @|green ✓|@ project catalog: " + backfilled + " made syncable"));
+    }
+  }
+
+  /**
+   * Scrubs each catalogued definition of the per-developer git identity and SSH keys a pre-brick
+   * catalog stored concretely, rewriting them to placeholders so one box's identity stops riding
+   * the synced state onto everyone else's. Idempotent; quiet when every definition is already
+   * clean.
+   */
+  private static void scrubProjectIdentity(Sqlite db, boolean jsonOutput) {
+    var scrubbed = new ProjectStore(db).canonicalizeDefinitions();
+    if (!jsonOutput && scrubbed > 0) {
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|green ✓|@ project catalog: "
+                  + scrubbed
+                  + " scrubbed of per-developer identity"));
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectApplyCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectApplyCommand.java
@@ -74,7 +74,7 @@ public final class ProjectApplyCommand implements Runnable {
                             + name
                             + "'. Sync it from main with 'sail sync', or author one with 'sail"
                             + " project init'."));
-    SailYaml config = SailYaml.fromMap(YamlUtil.parseMap(definitionText));
+    SailYaml config = ProjectDefinitions.resolveForProvisioning(definitionText);
     var singYamlPath =
         explicit != null ? explicit : ProjectDefinitions.materialize(name, definitionText);
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCreateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCreateCommand.java
@@ -102,7 +102,7 @@ public final class ProjectCreateCommand implements Runnable {
       throw new IllegalStateException(hint.toString());
     }
 
-    SailYaml config = SailYaml.fromMap(YamlUtil.parseFile(singYamlPath));
+    SailYaml config = ProjectDefinitions.resolveForProvisioning(Files.readString(singYamlPath));
 
     if (config.name() == null || config.name().isBlank()) {
       throw new IllegalStateException("sail.yaml must have a 'name' field.");

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/LocalIdentity.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/LocalIdentity.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.PlaceholderResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Answers a project definition's personal-field placeholders from <em>this</em> box: the git
+ * identity from {@code git config --global}, and {@code ${SSH_PUBLIC_KEY}} from the box's sail
+ * identity key — the same key {@code sail join} registers with main. Resolution happens once, when
+ * a project is provisioned, so the synced definition stays identity-free and each engineer's
+ * containers commit as them and trust only their own key. A missing value fails loud with the one
+ * command that fixes it, rather than silently provisioning with someone else's identity.
+ */
+public final class LocalIdentity {
+
+  private final ShellExec shell;
+  private final Path sshPublicKeyPath;
+
+  public LocalIdentity(ShellExec shell, Path sshPublicKeyPath) {
+    this.shell = shell;
+    this.sshPublicKeyPath = sshPublicKeyPath;
+  }
+
+  /** This box's identity: real git config and the sail sync public key. */
+  public static LocalIdentity detect() {
+    return new LocalIdentity(new ShellExecutor(false), SailPaths.syncPublicKeyPath());
+  }
+
+  /** Resolves one known placeholder name to this box's value, failing loud if it is not set. */
+  public String valueFor(String placeholder) {
+    return switch (placeholder) {
+      case PlaceholderResolver.GIT_NAME -> gitConfig("user.name");
+      case PlaceholderResolver.GIT_EMAIL -> gitConfig("user.email");
+      case PlaceholderResolver.SSH_PUBLIC_KEY -> sshPublicKey();
+      default ->
+          throw new IllegalArgumentException("No box-local source for ${" + placeholder + "}");
+    };
+  }
+
+  private String gitConfig(String key) {
+    var value = run(List.of("git", "config", "--global", "--get", key));
+    if (Strings.isBlank(value)) {
+      throw new IllegalStateException(
+          "This box has no git "
+              + key
+              + " set, so a project here can't take on your identity.\n"
+              + "  Set it once and re-run: git config --global "
+              + key
+              + " \"...\"");
+    }
+    return value;
+  }
+
+  private String sshPublicKey() {
+    try {
+      var key = Files.readString(sshPublicKeyPath).strip();
+      if (Strings.isBlank(key)) {
+        throw new IllegalStateException(missingKeyMessage());
+      }
+      return key;
+    } catch (IOException e) {
+      throw new IllegalStateException(missingKeyMessage());
+    }
+  }
+
+  private String missingKeyMessage() {
+    return "This box has no sail identity key yet ("
+        + sshPublicKeyPath
+        + ").\n  It is created when you run 'sail join' or 'sail host ssh-identity'.";
+  }
+
+  private String run(List<String> command) {
+    try {
+      var result = shell.exec(command);
+      return result.ok() ? result.stdout().strip() : "";
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return "";
+    } catch (IOException | TimeoutException e) {
+      return "";
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectDefinitions.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectDefinitions.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.config.PlaceholderResolver;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.store.ProjectStore;
@@ -87,6 +88,22 @@ public final class ProjectDefinitions {
                             + "'. Author one with 'sail project init', or sync it from main with"
                             + " 'sail sync'."));
     return SailYaml.fromMap(YamlUtil.parseMap(text));
+  }
+
+  /**
+   * Parses a definition for provisioning, resolving the personal-field placeholders ({@code
+   * ${GIT_NAME}}, {@code ${GIT_EMAIL}}, {@code ${SSH_PUBLIC_KEY}}) from this box's own identity. A
+   * definition with no placeholders — one authored locally with concrete values, not yet synced —
+   * is parsed unchanged and never touches the local identity. This is the seam where the fleet's
+   * identity-free definition becomes a container that commits as the engineer and trusts their key.
+   */
+  public static SailYaml resolveForProvisioning(String definitionText) {
+    return resolveForProvisioning(definitionText, LocalIdentity.detect());
+  }
+
+  static SailYaml resolveForProvisioning(String definitionText, LocalIdentity identity) {
+    var resolved = PlaceholderResolver.resolve(definitionText, identity::valueFor);
+    return SailYaml.fromMap(YamlUtil.parseMap(resolved));
   }
 
   /** Writes a definition to the canonical descriptor (the materialized view of the catalog). */

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/LocalIdentityTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/LocalIdentityTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LocalIdentityTest {
+
+  @TempDir Path dir;
+  private Path keyPath;
+
+  @BeforeEach
+  void setUp() {
+    keyPath = dir.resolve("sync_ed25519.pub");
+  }
+
+  private LocalIdentity identity(Map<String, String> gitConfig) {
+    return new LocalIdentity(stubGit(gitConfig), keyPath);
+  }
+
+  @Test
+  void resolvesGitIdentityFromGitConfig() {
+    var identity = identity(Map.of("user.name", "Mady M", "user.email", "mady@example.com"));
+    assertEquals("Mady M", identity.valueFor("GIT_NAME"));
+    assertEquals("mady@example.com", identity.valueFor("GIT_EMAIL"));
+  }
+
+  @Test
+  void resolvesSshKeyFromTheBoxIdentityFile() throws IOException {
+    Files.writeString(keyPath, "ssh-ed25519 AAAAMADY mady@box\n");
+    assertEquals("ssh-ed25519 AAAAMADY mady@box", identity(Map.of()).valueFor("SSH_PUBLIC_KEY"));
+  }
+
+  @Test
+  void failsLoudWhenGitNameIsUnset() {
+    var error =
+        assertThrows(IllegalStateException.class, () -> identity(Map.of()).valueFor("GIT_NAME"));
+    assertTrue(error.getMessage().contains("git config --global user.name"));
+  }
+
+  @Test
+  void failsLoudWhenTheIdentityKeyIsMissing() {
+    var error =
+        assertThrows(
+            IllegalStateException.class, () -> identity(Map.of()).valueFor("SSH_PUBLIC_KEY"));
+    assertTrue(error.getMessage().contains("sail join"));
+  }
+
+  @Test
+  void failsLoudWhenTheIdentityKeyIsBlank() throws IOException {
+    Files.writeString(keyPath, "   \n");
+    assertThrows(IllegalStateException.class, () -> identity(Map.of()).valueFor("SSH_PUBLIC_KEY"));
+  }
+
+  @Test
+  void rejectsAnUnknownPlaceholder() {
+    assertThrows(IllegalArgumentException.class, () -> identity(Map.of()).valueFor("MYSTERY"));
+  }
+
+  private static ShellExec stubGit(Map<String, String> config) {
+    return new ShellExec() {
+      @Override
+      public Result exec(List<String> command) {
+        var key = command.getLast();
+        return new Result(0, config.getOrDefault(key, ""), "");
+      }
+
+      @Override
+      public Result exec(List<String> command, Path workDir, java.time.Duration timeout) {
+        return exec(command);
+      }
+
+      @Override
+      public boolean isDryRun() {
+        return false;
+      }
+    };
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectDefinitionsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectDefinitionsTest.java
@@ -79,4 +79,52 @@ class ProjectDefinitionsTest {
     assertEquals(null, ProjectDefinitions.explicitFile(null));
     assertEquals(Path.of("custom.yaml"), ProjectDefinitions.explicitFile("custom.yaml"));
   }
+
+  @Test
+  void resolveForProvisioningFillsPlaceholdersFromTheLocalBox() throws Exception {
+    var keyPath = dir.resolve("sync_ed25519.pub");
+    Files.writeString(keyPath, "ssh-ed25519 AAAAMADY mady@box\n");
+    var identity = new LocalIdentity(gitConfig("Mady M", "mady@example.com"), keyPath);
+
+    var config =
+        ProjectDefinitions.resolveForProvisioning(
+            "name: acme\n"
+                + "resources:\n  cpu: 2\n  memory: 8GB\n  disk: 50GB\n"
+                + "git:\n  name: ${GIT_NAME}\n  email: ${GIT_EMAIL}\n"
+                + "ssh:\n  user: dev\n  authorized_keys:\n    - ${SSH_PUBLIC_KEY}\n",
+            identity);
+
+    assertEquals("Mady M", config.git().name());
+    assertEquals("mady@example.com", config.git().email());
+    assertEquals("ssh-ed25519 AAAAMADY mady@box", config.ssh().authorizedKeys().getFirst());
+  }
+
+  @Test
+  void resolveForProvisioningNeedsNoIdentityWhenThereAreNoPlaceholders() {
+    var noIdentity = new LocalIdentity(gitConfig("", ""), dir.resolve("missing.pub"));
+    var config =
+        ProjectDefinitions.resolveForProvisioning(
+            "name: acme\nresources:\n  cpu: 2\n  memory: 8GB\n  disk: 50GB\n", noIdentity);
+    assertEquals("acme", config.name());
+  }
+
+  private static ShellExec gitConfig(String name, String email) {
+    var values = java.util.Map.of("user.name", name, "user.email", email);
+    return new ShellExec() {
+      @Override
+      public Result exec(java.util.List<String> command) {
+        return new Result(0, values.getOrDefault(command.getLast(), ""), "");
+      }
+
+      @Override
+      public Result exec(java.util.List<String> command, Path workDir, java.time.Duration timeout) {
+        return exec(command);
+      }
+
+      @Override
+      public boolean isDryRun() {
+        return false;
+      }
+    };
+  }
 }


### PR DESCRIPTION
## The bug (security + correctness)

A project's `sail.yaml` mixes shared infrastructure with two fields that are inherently **per-developer**: the **git identity** commits are authored with, and the **SSH key** authorized into that box's containers. The sync comparable was the whole `definition` blob, so a project created on main carried main's `git.name`/`git.email` and `ssh.authorized_keys` to every node, and `ProjectProvisioner` applied them verbatim:

- **Wrong attribution** — a node's container committed as *main's* git identity.
- **Cross-box trust leak** — a node's containers had *main's* SSH key written into `authorized_keys`. Each box's containers should trust only that engineer's key. Found via `sail conflict show`.

## The fix

Split the definition. Shared fields sync; per-developer fields are **redacted to placeholders the moment a definition enters the catalog**, and **resolved back from the local box only at provision time**.

- **`PersonalFields.redact`** (pure, idempotent) — `git.name`/`email` → `${GIT_NAME}`/`${GIT_EMAIL}`, `ssh.authorized_keys` → `[${SSH_PUBLIC_KEY}]`. Reformats only when it changes something, so untouched definitions sync byte-identical.
- **`ProjectStore.upsert`** redacts at the single local-author seam; revisions arriving over sync are already redacted at their origin.
- **`LocalIdentity`** answers placeholders from this box: `git config --global` for the identity, the sail sync key for `${SSH_PUBLIC_KEY}` (the key `sail join` registers). Missing values fail loud with the command that fixes them.
- **`ProjectDefinitions.resolveForProvisioning`** fills placeholders at `create`/`apply` only; display and the catalog stay canonical. A definition with no placeholders never touches the local identity.
- **`migrate`** scrubs definitions written before this change (`canonicalizeDefinitions`). Redaction is deterministic, so a node that scrubs its main-derived rows reaches the same content main does and the two converge **without a conflict** (`ConflictDetector`: equal content → `Converged`).

## Field tiers

| Tier | Fields | Synced | Applied |
|---|---|---|---|
| Per-developer | `git.name/email`, `ssh.authorized_keys` | never (placeholders) | resolved once at provision |
| Shared-structural | `image`, `runtimes`, `services`, `repos`, `ssh.user` | yes | rebuild/restart |
| Shared-tunable | `resources.{cpu,memory,disk}` | yes | **follow-up (H2)**: live reconfigure |

## Tests

`PersonalFieldsTest`, `PlaceholderResolverTest` (provider resolve), `LocalIdentityTest`, `ProjectDefinitionsTest`, `ProjectStoreTest`, and two new `FleetSyncTest` regressions: main's identity/keys never reach a node, and two boxes scrubbing the same legacy project converge. **Full `sail-core` + `sail-infra` verify green (1628 tests), coverage gates met.**

Follow-up **H2** (separable, not security-critical): drive synced `resources` deltas into the live container via the existing `ProjectResourcesSetCommand`/`ProjectApplyCommand` machinery.
