### PR TITLE
feat: stream live agent logs for dispatched Claude agents (v1-stream-agent-logs)

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/engine/AgentCli.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/AgentCli.java
@@ -105,6 +105,25 @@ public enum AgentCli {
       String model,
       String reasoningEffort,
       String claudeSettingsPath) {
+    return headlessCommand(
+        taskFile, fullPermissions, model, reasoningEffort, claudeSettingsPath, false);
+  }
+
+  /**
+   * Same as {@link #headlessCommand(String, boolean, String, String, String)} but, when {@code
+   * stream} is true, makes Claude Code emit newline-delimited JSON events ({@code --output-format
+   * stream-json --verbose}) instead of a single final result, so {@code agent.log} fills live
+   * during a long-running dispatch. This must be scoped to the background dispatch path only: the
+   * review/foreground paths parse the agent's final {@code json} block and would break under
+   * streaming output. Codex already streams a readable transcript, so the flag is a no-op for it.
+   */
+  public String headlessCommand(
+      String taskFile,
+      boolean fullPermissions,
+      String model,
+      String reasoningEffort,
+      String claudeSettingsPath,
+      boolean stream) {
     var task = "\"$(cat " + taskFile + ")\"";
     return switch (this) {
       case CLAUDE_CODE -> {
@@ -112,7 +131,8 @@ public enum AgentCli {
         var perm = fullPermissions ? " --dangerously-skip-permissions" : "";
         var settings =
             Strings.isBlank(claudeSettingsPath) ? "" : " --settings " + claudeSettingsPath;
-        yield binaryName + " --print" + settings + perm + " -p " + task;
+        var streamFormat = stream ? " --output-format stream-json --verbose" : "";
+        yield binaryName + " --print" + streamFormat + settings + perm + " -p " + task;
       }
       case CODEX -> {
         var perm = fullPermissions ? " --dangerously-bypass-approvals-and-sandbox" : "";

--- a/sail-core/src/main/java/ai/singlr/sail/engine/AgentLogRenderer.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/AgentLogRenderer.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import ai.singlr.sail.config.YamlUtil;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Turns a single line of an agent log into a human-readable progress line.
+ *
+ * <p>Dispatched Claude Code agents stream newline-delimited JSON events ({@code --output-format
+ * stream-json}); this renderer detects such a line and collapses it to readable output — assistant
+ * text, a one-line tool-call summary, a tool-result status, or the final result. Any line that is
+ * not a recognised stream-json event (Codex's already-readable transcript, or a pre-stream-json
+ * log) passes through untouched, so the same renderer is correct for both agents and backward
+ * compatible with old logs.
+ */
+public final class AgentLogRenderer {
+
+  private AgentLogRenderer() {}
+
+  private static final int SUMMARY_LIMIT = 160;
+
+  private static final List<String> SUMMARY_KEYS =
+      List.of("command", "file_path", "path", "pattern", "url", "description", "prompt");
+
+  /**
+   * Renders one raw log line. Returns the readable form for stream-json events, the line unchanged
+   * for plain text, and an empty string for events that carry no progress to show (e.g. the noisy
+   * {@code system/init} event).
+   */
+  public static String render(String line) {
+    if (line == null || line.isBlank()) {
+      return "";
+    }
+    Map<String, Object> event;
+    try {
+      event = YamlUtil.parseMap(line);
+    } catch (RuntimeException e) {
+      return line;
+    }
+    if (!(event.get("type") instanceof String type)) {
+      return line;
+    }
+    return switch (type) {
+      case "assistant" -> renderAssistant(event);
+      case "user" -> renderUser(event);
+      case "result" -> renderResult(event);
+      case "system" -> "";
+      default -> line;
+    };
+  }
+
+  private static String renderAssistant(Map<String, Object> event) {
+    var lines = new ArrayList<String>();
+    for (var block : contentBlocks(event)) {
+      switch (Objects.toString(block.get("type"), "")) {
+        case "text" -> {
+          var text = Objects.toString(block.get("text"), "").strip();
+          if (!text.isEmpty()) {
+            lines.add(text);
+          }
+        }
+        case "tool_use" ->
+            lines.add(
+                "⚙ "
+                    + Objects.toString(block.get("name"), "tool")
+                    + summarizeInput(block.get("input")));
+        default -> {}
+      }
+    }
+    return String.join("\n", lines);
+  }
+
+  private static String renderUser(Map<String, Object> event) {
+    var lines = new ArrayList<String>();
+    for (var block : contentBlocks(event)) {
+      if ("tool_result".equals(block.get("type"))) {
+        lines.add(Boolean.TRUE.equals(block.get("is_error")) ? "  ↳ error" : "  ↳ ok");
+      }
+    }
+    return String.join("\n", lines);
+  }
+
+  private static String renderResult(Map<String, Object> event) {
+    var result = Objects.toString(event.get("result"), "").strip();
+    return result.isEmpty() ? "" : "── result ──\n" + result;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Map<String, Object>> contentBlocks(Map<String, Object> event) {
+    if (event.get("message") instanceof Map<?, ?> message
+        && message.get("content") instanceof List<?> content) {
+      return content.stream()
+          .filter(b -> b instanceof Map<?, ?>)
+          .map(b -> (Map<String, Object>) b)
+          .toList();
+    }
+    return List.of();
+  }
+
+  private static String summarizeInput(Object input) {
+    if (!(input instanceof Map<?, ?> map) || map.isEmpty()) {
+      return "";
+    }
+    for (var key : SUMMARY_KEYS) {
+      var value = map.get(key);
+      if (value != null) {
+        return "(" + truncate(oneLine(value.toString())) + ")";
+      }
+    }
+    return "(" + truncate(oneLine(map.keySet().toString())) + ")";
+  }
+
+  private static String oneLine(String value) {
+    return value.replace('\n', ' ').replace('\r', ' ').strip();
+  }
+
+  private static String truncate(String value) {
+    return value.length() <= SUMMARY_LIMIT ? value : value.substring(0, SUMMARY_LIMIT - 1) + "…";
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/engine/AgentCliTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/AgentCliTest.java
@@ -93,6 +93,32 @@ class AgentCliTest {
   }
 
   @Test
+  void headlessCommandClaudeCodeStreamingAddsStreamJson() {
+    var cmd = AgentCli.CLAUDE_CODE.headlessCommand(TASK, true, null, null, null, true);
+
+    assertTrue(
+        cmd.contains("claude --print --output-format stream-json --verbose"),
+        "streaming dispatch emits newline-delimited JSON events");
+    assertTrue(cmd.contains("-p \"$(cat " + TASK + ")\""));
+  }
+
+  @Test
+  void headlessCommandClaudeCodeNonStreamingHasNoStreamJson() {
+    var cmd = AgentCli.CLAUDE_CODE.headlessCommand(TASK, true, null, null, null, false);
+
+    assertFalse(cmd.contains("stream-json"));
+  }
+
+  @Test
+  void headlessCommandCodexIgnoresStreamFlag() {
+    var streamed = AgentCli.CODEX.headlessCommand(TASK, true, null, null, null, true);
+    var plain = AgentCli.CODEX.headlessCommand(TASK, true, null, null, null, false);
+
+    assertEquals(plain, streamed, "Codex streams readable text already; the flag is a no-op");
+    assertFalse(streamed.contains("stream-json"));
+  }
+
+  @Test
   void headlessCommandClaudeCodeWithoutPermissions() {
     var cmd = AgentCli.CLAUDE_CODE.headlessCommand(TASK, false);
 

--- a/sail-core/src/test/java/ai/singlr/sail/engine/AgentLogRendererTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/AgentLogRendererTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class AgentLogRendererTest {
+
+  @Test
+  void rendersAssistantText() {
+    var line =
+        """
+        {"type":"assistant","message":{"content":[{"type":"text","text":"Reading the config file."}]}}""";
+
+    assertEquals("Reading the config file.", AgentLogRenderer.render(line));
+  }
+
+  @Test
+  void rendersToolUseAsOneLineSummary() {
+    var line =
+        """
+        {"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"mvn test"}}]}}""";
+
+    var rendered = AgentLogRenderer.render(line);
+
+    assertTrue(rendered.contains("Bash"), "tool name must be shown");
+    assertTrue(rendered.contains("mvn test"), "a one-line summary of the input must be shown");
+    assertFalse(rendered.contains("\n"), "tool calls render to a single line");
+  }
+
+  @Test
+  void rendersToolResultStatus() {
+    var ok =
+        """
+        {"type":"user","message":{"content":[{"type":"tool_result","content":"done"}]}}""";
+    var err =
+        """
+        {"type":"user","message":{"content":[{"type":"tool_result","is_error":true,"content":"boom"}]}}""";
+
+    assertFalse(AgentLogRenderer.render(ok).isEmpty(), "a tool result must produce a status line");
+    assertTrue(
+        AgentLogRenderer.render(err).toLowerCase().contains("error"),
+        "an errored tool result must be marked as such");
+  }
+
+  @Test
+  void surfacesFinalResult() {
+    var line =
+        """
+        {"type":"result","subtype":"success","result":"All tests pass."}""";
+
+    assertTrue(
+        AgentLogRenderer.render(line).contains("All tests pass."),
+        "the terminal result event carries the final summary and must not be lost");
+  }
+
+  @Test
+  void skipsSystemInitEvent() {
+    var line =
+        """
+        {"type":"system","subtype":"init","model":"claude","tools":["Bash"]}""";
+
+    assertEquals("", AgentLogRenderer.render(line), "the noisy init event is not shown");
+  }
+
+  @Test
+  void passesPlainTextThrough() {
+    var line = "Codex: applying patch to src/main.rs";
+
+    assertEquals(line, AgentLogRenderer.render(line), "non-JSON transcript lines pass through");
+  }
+
+  @Test
+  void passesNonStreamJsonObjectThrough() {
+    var line = "key: a human readable colon line";
+
+    assertEquals(
+        line,
+        AgentLogRenderer.render(line),
+        "a plain line that happens to parse as a map but has no stream-json type is left untouched");
+  }
+
+  @Test
+  void toleratesMalformedJson() {
+    var line = "{not valid json";
+
+    assertEquals(line, AgentLogRenderer.render(line));
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/engine/AgentLogRendererTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/AgentLogRendererTest.java
@@ -93,4 +93,10 @@ class AgentLogRendererTest {
 
     assertEquals(line, AgentLogRenderer.render(line));
   }
+
+  @Test
+  void passesCommentAndBareScalarLinesThroughWithoutCrashing() {
+    assertEquals("# Summary of changes", AgentLogRenderer.render("# Summary of changes"));
+    assertEquals("Building the project now", AgentLogRenderer.render("Building the project now"));
+  }
 }

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
@@ -243,7 +243,7 @@ public final class AgentSession {
     var cli = Objects.requireNonNullElse(agentCli, AgentCli.CLAUDE_CODE);
     var settingsPath = cli == AgentCli.CLAUDE_CODE ? ClaudeCodeHookConfig.SETTINGS_PATH : null;
     var agentCmd =
-        cli.headlessCommand(TASK_FILE, fullPermissions, model, reasoningEffort, settingsPath);
+        cli.headlessCommand(TASK_FILE, fullPermissions, model, reasoningEffort, settingsPath, true);
     var effectiveSpec = Objects.requireNonNullElse(specId, "");
     var effectiveAgent = agentType == null || agentType.isBlank() ? cli.yamlName() : agentType;
     var script =

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
@@ -208,6 +208,41 @@ class AgentSessionTest {
   }
 
   @Test
+  void buildBackgroundLaunchCommandStreamsClaudeOutput() {
+    var cmd =
+        AgentSession.buildBackgroundLaunchCommand(
+            "acme", "dev", "/home/dev/workspace", false, AgentCli.CLAUDE_CODE);
+
+    var joined = String.join(" ", cmd);
+    assertTrue(
+        joined.contains("--output-format stream-json --verbose"),
+        "dispatched Claude agents must stream incremental events so the log fills live");
+  }
+
+  @Test
+  void buildForegroundTaskCommandDoesNotStream() {
+    var cmd =
+        AgentSession.buildForegroundTaskCommand(
+            "acme", "dev", "/home/dev/workspace", false, AgentCli.CLAUDE_CODE);
+
+    var joined = String.join(" ", cmd);
+    assertFalse(
+        joined.contains("stream-json"),
+        "foreground/review path keeps its non-streaming final-result output");
+  }
+
+  @Test
+  void buildBackgroundLaunchCommandCodexDoesNotGetStreamFlag() {
+    var cmd =
+        AgentSession.buildBackgroundLaunchCommand(
+            "acme", "dev", "/home/dev/workspace", false, AgentCli.CODEX);
+
+    var joined = String.join(" ", cmd);
+    assertFalse(
+        joined.contains("stream-json"), "Codex already streams readable text; no flag added");
+  }
+
+  @Test
   void buildBackgroundLaunchCommandPassesEmptySpecForAdHocLaunches() {
     var cmd =
         AgentSession.buildBackgroundLaunchCommand(
@@ -259,7 +294,7 @@ class AgentSessionTest {
     var joined = String.join(" ", cmd);
     assertTrue(
         joined.contains(
-            "claude --print --settings "
+            "claude --print --output-format stream-json --verbose --settings "
                 + ClaudeCodeHookConfig.SETTINGS_PATH
                 + " --dangerously-skip-permissions"));
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLogCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLogCommand.java
@@ -6,13 +6,17 @@
 package ai.singlr.sail.commands;
 
 import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.AgentLogRenderer;
 import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ShellExecutor;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -64,9 +68,18 @@ public final class AgentLogCommand implements Runnable {
     if (follow) {
       var tailCmd = ContainerExec.asDevUser(name, List.of("tail", "-f", logPath));
       var pb = new ProcessBuilder(tailCmd);
-      pb.inheritIO();
+      pb.redirectErrorStream(true);
       var process = pb.start();
-      try {
+      try (var reader =
+          new BufferedReader(
+              new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+        String line;
+        while ((line = reader.readLine()) != null) {
+          var rendered = AgentLogRenderer.render(line);
+          if (!rendered.isEmpty()) {
+            System.out.println(rendered);
+          }
+        }
         process.waitFor();
       } finally {
         process.destroyForcibly();
@@ -103,7 +116,18 @@ public final class AgentLogCommand implements Runnable {
         return;
       }
 
-      System.out.print(result.stdout());
+      System.out.print(renderLines(result.stdout()));
     }
+  }
+
+  private static String renderLines(String raw) {
+    var out = new StringBuilder();
+    for (var line : raw.split("\n", -1)) {
+      var rendered = AgentLogRenderer.render(line);
+      if (!rendered.isEmpty()) {
+        out.append(rendered).append('\n');
+      }
+    }
+    return out.toString();
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLogCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLogCommand.java
@@ -75,9 +75,9 @@ public final class AgentLogCommand implements Runnable {
               new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
         String line;
         while ((line = reader.readLine()) != null) {
-          var rendered = AgentLogRenderer.render(line);
-          if (!rendered.isEmpty()) {
-            System.out.println(rendered);
+          var out = renderForLog(line, json);
+          if (!out.isEmpty()) {
+            System.out.println(out);
           }
         }
         process.waitFor();
@@ -118,6 +118,14 @@ public final class AgentLogCommand implements Runnable {
 
       System.out.print(renderLines(result.stdout()));
     }
+  }
+
+  /**
+   * Output form for one log line: the raw line under {@code --json} so machine consumers (and the
+   * GUI's live stream) get the structured event verbatim, otherwise the human-rendered form.
+   */
+  static String renderForLog(String line, boolean json) {
+    return json ? line : AgentLogRenderer.render(line);
   }
 
   private static String renderLines(String raw) {

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentLogCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentLogCommandTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class AgentLogCommandTest {
+
+  private static final String STREAM_EVENT =
+      "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"Reading.\"}]}}";
+
+  @Test
+  void jsonOutputStreamsTheRawStructuredLineForMachineConsumers() {
+    assertEquals(
+        STREAM_EVENT,
+        AgentLogCommand.renderForLog(STREAM_EVENT, true),
+        "--json (incl. --follow --json) must stream raw NDJSON events, not human-rendered text");
+  }
+
+  @Test
+  void humanOutputRendersStreamJsonToReadableText() {
+    assertEquals("Reading.", AgentLogCommand.renderForLog(STREAM_EVENT, false));
+  }
+}


### PR DESCRIPTION
## Problem
A dispatched Claude Code agent produced **no observable output until it finished**. `sail agent log <project> --follow` tails `agent.log`, but the agent ran as `claude --print` (non-streaming) — so the log stayed **0 bytes for the entire run**, then got one final dump at exit. The operator could not tell a working agent from a hung one, watch progress, or intervene early.

Codex already streams a readable transcript, so this was specific to the Claude `--print` invocation.

## Change
- **Scoped streaming flag.** `AgentCli.headlessCommand(..., boolean stream)` emits `claude --print --output-format stream-json --verbose ...` when streaming. `buildBackgroundLaunchCommand` (dispatch) passes `stream=true`; `buildForegroundTaskCommand` and `ContainerReviewAgentRunner` keep `stream=false` and are **unchanged** — so review findings still parse (`FindingParser` untouched). Codex needs no flag.
- **`AgentLogRenderer`.** Detects stream-json lines and renders each event to a readable line — assistant text, a one-line `tool_use` summary, `tool_result` status, and the terminal `result` summary. Plain-text lines (Codex, pre-stream-json logs) pass through untouched, so it is format-detecting and backward compatible.
- **`AgentLogCommand`.** Renders both the live `--follow` path and the bounded `--tail` path. The `--json` machine path is left emitting raw lines.

## Tests (TDD)
- `AgentSessionTest` / `AgentCliTest`: the dispatch command for Claude contains `--output-format stream-json --verbose`; the foreground/review/Codex commands do **not**. Watched the dispatch test fail on `main` first.
- `AgentLogRendererTest`: assistant text, tool call, tool-result status, final result each render to the expected readable line; plain text and malformed JSON pass through unchanged.

Full suite (1807 tests) green; jacoco coverage gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)