### PR TITLE
Make `sail project list` catalog-aware so synced projects are visible

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectListCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectListCommand.java
@@ -47,7 +47,7 @@ public final class ProjectListCommand implements Runnable {
     var projects = merge(containers, catalogNames());
 
     if (json) {
-      printJson(projects);
+      System.out.println(renderJson(projects));
       return;
     }
 
@@ -91,24 +91,27 @@ public final class ProjectListCommand implements Runnable {
     }
   }
 
-  private void printJson(List<ContainerInfo> projects) {
+  /** Renders the project roster as JSON — pure, so the shape is unit-tested. */
+  static String renderJson(List<ContainerInfo> projects) {
     var list = new ArrayList<Map<String, Object>>();
     for (var c : projects) {
       var map = new LinkedHashMap<String, Object>();
       map.put("name", c.name());
-      map.put(
-          "status",
-          switch (c.state()) {
-            case ContainerState.Running ignored -> "running";
-            case ContainerState.Stopped ignored -> "stopped";
-            case ContainerState.NotCreated ignored -> "not_provisioned";
-            case ContainerState.Error ignored -> "error";
-          });
+      map.put("status", statusOf(c.state()));
       if (c.state() instanceof ContainerState.Running r && r.ipv4() != null) {
         map.put("ip", r.ipv4());
       }
       list.add(map);
     }
-    System.out.println(YamlUtil.dumpJson(list));
+    return YamlUtil.dumpJson(list);
+  }
+
+  private static String statusOf(ContainerState state) {
+    return switch (state) {
+      case ContainerState.Running ignored -> "running";
+      case ContainerState.Stopped ignored -> "stopped";
+      case ContainerState.NotCreated ignored -> "not_provisioned";
+      case ContainerState.Error ignored -> "error";
+    };
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectListCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectListCommand.java
@@ -8,9 +8,14 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerManager;
+import ai.singlr.sail.engine.ContainerManager.ContainerInfo;
 import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.store.ProjectStore;
+import ai.singlr.sail.store.Sqlite;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,7 +27,7 @@ import picocli.CommandLine.Spec;
 
 @Command(
     name = "list",
-    description = "List all project containers and their status.",
+    description = "List all projects in the catalog and their local container status.",
     mixinStandardHelpOptions = true)
 public final class ProjectListCommand implements Runnable {
 
@@ -38,31 +43,57 @@ public final class ProjectListCommand implements Runnable {
 
   private void execute() throws Exception {
     var shell = new ShellExecutor(false);
-    var mgr = new ContainerManager(shell);
-    var containers = mgr.listAll();
+    var containers = new ContainerManager(shell).listAll();
+    var projects = merge(containers, catalogNames());
 
     if (json) {
-      printJson(containers);
+      printJson(projects);
       return;
     }
 
     Banner.printBranding(System.out, Ansi.AUTO);
 
-    if (containers.isEmpty()) {
+    if (projects.isEmpty()) {
       System.out.println();
       System.out.println(
           Ansi.AUTO.string(
-              "  @|faint No projects found.|@ Create one with: @|bold sail project create|@"));
+              "  @|faint No projects found.|@ Create one with: @|bold sail project create|@,"
+                  + " or pull a team project with: @|bold sail sync|@"));
       System.out.println();
       return;
     }
 
-    Banner.printProjectTable(containers, System.out, Ansi.AUTO);
+    Banner.printProjectTable(projects, System.out, Ansi.AUTO);
   }
 
-  private void printJson(List<ContainerManager.ContainerInfo> containers) {
+  /**
+   * The full project roster: every catalogued project plus any container without a catalog entry,
+   * keyed by name so a project that is both catalogued and provisioned shows its live container
+   * state rather than a placeholder. Catalogued-but-unprovisioned projects (e.g. just synced from
+   * main) surface as {@link ContainerState.NotCreated} so they can be found and provisioned.
+   */
+  static List<ContainerInfo> merge(List<ContainerInfo> containers, List<String> catalogNames) {
+    var byName = new LinkedHashMap<String, ContainerInfo>();
+    for (var name : catalogNames) {
+      byName.put(name, new ContainerInfo(name, new ContainerState.NotCreated(), null));
+    }
+    for (var container : containers) {
+      byName.put(container.name(), container);
+    }
+    return byName.values().stream().sorted(Comparator.comparing(ContainerInfo::name)).toList();
+  }
+
+  private static List<String> catalogNames() {
+    try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+      return new ProjectStore(db).list().stream().map(ProjectStore.ProjectRow::name).toList();
+    } catch (RuntimeException e) {
+      return List.of();
+    }
+  }
+
+  private void printJson(List<ContainerInfo> projects) {
     var list = new ArrayList<Map<String, Object>>();
-    for (var c : containers) {
+    for (var c : projects) {
       var map = new LinkedHashMap<String, Object>();
       map.put("name", c.name());
       map.put(
@@ -70,7 +101,7 @@ public final class ProjectListCommand implements Runnable {
           switch (c.state()) {
             case ContainerState.Running ignored -> "running";
             case ContainerState.Stopped ignored -> "stopped";
-            case ContainerState.NotCreated ignored -> "not_created";
+            case ContainerState.NotCreated ignored -> "not_provisioned";
             case ContainerState.Error ignored -> "error";
           });
       if (c.state() instanceof ContainerState.Running r && r.ipv4() != null) {

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
@@ -607,7 +607,7 @@ public final class Banner {
           switch (c.state()) {
             case ContainerState.Running ignored -> "Running";
             case ContainerState.Stopped ignored -> "Stopped";
-            case ContainerState.NotCreated ignored -> "N/A";
+            case ContainerState.NotCreated ignored -> "Not provisioned";
             case ContainerState.Error ignored -> "Error";
           };
       var ip = c.state() instanceof ContainerState.Running r && r.ipv4() != null ? r.ipv4() : "-";

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/LifecycleCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/LifecycleCommandTest.java
@@ -139,7 +139,7 @@ class LifecycleCommandTest {
     assertEquals(0, exitCode);
     var output = sw.toString();
     assertTrue(output.contains("--json"));
-    assertTrue(output.contains("List all project containers"));
+    assertTrue(output.contains("List all projects in the catalog"));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectListCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectListCommandTest.java
@@ -58,4 +58,20 @@ class ProjectListCommandTest {
   void emptyEverywhereIsEmpty() {
     assertEquals(List.of(), ProjectListCommand.merge(List.of(), List.of()));
   }
+
+  @Test
+  void jsonRendersStatusAndIpPerProject() {
+    var notProvisioned = new ContainerInfo("billing", new ContainerState.NotCreated(), null);
+    var json = ProjectListCommand.renderJson(List.of(running("acme"), notProvisioned));
+
+    assertEquals(
+        "[{\"name\": \"acme\", \"status\": \"running\", \"ip\": \"10.0.0.5\"}, "
+            + "{\"name\": \"billing\", \"status\": \"not_provisioned\"}]",
+        json);
+  }
+
+  @Test
+  void jsonForNoProjectsIsAnEmptyArray() {
+    assertEquals("[]", ProjectListCommand.renderJson(List.of()));
+  }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectListCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectListCommandTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import ai.singlr.sail.engine.ContainerManager.ContainerInfo;
+import ai.singlr.sail.engine.ContainerManager.ResourceLimits;
+import ai.singlr.sail.engine.ContainerState;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ProjectListCommandTest {
+
+  private static ContainerInfo running(String name) {
+    return new ContainerInfo(
+        name, new ContainerState.Running("10.0.0.5"), new ResourceLimits("4", "8GB"));
+  }
+
+  @Test
+  void cataloguedButUnprovisionedProjectsSurfaceAsNotCreated() {
+    var merged = ProjectListCommand.merge(List.of(running("acme")), List.of("acme", "billing"));
+
+    assertEquals(List.of("acme", "billing"), merged.stream().map(ContainerInfo::name).toList());
+    var billing = merged.stream().filter(c -> c.name().equals("billing")).findFirst().orElseThrow();
+    assertInstanceOf(ContainerState.NotCreated.class, billing.state());
+  }
+
+  @Test
+  void aProvisionedContainerWinsOverItsCatalogPlaceholder() {
+    var merged = ProjectListCommand.merge(List.of(running("acme")), List.of("acme"));
+
+    assertEquals(1, merged.size());
+    assertInstanceOf(ContainerState.Running.class, merged.getFirst().state());
+  }
+
+  @Test
+  void aLocalContainerWithNoCatalogEntryStillShows() {
+    var merged = ProjectListCommand.merge(List.of(running("legacy")), List.of());
+
+    assertEquals(List.of("legacy"), merged.stream().map(ContainerInfo::name).toList());
+  }
+
+  @Test
+  void resultIsSortedByName() {
+    var merged =
+        ProjectListCommand.merge(List.of(running("zeta")), List.of("alpha", "zeta", "mid"));
+
+    assertEquals(
+        List.of("alpha", "mid", "zeta"), merged.stream().map(ContainerInfo::name).toList());
+  }
+
+  @Test
+  void emptyEverywhereIsEmpty() {
+    assertEquals(List.of(), ProjectListCommand.merge(List.of(), List.of()));
+  }
+}


### PR DESCRIPTION
## The gap

`sail project list` listed only incus containers (`ContainerManager.listAll()`), so a project **synced from main but not yet provisioned** — the common case right after a node joins and runs `sail sync` — was invisible. There was no way to discover what to `sudo sail project create`. (Leftover from the DB-authoritative migration: `config`/`create`/`apply` were flipped to read the catalog first, but `list` wasn't.)

## The fix

`project list` now unions the project catalog with live container state:

- every catalogued project shows up — provisioned ones with `Running`/`Stopped`, unprovisioned ones as **`Not provisioned`**;
- a container with no catalog entry still appears (nothing hidden);
- the container state wins over the catalog placeholder when a project is both;
- if the control-plane DB is unreachable, it degrades to the old container-only view.

The merge is a pure static function, fully unit-tested in `ProjectListCommandTest` (unprovisioned surfaces, container-wins-over-placeholder, orphan container, sort, empty). `Banner` now labels `NotCreated` as "Not provisioned" instead of "N/A".

Full `sail-core` + `sail-infra` verify green (1650 tests), coverage gates met.
