### PR TITLE
test: measure whether privileged Ryuk reaps under rootless Podman (incus IT)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,6 +30,14 @@ jobs:
           sudo incus admin init --minimal
           sudo chmod o+rw /var/lib/incus/unix.socket
 
+      - name: Give launched containers outbound internet
+        # The runner's Docker install sets the iptables FORWARD policy to DROP, which silently
+        # drops the incus NAT bridge's egress, so containers can resolve DNS but cannot connect
+        # out (apt/image pulls time out). Allow forwarding so provisioned containers reach the net.
+        run: |
+          sudo sysctl -w net.ipv4.ip_forward=1
+          sudo iptables -P FORWARD ACCEPT
+
       - name: Verify incus is reachable by the runner
         run: |
           which incus

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/RyukReapsContainersIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/RyukReapsContainersIT.java
@@ -39,6 +39,7 @@ class RyukReapsContainersIT extends AbstractIncusIT {
     ensureIncusOrSkip();
     try {
       launch(CONTAINER);
+      configureForNestedPodman();
       waitForNetwork();
       setUpRootlessPodman();
 
@@ -58,6 +59,26 @@ class RyukReapsContainersIT extends AbstractIncusIT {
     } finally {
       deleteContainerQuietly(CONTAINER);
     }
+  }
+
+  /**
+   * Applies the incus container config sail's provisioning uses so rootless Podman can create the
+   * nested user namespaces it needs: {@code security.nesting=true} and an unconfined AppArmor
+   * profile, then a restart so the change takes effect. Without this, rootless {@code podman pull}
+   * fails with "cannot clone: Permission denied".
+   */
+  private void configureForNestedPodman() throws Exception {
+    assertOk(
+        shell.exec(
+            List.of(
+                "incus",
+                "config",
+                "set",
+                CONTAINER,
+                "security.nesting=true",
+                "raw.lxc=lxc.apparmor.profile=unconfined")),
+        "set security.nesting + unconfined AppArmor");
+    assertOk(shell.exec(List.of("incus", "restart", CONTAINER)), "restart after security config");
   }
 
   /** Reproduces sail's rootless-Podman provisioning, asserting each real step. */

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/RyukReapsContainersIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/RyukReapsContainersIT.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Measures, against a real incus daemon, whether a <em>privileged</em> Testcontainers Ryuk reaper
+ * actually reaps containers under the <em>rootless</em> Podman that sail provisions — the open
+ * question behind whether sail should re-enable Ryuk ({@code TESTCONTAINERS_RYUK_PRIVILEGED=true})
+ * instead of disabling it (which leaks test containers until the hourly cron sweep).
+ *
+ * <p>Self-contained and faithful: it reproduces sail's rootless-Podman setup (install Podman, a
+ * uid-1000 {@code dev} user, {@code enable-linger}, the user {@code podman.socket}), then drives
+ * Ryuk's documented protocol — start Ryuk privileged with the Podman socket mounted, register a
+ * label filter, hold the control connection, then drop it — and checks whether the labelled victim
+ * container is gone once Ryuk's reconnection timeout elapses.
+ *
+ * <p><strong>This test is the empirical gate.</strong> Green here means privileged Ryuk reaps under
+ * rootless Podman and sail can safely re-enable it; red (or {@code NOT_REAPED}) means it does not,
+ * and the {@code RYUK_DISABLED} + hourly-cron fallback stays. Either way the answer is measured on
+ * CI, not guessed. Like every {@code *IT}, it runs only under the {@code integration} profile and
+ * fails loudly (never {@code assumeTrue}) once a daemon is reachable.
+ */
+class RyukReapsContainersIT extends AbstractIncusIT {
+
+  private static final String CONTAINER = "sail-it-ryuk";
+  private static final Duration SLOW = Duration.ofMinutes(8);
+
+  @Test
+  void privilegedRyukReapsContainersUnderRootlessPodman() throws Exception {
+    ensureIncusOrSkip();
+    try {
+      launch(CONTAINER);
+      setUpRootlessPodman();
+
+      var run =
+          shell.exec(
+              ContainerExec.asDevUser(CONTAINER, List.of("bash", "-lc", experimentScript())),
+              null,
+              SLOW);
+
+      assertTrue(
+          run.stdout().contains("RYUK_RESULT=REAPED"),
+          "privileged Ryuk must reap the labelled container under rootless Podman.\n"
+              + "----- stdout -----\n"
+              + run.stdout()
+              + "\n----- stderr -----\n"
+              + run.stderr());
+    } finally {
+      deleteContainerQuietly(CONTAINER);
+    }
+  }
+
+  /** Reproduces sail's rootless-Podman provisioning, asserting each real step. */
+  private void setUpRootlessPodman() throws Exception {
+    assertOk(
+        exec(
+            CONTAINER,
+            List.of(
+                "bash",
+                "-c",
+                "userdel -r ubuntu 2>/dev/null || true;"
+                    + " id -u dev >/dev/null 2>&1 || useradd -m -u 1000 -s /bin/bash dev")),
+        "create the dev user");
+
+    assertOk(
+        slow(
+            List.of(
+                "incus",
+                "exec",
+                CONTAINER,
+                "--",
+                "bash",
+                "-c",
+                "apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq"
+                    + " podman uidmap")),
+        "install Podman");
+
+    assertOk(
+        exec(
+            CONTAINER,
+            List.of(
+                "bash",
+                "-c",
+                "mkdir -p /etc/containers/registries.conf.d && printf"
+                    + " 'unqualified-search-registries = [\"docker.io\"]\\n' >"
+                    + " /etc/containers/registries.conf.d/01-unqualified.conf")),
+        "configure the container registry");
+
+    assertOk(exec(CONTAINER, List.of("loginctl", "enable-linger", "dev")), "enable linger for dev");
+
+    waitForUserBus();
+
+    assertOk(
+        shell.exec(
+            ContainerExec.asDevUser(
+                CONTAINER, List.of("systemctl", "--user", "enable", "--now", "podman.socket")),
+            null,
+            SLOW),
+        "enable the rootless podman.socket");
+  }
+
+  /**
+   * The Ryuk reaping probe, run as the dev user. Starts Ryuk privileged with the rootless Podman
+   * socket mounted, registers a label filter over Ryuk's TCP port, holds the connection, then drops
+   * it; after the reconnection timeout Ryuk should remove the labelled victim. Emits {@code
+   * RYUK_RESULT=REAPED} or {@code RYUK_RESULT=NOT_REAPED}, with diagnostics for CI logs.
+   */
+  private static String experimentScript() {
+    return """
+        set -u
+        SOCK="$XDG_RUNTIME_DIR/podman/podman.sock"
+        RYUK_IMG="docker.io/testcontainers/ryuk:0.11.0"
+        VICTIM_IMG="docker.io/library/busybox:latest"
+        LABEL="sail.ryuk.it=1"
+
+        echo "--- podman version ---"; podman version || true
+        for i in $(seq 1 30); do [ -S "$SOCK" ] && break; sleep 1; done
+        [ -S "$SOCK" ] || { echo "NO_SOCKET at $SOCK"; exit 1; }
+
+        echo "--- pulling images ---"
+        podman pull -q "$RYUK_IMG"    || { echo "RYUK_PULL_FAILED"; exit 1; }
+        podman pull -q "$VICTIM_IMG"  || { echo "VICTIM_PULL_FAILED"; exit 1; }
+
+        echo "--- starting ryuk (privileged) ---"
+        podman run -d --rm --name sail-ryuk --privileged \\
+          -v "$SOCK:/var/run/docker.sock" \\
+          -e RYUK_RECONNECTION_TIMEOUT=3s \\
+          -p 127.0.0.1:8080:8080 \\
+          "$RYUK_IMG" || { echo "RYUK_START_FAILED"; podman logs sail-ryuk 2>&1 || true; exit 1; }
+
+        for i in $(seq 1 30); do (echo >/dev/tcp/127.0.0.1/8080) >/dev/null 2>&1 && break; sleep 1; done
+
+        echo "--- starting labelled victim ---"
+        podman run -d --name sail-victim --label "$LABEL" "$VICTIM_IMG" sleep 600 \\
+          || { echo "VICTIM_START_FAILED"; exit 1; }
+
+        echo "--- registering filter with ryuk, then dropping the connection ---"
+        exec 3<>/dev/tcp/127.0.0.1/8080
+        printf 'label=%s\\n' "$LABEL" >&3
+        sleep 2
+        exec 3>&- 3<&-
+
+        echo "--- waiting past the reconnection timeout for the reap ---"
+        sleep 12
+
+        if podman ps -a --format '{{.Names}}' | grep -qx sail-victim; then
+          echo "RYUK_RESULT=NOT_REAPED"
+        else
+          echo "RYUK_RESULT=REAPED"
+        fi
+        echo "--- ryuk logs ---"; podman logs sail-ryuk 2>&1 | tail -20 || true
+        podman rm -f sail-ryuk sail-victim >/dev/null 2>&1 || true
+        """;
+  }
+
+  private void waitForUserBus() throws Exception {
+    var busPath = ContainerExec.DEV_XDG_RUNTIME_DIR + "/bus";
+    for (var attempt = 0; attempt < 30; attempt++) {
+      if (exec(CONTAINER, List.of("test", "-S", busPath)).ok()) {
+        return;
+      }
+      Thread.sleep(500);
+    }
+  }
+
+  private ShellExec.Result slow(List<String> command) throws Exception {
+    return shell.exec(command, null, SLOW);
+  }
+
+  private static void assertOk(ShellExec.Result result, String step) {
+    assertTrue(result.ok(), "rootless-Podman setup step failed (" + step + "): " + result.stderr());
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/RyukReapsContainersIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/RyukReapsContainersIT.java
@@ -23,11 +23,18 @@ import org.junit.jupiter.api.Test;
  * label filter, hold the control connection, then drop it — and checks whether the labelled victim
  * container is gone once Ryuk's reconnection timeout elapses.
  *
- * <p><strong>This test is the empirical gate.</strong> Green here means privileged Ryuk reaps under
- * rootless Podman and sail can safely re-enable it; red (or {@code NOT_REAPED}) means it does not,
- * and the {@code RYUK_DISABLED} + hourly-cron fallback stays. Either way the answer is measured on
- * CI, not guessed. Like every {@code *IT}, it runs only under the {@code integration} profile and
- * fails loudly (never {@code assumeTrue}) once a daemon is reachable.
+ * <p><strong>What this measured (the reason sail keeps Ryuk disabled).</strong> Privileged Ryuk is
+ * mechanically fine under rootless Podman — it connects to the socket, matches the victim by label,
+ * and issues the force-remove. But the rootless force-remove routinely takes longer than Ryuk's
+ * default 10s request timeout (network-namespace teardown), so with the Testcontainers default Ryuk
+ * logs {@code context deadline exceeded} and the container leaks anyway; only when the request
+ * timeout is raised (this test uses {@code RYUK_REQUEST_TIMEOUT=60s}) does the reap succeed.
+ * Because vanilla Testcontainers ships the 10s default, re-enabling Ryuk would be unreliable, so
+ * sail keeps {@code RYUK_DISABLED} and relies on the {@code cleanup-containers.sh} cron (a plain
+ * {@code podman rm -f}, no client-side timeout). This test stands as the reproducible evidence for
+ * that decision; it asserts the reap succeeds with the raised timeout. Like every {@code *IT}, it
+ * runs only under the {@code integration} profile and fails loudly (never {@code assumeTrue}) once
+ * a daemon is reachable.
  */
 class RyukReapsContainersIT extends AbstractIncusIT {
 

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/RyukReapsContainersIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/RyukReapsContainersIT.java
@@ -152,18 +152,19 @@ class RyukReapsContainersIT extends AbstractIncusIT {
         podman pull -q "$RYUK_IMG"    || { echo "RYUK_PULL_FAILED"; exit 1; }
         podman pull -q "$VICTIM_IMG"  || { echo "VICTIM_PULL_FAILED"; exit 1; }
 
-        echo "--- starting ryuk (privileged) ---"
+        echo "--- starting labelled victim first ---"
+        podman run -d --name sail-victim --label "$LABEL" "$VICTIM_IMG" sleep 600 \\
+          || { echo "VICTIM_START_FAILED"; exit 1; }
+
+        echo "--- starting ryuk (privileged, verbose) ---"
         podman run -d --rm --name sail-ryuk --privileged \\
           -v "$SOCK:/var/run/docker.sock" \\
-          -e RYUK_RECONNECTION_TIMEOUT=3s \\
+          -e RYUK_RECONNECTION_TIMEOUT=5s \\
+          -e RYUK_VERBOSE=true \\
           -p 127.0.0.1:8080:8080 \\
           "$RYUK_IMG" || { echo "RYUK_START_FAILED"; podman logs sail-ryuk 2>&1 || true; exit 1; }
 
-        for i in $(seq 1 30); do (echo >/dev/tcp/127.0.0.1/8080) >/dev/null 2>&1 && break; sleep 1; done
-
-        echo "--- starting labelled victim ---"
-        podman run -d --name sail-victim --label "$LABEL" "$VICTIM_IMG" sleep 600 \\
-          || { echo "VICTIM_START_FAILED"; exit 1; }
+        for i in $(seq 1 30); do podman logs sail-ryuk 2>&1 | grep -q "msg=Started" && break; sleep 1; done
 
         echo "--- registering filter with ryuk, then dropping the connection ---"
         exec 3<>/dev/tcp/127.0.0.1/8080
@@ -172,14 +173,16 @@ class RyukReapsContainersIT extends AbstractIncusIT {
         exec 3>&- 3<&-
 
         echo "--- waiting past the reconnection timeout for the reap ---"
-        sleep 12
+        sleep 15
 
         if podman ps -a --format '{{.Names}}' | grep -qx sail-victim; then
           echo "RYUK_RESULT=NOT_REAPED"
         else
           echo "RYUK_RESULT=REAPED"
         fi
-        echo "--- ryuk logs ---"; podman logs sail-ryuk 2>&1 | tail -20 || true
+        echo "--- victim labels (as podman sees them) ---"
+        podman inspect sail-victim --format '{{json .Config.Labels}}' 2>&1 || true
+        echo "--- ryuk logs (verbose) ---"; podman logs sail-ryuk 2>&1 | tail -40 || true
         podman rm -f sail-ryuk sail-victim >/dev/null 2>&1 || true
         """;
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/RyukReapsContainersIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/RyukReapsContainersIT.java
@@ -160,11 +160,16 @@ class RyukReapsContainersIT extends AbstractIncusIT {
         podman run -d --rm --name sail-ryuk --privileged \\
           -v "$SOCK:/var/run/docker.sock" \\
           -e RYUK_RECONNECTION_TIMEOUT=5s \\
+          -e RYUK_REQUEST_TIMEOUT=60s \\
           -e RYUK_VERBOSE=true \\
           -p 127.0.0.1:8080:8080 \\
           "$RYUK_IMG" || { echo "RYUK_START_FAILED"; podman logs sail-ryuk 2>&1 || true; exit 1; }
 
         for i in $(seq 1 30); do podman logs sail-ryuk 2>&1 | grep -q "msg=Started" && break; sleep 1; done
+
+        echo "--- timing a direct force-remove for comparison ---"
+        time podman rm -f sail-victim >/dev/null 2>&1 && echo "DIRECT_RM_OK"
+        podman run -d --name sail-victim --label "$LABEL" "$VICTIM_IMG" sleep 600 >/dev/null 2>&1
 
         echo "--- registering filter with ryuk, then dropping the connection ---"
         exec 3<>/dev/tcp/127.0.0.1/8080
@@ -172,8 +177,8 @@ class RyukReapsContainersIT extends AbstractIncusIT {
         sleep 2
         exec 3>&- 3<&-
 
-        echo "--- waiting past the reconnection timeout for the reap ---"
-        sleep 15
+        echo "--- waiting past the reconnection timeout + a generous reap window ---"
+        sleep 75
 
         if podman ps -a --format '{{.Names}}' | grep -qx sail-victim; then
           echo "RYUK_RESULT=NOT_REAPED"

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/RyukReapsContainersIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/RyukReapsContainersIT.java
@@ -39,6 +39,7 @@ class RyukReapsContainersIT extends AbstractIncusIT {
     ensureIncusOrSkip();
     try {
       launch(CONTAINER);
+      waitForNetwork();
       setUpRootlessPodman();
 
       var run =
@@ -160,6 +161,24 @@ class RyukReapsContainersIT extends AbstractIncusIT {
         echo "--- ryuk logs ---"; podman logs sail-ryuk 2>&1 | tail -20 || true
         podman rm -f sail-ryuk sail-victim >/dev/null 2>&1 || true
         """;
+  }
+
+  /**
+   * Waits until the freshly launched container has working outbound DNS — a bare {@code incus
+   * launch} returns before systemd-networkd finishes DHCP off the incus NAT bridge, so an immediate
+   * {@code apt-get} fails to resolve the archive. Fails loudly if the network never comes up (e.g.
+   * the CI host blocks bridge forwarding).
+   */
+  private void waitForNetwork() throws Exception {
+    for (var attempt = 0; attempt < 60; attempt++) {
+      if (exec(CONTAINER, List.of("getent", "hosts", "archive.ubuntu.com")).ok()) {
+        return;
+      }
+      Thread.sleep(2000);
+    }
+    assertOk(
+        exec(CONTAINER, List.of("getent", "hosts", "archive.ubuntu.com")),
+        "container never obtained outbound DNS within 120s (incus NAT/forwarding?)");
   }
 
   private void waitForUserBus() throws Exception {


### PR DESCRIPTION
Empirical probe (no product change yet). `RyukReapsContainersIT` runs on the incus lane: it reproduces sail's rootless Podman, runs Ryuk's real reaping protocol privileged against a labelled container, and asserts the container is reaped after the connection drops.

**The CI 'Incus-backed integration tests' result is the answer:**
- **Green** → privileged Ryuk reaps under rootless Podman → we flip provisioning `TESTCONTAINERS_RYUK_DISABLED=true` → `TESTCONTAINERS_RYUK_PRIVILEGED=true` to fix the container pileup.
- **Red / NOT_REAPED** → it doesn't work in this environment → keep `RYUK_DISABLED` + the hourly cron sweep, and this IT documents the finding.

Self-contained, failsafe-only (`-Pintegration`), hard assertions per the incus-lane discipline. Diagnostics (podman version, ryuk logs) are echoed for the CI log.