### PR TITLE
Project rename, ssh_key redaction, and the repo-rename sweep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
             ```sh
             cosign verify-blob \
               --bundle sail-linux-amd64.cosign.bundle \
-              --certificate-identity-regexp '^https://github.com/singlr-ai/sing/.github/workflows/release.yml@.*' \
+              --certificate-identity-regexp '^https://github.com/standardapplied/sail/.github/workflows/release.yml@.*' \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \
               sail-linux-amd64
             ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ dependencies, <1ms startup.
 ## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/singlr-ai/sing/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/standardapplied/sail/main/install.sh | bash
 ```
 
 `sail upgrade` updates the binary in place and converges the database. Linux (amd64) runs

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -6,7 +6,7 @@ apply, but the document needed to reflect the current `sail.yaml`-only posture a
 names: `sail-core`, `sail-harness`, and `sail-infra`.
 
 No intentional backwards compatibility remains for `sing.yaml` or the `sing` CLI alias. Remaining
-`singlr-ai/sing` references are GitHub repository slugs, not runtime branding or config aliases.
+`standardapplied/sail` references are GitHub repository slugs, not runtime branding or config aliases.
 
 ## Scope
 This audit covers the current `sail` CLI and runtime trust boundaries:

--- a/install.sh
+++ b/install.sh
@@ -4,11 +4,11 @@ set -euo pipefail
 # SAIL CLI installer — downloads from GitHub Releases (no authentication required).
 # Supports Linux (amd64) and macOS (arm64).
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/singlr-ai/sing/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/standardapplied/sail/main/install.sh | bash
 #   bash install.sh 0.11.2          # install specific version
 #   bash install.sh v0.11.2         # also works with v prefix
 
-GITHUB_REPO="singlr-ai/sing"
+GITHUB_REPO="standardapplied/sail"
 INSTALL_DIR="/usr/local/bin"
 BINARY="sail"
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <developer>
             <name>Standard Applied Intelligence Labs</name>
             <organization>Standard Applied Intelligence Labs</organization>
-            <organizationUrl>https://github.com/singlr-ai/sing</organizationUrl>
+            <organizationUrl>https://github.com/standardapplied/sail</organizationUrl>
         </developer>
     </developers>
 

--- a/sail-core/src/main/java/ai/singlr/sail/config/PersonalFields.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/PersonalFields.java
@@ -11,11 +11,13 @@ import java.util.Map;
 
 /**
  * The fields of a project definition that belong to whoever works a box, not to the project the
- * fleet shares: the git identity commits are authored with, and the SSH key authorized into that
- * box's containers. {@link #redact} rewrites these to {@code ${...}} placeholders so the
- * catalogued, synced definition every box agrees on never carries one engineer's identity or — the
- * part that matters for security — their keys. Each box fills them back in locally at provision
- * time from its own identity (see {@link PlaceholderResolver}).
+ * fleet shares: the git identity commits are authored with, the SSH key authorized into that box's
+ * containers, and the local path to the private key git pushes with. {@link #redact} rewrites the
+ * git identity and authorized keys to {@code ${...}} placeholders and drops the private-key path
+ * entirely, so the catalogued, synced definition every box agrees on never carries one engineer's
+ * identity or — the part that matters for security — their keys or key paths. Each box fills the
+ * placeholders back in locally at provision time from its own identity (see {@link
+ * PlaceholderResolver}); the dropped key path defaults to each box's own SSH key.
  *
  * <p>The transform is pure and idempotent: redacting an already-redacted definition returns it
  * unchanged, and a definition with no personal fields is returned byte-for-byte so a sync sees no
@@ -27,6 +29,7 @@ public final class PersonalFields {
   private static final String GIT = "git";
   private static final String NAME = "name";
   private static final String EMAIL = "email";
+  private static final String SSH_KEY = "ssh_key";
   private static final String SSH = "ssh";
   private static final String AUTHORIZED_KEYS = "authorized_keys";
 
@@ -37,7 +40,8 @@ public final class PersonalFields {
 
   /**
    * Returns the definition with the developer's git identity and authorized SSH keys replaced by
-   * placeholders, or the input unchanged when there is nothing personal to redact.
+   * placeholders and the local {@code git.ssh_key} path dropped, or the input unchanged when there
+   * is nothing personal to redact.
    */
   public static String redact(String definition) {
     if (Strings.isBlank(definition)) {
@@ -55,7 +59,16 @@ public final class PersonalFields {
     }
     var fields = (Map<String, Object>) git;
     var changed = placeholder(fields, NAME, PlaceholderResolver.GIT_NAME);
-    return placeholder(fields, EMAIL, PlaceholderResolver.GIT_EMAIL) || changed;
+    changed = placeholder(fields, EMAIL, PlaceholderResolver.GIT_EMAIL) || changed;
+    return strip(fields, SSH_KEY) || changed;
+  }
+
+  private static boolean strip(Map<String, Object> fields, String key) {
+    if (!fields.containsKey(key)) {
+      return false;
+    }
+    fields.remove(key);
+    return true;
   }
 
   @SuppressWarnings("unchecked")

--- a/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
@@ -69,6 +69,29 @@ public final class FileStore implements ConflictResolver {
         });
   }
 
