### PR TITLE
Pre-v1 hardening: catalog-first writes, sync correctness, old-box convergence, attribution

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/config/SailYamlUpdater.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/SailYamlUpdater.java
@@ -5,96 +5,65 @@
 
 package ai.singlr.sail.config;
 
-import ai.singlr.sail.gen.SailYamlGenerator;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Updates an existing {@code sail.yaml} by adding services or repos. Reads the current file, merges
- * the new entry, and writes back via {@link SailYamlGenerator} to preserve the standard commented
- * format.
- *
- * <p>Note: user-added comments are not preserved across updates — the generator produces its own
- * standard inline comments.
+ * Pure transforms over a {@link SailYaml} definition: add a service or repo, remove a service, or
+ * update resources, each returning a new definition. Persistence is deliberately not this class's
+ * concern — the database catalog is the source of truth, so callers route the result through {@code
+ * ProjectDefinitions.persist} rather than writing a file here. Keeping these transforms pure lets a
+ * mutation read the current definition catalog-first, transform it, and record the result, so an
+ * edit can never diverge from the catalog or be lost on the next sync.
  */
 public final class SailYamlUpdater {
 
   private SailYamlUpdater() {}
 
-  /**
-   * Adds a service to the sail.yaml at the given path. If the services section doesn't exist, it is
-   * created. If the service name already exists, throws.
-   */
-  public static SailYaml addService(Path singYamlPath, String serviceName, SailYaml.Service service)
-      throws IOException {
-    var config = readConfig(singYamlPath);
+  /** Returns a copy of {@code config} with the service added. Throws if the name already exists. */
+  public static SailYaml addService(SailYaml config, String serviceName, SailYaml.Service service) {
     var services =
         config.services() != null
             ? new LinkedHashMap<>(config.services())
             : new LinkedHashMap<String, SailYaml.Service>();
     if (services.containsKey(serviceName)) {
-      throw new IllegalStateException(
-          "Service '" + serviceName + "' already exists in " + singYamlPath);
+      throw new IllegalStateException("Service '" + serviceName + "' already exists.");
     }
     services.put(serviceName, service);
-    var updated = withServices(config, Map.copyOf(services));
-    writeConfig(singYamlPath, updated);
-    return updated;
+    return withServices(config, Map.copyOf(services));
   }
 
-  /**
-   * Removes a service from the sail.yaml at the given path. Throws if the service doesn't exist.
-   */
-  public static SailYaml removeService(Path singYamlPath, String serviceName) throws IOException {
-    var config = readConfig(singYamlPath);
+  /** Returns a copy of {@code config} with the service removed. Throws if it does not exist. */
+  public static SailYaml removeService(SailYaml config, String serviceName) {
     var services =
         config.services() != null
             ? new LinkedHashMap<>(config.services())
             : new LinkedHashMap<String, SailYaml.Service>();
     if (!services.containsKey(serviceName)) {
-      throw new IllegalStateException("Service '" + serviceName + "' not found in " + singYamlPath);
+      throw new IllegalStateException("Service '" + serviceName + "' not found.");
     }
     services.remove(serviceName);
-    var updated = withServices(config, services.isEmpty() ? null : Map.copyOf(services));
-    writeConfig(singYamlPath, updated);
-    return updated;
+    return withServices(config, services.isEmpty() ? null : Map.copyOf(services));
   }
 
-  /**
-   * Adds a repo to the sail.yaml at the given path. If the repos section doesn't exist, it is
-   * created. If a repo with the same path already exists, throws.
-   */
-  public static SailYaml addRepo(Path singYamlPath, SailYaml.Repo repo) throws IOException {
-    var config = readConfig(singYamlPath);
+  /** Returns a copy of {@code config} with the repo added. Throws if its path already exists. */
+  public static SailYaml addRepo(SailYaml config, SailYaml.Repo repo) {
     var repos =
         config.repos() != null ? new ArrayList<>(config.repos()) : new ArrayList<SailYaml.Repo>();
     for (var existing : repos) {
       if (existing.path().equals(repo.path())) {
-        throw new IllegalStateException(
-            "Repo with path '" + repo.path() + "' already exists in " + singYamlPath);
+        throw new IllegalStateException("Repo with path '" + repo.path() + "' already exists.");
       }
     }
     repos.add(repo);
-    var updated = withRepos(config, List.copyOf(repos));
-    writeConfig(singYamlPath, updated);
-    return updated;
+    return withRepos(config, List.copyOf(repos));
   }
 
-  /**
-   * Updates the resources block in the sail.yaml at the given path. Any null argument preserves the
-   * existing value.
-   */
-  public static SailYaml updateResources(Path singYamlPath, Integer cpu, String memory, String disk)
-      throws IOException {
-    var config = readConfig(singYamlPath);
-    var updated = withResources(config, mergeResources(config.resources(), cpu, memory, disk));
-    writeConfig(singYamlPath, updated);
-    return updated;
+  /** Returns a copy of {@code config} with resources merged; any null argument is preserved. */
+  public static SailYaml updateResources(SailYaml config, Integer cpu, String memory, String disk) {
+    return withResources(config, mergeResources(config.resources(), cpu, memory, disk));
   }
 
   /**
@@ -121,18 +90,6 @@ public final class SailYamlUpdater {
             "memory", memory != null ? memory : current.memory(),
             "disk", disk != null ? disk : current.disk());
     return SailYaml.Resources.fromMap(merged);
-  }
-
-  private static SailYaml readConfig(Path path) throws IOException {
-    if (!Files.exists(path)) {
-      throw new IllegalStateException("sail.yaml not found: " + path.toAbsolutePath());
-    }
-    return SailYaml.fromMap(YamlUtil.parseFile(path));
-  }
-
-  private static void writeConfig(Path path, SailYaml config) throws IOException {
-    var yaml = SailYamlGenerator.generate(config);
-    Files.writeString(path, yaml);
   }
 
   private static SailYaml withServices(SailYaml c, Map<String, SailYaml.Service> services) {

--- a/sail-core/src/main/java/ai/singlr/sail/config/SpecDirectory.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/SpecDirectory.java
@@ -12,11 +12,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Reads and writes the {@code specs/} directory structure used for spec-driven agent work. Each
- * spec lives in its own directory with {@code spec.yaml} metadata and {@code spec.md} details.
- *
- * <p>This class is pure parsing/generation logic with no I/O — callers pass content strings in and
- * receive content strings back.
+ * Parses and generates the {@code specs/} directory format used for spec-driven agent work — each
+ * spec a directory with {@code spec.yaml} metadata and {@code spec.md} details. Pure
+ * parsing/generation only: callers pass content strings in and receive content strings back, and
+ * this class performs no file I/O itself.
  */
 public final class SpecDirectory {
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
@@ -128,8 +128,9 @@ public final class FdeStore {
   /**
    * Amends an existing FDE in place — only the non-null arguments change; the rest are left as they
    * are, and the surrogate id (and the keys, tokens, and sessions that reference it) is preserved.
-   * Returns the updated FDE, or empty if the handle is unknown. The change propagates to every node
-   * on its next roster pull.
+   * Returns the updated FDE, or empty if the handle is unknown. The roster is main-authoritative
+   * and replicates one-way, so a change made on main reaches every node on its next pull; a change
+   * made on a node stays local and is overwritten by the next sync (the CLI guards against that).
    */
   public Optional<Fde> update(String handle, String displayName, String email, String role) {
     var existing = byHandle(handle).orElse(null);

--- a/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
@@ -94,7 +94,7 @@ public final class ProjectStore implements ConflictResolver {
   // ── Sync roles (mirrors FileStore): the database is the replicated source of truth ──
 
   public Map<String, Object> comparableSnapshot(String id) {
-    return findByName(id).map(row -> comparable(row.definition())).orElse(null);
+    return findByName(id).map(row -> comparable(row.definition(), row.updatedBy())).orElse(null);
   }
 
   public Map<String, Object> comparableAtRev(String id, String rev) {
@@ -177,7 +177,7 @@ public final class ProjectStore implements ConflictResolver {
             adoptDeletion(id, rev);
           } else {
             var definition = definitionOf(snapshot);
-            writeRow(id, definition, "sync");
+            writeRow(id, definition, actorOf(snapshot));
             recordRevision(id, definition, rev, "sync", false, true);
           }
         });
@@ -200,7 +200,7 @@ public final class ProjectStore implements ConflictResolver {
             return new PushOutcome.Accepted(rev);
           }
           var definition = definitionOf(snapshot);
-          writeRow(id, definition, "sync");
+          writeRow(id, definition, actorOf(snapshot));
           return new PushOutcome.Accepted(
               recordRevision(id, definition, null, "sync", false, false));
         });
@@ -230,7 +230,7 @@ public final class ProjectStore implements ConflictResolver {
       return adoptBaseDeletion(id);
     }
     var definition = definitionOf(remote);
-    writeRow(id, definition, "sync");
+    writeRow(id, definition, actorOf(remote));
     return recordRevision(id, definition, null, "sync", false, true);
   }
 
@@ -319,6 +319,16 @@ public final class ProjectStore implements ConflictResolver {
     return definition == null ? null : definition.toString();
   }
 
+  /**
+   * The author carried in a synced snapshot, defaulting to {@code sync} when absent (a peer that
+   * predates attribution). Read on the receiving side so a synced project is attributed to the
+   * engineer who actually edited it rather than to {@code sync}.
+   */
+  private static String actorOf(Map<String, Object> snapshot) {
+    var actor = snapshot == null ? null : snapshot.get(ACTOR);
+    return actor == null ? "sync" : actor.toString();
+  }
+
   private String rawBaseRev(String id) {
     var value =
         db.queryOne(
@@ -335,11 +345,32 @@ public final class ProjectStore implements ConflictResolver {
         .orElse("");
   }
 
+  /**
+   * The base/historical comparable carries only the work field. {@link ConflictDetector} ignores
+   * reserved {@code _}-prefixed keys, and the merge base's author is never needed, so the stored
+   * snapshot — and therefore the content-addressed revision — stays {@code {definition}} and two
+   * boxes still mint the same rev for the same definition.
+   */
   private static Map<String, Object> comparable(String definition) {
     var map = new LinkedHashMap<String, Object>();
     map.put("definition", definition);
     return map;
   }
+
+  /**
+   * The transmitted comparable additionally carries {@code _actor} so the receiving box can
+   * attribute the synced row to its real author. It rides outside the work fields, so it never
+   * counts toward a conflict and never enters the revision hash.
+   */
+  private static Map<String, Object> comparable(String definition, String actor) {
+    var map = comparable(definition);
+    if (actor != null) {
+      map.put(ACTOR, actor);
+    }
+    return map;
+  }
+
+  private static final String ACTOR = "_actor";
 
   private static final String SELECT =
       "SELECT name, definition, created_by, created_at, updated_by, updated_at FROM projects";

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -552,6 +552,23 @@ public final class SpecStore implements ConflictResolver {
   }
 
   /**
+   * Records a baseline revision for every spec that has none yet. A spec written before this store
+   * journaled its mutations has a row in {@code specs} but no change-log entry, so it is invisible
+   * to sync until journaled — the same gap {@link ProjectStore#backfillRevisions()} closes for
+   * projects. Idempotent: a spec already in the change log is left untouched. The minted rev is
+   * content-addressed, so two boxes backfilling the same pre-journal spec reach the same revision
+   * and converge without a conflict. Returns how many were backfilled.
+   */
+  public int backfillRevisions() {
+    var journaled = syncEntityIds();
+    var pending = list(SpecFilter.all()).stream().filter(s -> !journaled.contains(s.id())).toList();
+    for (var spec : pending) {
+      db.transaction(() -> recordRevision(spec.id(), "local", false));
+    }
+    return pending.size();
+  }
+
+  /**
    * Writes an authoritative state from main at its exact revision (no minting), marking it the new
    * synced ancestor ({@code base_rev = rev}). A null snapshot adopts a deletion. Used by the sync
    * engine; the revision is journaled with origin {@code sync}.

--- a/sail-core/src/test/java/ai/singlr/sail/config/SailYamlUpdaterTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/SailYamlUpdaterTest.java
@@ -204,6 +204,41 @@ class SailYamlUpdaterTest {
   }
 
   @Test
+  void mutateThenSerializePreservesEverySectionIncludingProcessesAndAgentContext() {
+    var full =
+        """
+        name: my-project
+        resources:
+          cpu: 2
+          memory: 8GB
+          disk: 50GB
+        image: ubuntu/24.04
+        processes:
+          web:
+            command: "npm run dev"
+            workdir: webapp
+        agent:
+          type: claude-code
+          config:
+            model: opus
+        agent_context:
+          tech_stack: "Java 25 + React"
+          conventions: "no inline comments"
+        """;
+
+    var mutated =
+        SailYamlUpdater.addRepo(parse(full), new SailYaml.Repo("https://x/y.git", "y", null));
+    var reparsed = SailYaml.fromMap(YamlUtil.parseMap(YamlUtil.dumpToString(mutated.toMap())));
+
+    assertNotNull(reparsed.processes(), "processes survives the mutate-and-serialize round trip");
+    assertEquals("npm run dev", reparsed.processes().get("web").command());
+    assertNotNull(reparsed.agentContext(), "agent_context survives the round trip");
+    assertEquals("Java 25 + React", reparsed.agentContext().techStack());
+    assertEquals("opus", reparsed.agent().config().get("model"), "agent.config survives too");
+    assertEquals("y", reparsed.repos().getFirst().path(), "and the mutation applied");
+  }
+
+  @Test
   void mergeResourcesRejectsInvalidValues() {
     var current = new SailYaml.Resources(2, "8GB", "50GB");
 

--- a/sail-core/src/test/java/ai/singlr/sail/config/SailYamlUpdaterTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/SailYamlUpdaterTest.java
@@ -11,14 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.file.Files;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 class SailYamlUpdaterTest {
-
-  @TempDir java.nio.file.Path tempDir;
 
   private static final String BASE_YAML =
       """
@@ -49,51 +45,51 @@ class SailYamlUpdaterTest {
       image: ubuntu/24.04
       """;
 
-  @Test
-  void addServiceToExistingServicesSection() throws Exception {
-    var path = writeTempYaml(BASE_YAML);
-
-    var redis = new SailYaml.Service("redis:7", List.of(6379), null, null, null);
-    var updated = SailYamlUpdater.addService(path, "redis", redis);
-
-    assertEquals(2, updated.services().size());
-    assertNotNull(updated.services().get("postgres"));
-    assertNotNull(updated.services().get("redis"));
-    assertEquals("redis:7", updated.services().get("redis").image());
-
-    var reloaded = SailYaml.fromMap(YamlUtil.parseFile(path));
-    assertEquals(2, reloaded.services().size());
+  private static SailYaml parse(String yaml) {
+    return SailYaml.fromMap(YamlUtil.parseMap(yaml));
   }
 
   @Test
-  void addServiceCreatesServicesSectionWhenMissing() throws Exception {
-    var path = writeTempYaml(MINIMAL_YAML);
+  void addServiceToExistingServicesSection() {
+    var redis = new SailYaml.Service("redis:7", List.of(6379), null, null, null);
+    var updated = SailYamlUpdater.addService(parse(BASE_YAML), "redis", redis);
 
+    assertEquals(2, updated.services().size());
+    assertNotNull(updated.services().get("postgres"));
+    assertEquals("redis:7", updated.services().get("redis").image());
+  }
+
+  @Test
+  void addServiceCreatesServicesSectionWhenMissing() {
     var pg = new SailYaml.Service("postgres:16", List.of(5432), null, null, null);
-    var updated = SailYamlUpdater.addService(path, "postgres", pg);
+    var updated = SailYamlUpdater.addService(parse(MINIMAL_YAML), "postgres", pg);
 
     assertEquals(1, updated.services().size());
     assertEquals("postgres:16", updated.services().get("postgres").image());
   }
 
   @Test
-  void addServiceThrowsOnDuplicate() throws Exception {
-    var path = writeTempYaml(BASE_YAML);
-
+  void addServiceThrowsOnDuplicate() {
     var pg = new SailYaml.Service("postgres:17", List.of(5432), null, null, null);
     var ex =
         assertThrows(
-            IllegalStateException.class, () -> SailYamlUpdater.addService(path, "postgres", pg));
-
+            IllegalStateException.class,
+            () -> SailYamlUpdater.addService(parse(BASE_YAML), "postgres", pg));
     assertTrue(ex.getMessage().contains("already exists"));
   }
 
   @Test
-  void addServicePreservesOtherSections() throws Exception {
-    var path = writeTempYaml(BASE_YAML);
+  void addServiceDoesNotMutateTheInput() {
+    var input = parse(BASE_YAML);
+    SailYamlUpdater.addService(
+        input, "redis", new SailYaml.Service("redis:7", null, null, null, null));
+    assertEquals(1, input.services().size(), "the original definition is untouched");
+  }
 
+  @Test
+  void addServicePreservesOtherSections() {
     var redis = new SailYaml.Service("redis:7", List.of(6379), null, null, null);
-    var updated = SailYamlUpdater.addService(path, "redis", redis);
+    var updated = SailYamlUpdater.addService(parse(BASE_YAML), "redis", redis);
 
     assertEquals("my-project", updated.name());
     assertEquals(2, updated.resources().cpu());
@@ -102,7 +98,7 @@ class SailYamlUpdaterTest {
   }
 
   @Test
-  void removeServiceFromExistingSection() throws Exception {
+  void removeServiceFromExistingSection() {
     var yaml =
         """
         name: my-project
@@ -114,130 +110,73 @@ class SailYamlUpdaterTest {
         services:
           postgres:
             image: postgres:16
-            ports: [5432]
           redis:
             image: redis:7
-            ports: [6379]
-        ssh:
-          user: dev
         """;
-    var path = writeTempYaml(yaml);
-
-    var updated = SailYamlUpdater.removeService(path, "redis");
+    var updated = SailYamlUpdater.removeService(parse(yaml), "redis");
 
     assertEquals(1, updated.services().size());
     assertNotNull(updated.services().get("postgres"));
     assertNull(updated.services().get("redis"));
-
-    var reloaded = SailYaml.fromMap(YamlUtil.parseFile(path));
-    assertEquals(1, reloaded.services().size());
   }
 
   @Test
-  void removeServiceNullsOutSectionWhenLastRemoved() throws Exception {
-    var path = writeTempYaml(BASE_YAML);
-
-    var updated = SailYamlUpdater.removeService(path, "postgres");
-
+  void removeServiceNullsOutSectionWhenLastRemoved() {
+    var updated = SailYamlUpdater.removeService(parse(BASE_YAML), "postgres");
     assertNull(updated.services());
   }
 
   @Test
-  void removeServiceThrowsWhenNotFound() throws Exception {
-    var path = writeTempYaml(BASE_YAML);
-
+  void removeServiceThrowsWhenNotFound() {
     var ex =
         assertThrows(
-            IllegalStateException.class, () -> SailYamlUpdater.removeService(path, "nonexistent"));
+            IllegalStateException.class,
+            () -> SailYamlUpdater.removeService(parse(BASE_YAML), "nonexistent"));
     assertTrue(ex.getMessage().contains("not found"));
   }
 
   @Test
-  void removeServiceThrowsWhenNoServicesSection() throws Exception {
-    var path = writeTempYaml(MINIMAL_YAML);
-
+  void removeServiceThrowsWhenNoServicesSection() {
     var ex =
         assertThrows(
-            IllegalStateException.class, () -> SailYamlUpdater.removeService(path, "postgres"));
+            IllegalStateException.class,
+            () -> SailYamlUpdater.removeService(parse(MINIMAL_YAML), "postgres"));
     assertTrue(ex.getMessage().contains("not found"));
   }
 
   @Test
-  void removeServicePreservesOtherSections() throws Exception {
-    var yaml =
-        """
-        name: my-project
-        resources:
-          cpu: 2
-          memory: 8GB
-          disk: 50GB
-        image: ubuntu/24.04
-        services:
-          postgres:
-            image: postgres:16
-            ports: [5432]
-          redis:
-            image: redis:7
-            ports: [6379]
-        repos:
-          - url: "https://github.com/org/backend.git"
-            path: backend
-        ssh:
-          user: dev
-        """;
-    var path = writeTempYaml(yaml);
-
-    var updated = SailYamlUpdater.removeService(path, "redis");
-
-    assertEquals("my-project", updated.name());
-    assertEquals(2, updated.resources().cpu());
-    assertEquals(1, updated.repos().size());
-    assertEquals("dev", updated.ssh().user());
-  }
-
-  @Test
-  void addRepoToExistingReposSection() throws Exception {
-    var path = writeTempYaml(BASE_YAML);
-
+  void addRepoToExistingReposSection() {
     var repo = new SailYaml.Repo("https://github.com/org/frontend.git", "frontend", "main");
-    var updated = SailYamlUpdater.addRepo(path, repo);
+    var updated = SailYamlUpdater.addRepo(parse(BASE_YAML), repo);
 
     assertEquals(2, updated.repos().size());
     assertEquals("backend", updated.repos().get(0).path());
     assertEquals("frontend", updated.repos().get(1).path());
     assertEquals("main", updated.repos().get(1).branch());
-
-    var reloaded = SailYaml.fromMap(YamlUtil.parseFile(path));
-    assertEquals(2, reloaded.repos().size());
   }
 
   @Test
-  void addRepoCreatesReposSectionWhenMissing() throws Exception {
-    var path = writeTempYaml(MINIMAL_YAML);
-
+  void addRepoCreatesReposSectionWhenMissing() {
     var repo = new SailYaml.Repo("https://github.com/org/app.git", "app", null);
-    var updated = SailYamlUpdater.addRepo(path, repo);
+    var updated = SailYamlUpdater.addRepo(parse(MINIMAL_YAML), repo);
 
     assertEquals(1, updated.repos().size());
     assertEquals("app", updated.repos().getFirst().path());
   }
 
   @Test
-  void addRepoThrowsOnDuplicatePath() throws Exception {
-    var path = writeTempYaml(BASE_YAML);
-
+  void addRepoThrowsOnDuplicatePath() {
     var repo = new SailYaml.Repo("https://github.com/other/backend.git", "backend", null);
-    var ex = assertThrows(IllegalStateException.class, () -> SailYamlUpdater.addRepo(path, repo));
-
+    var ex =
+        assertThrows(
+            IllegalStateException.class, () -> SailYamlUpdater.addRepo(parse(BASE_YAML), repo));
     assertTrue(ex.getMessage().contains("already exists"));
   }
 
   @Test
-  void addRepoPreservesOtherSections() throws Exception {
-    var path = writeTempYaml(BASE_YAML);
-
+  void addRepoPreservesOtherSections() {
     var repo = new SailYaml.Repo("https://github.com/org/frontend.git", "frontend", null);
-    var updated = SailYamlUpdater.addRepo(path, repo);
+    var updated = SailYamlUpdater.addRepo(parse(BASE_YAML), repo);
 
     assertEquals("my-project", updated.name());
     assertEquals(1, updated.services().size());
@@ -245,30 +184,8 @@ class SailYamlUpdaterTest {
   }
 
   @Test
-  void addServiceThrowsWhenFileNotFound() {
-    var path = tempDir.resolve("nonexistent.yaml");
-    var svc = new SailYaml.Service("redis:7", List.of(6379), null, null, null);
-
-    var ex =
-        assertThrows(
-            IllegalStateException.class, () -> SailYamlUpdater.addService(path, "redis", svc));
-    assertTrue(ex.getMessage().contains("not found"));
-  }
-
-  @Test
-  void addRepoThrowsWhenFileNotFound() {
-    var path = tempDir.resolve("nonexistent.yaml");
-    var repo = new SailYaml.Repo("https://github.com/org/app.git", "app", null);
-
-    var ex = assertThrows(IllegalStateException.class, () -> SailYamlUpdater.addRepo(path, repo));
-    assertTrue(ex.getMessage().contains("not found"));
-  }
-
-  @Test
-  void updateResourcesChangesRequestedFieldsAndPreservesOtherSections() throws Exception {
-    var path = writeTempYaml(BASE_YAML);
-
-    var updated = SailYamlUpdater.updateResources(path, 4, "16GB", null);
+  void updateResourcesChangesRequestedFieldsAndPreservesOtherSections() {
+    var updated = SailYamlUpdater.updateResources(parse(BASE_YAML), 4, "16GB", null);
 
     assertEquals(4, updated.resources().cpu());
     assertEquals("16GB", updated.resources().memory());
@@ -276,18 +193,11 @@ class SailYamlUpdaterTest {
     assertEquals("my-project", updated.name());
     assertEquals("dev", updated.ssh().user());
     assertEquals(1, updated.services().size());
-
-    var reloaded = SailYaml.fromMap(YamlUtil.parseFile(path));
-    assertEquals(4, reloaded.resources().cpu());
-    assertEquals("16GB", reloaded.resources().memory());
-    assertEquals("50GB", reloaded.resources().disk());
   }
 
   @Test
-  void updateResourcesNormalizesBareSizes() throws Exception {
-    var path = writeTempYaml(BASE_YAML);
-
-    var updated = SailYamlUpdater.updateResources(path, null, "32", "120");
+  void updateResourcesNormalizesBareSizes() {
+    var updated = SailYamlUpdater.updateResources(parse(BASE_YAML), null, "32", "120");
 
     assertEquals("32GB", updated.resources().memory());
     assertEquals("120GB", updated.resources().disk());
@@ -314,11 +224,5 @@ class SailYamlUpdaterTest {
             IllegalArgumentException.class,
             () -> SailYamlUpdater.mergeResources(current, null, null, " "));
     assertTrue(diskEx.getMessage().contains("disk"));
-  }
-
-  private java.nio.file.Path writeTempYaml(String content) throws Exception {
-    var path = tempDir.resolve("sail.yaml");
-    Files.writeString(path, content);
-    return path;
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/store/ProjectStoreSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ProjectStoreSyncTest.java
@@ -46,11 +46,15 @@ class ProjectStoreSyncTest {
     return Map.of("definition", definition);
   }
 
+  private static Map<String, Object> def(String definition, String actor) {
+    return Map.of("definition", definition, "_actor", actor);
+  }
+
   @Test
   void upsertJournalsAComparableRevision() {
     store.upsert("acme", "name: acme\n", "uday");
 
-    assertEquals(def("name: acme\n"), store.comparableSnapshot("acme"));
+    assertEquals(def("name: acme\n", "uday"), store.comparableSnapshot("acme"));
     assertNotEquals(null, store.latestRev("acme"));
     assertTrue(store.syncEntityIds().contains("acme"));
   }
@@ -63,7 +67,7 @@ class ProjectStoreSyncTest {
     store.upsert("acme", "v2", "uday");
 
     assertNotEquals(rev1, store.latestRev("acme"));
-    assertEquals(def("v2"), store.comparableSnapshot("acme"));
+    assertEquals(def("v2", "uday"), store.comparableSnapshot("acme"));
     assertEquals(def("v1"), store.comparableAtRev("acme", rev1));
   }
 
@@ -71,7 +75,7 @@ class ProjectStoreSyncTest {
   void applyRevisionAdoptsMainsStateAtItsExactRevAsTheBase() {
     store.applyRevision("acme", def("from-main"), "rev-xyz");
 
-    assertEquals(def("from-main"), store.comparableSnapshot("acme"));
+    assertEquals(def("from-main", "sync"), store.comparableSnapshot("acme"));
     assertEquals("rev-xyz", store.latestRev("acme"));
     assertEquals("rev-xyz", store.baseRevOf("acme"));
   }
@@ -85,7 +89,7 @@ class ProjectStoreSyncTest {
     var accepted = assertInstanceOf(PushOutcome.Accepted.class, outcome);
     assertNotEquals("rev-base", accepted.rev());
     assertEquals(accepted.rev(), store.latestRev("acme"));
-    assertEquals(def("pushed"), store.comparableSnapshot("acme"));
+    assertEquals(def("pushed", "sync"), store.comparableSnapshot("acme"));
   }
 
   @Test
@@ -96,7 +100,7 @@ class ProjectStoreSyncTest {
     var outcome = store.commitRevision("acme", def("racing"), "rev-base");
 
     var stale = assertInstanceOf(PushOutcome.Stale.class, outcome);
-    assertEquals(def("moved"), stale.currentSnapshot());
+    assertEquals(def("moved", "sync"), stale.currentSnapshot());
   }
 
   @Test
@@ -126,7 +130,7 @@ class ProjectStoreSyncTest {
 
     store.resolveConflict("acme", def("theirs"), def("theirs"));
 
-    assertEquals(def("theirs"), store.comparableSnapshot("acme"));
+    assertEquals(def("theirs", "sync"), store.comparableSnapshot("acme"));
   }
 
   @Test
@@ -155,7 +159,7 @@ class ProjectStoreSyncTest {
 
     store.resolveConflict("acme", def("mine"), def("theirs"));
 
-    assertEquals(def("mine"), store.comparableSnapshot("acme"));
+    assertEquals(def("mine", "resolve"), store.comparableSnapshot("acme"));
     assertNotEquals("rev-theirs", store.latestRev("acme"));
     assertNotEquals(
         store.baseRevOf("acme"), store.latestRev("acme"), "a forward local edit awaits push");

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SpecStatus;
@@ -390,5 +391,31 @@ class SpecStoreTest {
 
     assertEquals(List.of("auth"), store.findById("billing").orElseThrow().dependsOn());
     assertTrue(store.findById("auth").isEmpty(), "the dependency need not exist");
+  }
+
+  @Test
+  void backfillMakesAPreJournalSpecSyncable() {
+    store.create(spec("oauth", "OAuth flow", "done"));
+    db.execute("DELETE FROM change_log WHERE entity_type = 'spec' AND entity_id = ?", "oauth");
+    assertFalse(store.syncEntityIds().contains("oauth"), "simulated pre-journal spec");
+
+    assertEquals(1, store.backfillRevisions());
+    assertTrue(store.syncEntityIds().contains("oauth"), "now visible to sync");
+  }
+
+  @Test
+  void backfillIsANoOpForAnAlreadyJournaledSpec() {
+    store.create(spec("oauth", "OAuth flow", "done"));
+    assertEquals(0, store.backfillRevisions(), "create already journaled it");
+  }
+
+  @Test
+  void backfillJournalsEveryPreJournalSpecAcrossProjects() {
+    store.create(spec("a", "acme", "A", "pending"));
+    store.create(spec("b", "zenith", "B", "pending"));
+    db.execute("DELETE FROM change_log WHERE entity_type = 'spec'");
+
+    assertEquals(2, store.backfillRevisions());
+    assertTrue(store.syncEntityIds().containsAll(List.of("a", "b")));
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/sync/FleetSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/FleetSyncTest.java
@@ -225,6 +225,18 @@ class FleetSyncTest {
   }
 
   @Test
+  void aSyncedProjectIsAttributedToItsRealAuthorNotSync() {
+    main.projects.upsert("acme", "name: acme\nimage: ubuntu/24.04\n", "uday");
+
+    syncFromMain();
+
+    assertEquals(
+        "uday",
+        node.projects.findByName("acme").orElseThrow().updatedBy(),
+        "the synced row keeps its real author, not the literal 'sync'");
+  }
+
+  @Test
   void anUnjournaledSpecStaysInvisibleUntilBackfilled() {
     main.specs.create(spec("oauth", "OAuth flow", "done", List.of()));
     main.db.execute("DELETE FROM change_log WHERE entity_type = 'spec' AND entity_id = ?", "oauth");

--- a/sail-core/src/test/java/ai/singlr/sail/sync/FleetSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/FleetSyncTest.java
@@ -224,6 +224,22 @@ class FleetSyncTest {
     assertTrue(node.projects.findByName("outline").isPresent(), "backfill makes it replicate");
   }
 
+  @Test
+  void anUnjournaledSpecStaysInvisibleUntilBackfilled() {
+    main.specs.create(spec("oauth", "OAuth flow", "done", List.of()));
+    main.db.execute("DELETE FROM change_log WHERE entity_type = 'spec' AND entity_id = ?", "oauth");
+
+    syncFromMain();
+    assertTrue(
+        node.specs.findById("oauth").isEmpty(),
+        "without backfill, a spec predating the change log does not sync");
+
+    main.specs.backfillRevisions();
+    syncFromMain();
+
+    assertEquals("OAuth flow", node.specs.findById("oauth").orElseThrow().title());
+  }
+
   private static String decode(FileStore.FileRow row) {
     return new String(Base64.getDecoder().decode(row.content()));
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ServerConnectionConfig.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ServerConnectionConfig.java
@@ -58,10 +58,22 @@ public record ServerConnectionConfig(String serverUrl, String token) {
 
     if (url == null) url = DEFAULT_URL;
     if (token == null) {
-      throw new IOException(
-          "No API token configured. Set SAIL_TOKEN, pass --token-file, or run 'sail login'.");
+      throw new IOException(noTokenMessage());
     }
     return new ServerConnectionConfig(url, token);
+  }
+
+  /**
+   * Why there is no token, and the fix for each kind of box. A dev box gets its token when sail-api
+   * first starts, so an old box that never installed the service needs {@code host service install}
+   * — not {@code sail login}, which is the thin-client path. Naming both (and the env/file
+   * overrides) keeps the message honest wherever it surfaces.
+   */
+  static String noTokenMessage() {
+    return "No API token configured — sail-api may not be installed or started on this box.\n"
+        + "  On a dev box: sudo sail host service install (installs and starts the control plane).\n"
+        + "  On a thin client: sail login.\n"
+        + "  Or set SAIL_TOKEN, or pass --token-file.";
   }
 
   /** Reads a token from a file, trimming surrounding whitespace; {@code null} path yields null. */

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/Actor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/Actor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+/**
+ * Resolves the human behind a catalog mutation for attribution. Under {@code sudo} the real
+ * engineer is {@code SUDO_USER}, not {@code root}; otherwise it is the process owner. The
+ * resolution is pure so it can be unit-tested without touching the environment.
+ */
+final class Actor {
+
+  private Actor() {}
+
+  /** The actor for the current process, read from {@code SUDO_USER} then {@code user.name}. */
+  static String current() {
+    return resolve(System.getenv("SUDO_USER"), System.getProperty("user.name"));
+  }
+
+  static String resolve(String sudoUser, String userName) {
+    if (sudoUser != null && !sudoUser.isBlank() && !"root".equals(sudoUser)) {
+      return sudoUser;
+    }
+    return userName == null || userName.isBlank() ? "local" : userName;
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ConflictsCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ConflictsCommand.java
@@ -11,6 +11,7 @@ import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.store.ConflictResolver;
 import ai.singlr.sail.store.FileStore;
+import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.SyncConflicts;
@@ -45,7 +46,9 @@ import picocli.CommandLine.Parameters;
     subcommands = {ConflictsCommand.Show.class, ConflictsCommand.Resolve.class})
 public final class ConflictsCommand implements Callable<Integer> {
 
+  static final String SPEC = "spec";
   static final String FILE = "file";
+  static final String PROJECT = "project";
 
   @Option(names = "--json", description = "Output the pending conflicts as JSON.")
   private boolean json;
@@ -112,7 +115,12 @@ public final class ConflictsCommand implements Callable<Integer> {
   }
 
   static ConflictResolver resolverFor(Sqlite db, String entityType) {
-    return entityType.equals(FILE) ? new FileStore(db) : new SpecStore(db);
+    return switch (entityType) {
+      case SPEC -> new SpecStore(db);
+      case FILE -> new FileStore(db);
+      case PROJECT -> new ProjectStore(db);
+      default -> throw new IllegalStateException("Unknown conflict entity type: " + entityType);
+    };
   }
 
   @Command(
@@ -267,11 +275,13 @@ public final class ConflictsCommand implements Callable<Integer> {
     }
 
     /**
-     * A field-level merge needs both sides present and a mergeable structure, so it is offered only
-     * for spec conflicts that are not delete-vs-edit. A file's content is an opaque blob.
+     * A field-level merge needs both sides present and a structure with mergeable fields, so it is
+     * offered only for spec conflicts that are not delete-vs-edit. A file's content is an opaque
+     * blob and a project's definition is a single descriptor field, so both resolve with {@code
+     * --mine}/{@code --theirs}, never {@code --merge}.
      */
     static boolean mergeable(SyncConflicts.Conflict conflict) {
-      return !conflict.entityType().equals(FILE)
+      return conflict.entityType().equals(SPEC)
           && parse(conflict.baseSnapshot()) != null
           && parse(conflict.localSnapshot()) != null
           && parse(conflict.remoteSnapshot()) != null;

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ConnectCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ConnectCommand.java
@@ -10,9 +10,11 @@ import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerState;
 import ai.singlr.sail.engine.NameValidator;
+import ai.singlr.sail.engine.ProjectDefinitions;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
@@ -93,40 +95,75 @@ public final class ConnectCommand implements Runnable {
 
     var resolvedServerUser =
         Objects.requireNonNullElse(serverUser, System.getProperty("user.name"));
+    var containerUser = resolveContainerUser(name);
 
     if (json) {
-      var map = new LinkedHashMap<String, Object>();
-      map.put("project", name);
-      map.put("server_ip", resolvedServerIp);
-      map.put("server_user", resolvedServerUser);
-      map.put("container_ip", containerIp);
-      map.put("container_user", "dev");
-      System.out.println(YamlUtil.dumpJson(map));
+      System.out.println(
+          YamlUtil.dumpJson(
+              connectJson(name, resolvedServerIp, resolvedServerUser, containerIp, containerUser)));
       return;
     }
 
-    var snippet =
-        """
-          # Add to ~/.ssh/config on your Mac:
+    System.out.println(
+        connectSnippet(resolvedServerIp, resolvedServerUser, name, containerIp, containerUser));
+  }
 
-          Host singular-server
-              HostName %s
-              User %s
-              IdentityFile ~/.ssh/id_ed25519
+  /**
+   * The container login user from the project definition (catalog-first), defaulting to {@code dev}
+   * when the descriptor can't be read — a running container is reason enough to print a snippet, so
+   * a missing descriptor degrades to the default rather than failing.
+   */
+  private static String resolveContainerUser(String name) {
+    try {
+      return ProjectDefinitions.load(name, null).sshUser();
+    } catch (RuntimeException e) {
+      return "dev";
+    }
+  }
 
-          Host %s
-              HostName %s
-              User dev
-              ProxyJump singular-server
-              IdentityFile ~/.ssh/id_ed25519
+  static Map<String, Object> connectJson(
+      String name, String serverIp, String serverUser, String containerIp, String containerUser) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("project", name);
+    map.put("server_ip", serverIp);
+    map.put("server_user", serverUser);
+    map.put("container_ip", containerIp);
+    map.put("container_user", containerUser);
+    return map;
+  }
 
-          # Then connect:
-          #   ssh %s
-          #   zed ssh://dev@%s/home/dev/workspace
-          #
-          # Agent auth (port forwarding for subscription login):
-          #   ssh -N -L 3000:localhost:3000 %s"""
-            .formatted(resolvedServerIp, resolvedServerUser, name, containerIp, name, name, name);
-    System.out.println(snippet);
+  static String connectSnippet(
+      String serverIp, String serverUser, String name, String containerIp, String containerUser) {
+    return """
+        # Add to ~/.ssh/config on your Mac:
+
+        Host singular-server
+            HostName %s
+            User %s
+            IdentityFile ~/.ssh/id_ed25519
+
+        Host %s
+            HostName %s
+            User %s
+            ProxyJump singular-server
+            IdentityFile ~/.ssh/id_ed25519
+
+        # Then connect:
+        #   ssh %s
+        #   zed ssh://%s@%s/home/%s/workspace
+        #
+        # Agent auth (port forwarding for subscription login):
+        #   ssh -N -L 3000:localhost:3000 %s"""
+        .formatted(
+            serverIp,
+            serverUser,
+            name,
+            containerIp,
+            containerUser,
+            name,
+            containerUser,
+            name,
+            containerUser,
+            name);
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
@@ -54,6 +54,24 @@ public final class FdeCommand implements Runnable {
     return SailPaths.controlPlaneDb();
   }
 
+  /**
+   * Refuses an FDE roster edit on a node. The roster is main-authoritative and replicates one-way,
+   * so an add/update/remove on a node is silently overwritten by the next sync — failing loud with
+   * the right place to run it is far better than losing the edit.
+   */
+  private static void requireMainForRosterEdit(String action) {
+    if (HostSync.isNode(HostSync.config())) {
+      throw new IllegalStateException(rosterEditOnNodeMessage(action));
+    }
+  }
+
+  static String rosterEditOnNodeMessage(String action) {
+    return "The FDE roster is managed on the main devbox. "
+        + action
+        + " on a node is not propagated — it would be overwritten on the next sync.\n"
+        + "  Run this on main; the change replicates to every node automatically.";
+  }
+
   private static void registerKey(Sqlite db, FdeStore.Fde fde, String publicKey) throws Exception {
     var key = SshPublicKey.parse(publicKey);
     try {
@@ -115,6 +133,7 @@ public final class FdeCommand implements Runnable {
       CliCommand.run(
           spec,
           () -> {
+            requireMainForRosterEdit("Adding an FDE");
             var key = publicKey == null ? null : SshPublicKey.parse(publicKey);
             try (var db = Sqlite.open(dbPath())) {
               var fdeStore = new FdeStore(db);
@@ -181,6 +200,7 @@ public final class FdeCommand implements Runnable {
       CliCommand.run(
           spec,
           () -> {
+            requireMainForRosterEdit("Updating an FDE");
             if (displayName == null && email == null && role == null) {
               throw new IllegalArgumentException(
                   "Nothing to update. Pass --name, --email, and/or --role.");
@@ -218,6 +238,7 @@ public final class FdeCommand implements Runnable {
       CliCommand.run(
           spec,
           () -> {
+            requireMainForRosterEdit("Removing an FDE");
             try (var db = Sqlite.open(dbPath())) {
               var fdeStore = new FdeStore(db);
               var fde =

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostServiceStatusCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostServiceStatusCommand.java
@@ -68,8 +68,10 @@ public final class HostServiceStatusCommand implements Runnable {
     if (installed) {
       System.out.println(
           Ansi.AUTO.string("    @|bold Unit:|@      " + installer.serviceFilePath()));
-      System.out.println(
-          Ansi.AUTO.string("    @|bold Link:|@      " + installer.systemdLinkPath()));
+      if (installer.systemdLinkPath() != null) {
+        System.out.println(
+            Ansi.AUTO.string("    @|bold Link:|@      " + installer.systemdLinkPath()));
+      }
     }
     System.out.println(Ansi.AUTO.string("    @|bold User:|@      " + username));
     System.out.println(Ansi.AUTO.string("    @|bold Linger:|@    " + linger));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostServiceStatusCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostServiceStatusCommand.java
@@ -7,7 +7,10 @@ package ai.singlr.sail.commands;
 
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.engine.SystemdServiceInstaller.ServiceStatus;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -48,21 +51,14 @@ public final class HostServiceStatusCommand implements Runnable {
     var linger = installer.lingerStatus();
 
     if (json) {
-      var map = new LinkedHashMap<String, Object>();
-      map.put("installed", installed);
-      map.put("service_file", installer.serviceFilePath().toString());
-      map.put("systemd_link", installer.systemdLinkPath().toString());
-      map.put("user", username);
-      map.put("linger", linger);
-      if (status != null) {
-        map.put("load_state", status.loadState());
-        map.put("active_state", status.activeState());
-        map.put("sub_state", status.subState());
-        if (status.pid() != null) {
-          map.put("pid", status.pid());
-        }
-        map.put("running", status.running());
-      }
+      var map =
+          statusMap(
+              installed,
+              installer.serviceFilePath(),
+              installer.systemdLinkPath(),
+              username,
+              linger,
+              status);
       System.out.println(YamlUtil.dumpJson(map));
       return;
     }
@@ -85,5 +81,37 @@ public final class HostServiceStatusCommand implements Runnable {
         System.out.println(Ansi.AUTO.string("    @|bold PID:|@       " + status.pid()));
       }
     }
+  }
+
+  /**
+   * The JSON view of the service status. A system-scoped service has no per-user systemd link, so
+   * {@code systemdLink} is null and the key is omitted rather than rendered — the SYSTEM-mode case
+   * that used to throw a {@link NullPointerException}.
+   */
+  static Map<String, Object> statusMap(
+      boolean installed,
+      Path serviceFile,
+      Path systemdLink,
+      String username,
+      String linger,
+      ServiceStatus status) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("installed", installed);
+    map.put("service_file", serviceFile.toString());
+    if (systemdLink != null) {
+      map.put("systemd_link", systemdLink.toString());
+    }
+    map.put("user", username);
+    map.put("linger", linger);
+    if (status != null) {
+      map.put("load_state", status.loadState());
+      map.put("active_state", status.activeState());
+      map.put("sub_state", status.subState());
+      if (status.pid() != null) {
+        map.put("pid", status.pid());
+      }
+      map.put("running", status.running());
+    }
+    return map;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -87,16 +87,28 @@ public final class MigrateCommand implements Runnable {
       var prompter = nonInteractive ? DataMigration.Prompter.NON_INTERACTIVE : ttyPrompter();
       var animate = !jsonOutput && System.console() != null;
       var runs = applyMigrations(db, dbPath.toString(), prompter, animate, jsonOutput);
-      backfillSpecRevisions(db, jsonOutput);
-      importProjects(db, jsonOutput);
-      backfillProjectRevisions(db, jsonOutput);
-      scrubProjectIdentity(db, jsonOutput);
-      importFiles(db, jsonOutput);
-      seedDemo(db, jsonOutput);
+      applyDataBackfills(db, jsonOutput);
       relocateHostConfig(jsonOutput);
       syncAuthorizedKeys(db, jsonOutput);
       return runs;
     }
+  }
+
+  /**
+   * The database-only data backfills — every one idempotent and quiet when nothing is needed — that
+   * make pre-migration rows visible to sync and seed the bundled demo. Shared with {@link
+   * ServerStartCommand} so a daemon start is a genuine second chance: if the post-upgrade {@code
+   * migrate} sub-process ever fails, the next service start still converges the data. Host-level
+   * steps (relocating {@code host.yaml}, syncing {@code authorized_keys}) are not here — they need
+   * root and run only in the full {@link #runMigrations} path.
+   */
+  public static void applyDataBackfills(Sqlite db, boolean jsonOutput) {
+    backfillSpecRevisions(db, jsonOutput);
+    importProjects(db, jsonOutput);
+    backfillProjectRevisions(db, jsonOutput);
+    scrubProjectIdentity(db, jsonOutput);
+    importFiles(db, jsonOutput);
+    seedDemo(db, jsonOutput);
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -18,6 +18,7 @@ import ai.singlr.sail.store.DataMigrator;
 import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.MigrationRunner;
 import ai.singlr.sail.store.ProjectStore;
+import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -86,6 +87,7 @@ public final class MigrateCommand implements Runnable {
       var prompter = nonInteractive ? DataMigration.Prompter.NON_INTERACTIVE : ttyPrompter();
       var animate = !jsonOutput && System.console() != null;
       var runs = applyMigrations(db, dbPath.toString(), prompter, animate, jsonOutput);
+      backfillSpecRevisions(db, jsonOutput);
       importProjects(db, jsonOutput);
       backfillProjectRevisions(db, jsonOutput);
       scrubProjectIdentity(db, jsonOutput);
@@ -94,6 +96,18 @@ public final class MigrateCommand implements Runnable {
       relocateHostConfig(jsonOutput);
       syncAuthorizedKeys(db, jsonOutput);
       return runs;
+    }
+  }
+
+  /**
+   * Journals a baseline revision for specs that predate the sync machinery, so a spec sitting in
+   * the database without a change-log entry becomes visible to {@code sail sync}. The analog of
+   * {@link #backfillProjectRevisions} for specs. Quiet when nothing needed it.
+   */
+  private static void backfillSpecRevisions(Sqlite db, boolean jsonOutput) {
+    var backfilled = new SpecStore(db).backfillRevisions();
+    if (!jsonOutput && backfilled > 0) {
+      System.out.println(Ansi.AUTO.string("  @|green ✓|@ specs: " + backfilled + " made syncable"));
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddRepoCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddRepoCommand.java
@@ -17,7 +17,6 @@ import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ProjectApplier;
 import ai.singlr.sail.engine.ProjectDefinitions;
 import ai.singlr.sail.engine.ShellExecutor;
-import ai.singlr.sail.gen.SailYamlGenerator;
 import java.io.PrintStream;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -108,7 +107,7 @@ public final class ProjectAddRepoCommand implements Runnable {
         applier.applyRepos(
             name, List.of(repo), sshUser, GitCredentials.singleTokenMap(token), config.git());
 
-    var updatedText = SailYamlGenerator.generate(SailYamlUpdater.addRepo(config, repo));
+    var updatedText = YamlUtil.dumpToString((SailYamlUpdater.addRepo(config, repo)).toMap());
     ProjectMutations.persist(
         name,
         explicit,

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddRepoCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddRepoCommand.java
@@ -15,10 +15,10 @@ import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.GitCredentials;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ProjectApplier;
-import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.engine.ProjectDefinitions;
 import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.gen.SailYamlGenerator;
 import java.io.PrintStream;
-import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
@@ -77,15 +77,9 @@ public final class ProjectAddRepoCommand implements Runnable {
     var ansi = Ansi.AUTO;
     var out = System.out;
 
-    var singYamlPath = SailPaths.resolveSailYaml(name, file);
-    if (!Files.exists(singYamlPath)) {
-      throw new IllegalStateException(
-          "Project descriptor not found: "
-              + singYamlPath.toAbsolutePath()
-              + "\n  Create a sail.yaml in the current directory, or specify one with --file.");
-    }
-
-    var config = SailYaml.fromMap(YamlUtil.parseFile(singYamlPath));
+    var explicit = ProjectDefinitions.explicitFile(file);
+    var config =
+        SailYaml.fromMap(YamlUtil.parseMap(ProjectMutations.currentDefinition(name, explicit)));
     var shell = new ShellExecutor(dryRun);
     var mgr = new ContainerManager(shell);
     var state = mgr.queryState(name);
@@ -114,7 +108,14 @@ public final class ProjectAddRepoCommand implements Runnable {
         applier.applyRepos(
             name, List.of(repo), sshUser, GitCredentials.singleTokenMap(token), config.git());
 
-    SailYamlUpdater.addRepo(singYamlPath, repo);
+    var updatedText = SailYamlGenerator.generate(SailYamlUpdater.addRepo(config, repo));
+    ProjectMutations.persist(
+        name,
+        explicit,
+        updatedText,
+        dryRun,
+        out,
+        "record repo '" + repo.path() + "' in the catalog");
 
     if (json) {
       var map = new LinkedHashMap<String, Object>();

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddServiceCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddServiceCommand.java
@@ -16,7 +16,6 @@ import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ProjectApplier;
 import ai.singlr.sail.engine.ProjectDefinitions;
 import ai.singlr.sail.engine.ShellExecutor;
-import ai.singlr.sail.gen.SailYamlGenerator;
 import ai.singlr.sail.gen.ServicePresets;
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -110,7 +109,7 @@ public final class ProjectAddServiceCommand implements Runnable {
     var result = applier.applyServices(name, Map.of(svcName, service));
 
     var updatedText =
-        SailYamlGenerator.generate(SailYamlUpdater.addService(config, svcName, service));
+        YamlUtil.dumpToString((SailYamlUpdater.addService(config, svcName, service)).toMap());
     ProjectMutations.persist(
         name,
         explicit,

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddServiceCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectAddServiceCommand.java
@@ -14,11 +14,11 @@ import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ProjectApplier;
-import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.engine.ProjectDefinitions;
 import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.gen.SailYamlGenerator;
 import ai.singlr.sail.gen.ServicePresets;
 import java.io.PrintStream;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -79,14 +79,9 @@ public final class ProjectAddServiceCommand implements Runnable {
     var ansi = Ansi.AUTO;
     var out = System.out;
 
-    var singYamlPath = SailPaths.resolveSailYaml(name, file);
-    if (!Files.exists(singYamlPath)) {
-      throw new IllegalStateException(
-          "Project descriptor not found: "
-              + singYamlPath.toAbsolutePath()
-              + "\n  Create a sail.yaml in the current directory, or specify one with --file.");
-    }
-
+    var explicit = ProjectDefinitions.explicitFile(file);
+    var config =
+        SailYaml.fromMap(YamlUtil.parseMap(ProjectMutations.currentDefinition(name, explicit)));
     var shell = new ShellExecutor(dryRun);
     var mgr = new ContainerManager(shell);
     var state = mgr.queryState(name);
@@ -114,7 +109,15 @@ public final class ProjectAddServiceCommand implements Runnable {
     var applier = new ProjectApplier(shell, out);
     var result = applier.applyServices(name, Map.of(svcName, service));
 
-    SailYamlUpdater.addService(singYamlPath, svcName, service);
+    var updatedText =
+        SailYamlGenerator.generate(SailYamlUpdater.addService(config, svcName, service));
+    ProjectMutations.persist(
+        name,
+        explicit,
+        updatedText,
+        dryRun,
+        out,
+        "record service '" + svcName + "' in the catalog");
 
     if (json) {
       var map = new LinkedHashMap<String, Object>();

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectDestroyCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectDestroyCommand.java
@@ -12,6 +12,9 @@ import ai.singlr.sail.engine.ContainerState;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.store.ProjectStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -39,6 +42,13 @@ public final class ProjectDestroyCommand implements Runnable {
 
   @Option(names = "--yes", description = "Skip confirmation prompts.")
   private boolean yes;
+
+  @Option(
+      names = "--purge",
+      description =
+          "Also remove the project from the org catalog. This propagates the deletion to every box"
+              + " on the next sync — by default destroy only tears down this box's container.")
+  private boolean purge;
 
   @Option(names = "--json", description = "Output in JSON format.")
   private boolean json;
@@ -68,73 +78,110 @@ public final class ProjectDestroyCommand implements Runnable {
     var shell = new ShellExecutor(dryRun);
     var mgr = new ContainerManager(shell);
     var state = mgr.queryState(name);
+    var projectDir = SailPaths.projectDir(name);
+    var containerPresent = !(state instanceof ContainerState.NotCreated);
+    var dirPresent = Files.exists(projectDir);
 
-    if (state instanceof ContainerState.NotCreated) {
-      var projectDir = SailPaths.projectDir(name);
-      if (Files.exists(projectDir)) {
-        if (!dryRun) {
-          deleteDirectory(projectDir);
-        }
-        if (json) {
-          var map = new LinkedHashMap<String, Object>();
-          map.put("destroyed", name);
-          map.put("status", "state_cleaned");
-          System.out.println(YamlUtil.dumpJson(map));
-          return;
-        }
-        var msg = "  @|faint Container '" + name + "' already absent — cleaned up stale state.|@";
-        System.out.println(Ansi.AUTO.string(msg));
-        return;
-      }
-      if (json) {
-        var map = new LinkedHashMap<String, Object>();
-        map.put("destroyed", name);
-        map.put("status", "already_absent");
-        System.out.println(YamlUtil.dumpJson(map));
-        return;
-      }
-      System.out.println(
-          Ansi.AUTO.string("  @|faint Project '" + name + "' does not exist. Nothing to do.|@"));
+    if (!containerPresent && !dirPresent && !purge) {
+      emitNothingToDo();
       return;
     }
 
-    if (!json) {
+    if (!json && containerPresent) {
       System.out.println();
       Banner.printContainerStatus(name, state, System.out, Ansi.AUTO);
     }
 
-    if (!yes && !dryRun) {
-      System.out.println();
-      if (!ConsoleHelper.confirm("Destroy project " + name + "? This cannot be undone.")) {
-        System.out.println("  Aborted.");
-        return;
+    if ((containerPresent || purge)
+        && !yes
+        && !dryRun
+        && !ConsoleHelper.confirm(confirmPrompt(name, purge))) {
+      System.out.println("  Aborted.");
+      return;
+    }
+
+    if (containerPresent) {
+      if (!json) {
+        System.out.println();
+        System.out.println(Ansi.AUTO.string("  @|bold Deleting container|@ " + name + "..."));
       }
+      mgr.forceDelete(name);
     }
-
-    if (!json) {
-      System.out.println();
-      System.out.println(Ansi.AUTO.string("  @|bold Deleting container|@ " + name + "..."));
-    }
-    mgr.forceDelete(name);
-
-    var projectDir = SailPaths.projectDir(name);
-    if (Files.exists(projectDir)) {
+    if (dirPresent) {
       if (dryRun) {
         System.out.println("[dry-run] rm -rf " + projectDir);
       } else {
         deleteDirectory(projectDir);
       }
     }
+    var purged = purge && purgeFromCatalog();
 
+    emitResult(containerPresent, dirPresent, purged);
+  }
+
+  static String confirmPrompt(String name, boolean purge) {
+    if (purge) {
+      return "Destroy project "
+          + name
+          + " and remove it from the org catalog? It disappears from every box on the next sync,"
+          + " and this cannot be undone.";
+    }
+    return "Destroy project " + name + "? This cannot be undone.";
+  }
+
+  /** Tombstones the project in the catalog so the removal replicates. Idempotent if absent. */
+  private boolean purgeFromCatalog() {
+    if (dryRun) {
+      System.out.println(
+          "[dry-run] remove '" + name + "' from the catalog (propagates to other boxes on sync)");
+      return false;
+    }
+    try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+      new SchemaManager(db).migrate();
+      return new ProjectStore(db).delete(name);
+    }
+  }
+
+  private void emitNothingToDo() {
     if (json) {
       var map = new LinkedHashMap<String, Object>();
       map.put("destroyed", name);
+      map.put("status", "already_absent");
       System.out.println(YamlUtil.dumpJson(map));
       return;
     }
+    System.out.println(
+        Ansi.AUTO.string("  @|faint Project '" + name + "' does not exist. Nothing to do.|@"));
+  }
 
+  private void emitResult(boolean containerPresent, boolean dirPresent, boolean purged) {
+    if (json) {
+      var map = new LinkedHashMap<String, Object>();
+      map.put("destroyed", name);
+      if (!containerPresent) {
+        map.put("status", dirPresent ? "state_cleaned" : "catalog_only");
+      }
+      if (purge) {
+        map.put("purged", purged);
+      }
+      System.out.println(YamlUtil.dumpJson(map));
+      return;
+    }
     System.out.println();
-    Banner.printProjectDestroyed(name, System.out, Ansi.AUTO);
+    if (containerPresent) {
+      Banner.printProjectDestroyed(name, System.out, Ansi.AUTO);
+    } else if (dirPresent) {
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|faint Container '" + name + "' already absent — cleaned up stale state.|@"));
+    }
+    if (purged) {
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|green ✓|@ Removed '"
+                  + name
+                  + "' from the org catalog — it disappears from other boxes on the next sync."));
+    }
   }
 
   private static void deleteDirectory(Path dir) throws IOException {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectEditCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectEditCommand.java
@@ -8,7 +8,6 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.NameValidator;
-import ai.singlr.sail.engine.ProjectCatalog;
 import ai.singlr.sail.engine.ProjectDefinitions;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -73,8 +72,7 @@ public final class ProjectEditCommand implements Runnable {
     }
 
     validate(name, edited);
-    ProjectCatalog.record(name, edited, actor());
-    ProjectDefinitions.materialize(name, edited);
+    ProjectDefinitions.persist(name, null, edited, Actor.current());
 
     if (json) {
       var map = new LinkedHashMap<String, Object>();
@@ -127,14 +125,5 @@ public final class ProjectEditCommand implements Runnable {
     } finally {
       Files.deleteIfExists(tmp);
     }
-  }
-
-  private static String actor() {
-    var sudoUser = System.getenv("SUDO_USER");
-    if (sudoUser != null && !sudoUser.isBlank() && !"root".equals(sudoUser)) {
-      return sudoUser;
-    }
-    var user = System.getProperty("user.name");
-    return user == null || user.isBlank() ? "local" : user;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectMutations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectMutations.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.engine.ProjectDefinitions;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+
+/**
+ * Shared read/write seam for the commands that mutate one field of a project definition (add a repo
+ * or service, remove a service, change resources). They all read the current definition
+ * catalog-first and persist the result back to the catalog, so an edit can never read a stale
+ * on-disk copy or be silently dropped on the next sync. Centralizing it keeps every mutation on the
+ * same database-authoritative path as {@code project edit}.
+ */
+final class ProjectMutations {
+
+  private ProjectMutations() {}
+
+  /** The current definition text, catalog-first; throws with guidance if the project is unknown. */
+  static String currentDefinition(String name, Path explicitFile) {
+    return ProjectDefinitions.definition(name, explicitFile).orElseThrow(() -> notFound(name));
+  }
+
+  /**
+   * Persists an edited definition through the catalog seam, or prints the intent under {@code
+   * --dry-run}. {@code dryRunLabel} describes the change for the dry-run line.
+   */
+  static void persist(
+      String name,
+      Path explicitFile,
+      String definition,
+      boolean dryRun,
+      PrintStream out,
+      String dryRunLabel)
+      throws IOException {
+    if (dryRun) {
+      out.println("[dry-run] " + dryRunLabel);
+      return;
+    }
+    ProjectDefinitions.persist(name, explicitFile, definition, Actor.current());
+  }
+
+  static IllegalStateException notFound(String name) {
+    return new IllegalStateException(
+        "No project '"
+            + name
+            + "' in the catalog. Create it with 'sail project create', or sync it from main with"
+            + " 'sail sync'.");
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectRemoveServiceCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectRemoveServiceCommand.java
@@ -14,7 +14,6 @@ import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ProjectApplier;
 import ai.singlr.sail.engine.ProjectDefinitions;
 import ai.singlr.sail.engine.ShellExecutor;
-import ai.singlr.sail.gen.SailYamlGenerator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import picocli.CommandLine.Command;
@@ -78,7 +77,7 @@ public final class ProjectRemoveServiceCommand implements Runnable {
     var result = applier.removeServices(name, List.of(serviceName));
 
     var updatedText =
-        SailYamlGenerator.generate(SailYamlUpdater.removeService(config, serviceName));
+        YamlUtil.dumpToString((SailYamlUpdater.removeService(config, serviceName)).toMap());
     ProjectMutations.persist(
         name,
         explicit,

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectRemoveServiceCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectRemoveServiceCommand.java
@@ -12,9 +12,9 @@ import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ProjectApplier;
-import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.engine.ProjectDefinitions;
 import ai.singlr.sail.engine.ShellExecutor;
-import java.nio.file.Files;
+import ai.singlr.sail.gen.SailYamlGenerator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import picocli.CommandLine.Command;
@@ -60,18 +60,12 @@ public final class ProjectRemoveServiceCommand implements Runnable {
     var ansi = Ansi.AUTO;
     var out = System.out;
 
-    var singYamlPath = SailPaths.resolveSailYaml(name, file);
-    if (!Files.exists(singYamlPath)) {
-      throw new IllegalStateException(
-          "Project descriptor not found: "
-              + singYamlPath.toAbsolutePath()
-              + "\n  Create a sail.yaml in the current directory, or specify one with --file.");
-    }
-
-    var config = SailYaml.fromMap(YamlUtil.parseFile(singYamlPath));
+    var explicit = ProjectDefinitions.explicitFile(file);
+    var config =
+        SailYaml.fromMap(YamlUtil.parseMap(ProjectMutations.currentDefinition(name, explicit)));
     if (config.services() == null || !config.services().containsKey(serviceName)) {
       throw new IllegalStateException(
-          "Service '" + serviceName + "' not found in " + singYamlPath.toAbsolutePath());
+          "Service '" + serviceName + "' is not defined in project '" + name + "'.");
     }
 
     var shell = new ShellExecutor(dryRun);
@@ -83,7 +77,15 @@ public final class ProjectRemoveServiceCommand implements Runnable {
     var applier = new ProjectApplier(shell, out);
     var result = applier.removeServices(name, List.of(serviceName));
 
-    SailYamlUpdater.removeService(singYamlPath, serviceName);
+    var updatedText =
+        SailYamlGenerator.generate(SailYamlUpdater.removeService(config, serviceName));
+    ProjectMutations.persist(
+        name,
+        explicit,
+        updatedText,
+        dryRun,
+        out,
+        "remove service '" + serviceName + "' from the catalog");
 
     if (json) {
       var map = new LinkedHashMap<String, Object>();

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectResourcesSetCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectResourcesSetCommand.java
@@ -16,7 +16,6 @@ import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ProjectDefinitions;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.ShellExecutor;
-import ai.singlr.sail.gen.SailYamlGenerator;
 import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -133,7 +132,8 @@ public final class ProjectResourcesSetCommand implements Runnable {
 
     if (descriptorChanged) {
       var updatedText =
-          SailYamlGenerator.generate(SailYamlUpdater.updateResources(config, cpu, memory, disk));
+          YamlUtil.dumpToString(
+              (SailYamlUpdater.updateResources(config, cpu, memory, disk)).toMap());
       ProjectMutations.persist(
           name,
           explicit,

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectResourcesSetCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectResourcesSetCommand.java
@@ -13,11 +13,11 @@ import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerManager.ResourceLimits;
 import ai.singlr.sail.engine.ContainerState;
 import ai.singlr.sail.engine.NameValidator;
-import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.engine.ProjectDefinitions;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.gen.SailYamlGenerator;
 import java.io.PrintStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -93,17 +93,10 @@ public final class ProjectResourcesSetCommand implements Runnable {
           "Root privileges required. Run with: sudo sail project resources set " + name);
     }
 
-    var singYamlPath = SailPaths.resolveSailYaml(name, file);
-    if (!Files.exists(singYamlPath)) {
-      throw new IllegalStateException(
-          "Project descriptor not found: "
-              + singYamlPath.toAbsolutePath()
-              + "\n  Ensure ~/.sail/projects/"
-              + name
-              + "/sail.yaml exists.");
-    }
-
-    var config = SailYaml.fromMap(YamlUtil.parseFile(singYamlPath));
+    var explicit = ProjectDefinitions.explicitFile(file);
+    var descriptorPath = explicit != null ? explicit : ProjectDefinitions.canonicalPath(name);
+    var config =
+        SailYaml.fromMap(YamlUtil.parseMap(ProjectMutations.currentDefinition(name, explicit)));
     if (config.resources() == null) {
       throw new IllegalStateException(
           "sail.yaml must have a resources section with cpu, memory, and disk.");
@@ -134,16 +127,20 @@ public final class ProjectResourcesSetCommand implements Runnable {
     }
 
     if (!descriptorChanged && !liveLimitsChanged && !diskChanged) {
-      printAlreadyCurrent(singYamlPath, desiredResources);
+      printAlreadyCurrent(descriptorPath, desiredResources);
       return;
     }
 
     if (descriptorChanged) {
-      if (dryRun) {
-        out.println("[dry-run] update " + singYamlPath.toAbsolutePath() + " resources");
-      } else {
-        SailYamlUpdater.updateResources(singYamlPath, cpu, memory, disk);
-      }
+      var updatedText =
+          SailYamlGenerator.generate(SailYamlUpdater.updateResources(config, cpu, memory, disk));
+      ProjectMutations.persist(
+          name,
+          explicit,
+          updatedText,
+          dryRun,
+          out,
+          "record resources for '" + name + "' in the catalog");
     }
 
     var applyManager = new ContainerManager(applyShell());
@@ -161,7 +158,7 @@ public final class ProjectResourcesSetCommand implements Runnable {
     }
 
     printResult(
-        singYamlPath,
+        descriptorPath,
         config.resources(),
         desiredResources,
         descriptorChanged,

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -99,6 +99,7 @@ public final class ServerStartCommand implements Runnable {
     var migrationResult =
         MigrationRunner.applyAll(
             db, MigrateCommand.REGISTRY, DataMigration.Prompter.NON_INTERACTIVE);
+    MigrateCommand.applyDataBackfills(db, false);
     if (migrationResult.schemaAfter() > migrationResult.schemaBefore()) {
       System.out.println(
           Ansi.AUTO.string(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/UpgradeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/UpgradeCommand.java
@@ -367,9 +367,11 @@ public final class UpgradeCommand implements Runnable {
    * migration runs as a sub-process invocation of the freshly-installed binary's {@code sail
    * migrate --non-interactive}. That's the only way a release's new migrations can execute during
    * the upgrade itself — the alternative (running migrations from the OLD process's class files)
-   * has bitten us every release since 0.13.4. {@link ServerStartCommand} also runs the same
-   * migrations on every daemon start, so the post-upgrade restart is a second-chance fallback if
-   * the sub-process fails for any reason.
+   * has bitten us every release since 0.13.4. {@link ServerStartCommand} re-runs the schema
+   * migrations and the idempotent data backfills ({@link MigrateCommand#applyDataBackfills}) on
+   * every daemon start, so the post-upgrade restart is a genuine second-chance fallback if the
+   * sub-process fails for any reason. (The host-level steps — relocating {@code host.yaml}, syncing
+   * {@code authorized_keys} — run only in the full {@code migrate}, as they need root.)
    */
   private void migrateDatabase(boolean dryRun) {
     var dbPath = SailPaths.controlPlaneDb();

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/UpgradeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/UpgradeCommand.java
@@ -210,6 +210,22 @@ public final class UpgradeCommand implements Runnable {
    * immediately. Returns a short status string for the JSON payload. Failures are logged but never
    * fatal \u2014 the binary install already succeeded.
    */
+  /**
+   * Guidance when {@code sail upgrade} finds no sail-api on a box that should have one. A
+   * provisioned box (it has {@code host.yaml}) is a working dev box that dispatches agents and
+   * serves the board, so a missing service is a gap to fix, not a no-op — point at the one command
+   * that installs it. An unprovisioned box (a thin client) legitimately has no service, so there is
+   * nothing to say.
+   */
+  static Optional<String> missingApiRemediation(boolean provisioned) {
+    if (!provisioned) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        "  @|yellow Install it so you can dispatch agents and see the board here:|@"
+            + " @|bold sudo sail host service install|@");
+  }
+
   private RestartStatus restartSailApi(boolean dryRun) {
     var stepNum = 4;
     var totalSteps = 4;
@@ -239,9 +255,17 @@ public final class UpgradeCommand implements Runnable {
               HostServiceInstallers.currentUsername());
       if (!bootstrap.isInstalled()) {
         if (!json) {
+          var provisioned = Files.exists(SailPaths.hostConfigPath());
           System.out.println(
               Banner.stepDoneLine(
-                  stepNum, totalSteps, "sail-api not installed; nothing to restart", Ansi.AUTO));
+                  stepNum,
+                  totalSteps,
+                  provisioned
+                      ? "sail-api is not installed on this provisioned box"
+                      : "sail-api not installed; nothing to restart",
+                  Ansi.AUTO));
+          missingApiRemediation(provisioned)
+              .ifPresent(line -> System.out.println(Ansi.AUTO.string(line)));
         }
         return RestartStatus.NOT_INSTALLED;
       }

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/DemoSeeder.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/DemoSeeder.java
@@ -12,8 +12,9 @@ import ai.singlr.sail.store.Sqlite;
 /**
  * Seeds the bundled {@link DemoProject} into the control-plane catalog so {@code sail project demo}
  * is just another database-resident project — no network, no GitHub. Idempotent: it inserts the
- * demo only when no project named {@code demo} exists, so an engineer who customised or destroyed
- * theirs is never clobbered, and re-running on every install and upgrade is a no-op once seeded.
+ * demo only when the catalog has no record of one at all, so an engineer who customised or purged
+ * theirs is never clobbered or resurrected, and re-running on every install, upgrade, and daemon
+ * start is a no-op once seeded.
  */
 public final class DemoSeeder {
 
@@ -35,10 +36,16 @@ public final class DemoSeeder {
     }
   }
 
-  /** Seeds the demo into {@code store}'s database if absent; returns true when it inserted it. */
+  /**
+   * Seeds the demo into {@code store}'s database only if the catalog has never recorded it; returns
+   * true when it inserted it. The check is the change-log history, not just the live row, so a demo
+   * that was purged ({@code project destroy demo --purge} leaves a deletion tombstone) is not
+   * resurrected on the next daemon start — which would otherwise undo the team-wide purge on the
+   * next sync.
+   */
   public static boolean seedIfAbsent(Sqlite db) {
     var store = new ProjectStore(db);
-    if (store.findByName(DemoProject.NAME).isPresent()) {
+    if (store.latestRev(DemoProject.NAME) != null) {
       return false;
     }
     store.upsert(DemoProject.NAME, DemoProject.DEFINITION, "sail");

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectDefinitions.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectDefinitions.java
@@ -114,6 +114,24 @@ public final class ProjectDefinitions {
     return path;
   }
 
+  /**
+   * Persists an edited definition so it cannot diverge from the catalog. When an explicit {@code
+   * -f} file was given, the engineer is operating on that file directly, so the edit is written
+   * there and the catalog is left untouched. Otherwise the catalog (the replicated source of truth)
+   * is recorded first and the canonical descriptor re-materialized from it — exactly how {@code
+   * project edit} saves — so the change survives the next sync and re-materialize instead of being
+   * silently overwritten.
+   */
+  public static void persist(String name, Path explicitFile, String definition, String actor)
+      throws IOException {
+    if (explicitFile != null) {
+      Files.writeString(explicitFile, definition);
+      return;
+    }
+    ProjectCatalog.record(name, definition, actor);
+    materialize(name, definition);
+  }
+
   private static Optional<String> read(Path path) {
     try {
       return path != null && Files.exists(path)

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ServerConnectionConfigTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ServerConnectionConfigTest.java
@@ -32,9 +32,12 @@ class ServerConnectionConfigTest {
 
   @Test
   void missingTokenWithoutConfigThrows() {
-    assertThrows(
-        IOException.class,
-        () -> ServerConnectionConfig.resolve("http://localhost:7070", null, missingConfig()));
+    var error =
+        assertThrows(
+            IOException.class,
+            () -> ServerConnectionConfig.resolve("http://localhost:7070", null, missingConfig()));
+    assertTrue(error.getMessage().contains("host service install"));
+    assertTrue(error.getMessage().contains("sail login"));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ActorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ActorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ActorTest {
+
+  @Test
+  void prefersTheRealEngineerUnderSudo() {
+    assertEquals("mady", Actor.resolve("mady", "root"));
+  }
+
+  @Test
+  void fallsBackToProcessOwnerWhenNotSudo() {
+    assertEquals("uday", Actor.resolve(null, "uday"));
+  }
+
+  @Test
+  void ignoresASudoUserOfRoot() {
+    assertEquals("uday", Actor.resolve("root", "uday"));
+  }
+
+  @Test
+  void ignoresABlankSudoUser() {
+    assertEquals("uday", Actor.resolve("  ", "uday"));
+  }
+
+  @Test
+  void fallsBackToLocalWhenNothingIsKnown() {
+    assertEquals("local", Actor.resolve(null, null));
+    assertEquals("local", Actor.resolve("root", "  "));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ConflictsCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ConflictsCommandTest.java
@@ -10,11 +10,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.store.FileStore;
+import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
@@ -218,6 +220,28 @@ class ConflictsCommandTest {
   void resolverForDispatchesOnEntityType() {
     assertInstanceOf(FileStore.class, ConflictsCommand.resolverFor(db, "file"));
     assertInstanceOf(SpecStore.class, ConflictsCommand.resolverFor(db, "spec"));
+    assertInstanceOf(ProjectStore.class, ConflictsCommand.resolverFor(db, "project"));
+  }
+
+  @Test
+  void resolverForRejectsAnUnknownEntityType() {
+    var error =
+        assertThrows(
+            IllegalStateException.class, () -> ConflictsCommand.resolverFor(db, "mystery"));
+    assertTrue(error.getMessage().contains("mystery"));
+  }
+
+  @Test
+  void mergeIsOfferedOnlyForSpecsNotProjectsOrFiles() {
+    conflicts.record("project", "acme", "{}", "{}", "{}", List.of("definition"));
+    conflicts.record("file", "acme/x.txt", "{}", "{}", "{}", List.of("content"));
+
+    assertFalse(
+        ConflictsCommand.Resolve.mergeable(conflicts.pendingFor("project", "acme").orElseThrow()),
+        "a project definition is a single blob — resolve with --mine/--theirs");
+    assertFalse(
+        ConflictsCommand.Resolve.mergeable(
+            conflicts.pendingFor("file", "acme/x.txt").orElseThrow()));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ConnectCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ConnectCommandTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ConnectCommandTest {
+
+  @Test
+  void snippetUsesTheProjectsContainerUserNotAHardcodedDev() {
+    var snippet = ConnectCommand.connectSnippet("10.0.0.1", "uday", "acme", "10.1.1.5", "engineer");
+
+    assertTrue(snippet.contains("User engineer"), "container ssh user from the definition");
+    assertTrue(snippet.contains("zed ssh://engineer@acme/home/engineer/workspace"));
+    assertFalse(snippet.contains("dev@"), "no hardcoded dev user");
+  }
+
+  @Test
+  void jsonReportsTheResolvedContainerUser() {
+    var map = ConnectCommand.connectJson("acme", "10.0.0.1", "uday", "10.1.1.5", "engineer");
+    assertEquals("engineer", map.get("container_user"));
+    assertEquals("acme", map.get("project"));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/FdeCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/FdeCommandTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class FdeCommandTest {
+
+  @Test
+  void rosterEditOnNodeMessageNamesTheActionAndPointsAtMain() {
+    var message = FdeCommand.rosterEditOnNodeMessage("Adding an FDE");
+    assertTrue(message.contains("Adding an FDE"));
+    assertTrue(message.contains("main devbox"));
+    assertTrue(message.contains("Run this on main"));
+    assertTrue(message.contains("overwritten on the next sync"));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/HostServiceStatusCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/HostServiceStatusCommandTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.engine.SystemdServiceInstaller.ServiceStatus;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class HostServiceStatusCommandTest {
+
+  @Test
+  void systemModeOmitsTheSystemdLinkInsteadOfThrowing() {
+    var map =
+        HostServiceStatusCommand.statusMap(
+            true, Path.of("/etc/systemd/system/sail-api.service"), null, "root", "n/a", null);
+
+    assertFalse(map.containsKey("systemd_link"), "SYSTEM mode has no per-user link");
+    assertEquals("/etc/systemd/system/sail-api.service", map.get("service_file"));
+    assertEquals(true, map.get("installed"));
+  }
+
+  @Test
+  void userModeIncludesTheSystemdLinkAndRunningStatus() {
+    var status = new ServiceStatus("loaded", "active", "running", 4242);
+    var map =
+        HostServiceStatusCommand.statusMap(
+            true,
+            Path.of("/home/dev/.config/systemd/user/sail-api.service"),
+            Path.of("/home/dev/.config/systemd/user/sail-api.service"),
+            "dev",
+            "enabled",
+            status);
+
+    assertTrue(map.containsKey("systemd_link"));
+    assertEquals(true, map.get("running"));
+    assertEquals(4242, map.get("pid"));
+  }
+
+  @Test
+  void notInstalledOmitsStatusFields() {
+    var map =
+        HostServiceStatusCommand.statusMap(
+            false, Path.of("/etc/systemd/system/sail-api.service"), null, "root", "n/a", null);
+
+    assertFalse(map.containsKey("running"));
+    assertFalse(map.containsKey("pid"));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectDestroyCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectDestroyCommandTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ProjectDestroyCommandTest {
+
+  @Test
+  void defaultConfirmDoesNotMentionTheOrgCatalog() {
+    var prompt = ProjectDestroyCommand.confirmPrompt("acme", false);
+    assertTrue(prompt.contains("Destroy project acme"));
+    assertFalse(prompt.contains("org catalog"), "a plain destroy is local-only");
+  }
+
+  @Test
+  void purgeConfirmWarnsItPropagatesToEveryBox() {
+    var prompt = ProjectDestroyCommand.confirmPrompt("acme", true);
+    assertTrue(prompt.contains("org catalog"));
+    assertTrue(prompt.contains("every box"));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectMutationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectMutationsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ProjectMutationsTest {
+
+  @TempDir Path dir;
+  private final ByteArrayOutputStream captured = new ByteArrayOutputStream();
+  private PrintStream out;
+
+  @BeforeEach
+  void setUp() {
+    out = new PrintStream(captured, true, StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void currentDefinitionReadsAnExplicitFile() throws Exception {
+    var file = dir.resolve("custom.yaml");
+    Files.writeString(file, "name: acme\n");
+    assertEquals("name: acme\n", ProjectMutations.currentDefinition("acme", file));
+  }
+
+  @Test
+  void currentDefinitionFailsWithGuidanceWhenAbsent() {
+    var error =
+        assertThrows(
+            IllegalStateException.class,
+            () -> ProjectMutations.currentDefinition("ghost", dir.resolve("missing.yaml")));
+    assertTrue(error.getMessage().contains("sail project create"));
+    assertTrue(error.getMessage().contains("sail sync"));
+  }
+
+  @Test
+  void persistWritesTheExplicitFileWhenOneIsGiven() throws Exception {
+    var file = dir.resolve("custom.yaml");
+    Files.writeString(file, "name: acme\n");
+
+    ProjectMutations.persist("acme", file, "name: acme\nimage: ubuntu/24.04\n", false, out, "x");
+
+    assertEquals("name: acme\nimage: ubuntu/24.04\n", Files.readString(file));
+  }
+
+  @Test
+  void persistUnderDryRunPrintsTheIntentAndWritesNothing() throws Exception {
+    var file = dir.resolve("custom.yaml");
+    Files.writeString(file, "original\n");
+
+    ProjectMutations.persist("acme", file, "changed\n", true, out, "record repo 'x'");
+
+    assertEquals("original\n", Files.readString(file), "dry-run must not write");
+    assertTrue(captured.toString(StandardCharsets.UTF_8).contains("[dry-run] record repo 'x'"));
+  }
+
+  @Test
+  void notFoundNamesBothRemedies() {
+    var message = ProjectMutations.notFound("acme").getMessage();
+    assertTrue(message.contains("sail project create"));
+    assertTrue(message.contains("sail sync"));
+    assertFalse(message.contains("null"));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/UpgradeCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/UpgradeCommandTest.java
@@ -95,4 +95,15 @@ class UpgradeCommandTest {
         """);
     assertTrue(UpgradeCommand.readUnitEndpoint(unit).isEmpty());
   }
+
+  @Test
+  void aProvisionedBoxWithoutSailApiIsToldHowToInstallIt() {
+    var remediation = UpgradeCommand.missingApiRemediation(true).orElseThrow();
+    assertTrue(remediation.contains("sudo sail host service install"));
+  }
+
+  @Test
+  void anUnprovisionedBoxGetsNoSailApiNag() {
+    assertTrue(UpgradeCommand.missingApiRemediation(false).isEmpty());
+  }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/DemoSeederTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/DemoSeederTest.java
@@ -58,6 +58,20 @@ class DemoSeederTest {
   }
 
   @Test
+  void doesNotResurrectAPurgedDemo() {
+    DemoSeeder.seedIfAbsent(db);
+    assertTrue(store.delete(DemoProject.NAME), "purge tombstones the demo");
+    assertTrue(store.findByName(DemoProject.NAME).isEmpty());
+
+    assertFalse(
+        DemoSeeder.seedIfAbsent(db),
+        "a purged demo must not be re-seeded on the next daemon start");
+    assertTrue(
+        store.findByName(DemoProject.NAME).isEmpty(),
+        "and the tombstone stands, so sync keeps it gone");
+  }
+
+  @Test
   void seededDemoDefinitionParsesAsAValidProject() {
     DemoSeeder.seedIfAbsent(db);
     var definition = store.findByName(DemoProject.NAME).orElseThrow().definition();


### PR DESCRIPTION
Pre-v1 hardening pass. A read-only multi-agent audit swept for *siblings* of the bug classes we kept hitting (DB-authoritative migration finished on reads but not writes; journaling added without backfill; convergence/heterogeneous-box assumptions). Fixed as five logical commits, then an **adversarial review** of the branch caught two HIGH interaction bugs which are fixed in the final commit. **1675 tests green, all coverage gates met.**

## Commits
1. **Catalog-first project writes** — `repo add`/`service add`/`service remove`/`resources set` wrote only the on-disk file → edits lost on next sync, and `resources set` fought the H2 reconcile. Now catalog-first read + persist via shared `ProjectMutations`/`ProjectDefinitions.persist`/`Actor` seams (`SailYamlUpdater` → pure transforms). `destroy --purge` added (safe default = local-only).
2. **Conflict router + FDE node guard** — `resolverFor` routed *project* conflicts to `SpecStore`; now 3-way. `fde add/update/rm` refuse on a node (roster is one-way main-authoritative).
3. **Spec revision backfill** — pre-journal specs become syncable (the #77 project fix, never done for specs).
4. **Old/root-box dead-ends** — `upgrade` names the fix for a missing sail-api; "no token" error names `host service install`; `host service status --json` no longer NPEs in SYSTEM mode.
5. **Attribution + real second-chance migrate + cleanup** — synced projects attribute to their real author (`_actor` in the transmitted comparable only, never the hashed snapshot → rev determinism preserved); `ServerStartCommand` runs the idempotent data backfills too; `connect` reads `ssh.user`.
6. **Adversarial-review fixes (HIGH×2)** — (a) field-mutations were serializing through the human *scaffolding* generator, which drops `processes`/`agent_context`/agent sub-fields → fleet-wide loss; switched to the faithful `toMap()` serializer + round-trip test. (b) `destroy demo --purge` got resurrected on daemon restart (PR-5 runs `seedDemo` on every start); `DemoSeeder` is now tombstone-aware + regression test.

## Deliberately deferred (documented in spec §7)
File attribution (needs a schema column for ~zero value), the change_log internal author column, FDE main-side-delete tombstone propagation.
