### PR TITLE
fix: log swallowed sync errors server-side + surface root cause

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
@@ -65,6 +65,7 @@ public final class SyncRpcServer {
         case SyncWire.Bye ignored -> throw new IllegalStateException("Bye ends the session loop");
       };
     } catch (RuntimeException e) {
+      System.err.println("  [sync] request failed, returning Failed to client: " + e);
       return new SyncWire.Failed(
           "Main could not apply the request and made no change; retry the sync. Cause: "
               + rootMessage(e));
@@ -72,7 +73,11 @@ public final class SyncRpcServer {
   }
 
   private static String rootMessage(Throwable t) {
-    return Objects.toString(t.getMessage(), t.getClass().getSimpleName());
+    var root = t;
+    while (root.getCause() != null && root.getCause() != root) {
+      root = root.getCause();
+    }
+    return Objects.toString(root.getMessage(), root.getClass().getSimpleName());
   }
 
   private static void reply(Writer out, SyncWire.Response response) throws IOException {

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
@@ -7,9 +7,13 @@ package ai.singlr.sail.sync;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -140,5 +144,54 @@ class SyncRpcServerTest {
         .serve(new StringReader(SyncWire.encode(new SyncWire.Fetch("spec")) + "\n"), out);
 
     assertInstanceOf(SyncWire.Failed.class, SyncWire.decodeResponse(out.toString().strip()));
+  }
+
+  @Test
+  void aWrappedStoreExceptionSurfacesTheRootCauseInTheFailedMessage() throws Exception {
+    var throwing =
+        new FakeMain() {
+          @Override
+          public CommitOutcome commit(
+              String entityId, Map<String, Object> snapshot, String expectedRev) {
+            throw new IllegalStateException(
+                "commit failed", new RuntimeException("database is locked"));
+          }
+        };
+    var out = new StringWriter();
+    var request = new SyncWire.Commit("spec", "a", Map.of(), null);
+
+    new SyncRpcServer(throwing, true).serve(new StringReader(SyncWire.encode(request) + "\n"), out);
+
+    var failed =
+        assertInstanceOf(SyncWire.Failed.class, SyncWire.decodeResponse(out.toString().strip()));
+    assertTrue(
+        failed.message().contains("database is locked"),
+        "the actionable root cause must surface, not the wrapper: " + failed.message());
+  }
+
+  @Test
+  void aSwallowedStoreExceptionIsLoggedServerSide() throws Exception {
+    var throwing =
+        new FakeMain() {
+          @Override
+          public CommitOutcome commit(
+              String entityId, Map<String, Object> snapshot, String expectedRev) {
+            throw new IllegalStateException("database is locked");
+          }
+        };
+    var request = new SyncWire.Commit("spec", "a", Map.of(), null);
+    var captured = new ByteArrayOutputStream();
+    var originalErr = System.err;
+    System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+    try {
+      new SyncRpcServer(throwing, true)
+          .serve(new StringReader(SyncWire.encode(request) + "\n"), new StringWriter());
+    } finally {
+      System.setErr(originalErr);
+    }
+
+    assertTrue(
+        captured.toString(StandardCharsets.UTF_8).contains("database is locked"),
+        "a swallowed store exception must leave a server-side diagnostic");
   }
 }


### PR DESCRIPTION
## What & why

Follow-up to the B4 sync error boundary (#93), addressing the MEDIUM + LOW findings from its review.

`SyncRpcServer.respondTo()` converts every store exception into a client `Failed` response — correct for the client — but **logged nothing server-side**. A genuine server bug (NPE, logic error) became indistinguishable from an expected store rejection and left no stack trace: the same silent-failure class B4 otherwise closes. Separately, `rootMessage()` read the *top* exception's message, so a wrapped store exception hid the actionable SQLite cause from the client.

## Fix
- Log the swallowed exception to stderr before returning `Failed` (server keeps a diagnostic; client contract unchanged).
- `rootMessage()` walks `getCause()` to the deepest cause, so the `Failed` message carries the real reason.

## Tests (TDD, red→green)
- `aSwallowedStoreExceptionIsLoggedServerSide` — captures stderr, asserts the exception is logged (was: nothing).
- `aWrappedStoreExceptionSurfacesTheRootCauseInTheFailedMessage` — asserts the root cause surfaces, not the wrapper (was: wrapper message only).
- Full sail-core green: 1275 tests, coverage gates met.
