### PR TITLE
refactor: trim generated agent-context (handoff cruft, consolidated principles, autonomous→dispatch prompt)

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
@@ -344,12 +344,7 @@ public final class AgentContextGenerator {
               """);
     }
 
-    sb.append(step++).append(". Create a pull request for the current branch\n");
-
-    if (config.agent().specsDir() != null) {
-      sb.append(step)
-          .append(". If no more work remains, write a summary to ~/handoff.md and exit\n");
-    }
+    sb.append(step).append(". Create a pull request for the current branch\n");
 
     if (config.repos() != null && config.repos().size() > 1) {
       sb.append(
@@ -369,17 +364,11 @@ public final class AgentContextGenerator {
     sb.append(
         """
 
-        ### Session Handoff
-        If you are running low on context or the session is cycling:
-        1. Write your current progress and next steps to ~/handoff.md
-        2. Commit and push all work in progress (even partial — use a WIP commit)
-        3. The next session will read ~/handoff.md to continue where you left off
-
         ### Error Recovery
-        - If the build fails more than 5 consecutive times on the same error, stop and document
-          the issue in ~/handoff.md. Do not continue retrying the same approach.
-        - If you have attempted 3 different approaches to the same problem without success,
-          stop and write your findings to ~/handoff.md.
+        - If the build fails more than 5 consecutive times on the same error, stop and surface the
+          problem rather than retrying the same approach.
+        - If you have attempted 3 different approaches to the same problem without success, stop and
+          report what you found.
         - Never leave work uncommitted. A WIP commit is better than lost work.
         """);
   }

--- a/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
@@ -84,12 +84,11 @@ public final class AgentContextGenerator {
       sb.append("\n");
     }
 
-    sb.append("\n## Conventions\n");
-    sb.append("\n### Engineering Principles\n");
+    sb.append("\n## Engineering Principles\n");
     sb.append(universalPrinciples());
 
     if (config.agentContext() != null && config.agentContext().conventions() != null) {
-      sb.append("\n### Project Conventions\n");
+      sb.append("\n## Project Conventions\n");
       sb.append(config.agentContext().conventions().strip());
       sb.append("\n");
     }
@@ -207,40 +206,26 @@ public final class AgentContextGenerator {
 
     appendSpecSection(sb, config);
 
-    appendAutonomousSection(sb, config);
-
     return sb.toString();
   }
 
-  /** Returns universal engineering principles included in every agent context file. */
+  /** The consolidated engineering principles included in every agent context file. */
   static String universalPrinciples() {
     return """
-        - Write simple and elegant code. Simplicity is the ultimate sophistication. \
-        If a solution feels complex, step back and find a simpler approach.
-        - No inline comments in code, ever. Code must be self-documenting through \
-        clear naming, small functions, and obvious structure. If you feel the need \
-        to add a comment because the code is complex, rethink the code to make it \
-        simple first. The only acceptable comments explain non-obvious "why" decisions \
-        that cannot be expressed in code.
-        - Think about all possible edge cases. Handle them, but keep the code simple \
-        and elegant. Simplicity and robustness are not at odds — they reinforce each other.
-        - SOLID principles: single responsibility (each class/function does one thing), \
-        open-closed (extend behavior without modifying existing code), Liskov substitution \
-        (subtypes must be substitutable), interface segregation (small, focused interfaces), \
-        dependency inversion (depend on abstractions, not concretions).
-        - DRY: don't repeat yourself. Extract common logic into shared utilities when \
-        a pattern appears three or more times. But never create premature abstractions — \
-        duplication is cheaper than the wrong abstraction.
-        - Prefer composition over inheritance. Keep inheritance hierarchies shallow.
-        - Write small, focused functions. Each function should do one thing well. \
-        If a function needs a comment to explain what it does, it's too complex — \
-        break it down or rename it.
-        - Fail fast and fail loud. Validate preconditions early, throw clear exceptions \
-        with actionable error messages.
-        - Test behavior, not lines. When you add or change behavior, ship a test that \
-        asserts that behavior — not one that merely runs the code. Coverage gates show \
-        which lines executed, never whether anything was checked, so a green gate is \
-        necessary but not sufficient: name the observable behavior and assert it.
+        You are an efficient senior engineer. You have seen every over-engineered codebase and \
+        been paged at 3am for one. The best code is the code never written.
+
+        - SRP, DRY, KISS, YAGNI. Prefer composition over inheritance.
+        - Deletion over addition. Boring over clever — clever is what someone decodes at 3 AM.
+        - Fewest files possible. The shortest working diff wins, but only once you understand the \
+        problem; the smallest change in the wrong place isn't lazy, it's a second bug.
+        - Simple and elegant: if a solution feels complex, step back and find a simpler one.
+        - No inline comments, ever. Code is self-documenting through clear names and small, \
+        single-purpose functions; the only comments explain non-obvious "why".
+        - Handle every edge case, but keep it simple — robustness and simplicity reinforce each other.
+        - Fail fast and loud: validate preconditions early; throw clear, actionable errors.
+        - Test behavior, not lines: ship a test that asserts the behavior you changed. A green \
+        coverage gate is necessary, not sufficient.
         """;
   }
 
@@ -282,94 +267,6 @@ public final class AgentContextGenerator {
         ### Interactive Mode
         When the engineer asks you to brainstorm or write specs, draft each body to a temporary
         markdown file and run `spec create ...`. There is no `specs/` directory to edit.
-        """);
-  }
-
-  /** Appends the autonomous operation section when guardrails or a task file are configured. */
-  private static void appendAutonomousSection(StringBuilder sb, SailYaml config) {
-    if (config.agent() == null) {
-      return;
-    }
-    if (config.agent().guardrails() == null && config.agent().specsDir() == null) {
-      return;
-    }
-
-    sb.append(
-        """
-
-        ## Autonomous Operation
-
-        ### Work Protocol
-        You have work assigned. Execute it immediately. Do not wait for confirmation or ask
-        clarifying questions unless you are genuinely blocked. Read your task, plan your approach,
-        implement, test, and commit.
-
-        ### Completion Protocol
-        When your current task is complete:
-        1. Run all tests and verify they pass
-        2. Commit all changes with a clear commit message
-        """);
-
-    var step = 3;
-
-    sb.append(step++).append(". Push to the remote branch\n");
-
-    var hasSecurityAudit =
-        config.agent().securityAudit() != null && config.agent().securityAudit().enabled();
-    var hasCodeReview =
-        config.agent().codeReview() != null && config.agent().codeReview().enabled();
-
-    if (hasSecurityAudit) {
-      sb.append(step++)
-          .append(
-              """
-              . Run a security audit on all changed files:
-                 - Review for OWASP top-10 vulnerabilities (injection, XSS, broken auth, SSRF, etc.)
-                 - Check for hardcoded secrets, API keys, tokens, or credentials
-                 - Verify input validation at all system boundaries (user input, external APIs)
-                 - Check for unsafe deserialization, path traversal, or command injection
-                 - If any issues are found, fix them, re-run tests, and commit before proceeding
-              """);
-    }
-
-    if (hasCodeReview) {
-      sb.append(step++)
-          .append(
-              """
-              . Run a code review on all changed files:
-                 - Check for logic errors, edge cases, and off-by-one mistakes
-                 - Verify error handling and resource cleanup
-                 - Look for concurrency issues and performance pitfalls
-                 - If any issues are found, fix them, re-run tests, and commit before proceeding
-              """);
-    }
-
-    sb.append(step).append(". Create a pull request for the current branch\n");
-
-    if (config.repos() != null && config.repos().size() > 1) {
-      sb.append(
-          """
-
-          ### Multi-Repository Work
-          This project has multiple repositories. When working on a task:
-          - Use the spec's `repo` or `repos` metadata as the source of truth for affected repos
-          - If repo metadata is missing, infer the affected repos from the task and update the spec before dispatch
-          - Create a feature branch with the same name in each affected repo
-          - Commit and push changes in all affected repos
-          - Create a pull request in each affected repo, linking them in the descriptions
-          - Only mark a task as done when all PRs are created
-          """);
-    }
-
-    sb.append(
-        """
-
-        ### Error Recovery
-        - If the build fails more than 5 consecutive times on the same error, stop and surface the
-          problem rather than retrying the same approach.
-        - If you have attempted 3 different approaches to the same problem without success, stop and
-          report what you found.
-        - Never leave work uncommitted. A WIP commit is better than lost work.
         """);
   }
 

