### PR TITLE
refactor: trim generated agent-context content; drop cleanup-agents.sh

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
@@ -171,23 +171,6 @@ public final class AgentContextGenerator {
     sb.append("\n## Environment\n");
     sb.append("This workspace runs inside an Incus container managed by `sail`.\n");
     sb.append("Podman (rootless) is the container runtime. Services run as Podman containers.\n");
-
-    sb.append("\n## Testcontainers\n");
-    sb.append("Testcontainers is pre-configured to use Podman instead of Docker.\n");
-    sb.append(
-        "Environment variables are set system-wide via `/etc/profile.d/testcontainers.sh`:\n");
-    sb.append("```\n");
-    sb.append("DOCKER_HOST=unix:///run/user/1000/podman/podman.sock\n");
-    sb.append("TESTCONTAINERS_RYUK_DISABLED=true\n");
-    sb.append("```\n");
-    sb.append("These are sourced automatically in login shells.\n");
-    sb.append(
-        "If tests fail with \"Previous attempts to find a Docker environment failed\", verify:\n");
-    sb.append("1. The Podman socket is active: `systemctl --user status podman.socket`\n");
-    sb.append("2. The socket file exists: `ls -la /run/user/1000/podman/podman.sock`\n");
-    sb.append(
-        "3. `DOCKER_HOST` is set correctly (not `/run/podman/podman.sock` — that is the root socket)\n");
-    sb.append("Do NOT use Docker. Do NOT install Docker. Podman is the only container runtime.\n");
     if (config.git() != null) {
       sb.append("Git identity: ")
           .append(config.git().name())
@@ -200,8 +183,8 @@ public final class AgentContextGenerator {
     sb.append("\n## Security\n");
     sb.append(
         "Zero-trust posture: validate every input, authenticate every request, authorize every"
-            + " action. Never hardcode secrets, tokens, or credentials. A cross-agent security audit"
-            + " reviews changed files for OWASP Top-10 issues before work is considered done.\n");
+            + " action. Never hardcode secrets, tokens, or credentials. Never concatenate untrusted"
+            + " input into queries or commands — use parameterized queries and safe APIs.\n");
     if (config.agentContext() != null
         && config.agentContext().security() != null
         && !config.agentContext().security().isBlank()) {
@@ -233,8 +216,7 @@ public final class AgentContextGenerator {
   static String universalPrinciples() {
     return """
         - Write simple and elegant code. Simplicity is the ultimate sophistication. \
-        If a solution feels complex, step back and find a simpler approach. \
-        You are trained to be the world's best coder — write code that reads like prose.
+        If a solution feels complex, step back and find a simpler approach.
         - No inline comments in code, ever. Code must be self-documenting through \
         clear naming, small functions, and obvious structure. If you feel the need \
         to add a comment because the code is complex, rethink the code to make it \
@@ -249,10 +231,6 @@ public final class AgentContextGenerator {
         - DRY: don't repeat yourself. Extract common logic into shared utilities when \
         a pattern appears three or more times. But never create premature abstractions — \
         duplication is cheaper than the wrong abstraction.
-        - Zero trust security posture: validate all inputs, authenticate all requests, \
-        authorize all access.
-        - OWASP awareness: never concatenate user input into queries or commands. \
-        Use parameterized queries and safe APIs.
         - Prefer composition over inheritance. Keep inheritance hierarchies shallow.
         - Write small, focused functions. Each function should do one thing well. \
         If a function needs a comment to explain what it does, it's too complex — \

--- a/sail-core/src/test/java/ai/singlr/sail/gen/AgentContextGeneratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/gen/AgentContextGeneratorTest.java
@@ -176,10 +176,16 @@ class AgentContextGeneratorTest {
     assertTrue(md.contains("## Environment"));
     assertTrue(md.contains("Incus container managed by `sail`"));
     assertTrue(md.contains("Podman (rootless) is the container runtime"));
-    assertTrue(md.contains("## Testcontainers"));
-    assertTrue(md.contains("DOCKER_HOST=unix:///run/user/1000/podman/podman.sock"));
-    assertTrue(md.contains("TESTCONTAINERS_RYUK_DISABLED=true"));
-    assertTrue(md.contains("systemctl --user status podman.socket"));
+  }
+
+  @Test
+  void omitsTheTestcontainersEssay() {
+    var md = AgentContextGenerator.generateContextBody(fullConfig());
+
+    assertFalse(
+        md.contains("## Testcontainers"), "the Podman/Testcontainers essay is not generated");
+    assertFalse(md.contains("TESTCONTAINERS_RYUK_DISABLED"));
+    assertFalse(md.contains("DOCKER_HOST"));
   }
 
   @Test
@@ -903,13 +909,12 @@ class AgentContextGeneratorTest {
 
     assertTrue(content.contains("SOLID principles"));
     assertTrue(content.contains("DRY"));
-    assertTrue(content.contains("Zero trust"));
     assertTrue(content.contains("self-documenting"));
     assertTrue(content.contains("simple and elegant"));
     assertTrue(content.contains("No inline comments in code, ever"));
     assertTrue(content.contains("edge cases"));
-    assertTrue(content.contains("world's best coder"));
     assertTrue(content.contains("Test behavior, not lines"));
+    assertFalse(content.contains("world's best coder"), "the hype line is trimmed");
   }
 
   @Test
@@ -918,7 +923,10 @@ class AgentContextGeneratorTest {
 
     assertTrue(content.contains("## Security"));
     assertTrue(content.contains("Zero-trust posture"));
-    assertTrue(content.contains("security audit"), "it points at the review-time audit");
+    assertTrue(content.contains("parameterized queries"), "it carries the always-true coding rule");
+    assertFalse(
+        content.contains("security audit"),
+        "the stance makes no claim about an audit that may not be configured");
     assertFalse(content.contains("OWASP Top 10 Awareness"), "the full rubric lives in the audit");
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/CleanupScripts.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/CleanupScripts.java
@@ -6,24 +6,15 @@
 package ai.singlr.sail.engine;
 
 /**
- * Generates cleanup scripts that run inside Incus containers. Two scripts are produced:
- *
- * <ul>
- *   <li>{@code cleanup-containers.sh} — automated hourly cron job that kills stray Podman
- *       containers (Testcontainers leftovers, abandoned builds) while preserving infrastructure
- *       services. Uses restart-policy as the discriminator: services created by {@code sail} use
- *       {@code --restart=always}, while test containers do not.
- *   <li>{@code cleanup-agents.sh} — manual helper script that lists and kills stale agent processes
- *       (e.g. leaked Claude processes from IDE extensions). Not automated because killing agent
- *       processes risks terminating the active session.
- * </ul>
+ * Generates {@code cleanup-containers.sh}: an automated hourly cron job that force-removes stray
+ * Podman containers (Testcontainers leftovers, abandoned builds) while preserving infrastructure
+ * services. Uses restart-policy as the discriminator: services created by {@code sail} use {@code
+ * --restart=always}, while test containers do not.
  */
 public final class CleanupScripts {
 
   static final String SAIL_DIR = "/home/dev/.sail";
-  static final String WORKSPACE = "/home/dev/workspace";
   static final String CONTAINER_CLEANUP_PATH = SAIL_DIR + "/cleanup-containers.sh";
-  static final String AGENT_CLEANUP_PATH = WORKSPACE + "/cleanup-agents.sh";
 
   private CleanupScripts() {}
 
@@ -54,72 +45,6 @@ public final class CleanupScripts {
         fi
 
         podman system prune -f >/dev/null 2>&1
-        """;
-  }
-
-  /**
-   * Generates the manual agent process cleanup helper. Lists stale {@code claude} processes (older
-   * than 24 hours), preserving the most recently started one even if it exceeds the threshold. The
-   * engineer runs this manually when memory pressure is noticed.
-   */
-  public static String agentCleanupScript() {
-    return """
-        #!/bin/bash
-        MAX_AGE_SECONDS=86400
-
-        newest_pid=""
-        newest_start=0
-        stale_pids=()
-
-        while IFS= read -r line; do
-            [ -z "$line" ] && continue
-            pid=$(echo "$line" | awk '{print $1}')
-            etime=$(echo "$line" | awk '{print $2}')
-            start_epoch=$(echo "$line" | awk '{print $3}')
-
-            if [ "$start_epoch" -gt "$newest_start" ]; then
-                if [ -n "$newest_pid" ]; then
-                    stale_pids+=("$newest_pid")
-                fi
-                newest_pid="$pid"
-                newest_start="$start_epoch"
-            else
-                stale_pids+=("$pid")
-            fi
-        done < <(ps -eo pid,etimes,lstart,comm --no-headers | awk '$NF == "claude" {
-            cmd="date -d \\"" $3 " " $4 " " $5 " " $6 " " $7 "\\" +%s"
-            cmd | getline epoch
-            close(cmd)
-            print $1, $2, epoch
-        }')
-
-        if [ ${#stale_pids[@]} -eq 0 ]; then
-            echo "No stale claude processes found."
-            exit 0
-        fi
-
-        echo "Found ${#stale_pids[@]} stale claude process(es) (keeping newest PID $newest_pid):"
-        echo ""
-        for pid in "${stale_pids[@]}"; do
-            etime=$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' ')
-            rss=$(ps -o rss= -p "$pid" 2>/dev/null | tr -d ' ')
-            if [ -n "$etime" ] && [ -n "$rss" ]; then
-                hours=$((etime / 3600))
-                mb=$((rss / 1024))
-                echo "  PID $pid — ${hours}h old, ${mb}MB RSS"
-            fi
-        done
-
-        echo ""
-        read -p "Kill these processes? [y/N] " confirm
-        if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
-            for pid in "${stale_pids[@]}"; do
-                kill "$pid" 2>/dev/null && echo "  Killed PID $pid" || echo "  Failed to kill PID $pid"
-            done
-            echo "Done. Kept newest claude process (PID $newest_pid)."
-        else
-            echo "Aborted."
-        fi
         """;
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/CleanupScripts.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/CleanupScripts.java
@@ -49,16 +49,19 @@ public final class CleanupScripts {
   }
 
   /**
-   * Returns the cron line that invokes the automated container cleanup script hourly. Replaces the
-   * legacy {@code podman system prune} cron line.
+   * Returns the cron line that invokes the automated container cleanup script every 15 minutes, so
+   * stray test containers are swept promptly rather than lingering up to an hour. The age threshold
+   * in the script (not this cadence) is what protects in-flight containers from being removed.
    */
   public static String cronLine() {
-    return "0 * * * * " + CONTAINER_CLEANUP_PATH + " >/dev/null 2>&1\n";
+    return "*/15 * * * * " + CONTAINER_CLEANUP_PATH + " >/dev/null 2>&1\n";
   }
 
   /**
-   * Builds an upgraded crontab by removing legacy {@code podman system prune} lines and appending
-   * the new cleanup script invocation.
+   * Builds an upgraded crontab: drops the legacy {@code podman system prune} line and any prior
+   * cleanup-script line (whatever its cadence), then appends the current {@link #cronLine()}.
+   * Idempotent and cadence-correcting — re-running converges on exactly one current line, so an
+   * older box upgrades from the hourly cadence to the 15-minute one without duplicating entries.
    *
    * @param existingCron the current crontab content (may be empty)
    * @return the updated crontab content
@@ -67,7 +70,7 @@ public final class CleanupScripts {
     var cleaned =
         existingCron
             .lines()
-            .filter(l -> !l.contains(legacyCronPattern()))
+            .filter(l -> !l.contains(legacyCronPattern()) && !l.contains(CONTAINER_CLEANUP_PATH))
             .reduce("", (a, b) -> a.isEmpty() ? b : a + "\n" + b);
     return (cleaned.isEmpty() ? "" : cleaned + "\n") + cronLine();
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectApplier.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectApplier.java
@@ -326,8 +326,8 @@ public final class ProjectApplier {
                     name, List.of("test", "-f", CleanupScripts.CONTAINER_CLEANUP_PATH)))
             .ok();
 
-    if (existingCron.contains(CleanupScripts.CONTAINER_CLEANUP_PATH) && scriptsExist) {
-      out.println("  [skip] Container cleanup cron already upgraded");
+    if (existingCron.contains(CleanupScripts.cronLine().strip()) && scriptsExist) {
+      out.println("  [skip] Container cleanup cron already current");
       return new ApplyResult(0, 0, 1, List.of());
     }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectApplier.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectApplier.java
@@ -323,7 +323,7 @@ public final class ProjectApplier {
         shell
             .exec(
                 ContainerExec.asDevUser(
-                    name, List.of("test", "-f", CleanupScripts.AGENT_CLEANUP_PATH)))
+                    name, List.of("test", "-f", CleanupScripts.CONTAINER_CLEANUP_PATH)))
             .ok();
 
     if (existingCron.contains(CleanupScripts.CONTAINER_CLEANUP_PATH) && scriptsExist) {
@@ -339,7 +339,6 @@ public final class ProjectApplier {
         CleanupScripts.CONTAINER_CLEANUP_PATH,
         CleanupScripts.containerCleanupScript(),
         "0755");
-    pushFile(name, CleanupScripts.AGENT_CLEANUP_PATH, CleanupScripts.agentCleanupScript(), "0755");
 
     var newCron = CleanupScripts.buildUpgradedCrontab(existingCron);
     var mktemp =
@@ -357,7 +356,7 @@ public final class ProjectApplier {
           "Failed to install crontab for user '" + sshUser + "': " + cronResult.stderr());
     }
 
-    out.println("  [apply] Agent cleanup helper \u2192 " + CleanupScripts.AGENT_CLEANUP_PATH);
+    out.println("  [apply] Container cleanup cron \u2192 " + CleanupScripts.CONTAINER_CLEANUP_PATH);
     return new ApplyResult(1, 0, 0, List.of());
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectProvisioner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectProvisioner.java
@@ -383,6 +383,14 @@ public final class ProjectProvisioner {
     stepDone(7, "Podman (rootless) + socket + auto-restart");
   }
 
+  /**
+   * Points Testcontainers at the rootless Podman socket and disables Ryuk. Ryuk stays disabled by
+   * measurement, not assumption: {@code RyukReapsContainersIT} shows that even a privileged Ryuk on
+   * this rootless Podman reaps only if its request timeout is raised well past the Testcontainers
+   * default — the rootless force-remove routinely exceeds 10s, so the default Ryuk times out and
+   * leaks anyway. The hourly→15-minute {@code cleanup-containers.sh} cron (a plain {@code podman rm
+   * -f}, no client-side timeout to lose) is the reliable sweep instead.
+   */
   private void configureTestcontainers(SailYaml config) throws Exception {
     currentPhase = ProjectPhase.TESTCONTAINERS_CONFIGURED;
     if (tracker.isCompleted(currentPhase)) {

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectProvisioner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectProvisioner.java
@@ -941,8 +941,6 @@ public final class ProjectProvisioner {
         CleanupScripts.CONTAINER_CLEANUP_PATH,
         CleanupScripts.containerCleanupScript(),
         "0755");
-    pushFileToContainer(
-        name, CleanupScripts.AGENT_CLEANUP_PATH, CleanupScripts.agentCleanupScript(), "0755");
     execInContainer(name, List.of("chown", "-R", user + ":" + user, CleanupScripts.SAIL_DIR));
 
     var existingCron = check.ok() ? check.stdout() : "";

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/CleanupScriptsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/CleanupScriptsTest.java
@@ -37,30 +37,6 @@ class CleanupScriptsTest {
   }
 
   @Test
-  void agentCleanupScriptTargetsClaudeProcesses() {
-    var script = CleanupScripts.agentCleanupScript();
-
-    assertTrue(script.contains("claude"));
-    assertTrue(script.contains("MAX_AGE_SECONDS=86400"));
-  }
-
-  @Test
-  void agentCleanupScriptPreservesNewestProcess() {
-    var script = CleanupScripts.agentCleanupScript();
-
-    assertTrue(script.contains("newest_pid"));
-    assertTrue(script.contains("Kept newest claude process"));
-  }
-
-  @Test
-  void agentCleanupScriptRequiresConfirmation() {
-    var script = CleanupScripts.agentCleanupScript();
-
-    assertTrue(script.contains("read -p"));
-    assertTrue(script.contains("[y/N]"));
-  }
-
-  @Test
   void cronLineInvokesCleanupScript() {
     var cron = CleanupScripts.cronLine();
 
@@ -87,7 +63,7 @@ class CleanupScriptsTest {
   @Test
   void pathConstantsAreConsistent() {
     assertTrue(CleanupScripts.CONTAINER_CLEANUP_PATH.startsWith(CleanupScripts.SAIL_DIR));
-    assertTrue(CleanupScripts.AGENT_CLEANUP_PATH.startsWith(CleanupScripts.WORKSPACE));
+    assertTrue(CleanupScripts.CONTAINER_CLEANUP_PATH.endsWith("cleanup-containers.sh"));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/CleanupScriptsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/CleanupScriptsTest.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.engine;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -37,11 +38,11 @@ class CleanupScriptsTest {
   }
 
   @Test
-  void cronLineInvokesCleanupScript() {
+  void cronLineRunsEvery15Minutes() {
     var cron = CleanupScripts.cronLine();
 
     assertTrue(cron.contains(CleanupScripts.CONTAINER_CLEANUP_PATH));
-    assertTrue(cron.startsWith("0 * * * *"));
+    assertTrue(cron.startsWith("*/15 * * * *"), "cleanup sweeps every 15 minutes");
     assertTrue(cron.endsWith("\n"));
   }
 
@@ -92,6 +93,27 @@ class CleanupScriptsTest {
     var result = CleanupScripts.buildUpgradedCrontab("");
 
     assertTrue(result.contains(CleanupScripts.CONTAINER_CLEANUP_PATH));
-    assertTrue(result.startsWith("0 * * * *"));
+    assertTrue(result.startsWith("*/15 * * * *"));
+  }
+
+  @Test
+  void buildUpgradedCrontabReplacesAnOlderCadenceWithoutDuplicating() {
+    var hourly = "0 * * * * " + CleanupScripts.CONTAINER_CLEANUP_PATH + " >/dev/null 2>&1\n";
+
+    var result = CleanupScripts.buildUpgradedCrontab(hourly);
+
+    assertFalse(result.contains("0 * * * * "), "the old hourly cadence line is removed");
+    assertTrue(result.contains("*/15 * * * * "), "replaced with the 15-minute cadence");
+    assertEquals(
+        1,
+        result.lines().filter(l -> l.contains(CleanupScripts.CONTAINER_CLEANUP_PATH)).count(),
+        "exactly one cleanup cron line, never a duplicate");
+  }
+
+  @Test
+  void buildUpgradedCrontabIsIdempotent() {
+    var once = CleanupScripts.buildUpgradedCrontab("");
+
+    assertEquals(once, CleanupScripts.buildUpgradedCrontab(once), "re-applying converges");
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectApplierTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectApplierTest.java
@@ -857,8 +857,8 @@ class ProjectApplierTest {
   }
 
   @Test
-  void applyCleanupCronSkipsWhenAlreadyUpgraded() throws Exception {
-    var cronWithScript = "0 * * * * /home/dev/.sail/cleanup-containers.sh >/dev/null 2>&1\n";
+  void applyCleanupCronSkipsWhenAlreadyCurrent() throws Exception {
+    var cronWithScript = "*/15 * * * * /home/dev/.sail/cleanup-containers.sh >/dev/null 2>&1\n";
     var shell =
         new ScriptedShellExecutor()
             .onOk("crontab -l", cronWithScript)
@@ -870,6 +870,24 @@ class ProjectApplierTest {
     assertEquals(0, result.added());
     assertEquals(1, result.skipped());
     assertFalse(shell.invocations().stream().anyMatch(c -> c.contains("incus file push")));
+  }
+
+  @Test
+  void applyCleanupCronUpgradesAnOlderHourlyCadence() throws Exception {
+    var hourly = "0 * * * * /home/dev/.sail/cleanup-containers.sh >/dev/null 2>&1\n";
+    var shell =
+        new ScriptedShellExecutor()
+            .onOk("crontab -l", hourly)
+            .onOk("test -f /home/dev/.sail/cleanup-containers.sh")
+            .onOk("incus file push")
+            .onOk("mktemp", "/tmp/sail-crontab.x")
+            .onOk("crontab -u")
+            .onOk("rm -f");
+    var applier = applier(shell);
+
+    var result = applier.applyCleanupCron(CONTAINER, "dev");
+
+    assertEquals(1, result.added(), "a box on the old hourly cadence is upgraded, not skipped");
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectApplierTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectApplierTest.java
@@ -851,9 +851,9 @@ class ProjectApplierTest {
     assertTrue(
         shell.invocations().stream()
             .anyMatch(c -> c.contains("incus file push") && c.contains("cleanup-containers.sh")));
-    assertTrue(
-        shell.invocations().stream()
-            .anyMatch(c -> c.contains("incus file push") && c.contains("cleanup-agents.sh")));
+    assertFalse(
+        shell.invocations().stream().anyMatch(c -> c.contains("cleanup-agents.sh")),
+        "the manual agent-process killer is no longer generated");
   }
 
   @Test
@@ -862,7 +862,7 @@ class ProjectApplierTest {
     var shell =
         new ScriptedShellExecutor()
             .onOk("crontab -l", cronWithScript)
-            .onOk("test -f /home/dev/workspace/cleanup-agents.sh");
+            .onOk("test -f /home/dev/.sail/cleanup-containers.sh");
     var applier = applier(shell);
 
     var result = applier.applyCleanupCron(CONTAINER, "dev");


### PR DESCRIPTION
## Trim generated agent-context content; drop `cleanup-agents.sh`

Cleanup of what sail bakes into every generated `CLAUDE.md`/`AGENTS.md`, plus removal of a script we shouldn't ship.

### Security stance → unconditional
The `## Security` section used to claim *"A cross-agent security audit reviews changed files for OWASP Top-10 before work is considered done."* That audit only runs when `agent.security_audit` is configured — so the text **lied** for projects without it, and (since the generated file is a static snapshot) went **stale** the moment the config flipped. Now the stance states only what's always true:

> Zero-trust posture: validate every input, authenticate every request, authorize every action. Never hardcode secrets, tokens, or credentials. Never concatenate untrusted input into queries or commands — use parameterized queries and safe APIs.

No config-dependence, no staleness.

### Remove the `## Testcontainers` essay
The generated context shipped a full Podman/Testcontainers troubleshooting block (`DOCKER_HOST`, `TESTCONTAINERS_RYUK_DISABLED=true`, socket-debugging steps) into **every** project — even though it's not universally relevant (sail itself doesn't use Testcontainers) and it advertised the `RYUK_DISABLED` workaround. Removed from the context. The `DOCKER_HOST` **env** is still provisioned for projects that actually need it.

### Trim engineering principles
Dropped the "world's best coder / reads like prose" hype and the two security bullets now covered by `## Security` (zero-trust, OWASP-concatenation). The substantive house rules (no inline comments, test behavior not lines, fail fast, DRY, etc.) stay.

### Stop generating `cleanup-agents.sh`
It was a manual, interactive "kill stale `claude` processes" script pushed into `~/workspace/cleanup-agents.sh` — both unwanted and a violation of the engineer-owns-the-workspace boundary. Removed (script + both install sites + tests). The hourly **container** cleanup cron (`cleanup-containers.sh`) stays.

### Not here (next, empirical)
Whether to re-enable Ryuk privileged to fix Testcontainers container pileup will be settled by an **incus-lane integration test on CI** that actually exercises Ryuk under the provisioned rootless Podman — measured, not guessed.

### Tests & verification
TDD; full `mvn clean verify` green (all modules + JaCoCo gates). Updated `AgentContextGeneratorTest` (env/testcontainers/principles/stance), `CleanupScriptsTest`, `ProjectApplierTest`. No version bump — left for the merge + release step.
