### PR TITLE
Scope the spec board to its project and put the spec CLI on PATH

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -697,6 +697,10 @@ public final class SpecStore implements ConflictResolver {
   }
 
   public List<SpecRow> readySpecs() {
+    return readySpecs(null);
+  }
+
+  public List<SpecRow> readySpecs(String projectFilter) {
     return db
         .query(
             """
@@ -705,13 +709,16 @@ public final class SpecStore implements ConflictResolver {
                 s.updated_by
             FROM specs s
             WHERE s.status = 'pending'
+            AND (? IS NULL OR s.project = ?)
             AND NOT EXISTS (
                 SELECT 1 FROM spec_dependencies d
                 JOIN specs dep ON dep.id = d.depends_on
                 WHERE d.spec_id = s.id AND dep.status != 'done'
             )
             ORDER BY s.priority DESC, s.created_at ASC""",
-            this::mapSpec)
+            this::mapSpec,
+            projectFilter,
+            projectFilter)
         .stream()
         .map(this::hydrate)
         .toList();
@@ -722,12 +729,13 @@ public final class SpecStore implements ConflictResolver {
   }
 
   public BoardSummary board(String projectFilter) {
-    var sql = "SELECT status, COUNT(*) FROM specs WHERE status != 'archived'";
     var counts =
         projectFilter == null
-            ? db.query(sql + " GROUP BY status", row -> new Object[] {row.text(0), row.integer(1)})
+            ? db.query(
+                "SELECT status, COUNT(*) FROM specs GROUP BY status",
+                row -> new Object[] {row.text(0), row.integer(1)})
             : db.query(
-                sql + " AND project = ? GROUP BY status",
+                "SELECT status, COUNT(*) FROM specs WHERE project = ? GROUP BY status",
                 row -> new Object[] {row.text(0), row.integer(1)},
                 projectFilter);
     var draft = 0;
@@ -748,7 +756,7 @@ public final class SpecStore implements ConflictResolver {
         default -> {}
       }
     }