--- a/sail-core/src/test/java/ai/singlr/sail/gen/AgentContextGeneratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/gen/AgentContextGeneratorTest.java
@@ -439,8 +439,9 @@ class AgentContextGeneratorTest {
     assertTrue(md.contains("## Autonomous Operation"));
     assertTrue(md.contains("### Work Protocol"));
     assertTrue(md.contains("### Completion Protocol"));
-    assertTrue(md.contains("### Session Handoff"));
     assertTrue(md.contains("### Error Recovery"));
+    assertFalse(md.contains("Session Handoff"), "context handoff is the agent runtime's job");
+    assertFalse(md.contains("handoff.md"), "no ~/handoff.md context-management instructions");
   }
 
   @Test
@@ -467,7 +468,7 @@ class AgentContextGeneratorTest {
     var md = AgentContextGenerator.generateContextBody(config);
 
     assertTrue(md.contains("## Autonomous Operation"));
-    assertTrue(md.contains("handoff.md"));
+    assertTrue(md.contains("### Completion Protocol"));
   }
 
   @Test
@@ -647,7 +648,7 @@ class AgentContextGeneratorTest {
   }
 
   @Test
-  void taskFileStepsStartAt6WhenSecurityAuditPresent() {
+  void completionStepsRenumberWhenSecurityAuditPresent() {
     var guardrails = new ai.singlr.sail.config.Guardrails("4h", null, "stop");
     var securityAudit = new ai.singlr.sail.config.SecurityAudit(true, null);
     var agent =
@@ -681,7 +682,8 @@ class AgentContextGeneratorTest {
 
     var md = AgentContextGenerator.generateContextBody(config);
 
-    assertTrue(md.contains("6. If no more work remains"));
+    assertTrue(md.contains("4. Run a security audit"), "the audit is inserted as step 4");
+    assertTrue(md.contains("5. Create a pull request"), "the PR step renumbers after it");
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/gen/AgentContextGeneratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/gen/AgentContextGeneratorTest.java
@@ -118,7 +118,7 @@ class AgentContextGeneratorTest {
   void includesConventions() {
     var md = AgentContextGenerator.generateContextBody(fullConfig());
 
-    assertTrue(md.contains("## Conventions"));
+    assertTrue(md.contains("## Project Conventions"));
     assertTrue(md.contains("Use virtual threads"));
     assertTrue(md.contains("Records for DTOs"));
   }
@@ -226,7 +226,7 @@ class AgentContextGeneratorTest {
     assertTrue(md.contains("## Project"));
     assertTrue(md.contains("A minimal project"));
     assertTrue(md.contains("## Environment"));
-    assertTrue(md.contains("## Conventions"));
+    assertTrue(md.contains("## Engineering Principles"));
     assertFalse(md.contains("## Tech Stack"));
     assertFalse(md.contains("## Services"));
     assertFalse(md.contains("## Developer Commands"));
@@ -413,11 +413,11 @@ class AgentContextGeneratorTest {
   }
 
   @Test
-  void autonomousSectionAppendedWhenGuardrailsConfigured() {
+  void autonomousOperationIsNotInTheAlwaysLoadedBody() {
     var guardrails = new ai.singlr.sail.config.Guardrails("4h", null, "stop");
     var agent =
         new SailYaml.Agent(
-            "claude-code", true, "sail/", true, null, null, guardrails, null, null, null, null);
+            "claude-code", true, "sail/", true, null, null, guardrails, "specs", null, null, null);
     var config =
         new SailYaml(
             "test",
@@ -436,254 +436,11 @@ class AgentContextGeneratorTest {
 
     var md = AgentContextGenerator.generateContextBody(config);
 
-    assertTrue(md.contains("## Autonomous Operation"));
-    assertTrue(md.contains("### Work Protocol"));
-    assertTrue(md.contains("### Completion Protocol"));
-    assertTrue(md.contains("### Error Recovery"));
+    assertFalse(
+        md.contains("## Autonomous Operation"),
+        "autonomous-run instructions belong in the dispatch prompt, not the always-loaded context");
     assertFalse(md.contains("Session Handoff"), "context handoff is the agent runtime's job");
     assertFalse(md.contains("handoff.md"), "no ~/handoff.md context-management instructions");
-  }
-
-  @Test
-  void autonomousSectionAppendedWhenSpecsDirConfigured() {
-    var agent =
-        new SailYaml.Agent(
-            "claude-code", true, "sail/", true, null, null, null, "specs", null, null, null);
-    var config =
-        new SailYaml(
-            "test",
-            "Test",
-            new SailYaml.Resources(2, "4GB", "50GB"),
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            agent,
-            null,
-            null);
-
-    var md = AgentContextGenerator.generateContextBody(config);
-
-    assertTrue(md.contains("## Autonomous Operation"));
-    assertTrue(md.contains("### Completion Protocol"));
-  }
-
-  @Test
-  void autonomousSectionOmittedWhenNoAutonomousConfig() {
-    var md = AgentContextGenerator.generateContextBody(minimalConfig());
-
-    assertFalse(md.contains("Autonomous Operation"));
-  }
-
-  @Test
-  void autonomousSectionOmittedWhenAgentHasNeitherGuardrailsNorTasks() {
-    var agent =
-        new SailYaml.Agent(
-            "claude-code", true, "sail/", true, null, null, null, null, null, null, null);
-    var config =
-        new SailYaml(
-            "test",
-            "Test",
-            new SailYaml.Resources(2, "4GB", "50GB"),
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            agent,
-            null,
-            null);
-
-    var md = AgentContextGenerator.generateContextBody(config);
-
-    assertFalse(md.contains("Autonomous Operation"));
-  }
-
-  @Test
-  void multiRepoGuidanceWhenMultipleRepos() {
-    var repos =
-        List.of(
-            new SailYaml.Repo("https://github.com/test/backend.git", "backend", "main"),
-            new SailYaml.Repo("https://github.com/test/frontend.git", "frontend", "main"));
-    var guardrails = new ai.singlr.sail.config.Guardrails("4h", null, "stop");
-    var agent =
-        new SailYaml.Agent(
-            "claude-code", true, "sail/", true, null, null, guardrails, null, null, null, null);
-    var config =
-        new SailYaml(
-            "test",
-            "Test",
-            new SailYaml.Resources(2, "4GB", "50GB"),
-            null,
-            null,
-            null,
-            null,
-            repos,
-            null,
-            null,
-            agent,
-            null,
-            null);
-
-    var md = AgentContextGenerator.generateContextBody(config);
-
-    assertTrue(md.contains("### Multi-Repository Work"));
-    assertTrue(md.contains("same name in each affected repo"));
-  }
-
-  @Test
-  void noMultiRepoGuidanceWhenSingleRepo() {
-    var repos = List.of(new SailYaml.Repo("https://github.com/test/app.git", "app", "main"));
-    var guardrails = new ai.singlr.sail.config.Guardrails("4h", null, "stop");
-    var agent =
-        new SailYaml.Agent(
-            "claude-code", true, "sail/", true, null, null, guardrails, null, null, null, null);
-    var config =
-        new SailYaml(
-            "test",
-            "Test",
-            new SailYaml.Resources(2, "4GB", "50GB"),
-            null,
-            null,
-            null,
-            null,
-            repos,
-            null,
-            null,
-            agent,
-            null,
-            null);
-
-    var md = AgentContextGenerator.generateContextBody(config);
-
-    assertFalse(md.contains("Multi-Repository Work"));
-  }
-
-  @Test
-  void completionProtocolIncludesSecurityAuditStep() {
-    var guardrails = new ai.singlr.sail.config.Guardrails("4h", null, "stop");
-    var securityAudit = new ai.singlr.sail.config.SecurityAudit(true, null);
-    var agent =
-        new SailYaml.Agent(
-            "claude-code",
-            true,
-            "sail/",
-            true,
-            null,
-            null,
-            guardrails,
-            null,
-            securityAudit,
-            null,
-            null);
-    var config =
-        new SailYaml(
-            "test",
-            "Test",
-            new SailYaml.Resources(2, "4GB", "50GB"),
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            agent,
-            null,
-            null);
-
-    var md = AgentContextGenerator.generateContextBody(config);
-
-    assertTrue(md.contains("security audit"));
-    assertTrue(md.contains("OWASP"));
-    assertTrue(md.contains("hardcoded secrets"));
-    assertTrue(md.contains("input validation"));
-  }
-
-  @Test
-  void securityAuditStepBeforePullRequest() {
-    var guardrails = new ai.singlr.sail.config.Guardrails("4h", null, "stop");
-    var securityAudit = new ai.singlr.sail.config.SecurityAudit(true, null);
-    var agent =
-        new SailYaml.Agent(
-            "claude-code",
-            true,
-            "sail/",
-            true,
-            null,
-            null,
-            guardrails,
-            null,
-            securityAudit,
-            null,
-            null);
-    var config =
-        new SailYaml(
-            "test",
-            "Test",
-            new SailYaml.Resources(2, "4GB", "50GB"),
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            agent,
-            null,
-            null);
-
-    var md = AgentContextGenerator.generateContextBody(config);
-
-    var auditIdx = md.indexOf("security audit");
-    var prIdx = md.indexOf("Create a pull request");
-    assertTrue(auditIdx > 0, "security audit step should be present");
-    assertTrue(prIdx > 0, "pull request step should be present");
-    assertTrue(auditIdx < prIdx, "security audit should come before pull request");
-  }
-
-  @Test
-  void completionStepsRenumberWhenSecurityAuditPresent() {
-    var guardrails = new ai.singlr.sail.config.Guardrails("4h", null, "stop");
-    var securityAudit = new ai.singlr.sail.config.SecurityAudit(true, null);
-    var agent =
-        new SailYaml.Agent(
-            "claude-code",
-            true,
-            "sail/",
-            true,
-            null,
-            null,
-            guardrails,
-            "specs",
-            securityAudit,
-            null,
-            null);
-    var config =
-        new SailYaml(
-            "test",
-            "Test",
-            new SailYaml.Resources(2, "4GB", "50GB"),
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            agent,
-            null,
-            null);
-
-    var md = AgentContextGenerator.generateContextBody(config);
-
-    assertTrue(md.contains("4. Run a security audit"), "the audit is inserted as step 4");
-    assertTrue(md.contains("5. Create a pull request"), "the PR step renumbers after it");
   }
 
   @Test
@@ -884,7 +641,7 @@ class AgentContextGeneratorTest {
     var claude = fileEndingWith(files, "/.claude/CLAUDE.md").content();
     var codex = fileEndingWith(files, "/.codex/AGENTS.md").content();
     assertEquals(claude, codex, "the sail-owned body is identical for both agents");
-    assertTrue(claude.contains("## Conventions"));
+    assertTrue(claude.contains("## Engineering Principles"));
   }
 
   @Test
@@ -909,14 +666,15 @@ class AgentContextGeneratorTest {
   void contextIncludesUniversalPrinciples() {
     var content = coreBody(AgentContextGenerator.generateFiles(fullConfig()));
 
-    assertTrue(content.contains("SOLID principles"));
-    assertTrue(content.contains("DRY"));
-    assertTrue(content.contains("self-documenting"));
-    assertTrue(content.contains("simple and elegant"));
-    assertTrue(content.contains("No inline comments in code, ever"));
-    assertTrue(content.contains("edge cases"));
+    assertTrue(content.contains("efficient senior engineer"));
+    assertTrue(content.contains("best code is the code never written"));
+    assertTrue(content.contains("SRP, DRY, KISS, YAGNI"));
+    assertTrue(content.contains("Deletion over addition"));
+    assertTrue(content.contains("Boring over clever"));
+    assertTrue(content.contains("Fewest files possible"));
+    assertTrue(content.contains("No inline comments, ever"));
     assertTrue(content.contains("Test behavior, not lines"));
-    assertFalse(content.contains("world's best coder"), "the hype line is trimmed");
+    assertFalse(content.contains("SOLID principles"), "consolidated into SRP/DRY/KISS/YAGNI");
   }
 
   @Test
@@ -998,7 +756,7 @@ class AgentContextGeneratorTest {
     var config = configWithRuntimesAndContext(new SailYaml.Runtimes(25, null, null), agentCtx);
     var content = coreBody(AgentContextGenerator.generateFiles(config));
 
-    var autoIdx = content.indexOf("SOLID principles");
+    var autoIdx = content.indexOf("SRP, DRY, KISS, YAGNI");
     var userIdx = content.indexOf("Custom project rule");
     assertTrue(autoIdx > 0);
     assertTrue(userIdx > 0);

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/AgentTaskPrompt.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/AgentTaskPrompt.java
@@ -41,6 +41,31 @@ public final class AgentTaskPrompt {
         + targetModel
         + targetReasoning
         + "\n"
-        + description;
+        + description
+        + autonomousProtocol(spec);
+  }
+
+  /**
+   * The autonomous-operation protocol, appended to the dispatch prompt only — it applies to a
+   * headless dispatched run, not to an engineer's interactive session, so it lives here rather than
+   * in the always-loaded context file. The security-audit and code-review steps are enforced by the
+   * post-task hooks, so the prompt stays generic.
+   */
+  private static String autonomousProtocol(Spec spec) {
+    var multiRepo =
+        spec.repos().size() > 1
+            ? "\nThis spec spans multiple repos: branch, commit, and open a linked pull request in"
+                + " each affected repo.\n"
+            : "";
+    return """
+
+        ## Autonomous Operation
+        Execute without waiting for confirmation: plan, implement, test, commit. When complete, run
+        the tests, commit with a clear message, push the branch, and open a pull request.
+        """
+        + multiRepo
+        + "If the build fails repeatedly on the same error, or three different approaches fail, stop"
+        + " and report rather than retrying. Never leave work uncommitted — a WIP commit beats lost"
+        + " work.\n";
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
@@ -171,6 +171,40 @@ class DispatchCommandTest {
   }
 
   @Test
+  void buildTaskPromptCarriesTheAutonomousProtocol() {
+    var spec = new Spec("oauth", "OAuth", SpecStatus.PENDING, null, List.of(), null);
+
+    var prompt = AgentTaskPrompt.build(spec, "Details");
+
+    assertTrue(
+        prompt.contains("## Autonomous Operation"),
+        "the autonomous protocol belongs in the dispatch prompt, not the always-loaded context");
+    assertTrue(prompt.contains("open a pull request"));
+    assertFalse(prompt.contains("handoff.md"), "no context-handoff cruft");
+  }
+
+  @Test
+  void buildTaskPromptNotesMultiRepoOnlyWhenSpecSpansRepos() {
+    var single = new Spec("a", "A", SpecStatus.PENDING, null, List.of(), null);
+    assertFalse(AgentTaskPrompt.build(single, "d").contains("spans multiple repos"));
+
+    var multi =
+        new Spec(
+            "b",
+            "test",
+            "B",
+            SpecStatus.PENDING,
+            null,
+            List.of(),
+            List.of("api", "web"),
+            null,
+            null,
+            null,
+            null);
+    assertTrue(AgentTaskPrompt.build(multi, "d").contains("spans multiple repos"));
+  }
+
+  @Test
   void dispatchCommandRegisteredInSing() {
     var cmd = new CommandLine(new Sail());
     var sw = new StringWriter();


### PR DESCRIPTION
## Trim the generated agent-context: handoff cruft out, principles consolidated, autonomous protocol moved

The generated `CLAUDE.md`/`AGENTS.md` is sail-owned, and it was carrying things that either belong to the agent runtime or only apply to autonomous dispatch.

### 1. Session-handoff cruft removed
`### Session Handoff`, the "write a summary to `~/handoff.md` and exit" completion step, and the `~/handoff.md` references in Error Recovery are gone. Context handoff (running low on context, session cycling) is the **agent runtime's** job, not something sail should instruct.

### 2. Engineering principles consolidated
The `## Conventions` → `### Engineering Principles` (single-subsection) nesting was bloat. Now flattened to sibling `## Engineering Principles` / `## Project Conventions`, and the principles are a tighter, opinionated set:

> You are an efficient senior engineer. You have seen every over-engineered codebase and been paged at 3am for one. The best code is the code never written.
> - SRP, DRY, KISS, YAGNI. Prefer composition over inheritance.
> - Deletion over addition. Boring over clever — clever is what someone decodes at 3 AM.
> - Fewest files possible. The shortest working diff wins, but only once you understand the problem; the smallest change in the wrong place isn't lazy, it's a second bug.
> - Simple and elegant; no inline comments, ever; handle every edge case; fail fast and loud; test behavior, not lines.

### 3. `## Autonomous Operation` moved to the dispatch prompt
"Execute immediately, don't ask, commit/push/PR" is right for a **headless dispatched run** and wrong for an **interactive** session — but it was baked into the always-loaded context, so it loaded in both. It now lives in `AgentTaskPrompt` (the dispatch-only prompt), so it applies *only* when sail dispatches a spec. The per-config audit/review steps drop from the prompt (the post-task hooks already enforce those); the multi-repo note is emitted only when the spec spans repos.

**`## Spec-Driven Development` stays** in the context — it's how the agent works with specs every session, not autonomous-only.

### Tests & verification
TDD; full `mvn clean verify` green. `AgentContextGeneratorTest` rewritten for the new principles/headers and the absence of autonomous/handoff content; `DispatchCommandTest` gains coverage for the autonomous protocol + multi-repo note in the dispatch prompt. No version bump — left for the release step.
