### PR TITLE
feat: org-supplied path-scoped language rules

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -327,7 +327,12 @@ orientation (tech stack, conventions, runtimes, services), language-agnostic eng
 principles, a short security stance (the full OWASP rubric lives in the review/audit
 prompt), the spec-driven workflow (DB-authoritative — no `specs/` directory to edit), and
 the autonomous-operation protocol. Methodology/spec skills land under the home skills
-namespace; sail ships no hardcoded language standards.
+namespace; sail ships no hardcoded language standards. A project may supply its own via
+`agent_context.rules` (name → `{paths, body}`): sail materializes each into the agent's native
+"load only when relevant" channel — a path-scoped Claude rule (`~/.claude/rules/<name>.md` with a
+`paths:` glob) and a description-loaded Codex skill — so Java standards reach the agent only while
+it edits Java, never bloating the always-loaded context. The bodies are project-supplied; sail
+ships none.
 
 **Guardrails + rollback:** `agent.guardrails` sets a `max_duration` and an action
 (`snapshot-and-stop` / `stop` / `notify`). An event-driven watcher (`sail agent watch`,

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ai.singlr</groupId>
     <artifactId>sail</artifactId>
-    <version>0.13.118</version>
+    <version>0.13.119</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/sail-core/pom.xml
+++ b/sail-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.118</version>
+        <version>0.13.119</version>
     </parent>
 
     <artifactId>sail-core</artifactId>

--- a/sail-core/src/main/java/ai/singlr/sail/config/SailYaml.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/SailYaml.java
@@ -406,11 +406,21 @@ public record SailYaml(
       String conventions,
       String buildCommands,
       String projectSpecific,
-      String security) {
+      String security,
+      List<AgentRule> rules) {
 
     public AgentContext(
         String techStack, String conventions, String buildCommands, String projectSpecific) {
-      this(techStack, conventions, buildCommands, projectSpecific, null);
+      this(techStack, conventions, buildCommands, projectSpecific, null, null);
+    }
+
+    public AgentContext(
+        String techStack,
+        String conventions,
+        String buildCommands,
+        String projectSpecific,
+        String security) {
+      this(techStack, conventions, buildCommands, projectSpecific, security, null);
     }
 
     public static AgentContext fromMap(Map<String, Object> map) {
@@ -419,7 +429,8 @@ public record SailYaml(
           (String) map.get("conventions"),
           (String) map.get("build_commands"),
           (String) map.get("project_specific"),
-          (String) map.get("security"));
+          (String) map.get("security"),
+          AgentRule.listFromMap(map.get("rules")));
     }
 
     public Map<String, Object> toMap() {
@@ -429,6 +440,50 @@ public record SailYaml(
       if (buildCommands != null) map.put("build_commands", buildCommands);
       if (projectSpecific != null) map.put("project_specific", projectSpecific);
       if (security != null) map.put("security", security);
+      if (rules != null && !rules.isEmpty()) map.put("rules", AgentRule.listToMap(rules));
+      return map;
+    }
+  }
+
+  /**
+   * An org-supplied coding-standard rule the agent loads only when it touches matching files. The
+   * {@code body} is supplied verbatim by the project; sail materializes it into each agent's native
+   * path-scoped channel (a Claude {@code .claude/rules/<name>.md} with a {@code paths:} glob, a
+   * Codex skill loaded by description). Sail ships no rule content of its own.
+   */
+  public record AgentRule(String name, List<String> paths, String body) {
+
+    public AgentRule {
+      NameValidator.requireSafePath(name, "agent_context.rules name");
+      paths = paths == null ? List.of() : List.copyOf(paths);
+    }
+
+    @SuppressWarnings("unchecked")
+    static List<AgentRule> listFromMap(Object raw) {
+      if (!(raw instanceof Map<?, ?> map)) {
+        return null;
+      }
+      var rules = new ArrayList<AgentRule>();
+      for (var entry : map.entrySet()) {
+        if (entry.getValue() instanceof Map<?, ?> value) {
+          rules.add(
+              new AgentRule(
+                  (String) entry.getKey(),
+                  (List<String>) value.get("paths"),
+                  (String) value.get("body")));
+        }
+      }
+      return List.copyOf(rules);
+    }
+
+    static Map<String, Object> listToMap(List<AgentRule> rules) {
+      var map = new LinkedHashMap<String, Object>();
+      for (var rule : rules) {
+        var inner = new LinkedHashMap<String, Object>();
+        if (!rule.paths().isEmpty()) inner.put("paths", new ArrayList<>(rule.paths()));
+        if (rule.body() != null) inner.put("body", rule.body());
+        map.put(rule.name(), inner);
+      }
       return map;
     }
   }

--- a/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
@@ -39,12 +39,14 @@ public final class AgentContextGenerator {
     var body = generateContextBody(config);
     var methodology = config.agent() != null ? config.agent().methodology() : null;
     var specsDir = config.agent() != null ? config.agent().specsDir() : null;
+    var rules = config.agentContext() != null ? config.agentContext().rules() : null;
 
     var files = new ArrayList<GeneratedFile>();
     for (var agent : targetAgents) {
       files.add(new GeneratedFile(home + agent.homeContextPath(), body, false));
       files.addAll(MethodologyGenerator.generateFiles(agent, methodology, home));
       files.addAll(SpecSkillGenerator.generateFiles(agent, specsDir, home));
+      files.addAll(LanguageRulesGenerator.generateFiles(agent, rules, home));
     }
     return List.copyOf(files);
   }

--- a/sail-core/src/main/java/ai/singlr/sail/gen/LanguageRulesGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/LanguageRulesGenerator.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.gen;
+
+import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.engine.AgentCli;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Materializes org-supplied {@link SailYaml.AgentRule language rules} into each agent's native
+ * "load only when relevant" channel, so a project's coding standards reach the agent only while it
+ * touches the matching files — never bloating the always-loaded context. Sail ships no rule content
+ * of its own; the body is supplied verbatim by the project's {@code agent_context.rules}.
+ *
+ * <ul>
+ *   <li><b>Claude Code</b> — a path-scoped rule {@code ~/.claude/rules/<name>.md} whose {@code
+ *       paths:} frontmatter loads it only when a matching file enters context (or a session-start
+ *       rule when the project gives no globs).
+ *   <li><b>Codex</b> — a skill {@code ~/.agents/skills/<name>/SKILL.md} Codex loads by its
+ *       synthesized {@code description} when the work is relevant (Codex has no path glob).
+ * </ul>
+ *
+ * <p>Every file is sail-owned and overwritten on every run. Pure utility — no I/O, no shell.
+ */
+public final class LanguageRulesGenerator {
+
+  private LanguageRulesGenerator() {}
+
+  /**
+   * Generates the per-agent rule files for {@code rules}, or empty when none are configured.
+   *
+   * @param agent the target agent, which fixes the native channel and layout
+   * @param rules the org-supplied rules from {@code agent_context.rules}; may be {@code null}
+   * @param basePath the home base path with a trailing slash (e.g. {@code /home/dev/})
+   */
+  public static List<GeneratedFile> generateFiles(
+      AgentCli agent, List<SailYaml.AgentRule> rules, String basePath) {
+    if (rules == null || rules.isEmpty()) {
+      return List.of();
+    }
+    var files = new ArrayList<GeneratedFile>();
+    for (var rule : rules) {
+      var path =
+          switch (agent) {
+            case CLAUDE_CODE -> basePath + ".claude/rules/" + rule.name() + ".md";
+            case CODEX -> basePath + agent.skillsDir() + rule.name() + "/SKILL.md";
+          };
+      var content =
+          switch (agent) {
+            case CLAUDE_CODE -> claudeRule(rule);
+            case CODEX -> codexSkill(rule);
+          };
+      files.add(new GeneratedFile(path, content, false));
+    }
+    return List.copyOf(files);
+  }
+
+  /** A Claude rule: {@code paths:} frontmatter over the body, or just the body when unscoped. */
+  private static String claudeRule(SailYaml.AgentRule rule) {
+    if (rule.paths().isEmpty()) {
+      return body(rule);
+    }
+    var sb = new StringBuilder("---\npaths:\n");
+    for (var glob : rule.paths()) {
+      sb.append("  - \"").append(glob).append("\"\n");
+    }
+    return sb.append("---\n\n").append(body(rule)).toString();
+  }
+
+  /** A Codex skill: {@code name} + a synthesized {@code description} over the body. */
+  private static String codexSkill(SailYaml.AgentRule rule) {
+    return "---\nname: "
+        + rule.name()
+        + "\ndescription: >\n  "
+        + description(rule)
+        + "\n---\n\n"
+        + body(rule);
+  }
+
+  private static String description(SailYaml.AgentRule rule) {
+    var globs = String.join(", ", rule.paths());
+    var scope = globs.isEmpty() ? "" : " (" + globs + ")";
+    return capitalize(rule.name())
+        + " coding standards for this project. Apply when writing or reviewing "
+        + rule.name()
+        + scope
+        + ".";
+  }
+
+  private static String body(SailYaml.AgentRule rule) {
+    return rule.body() == null ? "" : rule.body().strip() + "\n";
+  }
+
+  private static String capitalize(String name) {
+    return Character.toUpperCase(name.charAt(0)) + name.substring(1);
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/config/SailYamlTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/SailYamlTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class SailYamlTest {
@@ -527,6 +528,75 @@ class SailYamlTest {
   }
 
   @Test
+  void agentContextRulesParsedFromYaml() throws Exception {
+    var yaml =
+        """
+        name: test
+        agent_context:
+          rules:
+            java:
+              paths: ["**/*.java", "**/*.kt"]
+              body: |
+                - Records for value types.
+            typescript:
+              paths: ["**/*.ts"]
+              body: |
+                - Strict null checks.
+        """;
+    var config = SailYaml.fromMap(YamlUtil.parseMap(yaml));
+
+    var rules = config.agentContext().rules();
+    assertEquals(2, rules.size());
+    var java = rules.getFirst();
+    assertEquals("java", java.name());
+    assertEquals(List.of("**/*.java", "**/*.kt"), java.paths());
+    assertTrue(java.body().contains("Records for value types."));
+    assertEquals("typescript", rules.get(1).name());
+  }
+
+  @Test
+  void agentContextRulesRoundTripThroughToMap() throws Exception {
+    var yaml =
+        """
+        name: test
+        agent_context:
+          rules:
+            java:
+              paths: ["**/*.java"]
+              body: |
+                - Sealed interfaces.
+        """;
+    var original = SailYaml.fromMap(YamlUtil.parseMap(yaml));
+
+    var reparsed = SailYaml.fromMap(original.toMap());
+
+    var rule = reparsed.agentContext().rules().getFirst();
+    assertEquals("java", rule.name());
+    assertEquals(List.of("**/*.java"), rule.paths());
+    assertTrue(rule.body().contains("Sealed interfaces."));
+  }
+
+  @Test
+  void agentContextWithoutRulesParsesToNull() throws Exception {
+    var yaml =
+        """
+        name: test
+        agent_context:
+          tech_stack: Java 25
+        """;
+    var config = SailYaml.fromMap(YamlUtil.parseMap(yaml));
+
+    assertNull(config.agentContext().rules());
+  }
+
+  @Test
+  void aRuleNameThatTraversesIsRejected() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new SailYaml.AgentRule("../etc/evil", List.of(), "body"));
+  }
+
+  @Test
   void securityAuditParsedFromYaml() throws Exception {
     var yaml =
         """
@@ -771,9 +841,9 @@ class SailYamlTest {
         """;
     var config = SailYaml.fromMap(YamlUtil.parseMap(yaml));
 
-    var updated = config.withAgentInstall(java.util.List.of("claude-code"));
+    var updated = config.withAgentInstall(List.of("claude-code"));
 
-    assertEquals(java.util.List.of("claude-code"), updated.agent().install());
+    assertEquals(List.of("claude-code"), updated.agent().install());
     assertEquals("claude-code", updated.agent().type());
     assertTrue(updated.agent().autoBranch());
   }

--- a/sail-core/src/test/java/ai/singlr/sail/gen/AgentContextGeneratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/gen/AgentContextGeneratorTest.java
@@ -956,6 +956,33 @@ class AgentContextGeneratorTest {
   }
 
   @Test
+  void configuredLanguageRulesAreMaterializedUnderTheHomeNamespace() {
+    var agentCtx =
+        new SailYaml.AgentContext(
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of(new SailYaml.AgentRule("java", List.of("**/*.java"), "- Records for DTOs.")));
+    var files = AgentContextGenerator.generateFiles(configWithRuntimesAndContext(null, agentCtx));
+
+    var rule = fileEndingWith(files, "/.claude/rules/java.md");
+    assertTrue(rule.content().contains("**/*.java"));
+    assertTrue(rule.content().contains("- Records for DTOs."));
+    assertFalse(
+        files.stream().anyMatch(f -> f.remotePath().contains("/workspace/")),
+        "rules land in sail's home namespace, never the engineer's workspace");
+  }
+
+  @Test
+  void noLanguageRulesWhenNoneConfigured() {
+    var files = AgentContextGenerator.generateFiles(fullConfig());
+
+    assertFalse(files.stream().anyMatch(f -> f.remotePath().contains("/rules/")));
+  }
+
+  @Test
   void userConventionsAppendedAfterUniversalPrinciples() {
     var agentCtx = new SailYaml.AgentContext(null, "- Custom project rule", null, null);
     var config = configWithRuntimesAndContext(new SailYaml.Runtimes(25, null, null), agentCtx);

--- a/sail-core/src/test/java/ai/singlr/sail/gen/LanguageRulesGeneratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/gen/LanguageRulesGeneratorTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.gen;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.engine.AgentCli;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LanguageRulesGeneratorTest {
+
+  private static final String HOME = "/home/dev/";
+
+  private static SailYaml.AgentRule java() {
+    return new SailYaml.AgentRule(
+        "java", List.of("**/*.java"), "- Records for value types.\n- Virtual threads for I/O.");
+  }
+
+  private static SailYaml.AgentRule typescript() {
+    return new SailYaml.AgentRule(
+        "typescript", List.of("**/*.ts", "**/*.tsx"), "- Functional components with hooks.");
+  }
+
+  @Test
+  void nullRulesGenerateNothing() {
+    assertTrue(LanguageRulesGenerator.generateFiles(AgentCli.CLAUDE_CODE, null, HOME).isEmpty());
+  }
+
+  @Test
+  void emptyRulesGenerateNothing() {
+    assertTrue(
+        LanguageRulesGenerator.generateFiles(AgentCli.CLAUDE_CODE, List.of(), HOME).isEmpty());
+  }
+
+  @Test
+  void claudeRuleIsAPathScopedRuleFile() {
+    var files = LanguageRulesGenerator.generateFiles(AgentCli.CLAUDE_CODE, List.of(java()), HOME);
+
+    assertEquals(1, files.size());
+    var rule = files.getFirst();
+    assertEquals(HOME + ".claude/rules/java.md", rule.remotePath());
+    assertFalse(rule.executable());
+    assertTrue(
+        rule.content().startsWith("---\npaths:\n"), "the rule is path-scoped via frontmatter");
+    assertTrue(rule.content().contains("\"**/*.java\""), "the glob is rendered");
+    assertTrue(rule.content().contains("- Records for value types."), "the org body is carried");
+  }
+
+  @Test
+  void claudeRuleRendersEveryGlob() {
+    var files =
+        LanguageRulesGenerator.generateFiles(AgentCli.CLAUDE_CODE, List.of(typescript()), HOME);
+
+    var content = files.getFirst().content();
+    assertTrue(content.contains("\"**/*.ts\""));
+    assertTrue(content.contains("\"**/*.tsx\""));
+  }
+
+  @Test
+  void aRuleWithoutPathsIsAlwaysOnForClaude() {
+    var rule = new SailYaml.AgentRule("house-style", List.of(), "- Always prefer composition.");
+
+    var content =
+        LanguageRulesGenerator.generateFiles(AgentCli.CLAUDE_CODE, List.of(rule), HOME)
+            .getFirst()
+            .content();
+
+    assertFalse(content.contains("paths:"), "no paths means a session-start rule, not path-scoped");
+    assertTrue(content.contains("- Always prefer composition."));
+  }
+
+  @Test
+  void codexRuleIsADescriptionLoadedSkill() {
+    var files = LanguageRulesGenerator.generateFiles(AgentCli.CODEX, List.of(java()), HOME);
+
+    assertEquals(1, files.size());
+    var skill = files.getFirst();
+    assertEquals(HOME + ".agents/skills/java/SKILL.md", skill.remotePath());
+    assertFalse(skill.executable());
+    assertTrue(skill.content().startsWith("---\n"));
+    assertTrue(skill.content().contains("name: java"));
+    assertTrue(skill.content().contains("description:"));
+    assertTrue(
+        skill.content().contains("**/*.java"), "the description names the files it applies to");
+    assertTrue(skill.content().contains("- Records for value types."), "the org body is carried");
+  }
+
+  @Test
+  void everyConfiguredRuleBecomesAFile() {
+    var files =
+        LanguageRulesGenerator.generateFiles(
+            AgentCli.CLAUDE_CODE, List.of(java(), typescript()), HOME);
+
+    assertEquals(2, files.size());
+    assertTrue(files.stream().anyMatch(f -> f.remotePath().endsWith("/rules/java.md")));
+    assertTrue(files.stream().anyMatch(f -> f.remotePath().endsWith("/rules/typescript.md")));
+  }
+
+  @Test
+  void generatedRulesAreNotExecutable() {
+    var files =
+        LanguageRulesGenerator.generateFiles(AgentCli.CODEX, List.of(java(), typescript()), HOME);
+
+    assertTrue(files.stream().noneMatch(GeneratedFile::executable));
+  }
+}

--- a/sail-harness/pom.xml
+++ b/sail-harness/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.118</version>
+        <version>0.13.119</version>
     </parent>
 
     <artifactId>sail-harness</artifactId>

--- a/sail-infra/pom.xml
+++ b/sail-infra/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ai.singlr</groupId>
         <artifactId>sail</artifactId>
-        <version>0.13.118</version>
+        <version>0.13.119</version>
     </parent>
 
     <artifactId>sail-infra</artifactId>


### PR DESCRIPTION
## Org-supplied path-scoped language rules

Lets a project deliver coding standards (JDK 25, Node/TS/React, …) that the agent loads **only when it touches matching files** — never bloating the always-loaded context, and never pushing Java rules at the agent while it edits TypeScript.

### Why
Sail ships no hardcoded language standards (open-source neutrality, settled in the agent-context rework). But an org *does* have standards it wants applied. Dumping them into `CLAUDE.md` is wrong twice — it bloats every session and mixes languages. Both agents have a native "only when relevant" channel; this wires the org's standards into it.

### Authoring (`sail.yaml`)
```yaml
agent_context:
  rules:
    java:
      paths: ["**/*.java"]
      body: |
        - Records for value types; sealed interfaces; virtual threads for I/O.
    typescript:
      paths: ["**/*.ts", "**/*.tsx"]
      body: |
        - Functional components with hooks; async/await; strict null checks.
```

### Materialization (per agent, sail-owned, overwritten)
- **Claude** → `~/.claude/rules/java.md` with `paths:` frontmatter → loads only when a `*.java` file enters context (or a session-start rule when no globs given).
- **Codex** → `~/.agents/skills/java/SKILL.md` with a synthesized `description` → loaded by description when the work is Java (Codex has no path glob).

Sail still ships **none** of the content — `body` is entirely project-supplied.

### Why it's KISS
`agent_context.rules` is ordinary `sail.yaml` config, so it rides the **existing project catalog/sync** to every box. **No DB entity, no replica, no CLI, no blunt `sail.yaml` deep-merge** (that "global defaults" idea was deliberately dropped — runtimes/packages must not be force-pushed onto projects that don't need them).

### Tests & verification
- TDD; full `mvn clean verify` green (all modules + JaCoCo gates).
- New `LanguageRulesGeneratorTest` (8 cases: Claude path-scoped rule, Codex description-skill, multi-rule, unscoped session-start rule, non-executable, empty/absent). `SailYamlTest` adds parse + `toMap` round-trip + traversal-name rejection. `AgentContextGeneratorTest` asserts rules materialize under the home namespace (never the workspace) and are absent when unconfigured.

### Not in this PR
- No version bump / release tag — left for the merge + `v*` cosign release step.
