### PR TITLE
fix: graceful shutdown of the control-plane server on SIGTERM (B3)

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -24,6 +24,7 @@ import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.WebauthnConfig;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.BindPolicy;
+import ai.singlr.sail.engine.GracefulShutdown;
 import ai.singlr.sail.engine.HostInfo;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
@@ -114,6 +115,8 @@ public final class ServerStartCommand implements Runnable {
     SailPaths.ensureDataDir(dbPath.getParent());
 
     var db = Sqlite.open(dbPath);
+    var shutdown = new GracefulShutdown().register(db);
+    Runtime.getRuntime().addShutdownHook(new Thread(shutdown::shutdown, "sail-shutdown"));
     var migrationResult =
         MigrationRunner.applyAll(
             db, MigrateCommand.REGISTRY, DataMigration.Prompter.NON_INTERACTIVE);
@@ -182,24 +185,24 @@ public final class ServerStartCommand implements Runnable {
     var auth =
         new SessionAwareAuth(new AuthSessionStore(db), new FdeStore(db), new TokenAuth(tokenStore));
 
-    try (var server =
-            new SailApiServer(
-                host,
-                port,
-                operations,
-                auth,
-                bus,
-                persister,
-                SailPaths.apiSocketPath(),
-                passkeyHandler,
-                specStore,
-                reviewController);
-        var sweeper = new ExpiredRowSweeper(dbPath);
-        var reconciler =
-            new StuckSpecReconciler(
-                dbPath,
-                StuckSpecReconciler.DEFAULT_THRESHOLD,
-                stranded -> surface(bus, stranded))) {
+    var server =
+        new SailApiServer(
+            host,
+            port,
+            operations,
+            auth,
+            bus,
+            persister,
+            SailPaths.apiSocketPath(),
+            passkeyHandler,
+            specStore,
+            reviewController);
+    var sweeper = new ExpiredRowSweeper(dbPath);
+    var reconciler =
+        new StuckSpecReconciler(
+            dbPath, StuckSpecReconciler.DEFAULT_THRESHOLD, stranded -> surface(bus, stranded));
+    shutdown.register(server).register(sweeper).register(reconciler);
+    try {
       server.start();
       sweeper.start();
       reconciler.start();
@@ -227,7 +230,7 @@ public final class ServerStartCommand implements Runnable {
       System.out.println(Ansi.AUTO.string("    @|faint Press Ctrl+C to stop.|@"));
       new CountDownLatch(1).await();
     } finally {
-      db.close();
+      shutdown.shutdown();
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/GracefulShutdown.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/GracefulShutdown.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Closes a set of {@link AutoCloseable} resources exactly once, newest-first, isolating failures so
+ * one bad close cannot strand the rest. The control-plane daemon registers this as a JVM shutdown
+ * hook: the server blocks on a latch until {@code systemctl stop}/upgrade sends SIGTERM, at which
+ * point the JVM does not unwind the stack — a try-with-resources never runs — so the hook is the
+ * only thing that drains in-flight review writes and closes the database cleanly. The same instance
+ * is also invoked from the normal exit path; the idempotency guard makes the two safe to race.
+ */
+public final class GracefulShutdown {
+
+  private final Deque<AutoCloseable> resources = new ArrayDeque<>();
+  private final AtomicBoolean done = new AtomicBoolean(false);
+
+  /** Registers a resource to close on shutdown. Resources close in reverse registration order. */
+  public synchronized GracefulShutdown register(AutoCloseable resource) {
+    resources.push(resource);
+    return this;
+  }
+
+  /** Closes every registered resource once, newest-first. Idempotent and failure-isolating. */
+  public void shutdown() {
+    if (!done.compareAndSet(false, true)) {
+      return;
+    }
+    List<AutoCloseable> ordered;
+    synchronized (this) {
+      ordered = new ArrayList<>(resources);
+    }
+    for (var resource : ordered) {
+      try {
+        resource.close();
+      } catch (Exception e) {
+        System.err.println("  [shutdown] failed to close " + resource + ": " + e);
+      }
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/GracefulShutdownTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/GracefulShutdownTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class GracefulShutdownTest {
+
+  @Test
+  void closesEveryResourceInReverseRegistrationOrder() {
+    var order = new ArrayList<String>();
+    var shutdown =
+        new GracefulShutdown()
+            .register(() -> order.add("db"))
+            .register(() -> order.add("server"))
+            .register(() -> order.add("sweeper"));
+
+    shutdown.shutdown();
+
+    assertEquals(
+        List.of("sweeper", "server", "db"),
+        order,
+        "resources must close newest-first, mirroring try-with-resources");
+  }
+
+  @Test
+  void isIdempotentSoTheHookAndTheNormalPathCannotDoubleClose() {
+    var closes = new AtomicInteger();
+    var shutdown = new GracefulShutdown().register(closes::incrementAndGet);
+
+    shutdown.shutdown();
+    shutdown.shutdown();
+
+    assertEquals(1, closes.get(), "the close body must run exactly once across repeated shutdowns");
+  }
+
+  @Test
+  void isolatesAFailingCloseSoTheRemainingResourcesStillClose() {
+    var order = new ArrayList<String>();
+    var shutdown =
+        new GracefulShutdown()
+            .register(() -> order.add("db"))
+            .register(
+                () -> {
+                  throw new IllegalStateException("boom");
+                })
+            .register(() -> order.add("sweeper"));
+
+    shutdown.shutdown();
+
+    assertEquals(
+        List.of("sweeper", "db"),
+        order,
+        "a single failing close must not strand the other resources");
+  }
+
+  @Test
+  void concurrentShutdownsCloseEachResourceExactlyOnce() throws Exception {
+    var closes = new AtomicInteger();
+    var shutdown = new GracefulShutdown().register(closes::incrementAndGet);
+    var gate = new CyclicBarrier(2);
+    Runnable racer =
+        () -> {
+          try {
+            gate.await();
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+          shutdown.shutdown();
+        };
+    var a = new Thread(racer);
+    var b = new Thread(racer);
+
+    a.start();
+    b.start();
+    a.join();
+    b.join();
+
+    assertEquals(1, closes.get(), "a SIGTERM hook racing the finally must still close once");
+  }
+}


### PR DESCRIPTION
## What & why

Closes v1-hardening blocker **B3**. The control-plane server blocks on a latch with the API server, sweeper, and reconciler in a try-with-resources whose `finally` closes the db. The systemd unit is `Type=simple`, so `systemctl stop` / upgrade sends **SIGTERM** and the JVM exits **without unwinding the stack** — the try-with-resources never runs. On every stop/upgrade, in-flight review-pipeline writes were interrupted and the db was left unclosed.

## Fix

A JVM shutdown hook is the only thing that runs on SIGTERM, so register one that closes the same resources.

- **`GracefulShutdown`** — closes each `AutoCloseable` exactly once, newest-first, isolating failures so one bad close can't strand the rest, guarded by a CAS so the hook and the normal-exit `finally` can race safely.
- **`ServerStartCommand`** registers the db the instant it opens (so a failed migration also closes cleanly), then the server/sweeper/reconciler, and installs the hook. Close order is `reconciler → sweeper → server → db`, matching the old try-with-resources. Closing the server drains in-flight reviews via `ReviewPipelineController.awaitCompletion(5000)` **before** the db they write to is closed.
- The latch-return/exception path calls the same idempotent `shutdown()` — **no double-close**.

## Tests (TDD, red→green)

`GracefulShutdownTest` (written first, failed on the missing class):
- closes in reverse registration order (the drain-before-db guarantee);
- idempotent across repeated shutdowns (hook + finally can't double-close);
- isolates a failing close so the rest still close;
- concurrent shutdowns close each resource exactly once (the SIGTERM-races-finally case).

Full sail-infra green: **1797 tests, coverage gates met.**

## Test boundary (honest)

The `GracefulShutdown` coordinator — the substance — is unit-tested for order, idempotency, failure-isolation, and concurrency. "SIGTERM fires the hook" is the JVM `addShutdownHook` contract, and the wiring (register resources + install hook) is a small reviewed change. An out-of-process test that boots the real server and sends SIGTERM end-to-end is the one residual gap; left as an optional follow-up rather than adding a heavy/flaky process-spawn harness.

## Out of scope

Switching the systemd unit type or `KillMode` tuning (the hook is sufficient).
