### PR TITLE
fix: refuse non-loopback API bind without explicit --allow-remote (B1)

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -80,8 +80,8 @@ verification and dependency scanning.
 ## Existing Controls Still Valid
 
 ### API bind address requires explicit remote opt-in
-`sail api` refuses to bind to non-loopback addresses unless `--allow-remote` is supplied. This keeps
-the default local API posture local-first even when an operator mistypes `--host 0.0.0.0`.
+`sail server start` refuses to bind to non-loopback addresses unless `--allow-remote` is supplied.
+This keeps the default local API posture local-first even when an operator mistypes `--host 0.0.0.0`.
 
 ### API token file hardening
 The API token store rejects non-regular token paths, reapplies owner-only permissions before reusing

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostServiceInstallCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostServiceInstallCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.engine.BindPolicy;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SystemdServiceInstaller;
 import picocli.CommandLine.Command;
@@ -28,6 +29,13 @@ public final class HostServiceInstallCommand implements Runnable {
   @Option(names = "--port", description = "Bind port.", defaultValue = "7070")
   private int port;
 
+  @Option(
+      names = "--allow-remote",
+      description =
+          "Permit a non-loopback bind address. The API is plaintext HTTP and any token can dispatch"
+              + " agents; only expose it behind a TLS reverse proxy with restricted access.")
+  private boolean allowRemote;
+
   @Option(names = "--dry-run", description = "Print commands instead of executing them.")
   private boolean dryRun;
 
@@ -39,6 +47,7 @@ public final class HostServiceInstallCommand implements Runnable {
   }
 
   private void execute() throws Exception {
+    BindPolicy.requireBindable(host, allowRemote);
     var shell = new ShellExecutor(dryRun);
     var username = HostServiceInstallers.currentUsername();
     var installer = HostServiceInstallers.create(shell, host, port, username);
@@ -60,7 +69,11 @@ public final class HostServiceInstallCommand implements Runnable {
     }
     System.out.println(
         Ansi.AUTO.string(
-            "    @|bold ExecStart:|@ sail server start --host " + host + " --port " + port));
+            "    @|bold ExecStart:|@ sail server start --host "
+                + host
+                + " --port "
+                + port
+                + (BindPolicy.isLoopback(host) ? "" : " --allow-remote")));
 
     if (!dryRun
         && installer.mode() == SystemdServiceInstaller.Mode.USER

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -23,6 +23,7 @@ import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.WebauthnConfig;
 import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.BindPolicy;
 import ai.singlr.sail.engine.HostInfo;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
@@ -75,6 +76,13 @@ public final class ServerStartCommand implements Runnable {
   private int port;
 
   @Option(
+      names = "--allow-remote",
+      description =
+          "Permit binding a non-loopback address. The API is plaintext HTTP and any token can"
+              + " dispatch agents; only expose it behind a TLS reverse proxy with restricted access.")
+  private boolean allowRemote;
+
+  @Option(
       names = "--rp-id",
       description =
           "WebAuthn Relying Party ID for passkey login (the registrable domain the proxy serves)."
@@ -101,6 +109,7 @@ public final class ServerStartCommand implements Runnable {
   }
 
   private void execute() throws Exception {
+    BindPolicy.requireBindable(host, allowRemote);
     var dbPath = SailPaths.controlPlaneDb();
     SailPaths.ensureDataDir(dbPath.getParent());
 
@@ -207,7 +216,7 @@ public final class ServerStartCommand implements Runnable {
         System.out.println(
             Ansi.AUTO.string("    @|faint Passkey login enabled for " + webauthn.rpId() + "|@"));
       }
-      if (!isLoopback(host)) {
+      if (!BindPolicy.isLoopback(host)) {
         System.out.println(
             Ansi.AUTO.string(
                 "  @|yellow ⚠|@ Bound to a non-loopback address over plaintext HTTP. Any holder"
@@ -280,9 +289,5 @@ public final class ServerStartCommand implements Runnable {
     } catch (Exception e) {
       return null;
     }
-  }
-
-  private static boolean isLoopback(String host) {
-    return "127.0.0.1".equals(host) || "localhost".equals(host) || "::1".equals(host);
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/BindPolicy.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/BindPolicy.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+/**
+ * Decides whether the control plane may bind a given address. The API is a single-trust-level
+ * surface served over plaintext HTTP — every token can dispatch agents (code execution in
+ * containers) — so a non-loopback bind exposes that to the network and must be opted into
+ * explicitly. Resolved without I/O so the guard is unit-tested and shared between the install-time
+ * check and the daemon entrypoint.
+ */
+public final class BindPolicy {
+
+  private BindPolicy() {}
+
+  public static boolean isLoopback(String host) {
+    return "127.0.0.1".equals(host) || "localhost".equals(host) || "::1".equals(host);
+  }
+
+  public static void requireBindable(String host, boolean allowRemote) {
+    if (!isLoopback(host) && !allowRemote) {
+      throw new IllegalArgumentException(
+          "Refusing to bind '"
+              + host
+              + "': the API is plaintext HTTP and any token can dispatch agents (code execution in"
+              + " containers). Bind loopback (the default), or pass --allow-remote to expose it on"
+              + " the network behind a TLS reverse proxy with restricted access.");
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/SystemdServiceInstaller.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/SystemdServiceInstaller.java
@@ -146,6 +146,7 @@ public final class SystemdServiceInstaller {
   public String renderUnit() {
     var userClause = mode == Mode.SYSTEM ? "User=root\n" : "";
     var wantedBy = mode == Mode.SYSTEM ? "multi-user.target" : "default.target";
+    var remoteFlag = BindPolicy.isLoopback(bindAddress) ? "" : " --allow-remote";
     return """
         [Unit]
         Description=Sail API server
@@ -154,7 +155,7 @@ public final class SystemdServiceInstaller {
 
         [Service]
         Type=simple
-        %sExecStart=%s server start --host %s --port %d
+        %sExecStart=%s server start --host %s --port %d%s
         Restart=on-failure
         RestartSec=2
         LimitNOFILE=4096
@@ -162,7 +163,7 @@ public final class SystemdServiceInstaller {
         [Install]
         WantedBy=%s
         """
-        .formatted(userClause, sailBinary, bindAddress, bindPort, wantedBy);
+        .formatted(userClause, sailBinary, bindAddress, bindPort, remoteFlag, wantedBy);
   }
 
   /**

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/BindPolicyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/BindPolicyTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class BindPolicyTest {
+
+  @Test
+  void loopbackIsAllowedWithoutOptIn() {
+    assertDoesNotThrow(() -> BindPolicy.requireBindable("127.0.0.1", false));
+    assertDoesNotThrow(() -> BindPolicy.requireBindable("localhost", false));
+    assertDoesNotThrow(() -> BindPolicy.requireBindable("::1", false));
+  }
+
+  @Test
+  void nonLoopbackWithoutOptInIsRefused() {
+    var error =
+        assertThrows(
+            IllegalArgumentException.class, () -> BindPolicy.requireBindable("0.0.0.0", false));
+    assertTrue(error.getMessage().contains("--allow-remote"));
+  }
+
+  @Test
+  void nonLoopbackWithOptInIsAllowed() {
+    assertDoesNotThrow(() -> BindPolicy.requireBindable("0.0.0.0", true));
+    assertDoesNotThrow(() -> BindPolicy.requireBindable("10.0.0.5", true));
+  }
+
+  @Test
+  void optInOnLoopbackStaysAllowed() {
+    assertDoesNotThrow(() -> BindPolicy.requireBindable("127.0.0.1", true));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/SystemdServiceInstallerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/SystemdServiceInstallerTest.java
@@ -149,6 +149,28 @@ class SystemdServiceInstallerTest {
     assertFalse(unit.contains("User=root"), "USER mode unit must not pin User=root");
   }
 
+  @Test
+  void loopbackBindDoesNotEmitAllowRemote(@TempDir Path home) {
+    assertFalse(userInstaller(home).renderUnit().contains("--allow-remote"));
+  }
+
+  @Test
+  void nonLoopbackBindEmitsAllowRemoteSoTheDaemonGuardPasses(@TempDir Path home) {
+    var installer =
+        new SystemdServiceInstaller(
+            new ScriptedShellExecutor(), Mode.USER, home, SAIL_BINARY, "0.0.0.0", PORT, USER);
+
+    assertTrue(
+        installer
+            .renderUnit()
+            .contains(
+                "ExecStart="
+                    + SAIL_BINARY
+                    + " server start --host 0.0.0.0 --port "
+                    + PORT
+                    + " --allow-remote"));
+  }
+
   // --------------------- USER mode: install / uninstall ---------------------
 
   @Test


### PR DESCRIPTION
## What & why

Closes v1-hardening blocker **B1**. The control-plane API is a single-trust-level surface over **plaintext HTTP** — any token can dispatch agents, which is **code execution inside containers**. A non-loopback bind exposes that to the network, but `sail server start` only printed a warning and proceeded. `SECURITY_AUDIT.md` claimed a `--allow-remote` refusal that **did not exist** (a security regression + stale doc).

`server start` is the **systemd daemon entrypoint** (`ExecStart=…`, `Restart=on-failure`), so the operator's bind choice is actually made at **install time** via `host service install`. A guard living only in the daemon would just crash-loop the unit. So the guard is primarily at install time, failing fast, with a daemon-level check as defense in depth.

## Design

| Layer | Behavior |
|---|---|
| `BindPolicy` (shared in `engine`) | Pure `isLoopback` + `requireBindable` — no I/O, unit-tested |
| `host service install --allow-remote` | **Fails fast** before writing a unit |
| `server start --allow-remote` | Same guard, first line of `execute()` |
| systemd unit | `ExecStart` derives `--allow-remote` from a non-loopback `--host` (single source of truth) |
| `sail upgrade` | Round-trips automatically — reconcile re-derives from preserved `--host`; **no upgrade-path code** |
| `SECURITY_AUDIT.md` | Corrected to the real command + behavior |

## Behavior

- Default (loopback) — unchanged.
- Non-loopback at install **or** daemon start without `--allow-remote` → fails fast, nothing written/bound, error names the flag.
- `--allow-remote` permits the bind; non-loopback units carry the flag so the daemon guard passes.

## Testing (TDD — red before green)

- `BindPolicyTest` + 2 new `SystemdServiceInstallerTest` cases — each watched fail first, then pass.
- Full `sail-infra` suite: **1792 tests, 0 failures**.
- JaCoCo coverage gates (`verify`): **all checks met**. Spotless: clean.
