### PR TITLE
test: real-server SIGTERM integration test for graceful shutdown

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/engine/GracefulShutdown.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/GracefulShutdown.java
@@ -46,5 +46,6 @@ public final class GracefulShutdown {
         System.err.println("  [shutdown] failed to close " + resource + ": " + e);
       }
     }
+    System.out.println("  [shutdown] closed " + ordered.size() + " resource(s) cleanly");
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ServerStartShutdownIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ServerStartShutdownIT.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Boots the real control-plane server in a child JVM, sends it a genuine SIGTERM (what {@code
+ * systemctl stop}/upgrade delivers), and asserts the shutdown hook ran and closed the server's
+ * resources. The bug this guards: a {@code Type=simple} unit's SIGTERM does not unwind the stack,
+ * so a try-with-resources never runs — only a registered hook drains in-flight work and closes the
+ * database. Deterministic: it synchronizes on the server's "listening" line and on process exit
+ * (bounded {@code poll}/{@code waitFor}), never on sleeps. Runs under the {@code integration}
+ * profile; it needs a Unix JVM, not incus.
+ */
+class ServerStartShutdownIT {
+
+  private static final String MAIN_CLASS = "ai.singlr.sail.Main";
+  private static final String SENTINEL = "<<stream-closed>>";
+
+  @Test
+  void sigtermRunsTheShutdownHookAndClosesResources() throws Exception {
+    var home =
+        Files.createDirectories(Files.createTempDirectory("sail-shutdown-it").resolve("home"));
+
+    var java = Path.of(System.getProperty("java.home"), "bin", "java").toString();
+    var process =
+        new ProcessBuilder(
+                java,
+                "-cp",
+                System.getProperty("java.class.path"),
+                "--enable-native-access=ALL-UNNAMED",
+                "-Duser.home=" + home,
+                MAIN_CLASS,
+                "server",
+                "start",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                String.valueOf(freePort()))
+            .redirectErrorStream(true)
+            .start();
+    process.getOutputStream().close();
+
+    var lines = new LinkedBlockingQueue<String>();
+    var reader = new Thread(() -> drainInto(process, lines), "server-output-reader");
+    reader.setDaemon(true);
+    reader.start();
+
+    var transcript = new StringBuilder();
+    try {
+      var listening = awaitLine(lines, transcript, "Sail server listening", 60);
+      assertTrue(listening, "server should start and announce it is listening:\n" + transcript);
+
+      new ProcessBuilder("kill", "-TERM", String.valueOf(process.pid()))
+          .inheritIO()
+          .start()
+          .waitFor();
+
+      var cleaned = awaitLine(lines, transcript, "[shutdown] closed", 30);
+      var exited = process.waitFor(30, TimeUnit.SECONDS);
+      assertTrue(exited, "server must exit after SIGTERM:\n" + transcript);
+      assertTrue(
+          cleaned,
+          "the shutdown hook must run on SIGTERM and close resources cleanly (exit="
+              + process.exitValue()
+              + "):\n"
+              + transcript);
+    } finally {
+      process.destroyForcibly();
+    }
+  }
+
+  private static boolean awaitLine(
+      LinkedBlockingQueue<String> lines,
+      StringBuilder transcript,
+      String needle,
+      int timeoutSeconds)
+      throws InterruptedException {
+    for (var line = lines.poll(timeoutSeconds, TimeUnit.SECONDS);
+        line != null;
+        line = lines.poll(timeoutSeconds, TimeUnit.SECONDS)) {
+      if (line.equals(SENTINEL)) {
+        return false;
+      }
+      transcript.append(line).append('\n');
+      if (line.contains(needle)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void drainInto(Process process, LinkedBlockingQueue<String> lines) {
+    try (var reader =
+        new BufferedReader(
+            new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+      for (var line = reader.readLine(); line != null; line = reader.readLine()) {
+        lines.put(line);
+      }
+    } catch (IOException | InterruptedException ignored) {
+    } finally {
+      lines.add(SENTINEL);
+    }
+  }
+
+  private static int freePort() throws IOException {
+    try (var socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/GracefulShutdownTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/GracefulShutdownTest.java
@@ -6,7 +6,11 @@
 package ai.singlr.sail.engine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CyclicBarrier;
@@ -86,5 +90,26 @@ class GracefulShutdownTest {
     b.join();
 
     assertEquals(1, closes.get(), "a SIGTERM hook racing the finally must still close once");
+  }
+
+  @Test
+  void announcesCleanCompletionExactlyOnceSoAStopIsObservable() {
+    var shutdown = new GracefulShutdown().register(() -> {}).register(() -> {});
+    var captured = new ByteArrayOutputStream();
+    var originalOut = System.out;
+    System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+    try {
+      shutdown.shutdown();
+      shutdown.shutdown();
+    } finally {
+      System.setOut(originalOut);
+    }
+
+    var output = captured.toString(StandardCharsets.UTF_8);
+    assertTrue(output.contains("shutdown] closed 2"), "a clean stop must be observable: " + output);
+    assertEquals(
+        1,
+        output.lines().filter(l -> l.contains("shutdown] closed")).count(),
+        "the completion line must print exactly once");
   }
 }


### PR DESCRIPTION
## What & why

You were right that "SIGTERM fires the hook" shouldn't be left as an unverified JVM-contract assumption when we have a real-Ubuntu integration lane. This adds the end-to-end proof that B3 (#96) was missing.

`ServerStartShutdownIT` boots the **real control-plane server** in a child JVM (pointed at a temp `user.home`), waits for its "listening" line, sends a **genuine SIGTERM**, and asserts the shutdown hook ran and closed every resource cleanly. This is the exact behavior the bug broke (a `Type=simple` SIGTERM skips the try-with-resources) and the test fails on the pre-B3 code (no hook → no clean shutdown).

## Deterministic, not flaky

- Synchronizes on the server's **"listening"** line and on **process exit** via bounded `poll`/`waitFor` — never on `Thread.sleep`.
- A reader thread drains the child's merged stdout/stderr into a queue; a sentinel guarantees the waiter is never stranded.
- SIGTERM is sent with an explicit `kill -TERM <pid>` — faithful to what `systemctl stop` delivers. (Notably, `Process.destroy()` did **not** reliably run the JVM's shutdown hooks in this environment; `kill -TERM` does, and is the real-world signal.)
- Verified green **5×** consecutively while developing.

## Also

`GracefulShutdown` now announces `[shutdown] closed N resource(s) cleanly` once on completion — a useful operational "stopped cleanly" signal, and the deterministic observable the IT asserts on.

## Tests

- New `ServerStartShutdownIT` (integration lane; needs a Unix JVM, not incus).
- `GracefulShutdownTest` gains a completion-log assertion (prints exactly once).
- Full sail-infra unit lane green: 1798 tests, coverage gates met.

Runs in the integration lane (`integration.yml`) on PRs to main.