+  /**
+   * Re-keys every shared file and its change-log history from project {@code old} to {@code
+   * renamed} when a project is renamed locally, keeping each file's relative path. Idempotent.
+   */
+  public void reproject(String old, String renamed) {
+    db.transaction(
+        () -> {
+          db.execute(
+              "UPDATE project_files SET id = ? || substr(id, ?), project = ? WHERE project = ?",
+              renamed,
+              old.length() + 1,
+              renamed,
+              old);
+          db.execute(
+              "UPDATE change_log SET entity_id = ? || substr(entity_id, ?)"
+                  + " WHERE entity_type = ? AND entity_id LIKE ?",
+              renamed,
+              old.length() + 1,
+              ENTITY,
+              old + "/%");
+        });
+  }
+
   public Optional<FileRow> find(String project, String path) {
     return findRow(idOf(project, path));
   }

--- a/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
@@ -83,6 +83,30 @@ public final class ProjectStore implements ConflictResolver {
         });
   }
 
+  /**
+   * Re-keys a project from {@code old} to {@code renamed} within this box's catalog: the row (its
+   * name and the redacted {@code newDefinition}, whose {@code name:} field the caller has already
+   * updated) and the project's change-log history. Idempotent — a no-op once {@code old} is gone. A
+   * local re-key only: it emits no sync rename event, so other boxes do not learn of it through
+   * {@code sail sync}.
+   */
+  public void rename(String old, String renamed, String newDefinition) {
+    var canonical = PersonalFields.redact(newDefinition);
+    db.transaction(
+        () -> {
+          db.execute(
+              "UPDATE projects SET name = ?, definition = ? WHERE name = ?",
+              renamed,
+              canonical,
+              old);
+          db.execute(
+              "UPDATE change_log SET entity_id = ? WHERE entity_type = ? AND entity_id = ?",
+              renamed,
+              ENTITY,
+              old);
+        });
+  }
+
   public Optional<ProjectRow> findByName(String name) {
     return db.queryOne(SELECT + " WHERE name = ?", ProjectStore::map, name);
   }

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -192,6 +192,15 @@ public final class SpecStore implements ConflictResolver {
         .toList();
   }
 
