### PR TITLE
Live resource reconcile on sync (H2) + one-command `sail init` (Brick F)

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/Sail.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/Sail.java
@@ -12,6 +12,7 @@ import ai.singlr.sail.commands.EventsCommand;
 import ai.singlr.sail.commands.FdeCommand;
 import ai.singlr.sail.commands.GatewayCommand;
 import ai.singlr.sail.commands.HostCommand;
+import ai.singlr.sail.commands.InitCommand;
 import ai.singlr.sail.commands.JoinCommand;
 import ai.singlr.sail.commands.LoginCommand;
 import ai.singlr.sail.commands.MigrateCommand;
@@ -32,6 +33,7 @@ import picocli.CommandLine.Help.Ansi;
     versionProvider = SailVersion.class,
     mixinStandardHelpOptions = true,
     subcommands = {
+      InitCommand.class,
       ClientInitCommand.class,
       HostCommand.class,
       ProjectCommand.class,

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ClientInitCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ClientInitCommand.java
@@ -20,11 +20,12 @@ import picocli.CommandLine.Spec;
 
 /**
  * Initializes the client config on the engineer's Mac. Creates {@code ~/.sail/config.yaml} with the
- * host connection details. The host can be an IP, hostname, or SSH config alias.
+ * host connection details. The host can be an IP, hostname, or SSH config alias. Top-level {@code
+ * init} is box onboarding ({@link InitCommand}); a thin client connects with {@code sail client}.
  */
 @Command(
-    name = "init",
-    description = "Initialize sail client — connect to a remote host.",
+    name = "client",
+    description = "Connect this thin client to a remote sail host.",
     mixinStandardHelpOptions = true)
 public final class ClientInitCommand implements Runnable {
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/InitCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/InitCommand.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.engine.Banner;
+import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.engine.ShellExecutor;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Spec;
+
+/**
+ * One command to bring a box fully online and connect it to the org. It converges from whatever
+ * state the box is in — fresh, or already partly set up — doing only what is missing, so it is safe
+ * to re-run. Every box is a full working dev box: it provisions the container host, installs and
+ * starts {@code sail-api} (so the engineer can dispatch agents locally), and then takes on its
+ * identity — {@code --as-main} makes it the org's source of truth, {@code --main <target>} joins it
+ * to an existing one.
+ *
+ * <p>It orchestrates the granular commands ({@code host init}, {@code host service install}, {@code
+ * host ssh-identity}, {@code host sync}, {@code join}), which remain available on their own. The
+ * sail-api install adapts to the box: a system service when run as root, a per-user service for the
+ * {@code sudo} user otherwise.
+ */
+@Command(
+    name = "init",
+    description = "Set up this box and connect it to the org in one step.",
+    mixinStandardHelpOptions = true)
+public final class InitCommand implements Runnable {
+
+  @Option(
+      names = "--as-main",
+      description = "Make this box the org's main devbox (the source of truth).")
+  private boolean asMain;
+
+  @Option(
+      names = "--main",
+      paramLabel = "TARGET",
+      description = "Join an existing main, e.g. maindevbox or sail@maindevbox.")
+  private String main;
+
+  @Option(names = "--handle", description = "Your FDE handle on main (node only; else prompted).")
+  private String handle;
+
+  @Option(names = "--name", description = "Your full name for the roster (node only).")
+  private String fullName;
+
+  @Option(names = "--email", description = "Your email for the roster (node only).")
+  private String email;
+
+  @Spec private CommandSpec spec;
+
+  @Override
+  public void run() {
+    CliCommand.run(spec, this::execute);
+  }
+
+  private void execute() {
+    var intent = InitIntent.resolve(asMain, main);
+    requireRoot();
+
+    System.out.println(Ansi.AUTO.string("  @|bold Setting up this box...|@"));
+    ensureProvisioned();
+    ensureSailApi();
+
+    switch (intent) {
+      case InitIntent.Main ignored -> {
+        runCommand(new HostSshIdentityCommand());
+        runCommand(new HostSyncCommand(), "--as-main");
+        printMainNextSteps();
+      }
+      case InitIntent.Node node -> joinMain(node.target());
+    }
+  }
+
+  private void requireRoot() {
+    if (ConsoleHelper.isRoot() || Strings.isNotBlank(System.getenv("SUDO_USER"))) {
+      return;
+    }
+    throw new IllegalStateException(
+        "Root privileges required. Re-run with: sudo sail init "
+            + (asMain ? "--as-main" : "--main " + main));
+  }
+
+  private void ensureProvisioned() {
+    if (Files.exists(SailPaths.hostConfigPath())) {
+      System.out.println(Ansi.AUTO.string("  @|faint Host already provisioned — skipping.|@"));
+      return;
+    }
+    runCommand(new HostInitCommand(), "--yes");
+  }
+
+  /**
+   * Installs and starts sail-api. As root with no {@code sudo} user it is a system service; under
+   * {@code sudo} it is a per-user service for the invoking user (which needs linger to survive
+   * logout), installed by re-running {@code host service install} as that user.
+   */
+  private void ensureSailApi() {
+    var sudoUser = System.getenv("SUDO_USER");
+    if (Strings.isBlank(sudoUser) || "root".equals(sudoUser)) {
+      runCommand(new HostServiceInstallCommand());
+      return;
+    }
+    var shell = new ShellExecutor(false);
+    try {
+      shell.exec(List.of("loginctl", "enable-linger", sudoUser));
+      var result =
+          shell.exec(
+              List.of("su", "-", sudoUser, "-c", SailPaths.binaryPath() + " host service install"));
+      if (!result.ok()) {
+        throw new IllegalStateException(result.stderr().strip());
+      }
+      System.out.print(result.stdout());
+    } catch (Exception e) {
+      throw new IllegalStateException(
+          "Could not install sail-api for '"
+              + sudoUser
+              + "': "
+              + e.getMessage()
+              + "\n  Install it manually as that user (no sudo): sail host service install");
+    }
+  }
+
+  private void joinMain(String target) {
+    var args = new ArrayList<String>();
+    args.add(target);
+    if (Strings.isNotBlank(handle)) {
+      args.add("--handle");
+      args.add(handle);
+    }
+    if (Strings.isNotBlank(fullName)) {
+      args.add("--name");
+      args.add(fullName);
+    }
+    if (Strings.isNotBlank(email)) {
+      args.add("--email");
+      args.add(email);
+    }
+    runCommand(new JoinCommand(), args.toArray(String[]::new));
+  }
+
+  private void printMainNextSteps() {
+    var out = System.out;
+    out.println();
+    out.println(
+        Ansi.AUTO.string("  @|bold,green ✓|@ This box is the org's @|bold main|@ and ready."));
+    out.println(
+        "  Add each engineer once they send you the line their 'sail init --main' printed, e.g.:");
+    out.println(Ansi.AUTO.string("    @|cyan sail fde add mady --role member --key \"…\"|@"));
+  }
+
+  private static void runCommand(Object command, String... args) {
+    var code = new CommandLine(command).execute(args);
+    if (code != 0) {
+      throw new IllegalStateException(
+          Banner.errorLine("Setup stopped — the step above failed.", Ansi.OFF).strip());
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/InitCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/InitCommand.java
@@ -29,7 +29,8 @@ import picocli.CommandLine.Spec;
  *
  * <p>It orchestrates the granular commands ({@code host init}, {@code host service install}, {@code
  * host ssh-identity}, {@code host sync}, {@code join}), which remain available on their own. The
- * sail-api install adapts to the box: a system service when run as root, a per-user service for the
+ * step sequence is decided by {@link InitPlan}; this class only runs each step. The sail-api
+ * install adapts to the box: a system service when run as root directly, a per-user service for the
  * {@code sudo} user otherwise.
  */
 @Command(
@@ -69,17 +70,30 @@ public final class InitCommand implements Runnable {
     var intent = InitIntent.resolve(asMain, main);
     requireRoot();
 
-    System.out.println(Ansi.AUTO.string("  @|bold Setting up this box...|@"));
-    ensureProvisioned();
-    ensureSailApi();
+    var sudoUser = System.getenv("SUDO_USER");
+    var perUserService = Strings.isNotBlank(sudoUser) && !"root".equals(sudoUser);
+    var plan = InitPlan.plan(intent, Files.exists(SailPaths.hostConfigPath()), perUserService);
 
-    switch (intent) {
-      case InitIntent.Main ignored -> {
-        runCommand(new HostSshIdentityCommand());
-        runCommand(new HostSyncCommand(), "--as-main");
-        printMainNextSteps();
-      }
-      case InitIntent.Node node -> joinMain(node.target());
+    System.out.println(Ansi.AUTO.string("  @|bold Setting up this box...|@"));
+    if (Files.exists(SailPaths.hostConfigPath())) {
+      System.out.println(Ansi.AUTO.string("  @|faint Host already provisioned — skipping.|@"));
+    }
+    for (var step : plan) {
+      runStep(step, sudoUser);
+    }
+    if (intent instanceof InitIntent.Main) {
+      printMainNextSteps();
+    }
+  }
+
+  private void runStep(InitPlan.Step step, String sudoUser) {
+    switch (step) {
+      case PROVISION -> runCommand(new HostInitCommand(), "--yes");
+      case INSTALL_API_SYSTEM -> runCommand(new HostServiceInstallCommand());
+      case INSTALL_API_USER -> installApiForUser(sudoUser);
+      case SSH_IDENTITY -> runCommand(new HostSshIdentityCommand());
+      case SYNC_AS_MAIN -> runCommand(new HostSyncCommand(), "--as-main");
+      case JOIN_MAIN -> joinMain();
     }
   }
 
@@ -92,25 +106,11 @@ public final class InitCommand implements Runnable {
             + (asMain ? "--as-main" : "--main " + main));
   }
 
-  private void ensureProvisioned() {
-    if (Files.exists(SailPaths.hostConfigPath())) {
-      System.out.println(Ansi.AUTO.string("  @|faint Host already provisioned — skipping.|@"));
-      return;
-    }
-    runCommand(new HostInitCommand(), "--yes");
-  }
-
   /**
-   * Installs and starts sail-api. As root with no {@code sudo} user it is a system service; under
-   * {@code sudo} it is a per-user service for the invoking user (which needs linger to survive
-   * logout), installed by re-running {@code host service install} as that user.
+   * Installs sail-api as a per-user service for the invoking {@code sudo} user, which needs linger
+   * to survive logout and must be installed as that user.
    */
-  private void ensureSailApi() {
-    var sudoUser = System.getenv("SUDO_USER");
-    if (Strings.isBlank(sudoUser) || "root".equals(sudoUser)) {
-      runCommand(new HostServiceInstallCommand());
-      return;
-    }
+  private void installApiForUser(String sudoUser) {
     var shell = new ShellExecutor(false);
     try {
       shell.exec(List.of("loginctl", "enable-linger", sudoUser));
@@ -131,9 +131,9 @@ public final class InitCommand implements Runnable {
     }
   }
 
-  private void joinMain(String target) {
+  private void joinMain() {
     var args = new ArrayList<String>();
-    args.add(target);
+    args.add(main);
     if (Strings.isNotBlank(handle)) {
       args.add("--handle");
       args.add(handle);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/InitIntent.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/InitIntent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.common.Strings;
+
+/**
+ * What {@code sail init} is being asked to make this box: the org's {@link Main} source of truth,
+ * or a {@link Node} that joins an existing main. Resolved without I/O so the validation is
+ * unit-tested.
+ */
+sealed interface InitIntent {
+
+  record Main() implements InitIntent {}
+
+  record Node(String target) implements InitIntent {}
+
+  static InitIntent resolve(boolean asMain, String mainTarget) {
+    var joining = Strings.isNotBlank(mainTarget);
+    if (asMain && joining) {
+      throw new IllegalArgumentException("Choose either --as-main or --main <target>, not both.");
+    }
+    if (asMain) {
+      return new Main();
+    }
+    if (joining) {
+      return new Node(mainTarget.strip());
+    }
+    throw new IllegalArgumentException(
+        "Say what this box is: --as-main (it coordinates the org) or --main <target> (it joins an"
+            + " existing main, e.g. --main sail@maindevbox).");
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/InitPlan.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/InitPlan.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The ordered steps that bring a box fully online, decided without I/O so the sequencing across
+ * heterogeneous box states is unit-tested. A box already provisioned skips provisioning; sail-api
+ * is installed as a system service when running as root directly, or a per-user service when
+ * running under {@code sudo} for a real login user; then the box takes on its identity — a main
+ * publishes its SSH identity and starts as the org's source of truth, a node joins an existing
+ * main.
+ */
+final class InitPlan {
+
+  enum Step {
+    PROVISION,
+    INSTALL_API_SYSTEM,
+    INSTALL_API_USER,
+    SSH_IDENTITY,
+    SYNC_AS_MAIN,
+    JOIN_MAIN
+  }
+
+  private InitPlan() {}
+
+  static List<Step> plan(InitIntent intent, boolean provisioned, boolean perUserService) {
+    var steps = new ArrayList<Step>();
+    if (!provisioned) {
+      steps.add(Step.PROVISION);
+    }
+    steps.add(perUserService ? Step.INSTALL_API_USER : Step.INSTALL_API_SYSTEM);
+    switch (intent) {
+      case InitIntent.Main ignored -> {
+        steps.add(Step.SSH_IDENTITY);
+        steps.add(Step.SYNC_AS_MAIN);
+      }
+      case InitIntent.Node ignored -> steps.add(Step.JOIN_MAIN);
+    }
+    return List.copyOf(steps);
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
@@ -11,9 +11,12 @@ import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SyncConfig;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
+import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.FileMaterializer;
 import ai.singlr.sail.engine.HostInfo;
+import ai.singlr.sail.engine.ProjectResourceReconciler;
 import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SshSyncChannel;
 import ai.singlr.sail.store.ChangeLog;
 import ai.singlr.sail.store.FdeStore;
@@ -203,7 +206,32 @@ public final class SyncCommand implements Callable<Integer> {
       }
       materialize(boxes.files());
       materializeProjects(boxes.projects());
+      reconcileLiveResources(boxes.projects(), projectReport);
       return combine(combine(specReport, fileReport), projectReport);
+    }
+  }
+
+  /**
+   * After a sync that changed projects, resizes each project's live container to the synced
+   * definition — CPU, memory, and disk, in place — so a resource edit on another box expands or
+   * contracts this box's container without anyone re-provisioning. Best-effort and never fatal:
+   * when incus is unreachable (an unprivileged sync) it is a quiet no-op, and a disk shrink the
+   * backend refuses is reported and skipped. Only runs when the round actually pulled or merged a
+   * project, so an unchanged sync touches no containers.
+   */
+  private void reconcileLiveResources(ProjectStore projects, SyncEngine.Report projectReport) {
+    if (projectReport.pulled() + projectReport.merged() == 0) {
+      return;
+    }
+    var reconciler = new ProjectResourceReconciler(new ContainerManager(new ShellExecutor(false)));
+    var outcome = reconciler.reconcileCatalog(projects.list());
+    for (var skipped : outcome.diskSkipped()) {
+      System.err.println(Banner.errorLine("Kept disk size for " + skipped, Ansi.AUTO));
+    }
+    if (!outcome.resized().isEmpty()) {
+      System.err.println(
+          Ansi.AUTO.string(
+              "  @|faint resized to match main: " + String.join(", ", outcome.resized()) + "|@"));
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerManager.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerManager.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 
 /**
@@ -124,6 +125,17 @@ public final class ContainerManager {
     }
     throw new IOException(
         "Failed to set disk quota for container '" + name + "': " + result.stderr());
+  }
+
+  /** Reads a container's current root disk quota, empty when it is unset or cannot be read. */
+  public Optional<String> queryDiskQuota(String name)
+      throws IOException, InterruptedException, TimeoutException {
+    var result = shell.exec(List.of("incus", "config", "device", "get", name, "root", "size"));
+    if (!result.ok()) {
+      return Optional.empty();
+    }
+    var value = result.stdout().strip();
+    return value.isEmpty() ? Optional.empty() : Optional.of(value);
   }
 
   /** Force-deletes a container (stops it first if running). Throws on failure. */

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectResourceReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectResourceReconciler.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.ContainerManager.ResourceLimits;
+import ai.singlr.sail.store.ProjectStore;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Brings a provisioned container's CPU, memory, and disk into line with its project definition,
+ * applied live — no recreate, no restart — so a resource change that synced from another box
+ * expands or contracts the local container in place. Idempotent: a container already at the desired
+ * size is left untouched, and a container that does not exist yet is skipped (provisioning will
+ * size it).
+ *
+ * <p>CPU and memory are compared against the container's live limits. Disk is compared against its
+ * current root quota; a shrink the storage backend refuses (ZFS below used space; advisory on the
+ * {@code dir} backend) is reported and skipped, never fatal — the rest of the sync stands.
+ */
+public final class ProjectResourceReconciler {
+
+  private final ContainerManager manager;
+
+  public ProjectResourceReconciler(ContainerManager manager) {
+    this.manager = manager;
+  }
+
+  /** What one reconcile did: whether the container was present, and which dimensions it moved. */
+  public record Outcome(
+      boolean present, boolean limitsApplied, boolean diskApplied, String diskSkipped) {
+
+    public boolean changed() {
+      return limitsApplied || diskApplied;
+    }
+
+    static Outcome absent() {
+      return new Outcome(false, false, false, null);
+    }
+  }
+
+  /** What reconciling a whole catalog moved: containers resized, and any disk changes skipped. */
+  public record FleetOutcome(List<String> resized, List<String> diskSkipped) {}
+
+  /**
+   * Reconciles every catalogued project that carries resources, returning the containers it resized
+   * and the disk changes it had to skip. Projects without a resources block or a provisioned
+   * container are passed over. If incus becomes unreachable mid-way (a binary error rather than a
+   * missing container), it stops and returns what it managed — the sync round is never failed by
+   * resource reconciliation.
+   */
+  public FleetOutcome reconcileCatalog(List<ProjectStore.ProjectRow> projects) {
+    var resized = new ArrayList<String>();
+    var diskSkipped = new ArrayList<String>();
+    for (var project : projects) {
+      var desired = resourcesOf(project.definition());
+      if (desired == null) {
+        continue;
+      }
+      try {
+        var outcome = reconcile(project.name(), desired);
+        if (outcome.changed()) {
+          resized.add(project.name());
+        }
+        if (outcome.diskSkipped() != null) {
+          diskSkipped.add(project.name() + " — " + outcome.diskSkipped());
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return new FleetOutcome(resized, diskSkipped);
+      } catch (IOException | TimeoutException e) {
+        return new FleetOutcome(resized, diskSkipped);
+      }
+    }
+    return new FleetOutcome(resized, diskSkipped);
+  }
+
+  private static SailYaml.Resources resourcesOf(String definition) {
+    try {
+      return SailYaml.fromMap(YamlUtil.parseMap(definition)).resources();
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+
+  public Outcome reconcile(String name, SailYaml.Resources desired)
+      throws IOException, InterruptedException, TimeoutException {
+    if (desired == null) {
+      return Outcome.absent();
+    }
+    var info = manager.queryInfo(name);
+    if (!isProvisioned(info.state())) {
+      return Outcome.absent();
+    }
+
+    var limitsApplied = false;
+    if (limitsDiffer(info.limits(), desired)) {
+      manager.setResourceLimits(
+          name, new ResourceLimits(String.valueOf(desired.cpu()), desired.memory()));
+      limitsApplied = true;
+    }
+
+    var diskApplied = false;
+    String diskSkipped = null;
+    var currentDisk = manager.queryDiskQuota(name).orElse(null);
+    if (currentDisk != null && !sameSize(currentDisk, desired.disk())) {
+      try {
+        manager.setDiskQuota(name, desired.disk());
+        diskApplied = true;
+      } catch (IOException e) {
+        diskSkipped = e.getMessage();
+      }
+    }
+    return new Outcome(true, limitsApplied, diskApplied, diskSkipped);
+  }
+
+  private static boolean isProvisioned(ContainerState state) {
+    return state instanceof ContainerState.Running || state instanceof ContainerState.Stopped;
+  }
+
+  private static boolean limitsDiffer(ResourceLimits limits, SailYaml.Resources desired) {
+    if (limits == null) {
+      return true;
+    }
+    return !Objects.equals(String.valueOf(desired.cpu()), limits.cpu())
+        || !sameSize(limits.memory(), desired.memory());
+  }
+
+  private static boolean sameSize(String a, String b) {
+    return normalize(a).equals(normalize(b));
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value.strip().replaceAll("\\s+", "").toUpperCase(Locale.ROOT);
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/RemoteCommandRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/RemoteCommandRunner.java
@@ -31,7 +31,7 @@ import picocli.CommandLine.Help.Ansi;
 public final class RemoteCommandRunner {
 
   private static final Set<String> LOCAL_COMMANDS =
-      Set.of("--version", "-V", "upgrade", "init", "login");
+      Set.of("--version", "-V", "upgrade", "init", "client", "login");
   private static final Set<String> INTERACTIVE_COMMANDS = Set.of("shell", "exec");
   private static final Set<String> HOST_ONLY_COMMANDS = Set.of("host");
   private static final Set<String> GATEWAY_COMMANDS =
@@ -51,8 +51,9 @@ public final class RemoteCommandRunner {
    * <p>Routes commands into three categories:
    *
    * <ul>
-   *   <li>Local: {@code --version}, {@code upgrade}, {@code init}, {@code login} — run on the
-   *       client, not forwarded ({@code login} drives the client's browser and a loopback callback)
+   *   <li>Local: {@code --version}, {@code upgrade}, {@code init}, {@code client}, {@code login} —
+   *       run on the client, not forwarded ({@code login} drives the client's browser and a
+   *       loopback callback; {@code client} writes this machine's client config)
    *   <li>Host-only: {@code host init}, {@code host config} — error with guidance
    *   <li>Everything else: forwarded to the remote host via SSH, as {@code sail@host} when the FDE
    *       gateway accepts the command and as the plain host otherwise

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
@@ -28,6 +28,7 @@ class CommandTaxonomyTest {
     assertEquals(
         Set.of(
             "init",
+            "client",
             "host",
             "project",
             "server",

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/InitCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/InitCommandTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class InitCommandTest {
+
+  @Test
+  void rejectsBothAsMainAndMain() {
+    var code = new CommandLine(new InitCommand()).execute("--as-main", "--main", "sail@host");
+    assertNotEquals(0, code, "asking to be both main and a node is invalid");
+  }
+
+  @Test
+  void rejectsNeitherAsMainNorMain() {
+    var code = new CommandLine(new InitCommand()).execute();
+    assertNotEquals(0, code, "the box must be told whether it is main or a node");
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/InitIntentTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/InitIntentTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class InitIntentTest {
+
+  @Test
+  void asMainResolvesToMain() {
+    assertEquals(new InitIntent.Main(), InitIntent.resolve(true, null));
+  }
+
+  @Test
+  void mainTargetResolvesToANode() {
+    assertEquals(new InitIntent.Node("sail@host"), InitIntent.resolve(false, "  sail@host "));
+  }
+
+  @Test
+  void bothFlagsAreRejected() {
+    var error =
+        assertThrows(
+            IllegalArgumentException.class, () -> InitIntent.resolve(true, "sail@host"));
+    assertTrue(error.getMessage().contains("not both"));
+  }
+
+  @Test
+  void neitherFlagIsRejected() {
+    var error =
+        assertThrows(IllegalArgumentException.class, () -> InitIntent.resolve(false, "  "));
+    assertTrue(error.getMessage().contains("--as-main"));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/InitIntentTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/InitIntentTest.java
@@ -26,15 +26,13 @@ class InitIntentTest {
   @Test
   void bothFlagsAreRejected() {
     var error =
-        assertThrows(
-            IllegalArgumentException.class, () -> InitIntent.resolve(true, "sail@host"));
+        assertThrows(IllegalArgumentException.class, () -> InitIntent.resolve(true, "sail@host"));
     assertTrue(error.getMessage().contains("not both"));
   }
 
   @Test
   void neitherFlagIsRejected() {
-    var error =
-        assertThrows(IllegalArgumentException.class, () -> InitIntent.resolve(false, "  "));
+    var error = assertThrows(IllegalArgumentException.class, () -> InitIntent.resolve(false, "  "));
     assertTrue(error.getMessage().contains("--as-main"));
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/InitPlanTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/InitPlanTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import ai.singlr.sail.commands.InitPlan.Step;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class InitPlanTest {
+
+  @Test
+  void freshMainProvisionsInstallsSystemApiThenTakesIdentity() {
+    assertEquals(
+        List.of(Step.PROVISION, Step.INSTALL_API_SYSTEM, Step.SSH_IDENTITY, Step.SYNC_AS_MAIN),
+        InitPlan.plan(new InitIntent.Main(), false, false));
+  }
+
+  @Test
+  void freshNodeProvisionsInstallsSystemApiThenJoins() {
+    assertEquals(
+        List.of(Step.PROVISION, Step.INSTALL_API_SYSTEM, Step.JOIN_MAIN),
+        InitPlan.plan(new InitIntent.Node("sail@main"), false, false));
+  }
+
+  @Test
+  void anAlreadyProvisionedBoxSkipsProvisioning() {
+    var plan = InitPlan.plan(new InitIntent.Main(), true, false);
+    assertFalse(plan.contains(Step.PROVISION));
+    assertEquals(Step.INSTALL_API_SYSTEM, plan.getFirst());
+  }
+
+  @Test
+  void underSudoTheApiIsInstalledPerUser() {
+    assertEquals(
+        List.of(Step.INSTALL_API_USER, Step.JOIN_MAIN),
+        InitPlan.plan(new InitIntent.Node("sail@main"), true, true));
+  }
+
+  @Test
+  void onlyMainPublishesAnSshIdentityAndSyncs() {
+    var node = InitPlan.plan(new InitIntent.Node("sail@main"), true, false);
+    assertFalse(node.contains(Step.SSH_IDENTITY));
+    assertFalse(node.contains(Step.SYNC_AS_MAIN));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectResourceReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectResourceReconcilerTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.store.ProjectStore;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ProjectResourceReconcilerTest {
+
+  private static SailYaml.Resources resources(int cpu, String memory, String disk) {
+    return new SailYaml.Resources(cpu, memory, disk);
+  }
+
+  @Test
+  void appliesCpuMemoryAndDiskWhenTheLiveContainerDrifts() throws Exception {
+    var shell = new FakeShell().running("acme", "2", "4GB").disk("acme", "50GB");
+
+    var outcome =
+        new ProjectResourceReconciler(new ContainerManager(shell))
+            .reconcile("acme", resources(8, "16GB", "100GB"));
+
+    assertTrue(outcome.present());
+    assertTrue(outcome.limitsApplied());
+    assertTrue(outcome.diskApplied());
+    assertTrue(shell.ran("incus config set acme limits.cpu=8 limits.memory=16GB"));
+    assertTrue(shell.ranPrefix("incus config device override acme root size=100GB"));
+  }
+
+  @Test
+  void isANoOpWhenAlreadyAtTheDesiredSize() throws Exception {
+    var shell = new FakeShell().running("acme", "8", "16GB").disk("acme", "100GB");
+
+    var outcome =
+        new ProjectResourceReconciler(new ContainerManager(shell))
+            .reconcile("acme", resources(8, "16GB", "100GB"));
+
+    assertFalse(outcome.changed());
+    assertFalse(shell.ranPrefix("incus config set acme"), "no limit write");
+    assertFalse(shell.ranPrefix("incus config device override"), "no disk write");
+    assertFalse(shell.ranPrefix("incus config device set"), "no disk write");
+  }
+
+  @Test
+  void skipsAContainerThatDoesNotExistYet() throws Exception {
+    var shell = new FakeShell();
+
+    var outcome =
+        new ProjectResourceReconciler(new ContainerManager(shell))
+            .reconcile("ghost", resources(8, "16GB", "100GB"));
+
+    assertFalse(outcome.present());
+    assertFalse(outcome.changed());
+  }
+
+  @Test
+  void reportsButDoesNotFailWhenADiskShrinkIsRefused() throws Exception {
+    var shell =
+        new FakeShell()
+            .running("acme", "8", "16GB")
+            .disk("acme", "100GB")
+            .failDevice("Failed to update device: not enough space");
+
+    var outcome =
+        new ProjectResourceReconciler(new ContainerManager(shell))
+            .reconcile("acme", resources(8, "16GB", "20GB"));
+
+    assertTrue(outcome.present());
+    assertFalse(outcome.diskApplied());
+    assertTrue(outcome.diskSkipped().contains("not enough space"));
+  }
+
+  @Test
+  void nullResourcesAreSkipped() throws Exception {
+    var outcome =
+        new ProjectResourceReconciler(new ContainerManager(new FakeShell()))
+            .reconcile("acme", null);
+    assertFalse(outcome.present());
+  }
+
+  @Test
+  void reconcileCatalogResizesOnlyDriftedProjectsWithAContainer() {
+    var shell =
+        new FakeShell()
+            .running("acme", "2", "4GB")
+            .disk("acme", "50GB")
+            .running("static", "8", "16GB")
+            .disk("static", "100GB");
+
+    var rows =
+        List.of(
+            row("acme", "name: acme\nresources:\n  cpu: 8\n  memory: 16GB\n  disk: 100GB\n"),
+            row("static", "name: static\nresources:\n  cpu: 8\n  memory: 16GB\n  disk: 100GB\n"),
+            row("ghost", "name: ghost\nresources:\n  cpu: 4\n  memory: 8GB\n  disk: 50GB\n"),
+            row("noresources", "name: noresources\n"));
+
+    var outcome = new ProjectResourceReconciler(new ContainerManager(shell)).reconcileCatalog(rows);
+
+    assertEquals(List.of("acme"), outcome.resized());
+    assertTrue(outcome.diskSkipped().isEmpty());
+  }
+
+  private static ProjectStore.ProjectRow row(String name, String definition) {
+    return new ProjectStore.ProjectRow(name, definition, "uday", "now", "uday", "now");
+  }
+
+  private static final class FakeShell implements ShellExec {
+    private final List<String> commands = new ArrayList<>();
+    private final java.util.Map<String, Result> listJson = new java.util.HashMap<>();
+    private final java.util.Map<String, String> diskByName = new java.util.HashMap<>();
+    private String deviceFailure;
+
+    FakeShell running(String name, String cpu, String memory) {
+      var json =
+          "[{\"name\":\""
+              + name
+              + "\",\"status\":\"Running\",\"state\":{\"network\":{}},"
+              + "\"config\":{\"limits.cpu\":\""
+              + cpu
+              + "\",\"limits.memory\":\""
+              + memory
+              + "\"}}]";
+      listJson.put(name, new Result(0, json, ""));
+      return this;
+    }
+
+    FakeShell disk(String name, String size) {
+      diskByName.put(name, size);
+      return this;
+    }
+
+    FakeShell failDevice(String message) {
+      this.deviceFailure = message;
+      return this;
+    }
+
+    boolean ran(String command) {
+      return commands.contains(command);
+    }
+
+    boolean ranPrefix(String prefix) {
+      return commands.stream().anyMatch(c -> c.startsWith(prefix));
+    }
+
+    @Override
+    public Result exec(List<String> command) {
+      commands.add(String.join(" ", command));
+      if (command.get(0).equals("incus") && command.get(1).equals("list")) {
+        var name = command.get(2).replace("^", "").replace("$", "");
+        return listJson.getOrDefault(name, new Result(0, "[]", ""));
+      }
+      if (command.contains("get")) {
+        var name = command.get(4);
+        return new Result(0, diskByName.getOrDefault(name, ""), "");
+      }
+      if (deviceFailure != null && command.contains("device")) {
+        return new Result(1, "", deviceFailure);
+      }
+      return new Result(0, "", "");
+    }
+
+    @Override
+    public Result exec(List<String> command, Path workDir, Duration timeout) {
+      return exec(command);
+    }
+
+    @Override
+    public boolean isDryRun() {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Stacked on #78 (Brick H1). Base is `feat/project-identity-separation` so the diff here is only H2 + F. Retarget to `main` once #78 merges.

## H2 — resize a project's live container to synced resource changes

H1 made `resources` (cpu/memory/disk) shared and bidirectional, but a synced change never reached the running container — you had to re-provision. Now a sync that pulls/merges a project brings each container's live limits into line with the definition.

- `ProjectResourceReconciler` applies cpu/memory/disk **in place — no recreate, no restart** (a background sync must never disrupt a running container).
- CPU/memory drift is read from live limits; `ContainerManager.queryDiskQuota` reads the current root size.
- **Best-effort, never fatal:** incus unreachable (unprivileged sync) is a quiet no-op; a disk shrink the backend refuses (ZFS below used space; advisory on `dir`) is reported and skipped.
- Runs only after a round that actually changed a project. `sudo sail host sync` (root) is the path that applies; the watch loop acts only where it has incus access.
- Tests: `ProjectResourceReconcilerTest` — drift apply, no-op, absent container, refused shrink, catalog sweep.

## F — `sail init`: one-command box onboarding

Bringing a box online took several manual steps in the right order, differing for main vs node and fresh vs half-set-up. Now:

```
sudo sail init --as-main                 # this box is the org's source of truth
sudo sail init --main sail@maindevbox    # this box joins an existing main
```

- Idempotent and re-runnable: skips provisioning when already provisioned; sail-api installs as a **system** service under root or a **per-user** service under sudo; then the box takes on its identity (main: ssh-identity + sync-as-main; node: join).
- The decision sequence is a pure, fully-tested `InitPlan`; `InitCommand` only runs each step, reusing the granular commands (which stay).
- **Naming:** top-level `init` previously set up a thin client; that moves to **`sail client <host>`** (box onboarding is the common case and deserves the name). `RemoteCommandRunner` routes both locally. This is a breaking change for thin-client users.
- Tests: `InitPlanTest`, `InitIntentTest`, `InitCommandTest`, `CommandTaxonomyTest`.

Full `sail-core` + `sail-infra` verify green; coverage gates met. No release cut — per the plan, H1 + H2 + F land together as one version.
