### PR TITLE
test: cover the auto-upgrade decision logic; defer cosign client-verify (B5)

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/engine/AutoUpgrader.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/AutoUpgrader.java
@@ -12,10 +12,12 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 import picocli.CommandLine.Help.Ansi;
 
 /**
@@ -52,15 +54,19 @@ public final class AutoUpgrader {
     }
   }
 
-  /** Package-private for testing. */
   static boolean shouldSkip(String[] args) {
-    if ("dev".equals(SailVersion.version())) {
+    return shouldSkip(SailVersion.version(), System::getenv, args);
+  }
+
+  /** Pure skip decision; version and environment are injected so it is unit-tested. */
+  static boolean shouldSkip(String version, UnaryOperator<String> env, String[] args) {
+    if ("dev".equals(version)) {
       return true;
     }
-    if ("1".equals(System.getenv("SAIL_NO_UPDATE_CHECK"))) {
+    if ("1".equals(env.apply("SAIL_NO_UPDATE_CHECK"))) {
       return true;
     }
-    if ("1".equals(System.getenv("SAIL_AUTO_UPGRADED"))) {
+    if ("1".equals(env.apply("SAIL_AUTO_UPGRADED"))) {
       return true;
     }
     for (var arg : args) {
@@ -71,6 +77,34 @@ public final class AutoUpgrader {
     return false;
   }
 
+  /** Whether {@code latestVersion} is strictly newer than {@code currentVersion}. */
+  static boolean shouldUpgrade(String currentVersion, String latestVersion) {
+    return SemVer.parse(currentVersion).compareTo(SemVer.parse(latestVersion)) < 0;
+  }
+
+  /**
+   * Whether a downloaded artifact may be trusted: its SHA-256 matches the published checksum and it
+   * carries the expected executable magic for the platform. The {@code osName} is injected so the
+   * accept/reject decision is unit-tested.
+   */
+  public static boolean isAcceptable(byte[] binary, String expectedChecksum) {
+    return isAcceptable(binary, expectedChecksum, System.getProperty("os.name", ""));
+  }
+
+  static boolean isAcceptable(byte[] binary, String expectedChecksum, String osName) {
+    return checksumMatches(binary, expectedChecksum)
+        && PlatformDetector.isValidBinary(binary, osName);
+  }
+
+  private static boolean checksumMatches(byte[] binary, String expectedChecksum) {
+    try {
+      var actual = HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(binary));
+      return actual.equalsIgnoreCase(expectedChecksum);
+    } catch (NoSuchAlgorithmException e) {
+      return false;
+    }
+  }
+
   private static void doUpgrade(String[] args) throws Exception {
     var cacheFile = SailPaths.updateCheckFile();
     var latestVersionStr = UpdateChecker.doCheck(cacheFile);
@@ -78,11 +112,10 @@ public final class AutoUpgrader {
       return;
     }
 
-    var current = SemVer.parse(SailVersion.version());
-    var latest = SemVer.parse(latestVersionStr);
-    if (current.compareTo(latest) >= 0) {
+    if (!shouldUpgrade(SailVersion.version(), latestVersionStr)) {
       return;
     }
+    var latest = SemVer.parse(latestVersionStr);
 
     var versionTag = "v" + latest;
     var binaryPath = SailPaths.binaryPath();
@@ -97,15 +130,8 @@ public final class AutoUpgrader {
                 + "...|@"));
 
     var binary = ReleaseFetcher.downloadBinary(versionTag);
-
     var expectedChecksum = ReleaseFetcher.fetchChecksum(versionTag);
-    var digest = MessageDigest.getInstance("SHA-256");
-    var actualChecksum = HexFormat.of().formatHex(digest.digest(binary));
-    if (!actualChecksum.equalsIgnoreCase(expectedChecksum)) {
-      return;
-    }
-
-    if (!PlatformDetector.isValidBinary(binary)) {
+    if (!isAcceptable(binary, expectedChecksum)) {
       return;
     }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/AutoUpgraderTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/AutoUpgraderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.Test;
+
+class AutoUpgraderTest {
+
+  private static final UnaryOperator<String> NO_ENV = key -> null;
+
+  @Test
+  void skipsDevBuilds() {
+    assertTrue(AutoUpgrader.shouldSkip("dev", NO_ENV, new String[] {"up"}));
+  }
+
+  @Test
+  void skipsWhenUpdateCheckIsDisabled() {
+    assertTrue(
+        AutoUpgrader.shouldSkip("0.13.0", env("SAIL_NO_UPDATE_CHECK", "1"), new String[] {"up"}));
+  }
+
+  @Test
+  void skipsWhenAlreadyReExecedByAnEarlierUpgrade() {
+    assertTrue(
+        AutoUpgrader.shouldSkip("0.13.0", env("SAIL_AUTO_UPGRADED", "1"), new String[] {"up"}));
+  }
+
+  @Test
+  void skipsTheSelfHandlingAndInformationalSubcommands() {
+    for (var arg : new String[] {"upgrade", "--version", "-V", "--help", "-h"}) {
+      assertTrue(AutoUpgrader.shouldSkip("0.13.0", NO_ENV, new String[] {arg}), arg);
+    }
+  }
+
+  @Test
+  void doesNotSkipANormalReleaseCommand() {
+    assertFalse(AutoUpgrader.shouldSkip("0.13.0", NO_ENV, new String[] {"up", "kubera"}));
+  }
+
+  @Test
+  void upgradesOnlyWhenTheCurrentVersionIsStrictlyOlder() {
+    assertTrue(AutoUpgrader.shouldUpgrade("0.13.0", "0.13.1"));
+    assertFalse(AutoUpgrader.shouldUpgrade("0.13.1", "0.13.1"));
+    assertFalse(AutoUpgrader.shouldUpgrade("0.13.2", "0.13.1"));
+  }
+
+  @Test
+  void acceptsABinaryWithAMatchingChecksumAndTheExpectedExecutableFormat() {
+    var binary = new byte[] {0x7f, 'E', 'L', 'F', 4, 5, 6, 7};
+    assertTrue(AutoUpgrader.isAcceptable(binary, sha256(binary), "Linux"));
+  }
+
+  @Test
+  void rejectsATamperedBinaryWhoseChecksumDoesNotMatch() {
+    var binary = new byte[] {0x7f, 'E', 'L', 'F', 4, 5, 6, 7};
+    assertFalse(AutoUpgrader.isAcceptable(binary, "00ff", "Linux"));
+  }
+
+  @Test
+  void rejectsABinaryThatIsNotInTheExpectedExecutableFormat() {
+    var notElf = new byte[] {1, 2, 3, 4, 5, 6, 7, 8};
+    assertFalse(AutoUpgrader.isAcceptable(notElf, sha256(notElf), "Linux"));
+  }
+
+  private static UnaryOperator<String> env(String key, String value) {
+    return Map.of(key, value)::get;
+  }
+
+  private static String sha256(byte[] binary) {
+    try {
+      return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(binary));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
## What & why

Re-scoped `v1-verify-self-upgrade` after a reality check, then did the valuable half.

**Dropped B2 (client-side cosign verification) as over-engineering for v1.** OpenAI's Codex CLI installer (`curl … | sh`) verifies **SHA-256 only — no signature verification** (rustup/deno/bun likewise), relying on HTTPS + GitHub trust. sail already does **SHA-256 + refuse-unverifiable + ELF/Mach-O magic** in install.sh, and SHA + format in the upgrader — at or above that bar. We still *publish* cosign signatures and document the manual `cosign verify-blob`. Required client-side verification is deferred to a post-v1 backlog item.

**Did B5 — the real gap.** `AutoUpgrader` is a 174-line silent, automatic binary-swap path (download → verify → install → re-exec the new binary) with **zero tests**, historically the most fragile area.

## Change (no behavior change, no new patterns)

Extracted the decision logic into pure, injected methods — mirroring the existing `PlatformDetector.isValidBinary(binary, osName)` seam:

- `shouldSkip(version, env, args)` — dev build, `SAIL_NO_UPDATE_CHECK`, the `SAIL_AUTO_UPGRADED` re-exec loop guard, self-handling subcommands.
- `shouldUpgrade(current, latest)` — upgrade only when strictly older.
- `isAcceptable(binary, checksum, osName)` — accept only when SHA-256 matches **and** the executable magic is right; rejects a tampered binary or wrong format.

`doUpgrade` now delegates to these tested decisions; the networked orchestration stays thin glue. (Confirmed in passing: the upgrader already re-execs the freshly-installed **new** binary immediately via `reExec`, guarded against looping — correct, just previously untested.)

## Tests (TDD, red→green)

`AutoUpgraderTest` — 9 cases covering every skip condition, the version gate, and accept/reject incl. **a tampered binary whose checksum doesn't match**. Full sail-infra green: 1807 tests, coverage gates met.