-    var ready = readySpecs();
+    var ready = readySpecs(projectFilter);
     var nextReadyId = ready.isEmpty() ? null : ready.getFirst().id();
     return new BoardSummary(draft, pending, inProgress, review, done, archived, nextReadyId);
   }

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
@@ -326,6 +326,7 @@ class SpecStoreTest {
     store.create(spec("d", "D", "in_progress"));
     store.create(spec("e", "E", "review"));
     store.create(spec("f", "F", "done"));
+    store.create(spec("g", "G", "archived"));
 
     var board = store.board();
     assertEquals(1, board.draft());
@@ -333,7 +334,33 @@ class SpecStoreTest {
     assertEquals(1, board.inProgress());
     assertEquals(1, board.review());
     assertEquals(1, board.done());
+    assertEquals(1, board.archived());
     assertEquals("b", board.nextReadyId());
+  }
+
+  @Test
+  void boardScopesCountsAndNextReadyToTheProject() {
+    store.create(spec("sing-ready", "sing", "Sing ready", "pending"));
+    store.create(spec("sing-archived", "sing", "Sing archived", "archived"));
+    store.create(spec("other-ready", "light-grid", "Other ready", "pending"));
+
+    var board = store.board("sing");
+
+    assertEquals(1, board.pending(), "counts only this project's specs");
+    assertEquals(1, board.archived(), "archived specs are counted, not dropped");
+    assertEquals(
+        "sing-ready", board.nextReadyId(), "next-ready never leaks another project's spec");
+  }
+
+  @Test
+  void readySpecsScopesToTheProject() {
+    store.create(spec("sing-ready", "sing", "Sing", "pending"));
+    store.create(spec("other-ready", "light-grid", "Other", "pending"));
+
+    var ready = store.readySpecs("sing");
+
+    assertEquals(1, ready.size());
+    assertEquals("sing-ready", ready.getFirst().id());
   }
 
   @Test

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/SpecCliHelper.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/SpecCliHelper.java
@@ -30,6 +30,14 @@ public final class SpecCliHelper {
   /** Container-side parent directory of {@link #SCRIPT_PATH}. */
   public static final String SCRIPT_DIR = "/home/dev/.sail/bin";
 
+  /** Dev-user login profile that {@link #install} puts {@link #SCRIPT_DIR} on the PATH through. */
+  public static final String PROFILE_PATH = "/home/dev/.profile";
+
+  /** Fixed-string marker proving the PATH line is already in {@link #PROFILE_PATH}. */
+  public static final String PATH_MARKER = ".sail/bin";
+
+  private static final String PATH_EXPORT = "export PATH=\"$HOME/.sail/bin:$PATH\"";
+
   private static final String SCRIPT =
       """
       #!/usr/bin/env bash
@@ -136,7 +144,8 @@ public final class SpecCliHelper {
 
   /**
    * Idempotently installs the helper script at {@link #SCRIPT_PATH} inside the given container,
-   * chmod 0755, owned by the dev user.
+   * chmod 0755, owned by the dev user, and ensures {@link #SCRIPT_DIR} is on the login PATH (so an
+   * agent can run {@code spec} by name) by adding an export to {@link #PROFILE_PATH} when absent.
    */
   public void install(String container) throws IOException, InterruptedException, TimeoutException {
     NameValidator.requireValidProjectName(container);
@@ -161,6 +170,23 @@ public final class SpecCliHelper {
     if (!write.ok()) {
       throw new IOException(
           "Failed to install " + SCRIPT_PATH + " in " + container + ": " + write.stderr());
+    }
+
+    var onPath =
+        shell.exec(
+            ContainerExec.asDevUser(
+                container,
+                List.of(
+                    "bash",
+                    "-c",
+                    "grep -qsF \"$1\" \"$2\" || printf '\\n%s\\n' \"$3\" >> \"$2\"",
+                    "bash",
+                    PATH_MARKER,
+                    PROFILE_PATH,
+                    PATH_EXPORT)));
+    if (!onPath.ok()) {
+      throw new IOException(
+          "Failed to add " + SCRIPT_DIR + " to PATH in " + container + ": " + onPath.stderr());
     }
   }
 }

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/SpecCliHelperTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/SpecCliHelperTest.java
@@ -60,10 +60,12 @@ class SpecCliHelperTest {
     new SpecCliHelper(shell).install("light-grid");
 
     var cmds = shell.invocations();
-    assertEquals(2, cmds.size());
+    assertEquals(3, cmds.size());
     assertTrue(cmds.get(0).contains("mkdir -p /home/dev/.sail/bin"));
     assertTrue(cmds.get(1).contains("chmod 0755"));
     assertTrue(cmds.get(1).contains("/home/dev/.sail/bin/spec"));
+    assertTrue(cmds.get(2).contains("/home/dev/.profile"), "puts ~/.sail/bin on the login PATH");
+    assertTrue(cmds.get(2).contains("grep -qsF"), "adds the PATH export only when absent");
   }
 
   @Test
@@ -80,6 +82,15 @@ class SpecCliHelperTest {
     var ex2 =
         assertThrows(IOException.class, () -> new SpecCliHelper(writeFail).install("light-grid"));
     assertTrue(ex2.getMessage().contains("disk full"));
+
+    var pathFail =
+        new ScriptedShellExecutor()
+            .onOk("mkdir -p /home/dev/.sail/bin")
+            .onOk("printf '%s'")
+            .onFail("/home/dev/.profile", "read-only file system");
+    var ex3 =
+        assertThrows(IOException.class, () -> new SpecCliHelper(pathFail).install("light-grid"));
+    assertTrue(ex3.getMessage().contains("read-only file system"));
   }
 
   @Test

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
@@ -81,7 +81,11 @@ public final class ContainerSailSetup {
                         + " && test -f "
                         + ClaudeCodeHookConfig.SETTINGS_PATH
                         + " && test -f "
-                        + CodexHookConfig.SETTINGS_PATH)));
+                        + CodexHookConfig.SETTINGS_PATH
+                        + " && grep -qsF "
+                        + SpecCliHelper.PATH_MARKER
+                        + " "
+                        + SpecCliHelper.PROFILE_PATH)));
     return probe.ok();
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerSailSetupTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerSailSetupTest.java
@@ -89,6 +89,9 @@ class ContainerSailSetupTest {
     assertTrue(probe.contains(SpecCliHelper.SCRIPT_PATH));
     assertTrue(probe.contains(ClaudeCodeHookConfig.SETTINGS_PATH));
     assertTrue(probe.contains(CodexHookConfig.SETTINGS_PATH));
+    assertTrue(
+        probe.contains(SpecCliHelper.PROFILE_PATH),
+        "the probe must detect a container missing the spec-CLI PATH entry so reconfigure retrofits it");
   }
 
   @Test


### PR DESCRIPTION
Three fixes found while reconciling a real project's board over the in-container `spec` CLI:

- **`next_ready_id` cross-project leak** — `readySpecs()` ran unscoped, so project A's board could surface project B's ready spec. Now project-scoped (`board(project)` passes the filter through).
- **`archived` count always 0** — the count query did `WHERE status != 'archived'`, dropping archived rows. Now counts every status.
- **`spec` not on PATH** — installed at `~/.sail/bin/spec` but not reachable by name. `SpecCliHelper` now adds it to the login PATH via `~/.profile` (idempotent, no root — the JDK/Maven mechanism), and `ContainerSailSetup`'s probe detects a missing entry so `reconfigure` retrofits it.

`mvn clean verify` green, coverage gates met. New/updated tests in `SpecStoreTest`, `SpecCliHelperTest`, `ContainerSailSetupTest`.