### PR TITLE
fix: close the dispatch stop->review loop for cleanly-exited agents

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
@@ -190,7 +190,7 @@ public final class FileStore implements ConflictResolver {
 
   /** Compare-and-set commit as main: accepts only if {@code expectedRev} still matches. */
   public PushOutcome commitRevision(String id, Map<String, Object> snapshot, String expectedRev) {
-    return db.transaction(
+    return db.immediateTransaction(
         () -> {
           if (!Objects.equals(latestRev(id), expectedRev)) {
             return new PushOutcome.Stale(latestRev(id), comparableSnapshot(id));

--- a/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
@@ -209,7 +209,7 @@ public final class ProjectStore implements ConflictResolver {
 
   /** Compare-and-set commit as main: accepts only if {@code expectedRev} still matches. */
   public PushOutcome commitRevision(String id, Map<String, Object> snapshot, String expectedRev) {
-    return db.transaction(
+    return db.immediateTransaction(
         () -> {
           if (!Objects.equals(latestRev(id), expectedRev)) {
             return new PushOutcome.Stale(latestRev(id), comparableSnapshot(id));

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -610,7 +610,7 @@ public final class SpecStore implements ConflictResolver {
    * pushing the same row can never both win. Used by the sync engine on the main side.
    */
   public PushOutcome commitRevision(String id, Map<String, Object> snapshot, String expectedRev) {
-    return db.transaction(
+    return db.immediateTransaction(
         () -> {
           if (!Objects.equals(latestRev(id), expectedRev)) {
             return new PushOutcome.Stale(latestRev(id), comparableSnapshot(id));

--- a/sail-core/src/main/java/ai/singlr/sail/store/Sqlite.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/Sqlite.java
@@ -146,7 +146,22 @@ public final class Sqlite implements AutoCloseable {
   }
 
   public <T> T transaction(Supplier<T> work) {
-    execute("BEGIN");
+    return transaction("BEGIN", work);
+  }
+
+  /**
+   * Runs {@code work} under {@code BEGIN IMMEDIATE}, taking the write lock at the start of the
+   * transaction instead of on first write. A compare-and-set that reads then writes needs this:
+   * deferred {@code BEGIN} lets two writers both read the same revision before either writes, so
+   * the second's write fails on the now-stale snapshot rather than seeing the first and rejecting
+   * cleanly. Taking the lock up front serializes them, closing that read-then-write window.
+   */
+  public <T> T immediateTransaction(Supplier<T> work) {
+    return transaction("BEGIN IMMEDIATE", work);
+  }
+
+  private <T> T transaction(String begin, Supplier<T> work) {
+    execute(begin);
     try {
       var result = work.get();
       execute("COMMIT");

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
@@ -42,15 +42,37 @@ public final class SyncRpcServer {
 
   public void serve(Reader in, Writer out) throws IOException {
     for (var line = SyncWire.readFramed(in); line != null; line = SyncWire.readFramed(in)) {
-      switch (SyncWire.decodeRequest(line)) {
-        case SyncWire.Bye ignored -> {
-          return;
-        }
-        case SyncWire.Fetch fetch -> reply(out, fetched(fetch.entityType()));
-        case SyncWire.FetchFdes ignored -> reply(out, new SyncWire.Fdes(fdeRoster.entries()));
-        case SyncWire.Commit commit -> reply(out, onCommit(commit));
+      var request = SyncWire.decodeRequest(line);
+      if (request instanceof SyncWire.Bye) {
+        return;
       }
+      reply(out, respondTo(request));
     }
+  }
+
+  /**
+   * Computes one response, converting any store-side failure into a {@link SyncWire.Failed} the
+   * client can read, rather than letting it propagate and drop the session with no reply — the
+   * client must always be able to tell a refused commit from a broken connection. The clean {@link
+   * SyncWire.Rejected} staleness path is unaffected; only thrown failures land here.
+   */
+  private SyncWire.Response respondTo(SyncWire.Request request) {
+    try {
+      return switch (request) {
+        case SyncWire.Fetch fetch -> fetched(fetch.entityType());
+        case SyncWire.FetchFdes ignored -> new SyncWire.Fdes(fdeRoster.entries());
+        case SyncWire.Commit commit -> onCommit(commit);
+        case SyncWire.Bye ignored -> throw new IllegalStateException("Bye ends the session loop");
+      };
+    } catch (RuntimeException e) {
+      return new SyncWire.Failed(
+          "Main could not apply the request and made no change; retry the sync. Cause: "
+              + rootMessage(e));
+    }
+  }
+
+  private static String rootMessage(Throwable t) {
+    return Objects.toString(t.getMessage(), t.getClass().getSimpleName());
   }
 
   private static void reply(Writer out, SyncWire.Response response) throws IOException {

--- a/sail-core/src/test/java/ai/singlr/sail/store/FileStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FileStoreTest.java
@@ -15,6 +15,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CyclicBarrier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -224,5 +226,57 @@ class FileStoreTest {
     files.resolveConflict(id("a.txt"), null, Map.of("content", "theirs"));
 
     assertTrue(files.find("acme", "a.txt").isEmpty());
+  }
+
+  @Test
+  void concurrentCommitsAgainstTheSameBaseYieldOneWinnerAndOneCleanStale() throws Exception {
+    try (var db2 = Sqlite.open(tempDir.resolve("test.db"))) {
+      var files2 = new FileStore(db2);
+      for (var i = 0; i < 64; i++) {
+        var fid = id("race-" + i + ".txt");
+        var base = i + "-base";
+        files.applyRevision(fid, Map.of("content", "BASE"), base);
+
+        var gate = new CyclicBarrier(2);
+        var outcomes = new ConcurrentLinkedQueue<PushOutcome>();
+        var errors = new ConcurrentLinkedQueue<Throwable>();
+        var a = racer(files, fid, "A", base, gate, outcomes, errors);
+        var b = racer(files2, fid, "B", base, gate, outcomes, errors);
+        a.start();
+        b.start();
+        a.join();
+        b.join();
+
+        var iteration = i;
+        assertTrue(errors.isEmpty(), () -> "iteration " + iteration + " raced into " + errors);
+        assertEquals(
+            1,
+            outcomes.stream().filter(o -> o instanceof PushOutcome.Accepted).count(),
+            "exactly one writer wins the race");
+        assertEquals(
+            1,
+            outcomes.stream().filter(o -> o instanceof PushOutcome.Stale).count(),
+            "the loser is cleanly rejected as stale, never lost or errored");
+      }
+    }
+  }
+
+  private static Thread racer(
+      FileStore store,
+      String fid,
+      String content,
+      String base,
+      CyclicBarrier gate,
+      ConcurrentLinkedQueue<PushOutcome> outcomes,
+      ConcurrentLinkedQueue<Throwable> errors) {
+    return new Thread(
+        () -> {
+          try {
+            gate.await();
+            outcomes.add(store.commitRevision(fid, Map.of("content", content), base));
+          } catch (Throwable t) {
+            errors.add(t);
+          }
+        });
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 /** The server loop in isolation over a fake authority: framing, the write gate, and clean EOF. */
 class SyncRpcServerTest {
 
-  private static final class FakeMain implements MainReplica {
+  private static class FakeMain implements MainReplica {
     @Override
     public String id() {
       return "main";
@@ -105,5 +105,40 @@ class SyncRpcServerTest {
   void anUnknownEntityTypeCommitIsRefused() throws Exception {
     assertInstanceOf(
         SyncWire.Failed.class, serve(true, new SyncWire.Commit("bogus", "a", Map.of(), null)));
+  }
+
+  @Test
+  void aStoreExceptionOnCommitBecomesAFailedResponseNotADroppedSession() throws Exception {
+    var throwing =
+        new FakeMain() {
+          @Override
+          public CommitOutcome commit(
+              String entityId, Map<String, Object> snapshot, String expectedRev) {
+            throw new IllegalStateException("database is locked");
+          }
+        };
+    var out = new StringWriter();
+    var request = new SyncWire.Commit("spec", "a", Map.of(), null);
+
+    new SyncRpcServer(throwing, true).serve(new StringReader(SyncWire.encode(request) + "\n"), out);
+
+    assertInstanceOf(SyncWire.Failed.class, SyncWire.decodeResponse(out.toString().strip()));
+  }
+
+  @Test
+  void aStoreExceptionOnFetchBecomesAFailedResponse() throws Exception {
+    var throwing =
+        new FakeMain() {
+          @Override
+          public Set<String> entityIds() {
+            throw new IllegalStateException("database is locked");
+          }
+        };
+    var out = new StringWriter();
+
+    new SyncRpcServer(throwing, true)
+        .serve(new StringReader(SyncWire.encode(new SyncWire.Fetch("spec")) + "\n"), out);
+
+    assertInstanceOf(SyncWire.Failed.class, SyncWire.decodeResponse(out.toString().strip()));
   }
 }

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
@@ -77,12 +77,27 @@ public final class AgentSession {
     }
   }
 
-  /** Writes session metadata JSON inside the container. */
+  /** Writes session metadata JSON inside the container for an ad-hoc (non-spec) launch. */
   public void writeSession(String containerName, String task, String branch)
+      throws IOException, InterruptedException, TimeoutException {
+    writeSession(containerName, task, branch, "", "");
+  }
+
+  /**
+   * Writes session metadata JSON inside the container. The {@code specId} and {@code agentType} are
+   * the durable record of which spec this dispatch is for: the systemd unit's environment carries
+   * them too, but a successfully-exited transient unit is garbage-collected within seconds, taking
+   * its environment with it. The watcher therefore recovers them from this file when the unit is
+   * already gone, so a clean agent exit still produces a spec-attributed stop signal.
+   */
+  public void writeSession(
+      String containerName, String task, String branch, String specId, String agentType)
       throws IOException, InterruptedException, TimeoutException {
     var map = new LinkedHashMap<String, Object>();
     map.put("task", task);
     map.put("branch", branch);
+    map.put("spec_id", Objects.requireNonNullElse(specId, ""));
+    map.put("agent_type", Objects.requireNonNullElse(agentType, ""));
     map.put("started_at", Instant.now().toString());
     map.put("log_path", LOG_FILE);
     var json = YamlUtil.dumpJson(map);
@@ -355,7 +370,35 @@ public final class AgentSession {
                 "--property=ExecMainStatus",
                 "--property=Environment"));
     var result = shell.exec(cmd);
-    return parseExitState(result.ok() ? result.stdout() : "");
+    var state = parseExitState(result.ok() ? result.stdout() : "");
+    if (!state.specId().isBlank()) {
+      return state;
+    }
+    var durable = readSessionDescriptor(containerName);
+    return new ExitState(
+        state.active(),
+        state.exitCode(),
+        durable.specId(),
+        state.agentType().isBlank() ? durable.agentType() : state.agentType());
+  }
+
+  private record SessionDescriptor(String specId, String agentType) {}
+
+  /**
+   * Reads {@code spec_id}/{@code agent_type} from the durable session file. Used as the fallback
+   * when a collected unit no longer reports its environment; returns blanks for an ad-hoc session.
+   */
+  @SuppressWarnings("unchecked")
+  private SessionDescriptor readSessionDescriptor(String containerName)
+      throws IOException, InterruptedException, TimeoutException {
+    var cmd = ContainerExec.asDevUser(containerName, List.of("cat", SESSION_FILE));
+    var result = shell.exec(cmd);
+    if (!result.ok() || result.stdout().isBlank()) {
+      return new SessionDescriptor("", "");
+    }
+    var meta = (Map<String, Object>) YamlUtil.parseMap(result.stdout());
+    return new SessionDescriptor(
+        Objects.toString(meta.get("spec_id"), ""), Objects.toString(meta.get("agent_type"), ""));
   }
 
   static ExitState parseExitState(String show) {

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
@@ -548,4 +548,68 @@ class AgentSessionTest {
 
     assertTrue(state.active());
   }
+
+  @Test
+  void queryExitStatusRecoversSpecIdFromTheSessionFileWhenTheUnitWasCollected() throws Exception {
+    var shell =
+        new ScriptedShellExecutor()
+            .onOk(
+                "systemctl --user show sail-agent.service",
+                """
+                ActiveState=inactive
+                ExecMainStatus=0
+                Environment=
+                """)
+            .onOk(
+                "cat /home/dev/.sail/agent-session.json",
+                """
+                {"task":"t","branch":"b","spec_id":"v1-sync-commit-integrity","agent_type":"claude-code","started_at":"2026-06-30T16:55:14Z","log_path":"/home/dev/.sail/agent.log"}
+                """);
+    var session = new AgentSession(shell);
+
+    var state = session.queryExitStatus("sail-mast");
+
+    assertFalse(state.active(), "a successfully-exited unit is collected and reads as inactive");
+    assertEquals(0, state.exitCode());
+    assertEquals(
+        "v1-sync-commit-integrity",
+        state.specId(),
+        "spec id must survive unit garbage collection via the durable session file");
+    assertEquals("claude-code", state.agentType());
+  }
+
+  @Test
+  void queryExitStatusPrefersUnitEnvironmentWhileItIsStillPresent() throws Exception {
+    var shell =
+        new ScriptedShellExecutor()
+            .onOk(
+                "systemctl --user show sail-agent.service",
+                """
+                ActiveState=active
+                ExecMainStatus=0
+                Environment=SAIL_SPEC_ID=scrum-12 SAIL_AGENT=codex
+                """);
+    var session = new AgentSession(shell);
+
+    var state = session.queryExitStatus("acme");
+
+    assertTrue(state.active());
+    assertEquals("scrum-12", state.specId());
+    assertEquals("codex", state.agentType());
+  }
+
+  @Test
+  void writeSessionPersistsSpecIdAndAgentTypeForDurableRecovery() throws Exception {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
+    var session = new AgentSession(shell);
+
+    session.writeSession(
+        "acme", "implement auth", "branch", "v1-sync-commit-integrity", "claude-code");
+
+    var cmd = shell.invocations().getFirst();
+    assertTrue(cmd.contains("agent-session.json"));
+    assertTrue(cmd.contains("spec_id"), "session must persist spec_id for watcher recovery");
+    assertTrue(cmd.contains("v1-sync-commit-integrity"));
+    assertTrue(cmd.contains("claude-code"));
+  }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -559,7 +559,8 @@ public final class SailApiOperations implements ApiOperations {
       var session = new AgentSession(shell);
       session.ensureDirectory(project);
       session.writeTaskFile(project, task);
-      session.writeSession(project, task, Objects.requireNonNullElse(branch, ""));
+      session.writeSession(
+          project, task, Objects.requireNonNullElse(branch, ""), spec.id(), agentType);
       var agentCli = AgentCli.fromYamlName(agentType);
       var workDir = AgentSession.launchWorkDir(config.sshUser(), targetRepos);
       var command =

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
@@ -377,11 +377,26 @@ public final class AgentWatchCommand implements Runnable {
 
   static void emitSyntheticStop(
       StopPublisher publisher, String project, AgentSession.ExitState exit) {
-    if (publisher == null || Strings.isBlank(exit.specId())) {
+    if (publisher == null) {
+      return;
+    }
+    if (Strings.isBlank(exit.specId())) {
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|faint [watch] no spec id for "
+                  + project
+                  + "; ad-hoc session, no stop published|@"));
       return;
     }
     try {
       publisher.publish(syntheticStop(project, exit));
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|faint [watch] published stop for spec "
+                  + exit.specId()
+                  + " (exit "
+                  + exit.exitCode()
+                  + ")|@"));
     } catch (Exception e) {
       System.err.println(
           "  [watch] could not publish synthetic stop for " + project + ": " + e.getMessage());

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
@@ -258,7 +258,8 @@ public final class DispatchCommand implements Runnable {
     ensureSailSetup(shell, name);
     agentSession.ensureDirectory(name);
     agentSession.writeTaskFile(name, task);
-    agentSession.writeSession(name, task, Objects.requireNonNullElse(branchName, ""));
+    agentSession.writeSession(
+        name, task, Objects.requireNonNullElse(branchName, ""), nextSpec.id(), agentType);
 
     if (background) {
       var sshCmd =

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentWatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentWatchCommandTest.java
@@ -9,11 +9,13 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.api.Event;
 import ai.singlr.sail.engine.AgentSession;
+import ai.singlr.sail.engine.ScriptedShellExecutor;
 import java.time.Instant;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -213,6 +215,36 @@ class AgentWatchCommandTest {
     AgentWatchCommand.emitSyntheticStop(captured::set, "acme", exit);
 
     assertNull(captured.get());
+  }
+
+  @Test
+  void watcherProducesASpecAttributedStopWhenTheUnitWasAlreadyCollected() throws Exception {
+    var shell =
+        new ScriptedShellExecutor()
+            .onOk(
+                "systemctl --user show sail-agent.service",
+                """
+                ActiveState=inactive
+                ExecMainStatus=0
+                Environment=
+                """)
+            .onOk(
+                "cat /home/dev/.sail/agent-session.json",
+                """
+                {"task":"t","branch":"b","spec_id":"auth","agent_type":"claude-code","started_at":"2026-06-30T16:55:14Z","log_path":"/home/dev/.sail/agent.log"}
+                """);
+    var exit = new AgentSession(shell).queryExitStatus("acme");
+
+    var captured = new java.util.concurrent.atomic.AtomicReference<Event>();
+    AgentWatchCommand.emitSyntheticStop(captured::set, "acme", exit);
+
+    var event = captured.get();
+    assertNotNull(
+        event, "a clean exit on a collected unit must still publish a spec-attributed stop");
+    assertEquals(Event.WellKnownTypes.AGENT_SESSION_STOPPED, event.type());
+    assertEquals("auth", event.spec());
+    assertEquals("claude-code", event.agent());
+    assertEquals(0, event.data().get("exit_code"));
   }
 
   @Test


### PR DESCRIPTION
## What & why

A real `sail spec dispatch` of a spec (v1-sync-commit-integrity) ran to completion — the agent finished and opened a PR — but the spec stayed stuck in `in_progress` and **no review fired**. The autonomous loop silently dead-ended.

### Root cause (empirically reproduced)

The watcher's only source for "which spec just exited" was the systemd unit's `Environment` (`SAIL_SPEC_ID`), read via `systemctl show` *after* exit. A transient unit that exits **0 is garbage-collected within seconds**:

```
running:        Environment=SAIL_SPEC_ID=v1-sync-commit-integrity ...   ActiveState=active
3s after exit-0: Environment=                                            ActiveState=inactive
```

So `queryExitStatus` reads back an empty environment → `specId=""` → `emitSyntheticStop` treats it as an ad-hoc session and **drops the stop** → no `agent_session_stopped` → no `SpecLifecycleReactor` transition → no review. Failed units linger in `failed` state with their env intact, so **failures published while successes silently dead-ended** — backwards.

### Why existing tests missed it

`ReviewAgentLoopIT.theReviewLoopReachesDoneAgainstARealContainer` hand-feeds a perfect `agent_session_stopped` straight into `controller.onEvent(...)`, bypassing `queryExitStatus`/`emitSyntheticStop`/unit GC entirely. It proved the server reacts to a clean event and skipped the seam that produces it.

## Fix

Make the durable `agent-session.json` (written at launch, survives GC) the authoritative source of the spec id:

- `writeSession` persists `spec_id`/`agent_type`; `queryExitStatus` recovers them from the session file when the collected unit no longer reports its environment. Live-unit env path unchanged.
- Both spec-dispatch paths wired to persist it: **`DispatchCommand`** (CLI) and **`SailApiOperations.launchAgent`** (server / review pipeline). Ad-hoc `agent launch`/`run` correctly stay blank.
- `emitSyntheticStop` now logs what it published (or why it didn't) — `watch.log` is self-documenting instead of a silent dead-end.

## Tests (TDD, red→green)

- `AgentSessionTest`: reproduces the collected-unit spec-id loss and the durable recovery (+ env-precedence + persistence guards).
- `AgentWatchCommandTest`: a new test drives the **real** `queryExitStatus → emitSyntheticStop` seam against a collected-unit scenario — the path the IT hand-fed past. This is the regression that would have caught the bug.
- Full suites green: sail-harness 136 + sail-infra 1793, all coverage gates met.

## Follow-up (not in this PR)

The stuck `v1-sync-commit-integrity` spec (PR #93) needs a one-time unblock after this ships — its code fix is already done; only the lifecycle transition was lost.