+  /**
+   * Re-keys every spec from project {@code old} to {@code renamed} when a project is renamed
+   * locally. A spec's change-log identity is its own id, not the project, so only the {@code
+   * project} column moves. Idempotent.
+   */
+  public void reproject(String old, String renamed) {
+    db.execute("UPDATE specs SET project = ? WHERE project = ?", renamed, old);
+  }
+
   public void update(SpecRow spec) {
     var now = DateTimeUtils.now().toString();
     db.transaction(

--- a/sail-core/src/test/java/ai/singlr/sail/config/PersonalFieldsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/PersonalFieldsTest.java
@@ -35,6 +35,26 @@ class PersonalFieldsTest {
   }
 
   @Test
+  void dropsTheLocalGitSshKeyPath() {
+    var redacted =
+        PersonalFields.redact(
+            "git:\n  name: Uday\n  email: uday@example.com\n  auth: ssh\n"
+                + "  ssh_key: ~/.ssh/id_ed25519\n");
+    var git = git(redacted);
+    assertFalse(git.containsKey("ssh_key"), "the local private-key path is never synced");
+    assertEquals("ssh", git.get("auth"), "git.auth (token vs ssh) stays — a project choice");
+    assertEquals("${GIT_NAME}", git.get("name"));
+    assertFalse(
+        redacted.contains("id_ed25519"), "no key path leaks into the catalogued definition");
+  }
+
+  @Test
+  void strippingSshKeyAloneCountsAsAChange() {
+    var redacted = PersonalFields.redact("git:\n  name: '${GIT_NAME}'\n  ssh_key: ~/.ssh/k\n");
+    assertFalse(git(redacted).containsKey("ssh_key"));
+  }
+
+  @Test
   void leavesSharedFieldsUntouched() {
     var redacted =
         PersonalFields.redact(

--- a/sail-core/src/test/java/ai/singlr/sail/store/FileStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FileStoreTest.java
@@ -43,6 +43,23 @@ class FileStoreTest {
   }
 
   @Test
+  void reprojectRekeysFilesAndHistoryKeepingPaths() {
+    files.put("old", "a.txt", "AAA");
+    files.put("old", "dir/b.txt", "BBB");
+
+    files.reproject("old", "renamed");
+
+    assertTrue(files.find("old", "a.txt").isEmpty(), "nothing left under the old project");
+    assertEquals("AAA", files.find("renamed", "a.txt").orElseThrow().content());
+    assertEquals("BBB", files.find("renamed", "dir/b.txt").orElseThrow().content());
+    assertEquals(
+        List.of("renamed/a.txt", "renamed/dir/b.txt"),
+        files.idsForProject("renamed").stream().sorted().toList(),
+        "change-log ids re-keyed to the new project, paths intact");
+    assertTrue(files.idsForProject("old").isEmpty());
+  }
+
+  @Test
   void putAndFindAndList() {
     files.put("acme", "a.txt", "AAA");
     files.put("acme", "dir/b.txt", "BBB");

--- a/sail-core/src/test/java/ai/singlr/sail/store/ProjectStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ProjectStoreTest.java
@@ -37,6 +37,30 @@ class ProjectStoreTest {
   }
 
   @Test
+  void renameRekeysTheRowAndMovesChangeLogHistory() {
+    store.upsert("old", "name: old\nimage: ubuntu/24.04\n", "uday");
+    var rev = store.latestRev("old");
+
+    store.rename("old", "renamed", "name: renamed\nimage: ubuntu/24.04\n");
+
+    assertTrue(store.findByName("old").isEmpty(), "the old name is gone");
+    var row = store.findByName("renamed").orElseThrow();
+    assertTrue(row.definition().contains("name: renamed"));
+    assertEquals(rev, store.latestRev("renamed"), "history moved to the new id");
+    assertNull(store.latestRev("old"), "no history left under the old id");
+  }
+
+  @Test
+  void renameIsIdempotentOnceTheOldNameIsGone() {
+    store.upsert("old", "name: old\n", "uday");
+    store.rename("old", "renamed", "name: renamed\n");
+
+    store.rename("old", "renamed", "name: renamed\n");
+
+    assertTrue(store.findByName("renamed").isPresent());
+  }
+
+  @Test
   void upsertInsertsAndRoundTripsTheDefinitionBlob() {
     store.upsert("acme", "name: acme\nresources:\n  cpu: 2\n", "uday");
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
@@ -364,6 +364,19 @@ class SpecStoreTest {
   }
 
   @Test
+  void reprojectMovesEverySpecToTheNewProjectAndLeavesOthers() {
+    store.create(spec("a", "old", "A", "pending"));
+    store.create(spec("b", "old", "B", "done"));
+    store.create(spec("c", "other", "C", "pending"));
+
+    store.reproject("old", "renamed");
+
+    assertEquals(2, store.projectSpecs("renamed").size());
+    assertTrue(store.projectSpecs("old").isEmpty());
+    assertEquals(1, store.projectSpecs("other").size(), "other projects are untouched");
+  }
+
+  @Test
   void deleteCascadesDependenciesAndContent() {
     store.create(spec("base", "Base", "done"));
     var child =

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/ReleaseFetcher.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/ReleaseFetcher.java
@@ -22,7 +22,7 @@ import java.util.Map;
  */
 public final class ReleaseFetcher {
 
-  static final String GITHUB_REPO = "singlr-ai/sing";
+  static final String GITHUB_REPO = "standardapplied/sail";
   static final String API_BASE = "https://api.github.com/repos/" + GITHUB_REPO;
   static final String DOWNLOAD_BASE = "https://github.com/" + GITHUB_REPO + "/releases/download";
   private static final Duration META_TIMEOUT = Duration.ofSeconds(30);

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/ReleaseFetcherTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/ReleaseFetcherTest.java
@@ -15,21 +15,21 @@ class ReleaseFetcherTest {
   @Test
   void buildDownloadUrlForBinary() {
     assertEquals(
-        "https://github.com/singlr-ai/sing/releases/download/v0.9.2/sail",
+        "https://github.com/standardapplied/sail/releases/download/v0.9.2/sail",
         ReleaseFetcher.buildDownloadUrl("v0.9.2", "sail"));
   }
 
   @Test
   void buildDownloadUrlForChecksum() {
     assertEquals(
-        "https://github.com/singlr-ai/sing/releases/download/v0.9.2/sail.sha256",
+        "https://github.com/standardapplied/sail/releases/download/v0.9.2/sail.sha256",
         ReleaseFetcher.buildDownloadUrl("v0.9.2", "sail.sha256"));
   }
 
   @Test
   void apiBasePointsToGitHub() {
     assertTrue(ReleaseFetcher.API_BASE.contains("api.github.com"));
-    assertTrue(ReleaseFetcher.API_BASE.contains("singlr-ai/sing"));
+    assertTrue(ReleaseFetcher.API_BASE.contains("standardapplied/sail"));
   }
 
   @Test
@@ -50,6 +50,6 @@ class ReleaseFetcherTest {
 
   @Test
   void githubRepoIsCorrect() {
-    assertEquals("singlr-ai/sing", ReleaseFetcher.GITHUB_REPO);
+    assertEquals("standardapplied/sail", ReleaseFetcher.GITHUB_REPO);
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCommand.java
@@ -16,6 +16,7 @@ import picocli.CommandLine.Command;
       ProjectCreateCommand.class,
       ProjectApplyCommand.class,
       ProjectEditCommand.class,
+      ProjectRenameCommand.class,
       UpCommand.class,
       DownCommand.class,
       SwitchCommand.class,

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectRenameCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectRenameCommand.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.Banner;
+import ai.singlr.sail.engine.ContainerManager;
+import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.NameValidator;
+import ai.singlr.sail.engine.ProjectRenamer;
+import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.store.ProjectStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.util.LinkedHashMap;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+/**
+ * Renames a project on this box. Re-keys the catalog, specs, shared files, on-disk state, the Incus
+ * container, and the guest hostname (see {@link ProjectRenamer}). The rename is local: it does not
+ * propagate through {@code sail sync}, which the command states on success.
+ */
+@Command(
+    name = "rename",
+    description = "Rename a project on this box (local only — does not sync to other boxes).",
+    mixinStandardHelpOptions = true)
+public final class ProjectRenameCommand implements Runnable {
+
+  @Parameters(index = "0", description = "Current project name.")
+  private String name;
+
+  @Parameters(index = "1", description = "New project name.")
+  private String newName;
+
+  @Option(names = "--dry-run", description = "Print what would happen instead of doing it.")
+  private boolean dryRun;
+
+  @Option(names = "--yes", description = "Skip the confirmation prompt.")
+  private boolean yes;
+
+  @Option(names = "--json", description = "Output in JSON format.")
+  private boolean json;
+
+  @Spec private CommandSpec spec;
+
+  @Override
+  public void run() {
+    CliCommand.run(spec, this::execute);
+  }
+
+  private void execute() throws Exception {
+    NameValidator.requireValidProjectName(name);
+    NameValidator.requireValidProjectName(newName);
+    if (name.equals(newName)) {
+      throw new IllegalArgumentException("'" + newName + "' is already the project's name.");
+    }
+    if (!json && !dryRun) {
+      Banner.printBranding(System.out, Ansi.AUTO);
+    }
+    if (!dryRun && !ConsoleHelper.isRoot()) {
+      throw new IllegalStateException(
+          "Root privileges required. Run with: sudo sail project rename " + name + " " + newName);
+    }
+
+    try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+      new SchemaManager(db).migrate();
+      var projects = new ProjectStore(db);
+      if (projects.findByName(name).isEmpty()) {
+        throw new IllegalStateException(
+            "No project '" + name + "' in the catalog. Run 'sail project list' to see projects.");
+      }
+      if (projects.findByName(newName).isPresent()) {
+        throw new IllegalStateException("A project named '" + newName + "' already exists.");
+      }
+
+      if (dryRun) {
+        printDryRun();
+        return;
+      }
+      if (!json && !confirm()) {
+        System.out.println(Ansi.AUTO.string("  @|faint Cancelled.|@"));
+        return;
+      }
+
+      var renamer = new ProjectRenamer(db, new ShellExecutor(false), SailPaths.projectsDir());
+      var result = renamer.rename(name, newName);
+      emit(result);
+    }
+  }
+
+  private boolean confirm() {
+    return ConsoleHelper.confirm(
+        "Rename '" + name + "' to '" + newName + "'? This stops and restarts the container.");
+  }
+
+  private void printDryRun() throws Exception {
+    var hasContainer =
+        !(new ContainerManager(new ShellExecutor(false)).queryState(name)
+            instanceof ContainerState.NotCreated);
+    System.out.println("[dry-run] rename project '" + name + "' to '" + newName + "':");
+    if (hasContainer) {
+      System.out.println("[dry-run]   stop, 'incus rename " + name + " " + newName + "', restart");
+      System.out.println("[dry-run]   set the container hostname to " + newName);
+    }
+    System.out.println("[dry-run]   re-key catalog, specs, and shared files to " + newName);
+    System.out.println(
+        "[dry-run]   move " + SailPaths.projectDir(name) + " -> " + SailPaths.projectDir(newName));
+    System.out.println("[dry-run]   local only: not propagated to other boxes via sail sync");
+  }
+
+  private void emit(ProjectRenamer.Result result) {
+    if (json) {
+      var map = new LinkedHashMap<String, Object>();
+      map.put("action", "rename");
+      map.put("from", result.from());
+      map.put("to", result.to());
+      map.put("container_renamed", result.containerRenamed());
+      map.put("local_only", true);
+      if (!result.warnings().isEmpty()) {
+        map.put("warnings", result.warnings());
+      }
+      System.out.println(YamlUtil.dumpJson(map));
+      return;
+    }
+    System.out.println();
+    System.out.println(
+        Ansi.AUTO.string(
+            "  @|bold,green ✓|@ Renamed @|bold "
+                + result.from()
+                + "|@ → @|bold "
+                + result.to()
+                + "|@"
+                + (result.containerRenamed() ? " (container and all state)" : " (catalog only)")));
+    for (var warning : result.warnings()) {
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|yellow ⚠|@ "
+                  + warning
+                  + " — run 'sail project reconfigure "
+                  + result.to()
+                  + "'"));
+    }
+    System.out.println();
+    System.out.println(
+        Ansi.AUTO.string(
+            "  @|yellow ⚠ This rename is local to this box.|@ Other boxes won't see it through"
+                + " @|bold sail sync|@ — rename it there too (or re-sync) once your FDEs are on"
+                + " board."));
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
@@ -74,7 +74,7 @@ public final class Banner {
     out.println();
     out.println(
         "  " + d + "Isolated dev environments for AI agents  ·  v" + SailVersion.version() + r);
-    out.println("  " + d + "https://github.com/singlr-ai/sing" + r);
+    out.println("  " + d + "https://github.com/standardapplied/sail" + r);
   }
 
   static boolean shouldAnimateBranding(

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerManager.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerManager.java
@@ -88,6 +88,19 @@ public final class ContainerManager {
     }
   }
 
+  /**
+   * Renames the container from {@code old} to {@code renamed} (snapshots travel with it). Incus
+   * requires the instance to be stopped first. Throws on failure.
+   */
+  public void rename(String old, String renamed)
+      throws IOException, InterruptedException, TimeoutException {
+    var result = shell.exec(List.of("incus", "rename", old, renamed));
+    if (!result.ok()) {
+      throw new IOException(
+          "Failed to rename container '" + old + "' to '" + renamed + "': " + result.stderr());
+    }
+  }
+
   /** Applies CPU and memory limits to a container. Throws on failure. */
   public void setResourceLimits(String name, ResourceLimits limits)
       throws IOException, InterruptedException, TimeoutException {

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectRenamer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectRenamer.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.store.FileStore;
+import ai.singlr.sail.store.ProjectStore;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Renames a project on this box — re-keying every place its name is the identity: the catalog, its
+ * specs and shared files, the on-disk state directory, the Incus container, and the guest hostname
+ * the in-container {@code spec} CLI reads. A purely local operation: it emits no sync rename event,
+ * so other boxes do not learn of it through {@code sail sync} (the caller surfaces that to the
+ * engineer).
+ *
+ * <p>The mutating steps run in an order whose every prior step has a compensation, recorded on a
+ * stack as it succeeds; any failure unwinds them in reverse so a half-done rename never corrupts
+ * state. The finishing touches (guest hostname, re-wiring the sail plumbing, regenerating agent
+ * context, restart) run after the rename has committed and are best-effort — a failure there is
+ * reported and recovered with {@code sail project reconfigure}, not rolled back.
+ */
+public final class ProjectRenamer {
+
+  @FunctionalInterface
+  private interface Compensation {
+    void run() throws Exception;
+  }
+
+  /**
+   * Outcome of a rename: the names, whether a container was renamed, and any best-effort warnings.
+   */
+  public record Result(String from, String to, boolean containerRenamed, List<String> warnings) {
+    public Result {
+      warnings = List.copyOf(warnings);
+    }
+  }
+
+  private final Sqlite db;
+  private final ShellExec shell;
+  private final Path projectsDir;
+
+  public ProjectRenamer(Sqlite db, ShellExec shell, Path projectsDir) {
+    this.db = Objects.requireNonNull(db, "db");
+    this.shell = Objects.requireNonNull(shell, "shell");
+    this.projectsDir = Objects.requireNonNull(projectsDir, "projectsDir");
+  }
+
+  public Result rename(String old, String renamed) throws Exception {
+    NameValidator.requireValidProjectName(old);
+    NameValidator.requireValidProjectName(renamed);
+    if (old.equals(renamed)) {
+      throw new IllegalArgumentException("'" + renamed + "' is already the project's name.");
+    }
+
+    var projects = new ProjectStore(db);
+    var specs = new SpecStore(db);
+    var files = new FileStore(db);
+    var containers = new ContainerManager(shell);
+
+    var existing =
+        projects
+            .findByName(old)
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "No project '" + old + "' in the catalog to rename."));
+    if (projects.findByName(renamed).isPresent()) {
+      throw new IllegalStateException("A project named '" + renamed + "' already exists.");
+    }
+    if (!(containers.queryState(renamed) instanceof ContainerState.NotCreated)) {
+      throw new IllegalStateException("A container named '" + renamed + "' already exists.");
+    }
+
+    var oldState = containers.queryState(old);
+    if (oldState instanceof ContainerState.Error error) {
+      throw new IllegalStateException("Cannot inspect container '" + old + "': " + error.message());
+    }
+    var hasContainer =
+        oldState instanceof ContainerState.Running || oldState instanceof ContainerState.Stopped;
+    var wasRunning = oldState instanceof ContainerState.Running;
+    var newDefinition = withName(existing.definition(), renamed);
+
+    var undo = new ArrayDeque<Compensation>();
+    try {
+      if (wasRunning) {
+        containers.stop(old);
+        undo.push(() -> containers.start(old));
+      }
+      if (hasContainer) {
+        containers.rename(old, renamed);
+        undo.push(() -> containers.rename(renamed, old));
+      }
+      projects.rename(old, renamed, newDefinition);
+      undo.push(() -> projects.rename(renamed, old, existing.definition()));
+      specs.reproject(old, renamed);
+      undo.push(() -> specs.reproject(renamed, old));
+      files.reproject(old, renamed);
+      undo.push(() -> files.reproject(renamed, old));
+      moveProjectDir(old, renamed);
+      undo.push(() -> moveProjectDir(renamed, old));
+      materialize(renamed, newDefinition);
+    } catch (Exception e) {
+      rollback(undo);
+      throw e;
+    }
+
+    var warnings = new ArrayList<String>();
+    if (hasContainer) {
+      finish(renamed, newDefinition, warnings);
+      if (wasRunning) {
+        attempt(() -> containers.start(renamed), warnings, "restart the container");
+      }
+    }
+    return new Result(old, renamed, hasContainer, warnings);
+  }
+
+  private void finish(String container, String definition, List<String> warnings) {
+    attempt(() -> setHostname(container), warnings, "set the container hostname");
+    attempt(() -> ContainerSailSetup.ensureInstalled(shell, container), warnings, "re-wire sail");
+    attempt(
+        () -> AgentContextInstaller.install(shell, container, parse(definition)),
+        warnings,
+        "regenerate agent context");
+  }
+
+  private void setHostname(String container)
+      throws IOException, InterruptedException, java.util.concurrent.TimeoutException {
+    var script =
+        "set -e; printf '%s\\n' \"$1\" > /etc/hostname; hostname \"$1\";"
+            + " sed -i \"s/^\\(127\\.0\\.1\\.1[[:space:]]*\\).*/\\1$1/\" /etc/hosts 2>/dev/null"
+            + " || true";
+    var result =
+        shell.exec(
+            List.of("incus", "exec", container, "--", "bash", "-c", script, "bash", container));
+    if (!result.ok()) {
+      throw new IOException(result.stderr());
+    }
+  }
+
+  private void moveProjectDir(String from, String to) throws IOException {
+    var src = projectsDir.resolve(from);
+    if (!Files.exists(src)) {
+      return;
+    }
+    var dst = projectsDir.resolve(to);
+    Files.createDirectories(dst.getParent());
+    Files.move(src, dst);
+  }
+
+  private void materialize(String name, String definition) throws IOException {
+    var dir = projectsDir.resolve(name);
+    Files.createDirectories(dir);
+    Files.writeString(dir.resolve(SailPaths.PROJECT_DESCRIPTOR), definition);
+  }
+
+  static String withName(String definition, String name) {
+    var map = YamlUtil.parseMap(definition);
+    map.put("name", name);
+    return YamlUtil.dumpToString(map);
+  }
+
+  private static SailYaml parse(String definition) {
+    return ProjectDefinitions.resolveForProvisioning(definition);
+  }
+
+  private static void attempt(Compensation step, List<String> warnings, String what) {
+    try {
+      step.run();
+    } catch (Exception e) {
+      warnings.add("could not " + what + ": " + e.getMessage());
+    }
+  }
+
+  private static void rollback(Deque<Compensation> undo) {
+    while (!undo.isEmpty()) {
+      try {
+        undo.pop().run();
+      } catch (Exception ignored) {
+        // Best-effort unwind; the original failure is what the caller sees.
+      }
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/SystemdServiceInstaller.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/SystemdServiceInstaller.java
@@ -149,7 +149,7 @@ public final class SystemdServiceInstaller {
     return """
         [Unit]
         Description=Sail API server
-        Documentation=https://github.com/singlr-ai/sing
+        Documentation=https://github.com/standardapplied/sail
         After=network.target
 
         [Service]

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectRenameCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ProjectRenameCommandTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.Sail;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class ProjectRenameCommandTest {
+
+  @Test
+  void registeredUnderProject() {
+    var cmd = new CommandLine(new Sail());
+    var sw = new StringWriter();
+    cmd.setOut(new PrintWriter(sw));
+
+    cmd.execute("project", "--help");
+
+    assertTrue(sw.toString().contains("rename"));
+  }
+
+  @Test
+  void helpAdvertisesArgsAndFlags() {
+    var cmd = new CommandLine(new Sail());
+    var sw = new StringWriter();
+    cmd.setOut(new PrintWriter(sw));
+
+    var exit = cmd.execute("project", "rename", "--help");
+
+    assertEquals(0, exit);
+    var help = sw.toString();
+    assertTrue(help.contains("--dry-run"));
+    assertTrue(help.contains("--json"));
+    assertTrue(help.toLowerCase().contains("local only"));
+  }
+
+  @Test
+  void rejectsRenamingToTheSameName() {
+    var cmd = new CommandLine(new Sail());
+    var sw = new StringWriter();
+    cmd.setErr(new PrintWriter(sw));
+
+    var exit = cmd.execute("project", "rename", "web", "web");
+
+    assertNotEquals(0, exit, "renaming a project to its own name is rejected before any work");
+  }
+
+  @Test
+  void rejectsMissingNewName() {
+    var cmd = new CommandLine(new Sail());
+    var sw = new StringWriter();
+    cmd.setErr(new PrintWriter(sw));
+
+    var exit = cmd.execute("project", "rename", "web");
+
+    assertNotEquals(0, exit);
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/BannerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/BannerTest.java
@@ -174,7 +174,7 @@ class BannerTest {
 
     assertTrue(output.contains("/##\\"));
     assertTrue(output.contains("███████"));
-    assertTrue(output.contains("singlr-ai/sing"));
+    assertTrue(output.contains("standardapplied/sail"));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerManagerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerManagerTest.java
@@ -455,4 +455,25 @@ class ContainerManagerTest {
     assertTrue(ex.getMessage().contains("Failed to restart"));
     assertTrue(ex.getMessage().contains("permission denied"));
   }
+
+  @Test
+  void renameInvokesIncusRename() throws Exception {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
+    var mgr = new ContainerManager(shell);
+
+    mgr.rename("old", "renamed");
+
+    assertEquals("incus rename old renamed", shell.invocations().getFirst());
+  }
+
+  @Test
+  void renameThrowsOnFailure() {
+    var shell = new ScriptedShellExecutor().onFail("incus rename", "instance is running");
+    var mgr = new ContainerManager(shell);
+
+    var ex = assertThrows(IOException.class, () -> mgr.rename("old", "renamed"));
+
+    assertTrue(ex.getMessage().contains("Failed to rename"));
+    assertTrue(ex.getMessage().contains("instance is running"));
+  }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectRenamerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectRenamerTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.store.FileStore;
+import ai.singlr.sail.store.ProjectStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ProjectRenamerTest {
+
+  private static final String RUNNING = "[{\"name\": \"old\", \"status\": \"Running\"}]";
+  private static final String DEFINITION =
+      "name: old\nimage: ubuntu/24.04\n"
+          + "resources:\n  cpu: 2\n  memory: 4GB\n  disk: 20GB\n"
+          + "agent:\n  type: claude-code\nssh:\n  user: dev\n";
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private Path projectsDir;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    new ProjectStore(db).upsert("old", DEFINITION, "uday");
+    new SpecStore(db).create(spec("s1", "old"));
+    new FileStore(db).put("old", "start-dev.sh", "ZWNobyBoaQ==");
+    projectsDir = tempDir.resolve("projects");
+    Files.createDirectories(projectsDir.resolve("old"));
+    Files.writeString(projectsDir.resolve("old").resolve("sail.yaml"), DEFINITION);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  private static SpecStore.SpecRow spec(String id, String project) {
+    return new SpecStore.SpecRow(
+        id,
+        project,
+        "Spec",
+        SpecStatus.fromWire("pending"),
+        null,
+        null,
+        null,
+        null,
+        null,
+        0,
+        "uday",
+        "",
+        "",
+        "uday",
+        List.of(),
+        List.of());
+  }
+
+  private static ScriptedShellExecutor runningShell() {
+    return new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+        .onOk("incus list ^old$", RUNNING);
+  }
+
+  private ProjectRenamer renamer(ScriptedShellExecutor shell) {
+    return new ProjectRenamer(db, shell, projectsDir);
+  }
+
+  @Test
+  void renamesContainerCatalogSpecsFilesAndState() throws Exception {
+    var shell = runningShell();
+
+    var result = renamer(shell).rename("old", "renamed");
+
+    assertTrue(result.containerRenamed());
+    assertTrue(new ProjectStore(db).findByName("renamed").isPresent());
+    assertTrue(new ProjectStore(db).findByName("old").isEmpty());
+    assertEquals(1, new SpecStore(db).projectSpecs("renamed").size());
+    assertTrue(new SpecStore(db).projectSpecs("old").isEmpty());
+    assertTrue(new FileStore(db).find("renamed", "start-dev.sh").isPresent());
+    assertTrue(Files.exists(projectsDir.resolve("renamed").resolve("sail.yaml")));
+    assertFalse(Files.exists(projectsDir.resolve("old")));
+    var cmds = shell.invocations();
+    assertTrue(cmds.stream().anyMatch(c -> c.equals("incus rename old renamed")));
+    assertTrue(
+        cmds.stream().anyMatch(c -> c.contains("/etc/hostname")),
+        "the guest hostname is updated so the spec CLI files under the new name");
+  }
+
+  @Test
+  void renamesCatalogOnlyWhenThereIsNoContainer() throws Exception {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
+
+    var result = renamer(shell).rename("old", "renamed");
+
+    assertFalse(result.containerRenamed());
+    assertTrue(new ProjectStore(db).findByName("renamed").isPresent());
+    assertTrue(Files.exists(projectsDir.resolve("renamed")));
+    assertFalse(
+        shell.invocations().stream().anyMatch(c -> c.contains("incus rename")),
+        "no container to rename");
+  }
+
+  @Test
+  void collectsAWarningWhenAFinishStepFails() throws Exception {
+    var shell = runningShell().onFail("/etc/hostname", "read-only file system");
+
+    var result = renamer(shell).rename("old", "renamed");
+
+    assertTrue(
+        new ProjectStore(db).findByName("renamed").isPresent(), "the rename still committed");
+    assertTrue(
+        result.warnings().stream().anyMatch(w -> w.contains("hostname")),
+        "a best-effort failure is reported, not fatal");
+  }
+
+  @Test
+  void rollsBackWhenTheContainerRenameFails() {
+    var shell = runningShell().onFail("incus rename", "instance is busy");
+
+    assertThrows(Exception.class, () -> renamer(shell).rename("old", "renamed"));
+
+    assertTrue(new ProjectStore(db).findByName("old").isPresent(), "the catalog is untouched");
+    assertTrue(new ProjectStore(db).findByName("renamed").isEmpty());
+    assertTrue(
+        shell.invocations().stream().anyMatch(c -> c.equals("incus start old")),
+        "the stop is compensated by restarting the original container");
+  }
+
+  @Test
+  void rejectsRenamingToTheSameName() {
+    assertThrows(
+        IllegalArgumentException.class, () -> renamer(runningShell()).rename("old", "old"));
+  }
+
+  @Test
+  void rejectsAnUnknownProject() {
+    assertThrows(
+        IllegalStateException.class, () -> renamer(runningShell()).rename("ghost", "renamed"));
+  }
+
+  @Test
+  void rejectsATargetNameAlreadyInTheCatalog() throws Exception {
+    new ProjectStore(db).upsert("taken", "name: taken\n", "uday");
+
+    assertThrows(IllegalStateException.class, () -> renamer(runningShell()).rename("old", "taken"));
+  }
+}


### PR DESCRIPTION
Three independent, green changesets (full `mvn clean verify` passed together):

- **`sail project rename <old> <new>`** — local project rename. Re-keys the catalog, specs, shared files, on-disk state, the Incus container, and the **guest hostname** (so the in-container `spec` CLI files under the new name), preserving container state + snapshots. Compensating rollback across the mutating sequence; best-effort finishing touches recovered via `reconfigure`. Prints a **local-only** warning (no sync rename event — name-as-key per YAGNI; sync-aware rename is a documented follow-up).
- **`git.ssh_key` redaction** — `PersonalFields` now drops the per-host private-key path from the synced definition (it was leaking and causing project-definition conflicts). `git.auth` stays.
- **Repo rename** — all `singlr-ai/sing` → `standardapplied/sail` references (release.yml cosign identity, upgrade fetcher, banner, systemd docs, install.sh, pom, README/SECURITY).

`mvn clean verify` green, all coverage gates met. New tests: `ProjectRenamerTest`, `ProjectRenameCommandTest`, plus store/container re-key tests and the redaction test.