### PR TITLE
fix: sync commit integrity — atomic CAS + error responses (B4)

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
@@ -190,7 +190,7 @@ public final class FileStore implements ConflictResolver {
 
   /** Compare-and-set commit as main: accepts only if {@code expectedRev} still matches. */
   public PushOutcome commitRevision(String id, Map<String, Object> snapshot, String expectedRev) {
-    return db.transaction(
+    return db.immediateTransaction(
         () -> {
           if (!Objects.equals(latestRev(id), expectedRev)) {
             return new PushOutcome.Stale(latestRev(id), comparableSnapshot(id));

--- a/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
@@ -209,7 +209,7 @@ public final class ProjectStore implements ConflictResolver {
 
   /** Compare-and-set commit as main: accepts only if {@code expectedRev} still matches. */
   public PushOutcome commitRevision(String id, Map<String, Object> snapshot, String expectedRev) {
-    return db.transaction(
+    return db.immediateTransaction(
         () -> {
           if (!Objects.equals(latestRev(id), expectedRev)) {
             return new PushOutcome.Stale(latestRev(id), comparableSnapshot(id));

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -610,7 +610,7 @@ public final class SpecStore implements ConflictResolver {
    * pushing the same row can never both win. Used by the sync engine on the main side.
    */
   public PushOutcome commitRevision(String id, Map<String, Object> snapshot, String expectedRev) {
-    return db.transaction(
+    return db.immediateTransaction(
         () -> {
           if (!Objects.equals(latestRev(id), expectedRev)) {
             return new PushOutcome.Stale(latestRev(id), comparableSnapshot(id));

--- a/sail-core/src/main/java/ai/singlr/sail/store/Sqlite.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/Sqlite.java
@@ -146,7 +146,22 @@ public final class Sqlite implements AutoCloseable {
   }
 
   public <T> T transaction(Supplier<T> work) {
-    execute("BEGIN");
+    return transaction("BEGIN", work);
+  }
+
+  /**
+   * Runs {@code work} under {@code BEGIN IMMEDIATE}, taking the write lock at the start of the
+   * transaction instead of on first write. A compare-and-set that reads then writes needs this:
+   * deferred {@code BEGIN} lets two writers both read the same revision before either writes, so
+   * the second's write fails on the now-stale snapshot rather than seeing the first and rejecting
+   * cleanly. Taking the lock up front serializes them, closing that read-then-write window.
+   */
+  public <T> T immediateTransaction(Supplier<T> work) {
+    return transaction("BEGIN IMMEDIATE", work);
+  }
+
+  private <T> T transaction(String begin, Supplier<T> work) {
+    execute(begin);
     try {
       var result = work.get();
       execute("COMMIT");

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
@@ -42,15 +42,37 @@ public final class SyncRpcServer {
 
   public void serve(Reader in, Writer out) throws IOException {
     for (var line = SyncWire.readFramed(in); line != null; line = SyncWire.readFramed(in)) {
-      switch (SyncWire.decodeRequest(line)) {
-        case SyncWire.Bye ignored -> {
-          return;
-        }
-        case SyncWire.Fetch fetch -> reply(out, fetched(fetch.entityType()));
-        case SyncWire.FetchFdes ignored -> reply(out, new SyncWire.Fdes(fdeRoster.entries()));
-        case SyncWire.Commit commit -> reply(out, onCommit(commit));
+      var request = SyncWire.decodeRequest(line);
+      if (request instanceof SyncWire.Bye) {
+        return;
       }
+      reply(out, respondTo(request));
     }
+  }
+
+  /**
+   * Computes one response, converting any store-side failure into a {@link SyncWire.Failed} the
+   * client can read, rather than letting it propagate and drop the session with no reply — the
+   * client must always be able to tell a refused commit from a broken connection. The clean {@link
+   * SyncWire.Rejected} staleness path is unaffected; only thrown failures land here.
+   */
+  private SyncWire.Response respondTo(SyncWire.Request request) {
+    try {
+      return switch (request) {
+        case SyncWire.Fetch fetch -> fetched(fetch.entityType());
+        case SyncWire.FetchFdes ignored -> new SyncWire.Fdes(fdeRoster.entries());
+        case SyncWire.Commit commit -> onCommit(commit);
+        case SyncWire.Bye ignored -> throw new IllegalStateException("Bye ends the session loop");
+      };
+    } catch (RuntimeException e) {
+      return new SyncWire.Failed(
+          "Main could not apply the request and made no change; retry the sync. Cause: "
+              + rootMessage(e));
+    }
+  }
+
+  private static String rootMessage(Throwable t) {
+    return Objects.toString(t.getMessage(), t.getClass().getSimpleName());
   }
 
   private static void reply(Writer out, SyncWire.Response response) throws IOException {

--- a/sail-core/src/test/java/ai/singlr/sail/store/FileStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FileStoreTest.java
@@ -15,6 +15,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CyclicBarrier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -224,5 +226,57 @@ class FileStoreTest {
     files.resolveConflict(id("a.txt"), null, Map.of("content", "theirs"));
 
     assertTrue(files.find("acme", "a.txt").isEmpty());
+  }
+
+  @Test
+  void concurrentCommitsAgainstTheSameBaseYieldOneWinnerAndOneCleanStale() throws Exception {
+    try (var db2 = Sqlite.open(tempDir.resolve("test.db"))) {
+      var files2 = new FileStore(db2);
+      for (var i = 0; i < 64; i++) {
+        var fid = id("race-" + i + ".txt");
+        var base = i + "-base";
+        files.applyRevision(fid, Map.of("content", "BASE"), base);
+
+        var gate = new CyclicBarrier(2);
+        var outcomes = new ConcurrentLinkedQueue<PushOutcome>();
+        var errors = new ConcurrentLinkedQueue<Throwable>();
+        var a = racer(files, fid, "A", base, gate, outcomes, errors);
+        var b = racer(files2, fid, "B", base, gate, outcomes, errors);
+        a.start();
+        b.start();
+        a.join();
+        b.join();
+
+        var iteration = i;
+        assertTrue(errors.isEmpty(), () -> "iteration " + iteration + " raced into " + errors);
+        assertEquals(
+            1,
+            outcomes.stream().filter(o -> o instanceof PushOutcome.Accepted).count(),
+            "exactly one writer wins the race");
+        assertEquals(
+            1,
+            outcomes.stream().filter(o -> o instanceof PushOutcome.Stale).count(),
+            "the loser is cleanly rejected as stale, never lost or errored");
+      }
+    }
+  }
+
+  private static Thread racer(
+      FileStore store,
+      String fid,
+      String content,
+      String base,
+      CyclicBarrier gate,
+      ConcurrentLinkedQueue<PushOutcome> outcomes,
+      ConcurrentLinkedQueue<Throwable> errors) {
+    return new Thread(
+        () -> {
+          try {
+            gate.await();
+            outcomes.add(store.commitRevision(fid, Map.of("content", content), base));
+          } catch (Throwable t) {
+            errors.add(t);
+          }
+        });
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 /** The server loop in isolation over a fake authority: framing, the write gate, and clean EOF. */
 class SyncRpcServerTest {
 
-  private static final class FakeMain implements MainReplica {
+  private static class FakeMain implements MainReplica {
     @Override
     public String id() {
       return "main";
@@ -105,5 +105,40 @@ class SyncRpcServerTest {
   void anUnknownEntityTypeCommitIsRefused() throws Exception {
     assertInstanceOf(
         SyncWire.Failed.class, serve(true, new SyncWire.Commit("bogus", "a", Map.of(), null)));
+  }
+
+  @Test
+  void aStoreExceptionOnCommitBecomesAFailedResponseNotADroppedSession() throws Exception {
+    var throwing =
+        new FakeMain() {
+          @Override
+          public CommitOutcome commit(
+              String entityId, Map<String, Object> snapshot, String expectedRev) {
+            throw new IllegalStateException("database is locked");
+          }
+        };
+    var out = new StringWriter();
+    var request = new SyncWire.Commit("spec", "a", Map.of(), null);
+
+    new SyncRpcServer(throwing, true).serve(new StringReader(SyncWire.encode(request) + "\n"), out);
+
+    assertInstanceOf(SyncWire.Failed.class, SyncWire.decodeResponse(out.toString().strip()));
+  }
+
+  @Test
+  void aStoreExceptionOnFetchBecomesAFailedResponse() throws Exception {
+    var throwing =
+        new FakeMain() {
+          @Override
+          public Set<String> entityIds() {
+            throw new IllegalStateException("database is locked");
+          }
+        };
+    var out = new StringWriter();
+
+    new SyncRpcServer(throwing, true)
+        .serve(new StringReader(SyncWire.encode(new SyncWire.Fetch("spec")) + "\n"), out);
+
+    assertInstanceOf(SyncWire.Failed.class, SyncWire.decodeResponse(out.toString().strip()));
   }
 }


### PR DESCRIPTION
## Problem (blocker B4)

Two defects on the sync commit path:

1. **No error boundary in `SyncRpcServer`.** `serve()` / `onCommit()` had no try-catch, so a `SqliteException` from `main.commit()` / `entityIds()` propagated uncaught and dropped the SSH session with **no `SyncWire.Failed` response** — the client could not tell a rejected commit from a dropped connection.
2. **Non-atomic CAS.** `commitRevision()` (SpecStore/FileStore/ProjectStore) did a Java-side read-then-write over a plain deferred `BEGIN`. Two writers could both read the same revision before either wrote; the loser then failed on a now-stale snapshot (`SQLITE_BUSY`) instead of cleanly rejecting as `Stale`.

## Fix

- `serve()` routes every request through `respondTo()`, which wraps response computation and converts any thrown store failure into a `SyncWire.Failed` with an actionable reason. The clean `Rejected` staleness path is unaffected.
- Added `Sqlite.immediateTransaction()` (`BEGIN IMMEDIATE`) and switched the CAS in all three stores to it, taking the write lock up front so concurrent commits serialize — the loser re-reads and rejects cleanly.

## Method (TDD)

Both tests were written first and **fail on current `main`**:

- `SyncRpcServerTest`: a store exception on commit (and on fetch) now yields `Failed`, not a propagated exception / dropped session. *(Was: `IllegalStateException` escapes `serve()`.)*
- `FileStoreTest`: 64 barrier-aligned races against the same base now yield exactly one `Accepted` and one clean `Stale`, never an error or lost update. *(Was: loser threw `database is locked`.)*

## Acceptance

- Store exception on commit → client gets `Failed`, session stays well-defined. ✅
- Stale-revision commit → deterministic rejection, no lost update. ✅
- Both tests fail on `main`, pass after the fix. ✅
- Full reactor build green (1273 sail-core tests + all modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)