### PR TITLE
fix: containers trust the box owner's workstation key, not the sync key

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
@@ -137,6 +137,16 @@ public final class SailPaths {
   }
 
   /**
+   * The box owner's workstation (laptop) SSH public key: {@code ~/.sail/workstation_key.pub}. This
+   * is the human key an engineer connects to project containers with — distinct from the machine
+   * {@link #syncKeyPath() sync key}. Each box has a single owner, so one workstation key authorizes
+   * that owner into the box's containers.
+   */
+  public static Path workstationPublicKeyPath() {
+    return SAIL_DIR.resolve("workstation_key.pub");
+  }
+
+  /**
    * Resolves the project descriptor path for a project. Checks in order:
    *
    * <ol>

--- a/sail-core/src/main/java/ai/singlr/sail/ssh/SshPublicKey.java
+++ b/sail-core/src/main/java/ai/singlr/sail/ssh/SshPublicKey.java
@@ -34,7 +34,11 @@ public record SshPublicKey(String type, String blob, String comment, String fing
     if (Strings.isBlank(input)) {
       throw new IllegalArgumentException("SSH public key is empty.");
     }
-    var parts = input.strip().split("\\s+", 3);
+    var line = input.strip();
+    if (line.indexOf('\n') >= 0 || line.indexOf('\r') >= 0) {
+      throw new IllegalArgumentException("SSH public key must be a single line.");
+    }
+    var parts = line.split("\\s+", 3);
     if (parts.length < 2) {
       throw new IllegalArgumentException(
           "Not a valid SSH public key. Expected '<type> <base64> [comment]'.");
@@ -62,6 +66,18 @@ public record SshPublicKey(String type, String blob, String comment, String fing
   /** The canonical single-line form for an {@code authorized_keys} entry. */
   public String line() {
     return Strings.isBlank(comment) ? type + " " + blob : type + " " + blob + " " + comment;
+  }
+
+  /**
+   * The conventional OpenSSH private-key filename for this key's algorithm (e.g. {@code
+   * id_ed25519}, {@code id_rsa}, {@code id_ecdsa}) — used to point a connect snippet at the
+   * matching {@code IdentityFile} instead of guessing {@code id_ed25519}.
+   */
+  public String defaultPrivateKeyName() {
+    if (type.startsWith("ecdsa-")) {
+      return "id_ecdsa";
+    }
+    return "id_" + (type.startsWith("ssh-") ? type.substring("ssh-".length()) : type);
   }
 
   private static boolean declaredTypeMatchesBlob(String type, byte[] blob) {

--- a/sail-core/src/test/java/ai/singlr/sail/ssh/SshPublicKeyTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/ssh/SshPublicKeyTest.java
@@ -71,4 +71,19 @@ class SshPublicKeyTest {
         IllegalArgumentException.class,
         () -> SshPublicKey.parse("ssh-rsa " + realEd25519Blob + " spoofed"));
   }
+
+  @Test
+  void rejectsMultiLineInputSoItCannotInjectAnExtraAuthorizedKeysLine() {
+    var twoKeys = TestSshKeys.ed25519("a", null) + "\n" + TestSshKeys.ed25519("b", null);
+    assertThrows(IllegalArgumentException.class, () -> SshPublicKey.parse(twoKeys));
+  }
+
+  @Test
+  void defaultPrivateKeyNameMapsAlgorithmToConventionalFilename() {
+    assertEquals(
+        "id_ed25519", new SshPublicKey("ssh-ed25519", "", null, "").defaultPrivateKeyName());
+    assertEquals("id_rsa", new SshPublicKey("ssh-rsa", "", null, "").defaultPrivateKeyName());
+    assertEquals(
+        "id_ecdsa", new SshPublicKey("ecdsa-sha2-nistp256", "", null, "").defaultPrivateKeyName());
+  }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ConnectCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ConnectCommand.java
@@ -13,10 +13,12 @@ import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ProjectDefinitions;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.engine.WorkstationIdentity;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -97,15 +99,33 @@ public final class ConnectCommand implements Runnable {
         Objects.requireNonNullElse(serverUser, System.getProperty("user.name"));
     var containerUser = resolveContainerUser(name);
 
+    var identityFile = WorkstationIdentity.identityFile();
+
     if (json) {
       System.out.println(
           YamlUtil.dumpJson(
-              connectJson(name, resolvedServerIp, resolvedServerUser, containerIp, containerUser)));
+              connectJson(
+                  name,
+                  resolvedServerIp,
+                  resolvedServerUser,
+                  containerIp,
+                  containerUser,
+                  identityFile,
+                  WorkstationIdentity.registered().isPresent())));
       return;
     }
 
+    if (WorkstationIdentity.registered().isEmpty()) {
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|yellow ⚠|@ No workstation key is registered on this box; the snippet below"
+                  + " assumes ~/.ssh/id_ed25519. If the container rejects your key, register the"
+                  + " one you connect with, then re-create the project:"));
+      System.out.println(Ansi.AUTO.string("    @|bold " + WorkstationIdentity.SET_KEY_HINT + "|@"));
+    }
     System.out.println(
-        connectSnippet(resolvedServerIp, resolvedServerUser, name, containerIp, containerUser));
+        connectSnippet(
+            resolvedServerIp, resolvedServerUser, name, containerIp, containerUser, identityFile));
   }
 
   /**
@@ -122,31 +142,44 @@ public final class ConnectCommand implements Runnable {
   }
 
   static Map<String, Object> connectJson(
-      String name, String serverIp, String serverUser, String containerIp, String containerUser) {
+      String name,
+      String serverIp,
+      String serverUser,
+      String containerIp,
+      String containerUser,
+      String identityFile,
+      boolean workstationKeySet) {
     var map = new LinkedHashMap<String, Object>();
     map.put("project", name);
     map.put("server_ip", serverIp);
     map.put("server_user", serverUser);
     map.put("container_ip", containerIp);
     map.put("container_user", containerUser);
+    map.put("identity_file", identityFile);
+    map.put("workstation_key_set", workstationKeySet);
     return map;
   }
 
   static String connectSnippet(
-      String serverIp, String serverUser, String name, String containerIp, String containerUser) {
+      String serverIp,
+      String serverUser,
+      String name,
+      String containerIp,
+      String containerUser,
+      String identityFile) {
     return """
         # Add to ~/.ssh/config on your Mac:
 
         Host singular-server
             HostName %s
             User %s
-            IdentityFile ~/.ssh/id_ed25519
+            IdentityFile %s
 
         Host %s
             HostName %s
             User %s
             ProxyJump singular-server
-            IdentityFile ~/.ssh/id_ed25519
+            IdentityFile %s
 
         # Then connect:
         #   ssh %s
@@ -157,9 +190,11 @@ public final class ConnectCommand implements Runnable {
         .formatted(
             serverIp,
             serverUser,
+            identityFile,
             name,
             containerIp,
             containerUser,
+            identityFile,
             name,
             containerUser,
             name,

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostConfigSetCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostConfigSetCommand.java
@@ -11,7 +11,11 @@ import ai.singlr.sail.config.WebauthnConfig;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.NetworkDetector;
 import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.ssh.SshPublicKey;
+import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
@@ -32,6 +36,7 @@ public final class HostConfigSetCommand implements Runnable {
   private static final Set<String> SETTABLE_KEYS =
       Set.of(
           "server-ip",
+          "ssh-public-key",
           "webauthn-rp-id",
           "webauthn-rp-name",
           "webauthn-origin",
@@ -76,6 +81,11 @@ public final class HostConfigSetCommand implements Runnable {
 
     validate(key, value);
 
+    if ("ssh-public-key".equals(key)) {
+      applyWorkstationKey();
+      return;
+    }
+
     var hostYamlPath = SailPaths.hostConfigPath();
     if (!Files.exists(hostYamlPath)) {
       throw new IllegalStateException("Server not initialized. Run 'sail host init' first.");
@@ -107,6 +117,43 @@ public final class HostConfigSetCommand implements Runnable {
     }
   }
 
+  private void applyWorkstationKey() throws IOException {
+    var dest = SailPaths.workstationPublicKeyPath();
+    if (dryRun) {
+      System.out.println("[dry-run] Would set ssh-public-key in " + dest);
+      return;
+    }
+    var written = writeWorkstationKey(dest, value);
+    if (json) {
+      var map = new LinkedHashMap<String, Object>();
+      map.put("key", key);
+      map.put("value", written.line());
+      map.put("status", "updated");
+      System.out.println(YamlUtil.dumpJson(map));
+      return;
+    }
+    System.out.println(
+        Ansi.AUTO.string("  @|bold,green ✓|@ ssh-public-key set (" + written.fingerprint() + ")"));
+  }
+
+  /**
+   * Validates and writes the box owner's workstation public key, returning the parsed key.
+   * Package-private so the parse/write behaviour is unit-tested without root or a real host.
+   */
+  static SshPublicKey writeWorkstationKey(Path dest, String value) throws IOException {
+    var key = SshPublicKey.parse(value);
+    SailPaths.ensureDataDir(dest.getParent());
+    Files.writeString(dest, key.line() + "\n");
+    Files.setPosixFilePermissions(
+        dest,
+        Set.of(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.GROUP_READ,
+            PosixFilePermission.OTHERS_READ));
+    return key;
+  }
+
   static void validate(String key, String value) {
     switch (key) {
       case "server-ip" -> {
@@ -115,6 +162,7 @@ public final class HostConfigSetCommand implements Runnable {
               "Invalid IPv4 address: '" + value + "'. Expected format: 192.168.1.100");
         }
       }
+      case "ssh-public-key" -> SshPublicKey.parse(value);
       case "webauthn-rp-id" -> {
         if (!RP_ID.matcher(value).matches()) {
           throw new IllegalArgumentException(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostInitCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostInitCommand.java
@@ -20,6 +20,7 @@ import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SystemdServiceInstaller;
+import ai.singlr.sail.ssh.SshPublicKey;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -64,6 +65,14 @@ public final class HostInitCommand implements Runnable {
           "Server's public IP address (for SSH config generation in 'sail project connect').")
   private String serverIp;
 
+  @Option(
+      names = "--ssh-public-key",
+      description =
+          "Your workstation SSH public key, authorized into this box's project containers so you"
+              + " can connect from your laptop. Set it later with 'sail host config set"
+              + " ssh-public-key'.")
+  private String sshPublicKey;
+
   @Option(names = "--yes", description = "Skip confirmation prompts (for non-interactive use).")
   private boolean yes;
 
@@ -87,6 +96,9 @@ public final class HostInitCommand implements Runnable {
     }
 
     var isZfs = HostYaml.BACKEND_ZFS.equals(storage);
+    if (Strings.isNotBlank(sshPublicKey)) {
+      SshPublicKey.parse(sshPublicKey);
+    }
 
     if (!json) {
       Banner.printBranding(System.out, Ansi.AUTO);
@@ -94,6 +106,10 @@ public final class HostInitCommand implements Runnable {
 
     if (!dryRun && !ConsoleHelper.isRoot()) {
       throw new IllegalStateException("Root privileges required. Run with: sudo sail host init");
+    }
+
+    if (Strings.isNotBlank(sshPublicKey) && !dryRun) {
+      HostConfigSetCommand.writeWorkstationKey(SailPaths.workstationPublicKeyPath(), sshPublicKey);
     }
 
     var hostYamlPath = SailPaths.hostConfigPath();

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/InteractiveIdentity.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/InteractiveIdentity.java
@@ -15,9 +15,9 @@ import picocli.CommandLine.Help.Ansi;
  * Answers a synced descriptor's per-developer placeholders when {@code project create} provisions
  * it. Git identity is prompted — offering this box's {@code git config} as a default to accept or
  * override — so each engineer's containers commit as them even when their box has a different (or
- * no) global identity. {@code ${SSH_PUBLIC_KEY}} stays box-resolved from the sail sync key, never
- * typed. When the box cannot prompt ({@code --yes}/{@code --json}/no TTY) it falls back to the
- * box's own identity and fails loud with the one command that fixes it.
+ * no) global identity. {@code ${SSH_PUBLIC_KEY}} stays box-resolved from the box owner's registered
+ * workstation key, never typed. When the box cannot prompt ({@code --yes}/{@code --json}/no TTY) it
+ * falls back to the box's own identity and fails loud with the one command that fixes it.
  */
 public final class InteractiveIdentity implements UnaryOperator<String> {
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCreateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectCreateCommand.java
@@ -24,6 +24,7 @@ import ai.singlr.sail.engine.ProvisionListener;
 import ai.singlr.sail.engine.ProvisionTracker;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.engine.WorkstationIdentity;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -199,7 +200,14 @@ public final class ProjectCreateCommand implements Runnable {
       var serverIp = hostYaml.serverIp();
       var serverUser = System.getProperty("user.name");
       if (serverIp != null) {
-        Banner.printSshConfig(config.name(), serverIp, serverUser, r.ipv4(), System.out, Ansi.AUTO);
+        Banner.printSshConfig(
+            config.name(),
+            serverIp,
+            serverUser,
+            r.ipv4(),
+            WorkstationIdentity.identityFile(),
+            System.out,
+            Ansi.AUTO);
       } else {
         System.out.println();
         System.out.println(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectDemoCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectDemoCommand.java
@@ -170,7 +170,8 @@ public final class ProjectDemoCommand implements Runnable {
       var serverIp = hostYaml.serverIp();
       var serverUser = System.getProperty("user.name");
       if (serverIp != null) {
-        Banner.printSshConfig(config.name(), serverIp, serverUser, r.ipv4(), out, ansi);
+        Banner.printSshConfig(
+            config.name(), serverIp, serverUser, r.ipv4(), "~/.ssh/id_ed25519", out, ansi);
       }
 
       var ports = ContainerExec.queryServicePorts(shell, config.name());

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
@@ -504,6 +504,7 @@ public final class Banner {
       String serverIp,
       String serverUser,
       String containerIp,
+      String identityFile,
       PrintStream out,
       Ansi ansi) {
     out.println();
@@ -512,13 +513,13 @@ public final class Banner {
     out.println(amber(ansi, "    @|faint Host singular-server|@"));
     out.println(amber(ansi, "    @|faint     HostName " + serverIp + "|@"));
     out.println(amber(ansi, "    @|faint     User " + serverUser + "|@"));
-    out.println(amber(ansi, "    @|faint     IdentityFile ~/.ssh/id_ed25519|@"));
+    out.println(amber(ansi, "    @|faint     IdentityFile " + identityFile + "|@"));
     out.println();
     out.println(amber(ansi, "    @|faint Host " + name + "|@"));
     out.println(amber(ansi, "    @|faint     HostName " + containerIp + "|@"));
     out.println(amber(ansi, "    @|faint     User dev|@"));
     out.println(amber(ansi, "    @|faint     ProxyJump singular-server|@"));
-    out.println(amber(ansi, "    @|faint     IdentityFile ~/.ssh/id_ed25519|@"));
+    out.println(amber(ansi, "    @|faint     IdentityFile " + identityFile + "|@"));
     out.println();
     out.println(
         amber(ansi, "    @|bold \u2192 Zed:|@     zed ssh://dev@" + name + "/home/dev/workspace"));

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/LocalIdentity.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/LocalIdentity.java
@@ -7,8 +7,8 @@ package ai.singlr.sail.engine;
 
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.PlaceholderResolver;
+import ai.singlr.sail.ssh.SshPublicKey;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -16,11 +16,12 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * Answers a project definition's personal-field placeholders from <em>this</em> box: the git
- * identity from {@code git config --global}, and {@code ${SSH_PUBLIC_KEY}} from the box's sail
- * identity key — the same key {@code sail join} registers with main. Resolution happens once, when
- * a project is provisioned, so the synced definition stays identity-free and each engineer's
- * containers commit as them and trust only their own key. A missing value fails loud with the one
- * command that fixes it, rather than silently provisioning with someone else's identity.
+ * identity from {@code git config --global}, and {@code ${SSH_PUBLIC_KEY}} from the box owner's
+ * workstation key ({@link SailPaths#workstationPublicKeyPath()}) — the human key an engineer SSHes
+ * into containers with, distinct from the machine sync key. Resolution happens once, when a project
+ * is provisioned, so the synced definition stays identity-free and each box's containers trust
+ * their owner's laptop key. A missing value fails loud with the one command that fixes it, rather
+ * than silently provisioning a container no laptop can reach.
  */
 public final class LocalIdentity {
 
@@ -32,9 +33,9 @@ public final class LocalIdentity {
     this.sshPublicKeyPath = sshPublicKeyPath;
   }
 
-  /** This box's identity: real git config and the sail sync public key. */
+  /** This box's identity: real git config and the box owner's workstation public key. */
   public static LocalIdentity detect() {
-    return new LocalIdentity(new ShellExecutor(false), SailPaths.syncPublicKeyPath());
+    return new LocalIdentity(new ShellExecutor(false), SailPaths.workstationPublicKeyPath());
   }
 
   /**
@@ -82,21 +83,18 @@ public final class LocalIdentity {
   }
 
   private String sshPublicKey() {
-    try {
-      var key = Files.readString(sshPublicKeyPath).strip();
-      if (Strings.isBlank(key)) {
-        throw new IllegalStateException(missingKeyMessage());
-      }
-      return key;
-    } catch (IOException e) {
-      throw new IllegalStateException(missingKeyMessage());
-    }
+    return WorkstationIdentity.registeredAt(sshPublicKeyPath)
+        .map(SshPublicKey::line)
+        .orElseThrow(() -> new IllegalStateException(missingKeyMessage()));
   }
 
   private String missingKeyMessage() {
-    return "This box has no sail identity key yet ("
-        + sshPublicKeyPath
-        + ").\n  It is created when you run 'sail join' or 'sail host ssh-identity'.";
+    return """
+        This box has no valid workstation SSH key set (%s), so a container here can't authorize \
+        you to connect from your laptop.
+          Set it once with the public key you SSH with:
+            %s"""
+        .formatted(sshPublicKeyPath, WorkstationIdentity.SET_KEY_HINT);
   }
 
   private String run(List<String> command) {

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/WorkstationIdentity.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/WorkstationIdentity.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import ai.singlr.sail.ssh.SshPublicKey;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * The box owner's workstation SSH key — the human key authorized into this box's project containers
+ * (see {@link SailPaths#workstationPublicKeyPath()}). Connect snippets read it to point their
+ * {@code IdentityFile} at the matching local private key instead of guessing {@code id_ed25519},
+ * and to warn when it is unset (a container provisioned without it trusts no laptop).
+ */
+public final class WorkstationIdentity {
+
+  /**
+   * The one command that registers a box's workstation key — shared so the guidance can't drift.
+   */
+  public static final String SET_KEY_HINT =
+      "sail host config set ssh-public-key \"$(cat ~/.ssh/id_ed25519.pub)\"";
+
+  private WorkstationIdentity() {}
+
+  /** The registered workstation key, or empty when the box owner has not set one. */
+  public static Optional<SshPublicKey> registered() {
+    return registeredAt(SailPaths.workstationPublicKeyPath());
+  }
+
+  static Optional<SshPublicKey> registeredAt(Path path) {
+    if (!Files.isRegularFile(path)) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(SshPublicKey.parse(Files.readString(path).strip()));
+    } catch (IOException | RuntimeException e) {
+      return Optional.empty();
+    }
+  }
+
+  /** The Mac-side {@code IdentityFile} a connect snippet should reference for this box's owner. */
+  public static String identityFile() {
+    return identityFileFor(registered());
+  }
+
+  static String identityFileFor(Optional<SshPublicKey> key) {
+    return "~/.ssh/" + key.map(SshPublicKey::defaultPrivateKeyName).orElse("id_ed25519");
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ConnectCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ConnectCommandTest.java
@@ -15,7 +15,9 @@ class ConnectCommandTest {
 
   @Test
   void snippetUsesTheProjectsContainerUserNotAHardcodedDev() {
-    var snippet = ConnectCommand.connectSnippet("10.0.0.1", "uday", "acme", "10.1.1.5", "engineer");
+    var snippet =
+        ConnectCommand.connectSnippet(
+            "10.0.0.1", "uday", "acme", "10.1.1.5", "engineer", "~/.ssh/id_ed25519");
 
     assertTrue(snippet.contains("User engineer"), "container ssh user from the definition");
     assertTrue(snippet.contains("zed ssh://engineer@acme/home/engineer/workspace"));
@@ -23,9 +25,23 @@ class ConnectCommandTest {
   }
 
   @Test
-  void jsonReportsTheResolvedContainerUser() {
-    var map = ConnectCommand.connectJson("acme", "10.0.0.1", "uday", "10.1.1.5", "engineer");
+  void snippetPointsIdentityFileAtTheRegisteredKey() {
+    var snippet =
+        ConnectCommand.connectSnippet(
+            "10.0.0.1", "uday", "acme", "10.1.1.5", "engineer", "~/.ssh/id_rsa");
+
+    assertTrue(snippet.contains("IdentityFile ~/.ssh/id_rsa"), "uses the derived identity file");
+    assertFalse(snippet.contains("id_ed25519"), "no hardcoded ed25519 when another key is set");
+  }
+
+  @Test
+  void jsonReportsTheResolvedContainerUserAndKeyStatus() {
+    var map =
+        ConnectCommand.connectJson(
+            "acme", "10.0.0.1", "uday", "10.1.1.5", "engineer", "~/.ssh/id_ed25519", false);
     assertEquals("engineer", map.get("container_user"));
     assertEquals("acme", map.get("project"));
+    assertEquals("~/.ssh/id_ed25519", map.get("identity_file"));
+    assertEquals(false, map.get("workstation_key_set"));
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/HostConfigSetCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/HostConfigSetCommandTest.java
@@ -237,4 +237,51 @@ class HostConfigSetCommandTest {
             () -> HostConfigSetCommand.validate("webauthn-origin", "http://localhost:7070/"));
     assertTrue(thrown.getMessage().contains("trailing slash"));
   }
+
+  @Test
+  void validateRejectsAMalformedSshPublicKey() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> HostConfigSetCommand.validate("ssh-public-key", "not a real key"));
+  }
+
+  @Test
+  void writeWorkstationKeyStoresTheCanonicalLine(@TempDir Path tmp) throws Exception {
+    var dest = tmp.resolve("workstation_key.pub");
+    var value = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILDpT0mMcK sumesh@macbook";
+
+    var written = HostConfigSetCommand.writeWorkstationKey(dest, value);
+
+    assertEquals(value, written.line(), "returns the parsed key whose canonical line was written");
+    assertEquals(value + "\n", java.nio.file.Files.readString(dest));
+  }
+
+  @Test
+  void dryRunForSshPublicKeyReportsWithoutRequiringRootOrHostYaml() {
+    var cmd = new CommandLine(new Sail());
+    cmd.setErr(new PrintWriter(new StringWriter()));
+
+    var exit =
+        cmd.execute(
+            "host",
+            "config",
+            "set",
+            "ssh-public-key",
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILDpT0mMcK me@mac",
+            "--dry-run");
+
+    assertEquals(0, exit);
+    assertTrue(capturedOut.toString().contains("ssh-public-key"));
+  }
+
+  @Test
+  void rejectsAMalformedSshPublicKeyThroughTheCommand() {
+    var cmd = new CommandLine(new Sail());
+    cmd.setErr(new PrintWriter(new StringWriter()));
+
+    var exit =
+        cmd.execute("host", "config", "set", "ssh-public-key", "not-a-real-key", "--dry-run");
+
+    assertNotEquals(0, exit, "a malformed key must be rejected");
+  }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/HostInitCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/HostInitCommandTest.java
@@ -6,16 +6,32 @@
 package ai.singlr.sail.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.singlr.sail.Sail;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
 
 class HostInitCommandTest {
 
   @TempDir Path home;
+
+  @Test
+  void anInvalidWorkstationKeyAbortsBeforeAnyProvisioning() {
+    var cmd = new CommandLine(new Sail());
+    cmd.setOut(new PrintWriter(new StringWriter()));
+    cmd.setErr(new PrintWriter(new StringWriter()));
+
+    var exit = cmd.execute("host", "init", "--ssh-public-key", "not-a-real-key", "--dry-run");
+
+    assertNotEquals(0, exit, "a malformed workstation key must fail host init fast");
+  }
 
   @Test
   void apiServiceIsNotInstalledOnAFreshHome() {

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/InteractiveIdentityTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/InteractiveIdentityTest.java
@@ -111,8 +111,9 @@ class InteractiveIdentityTest {
 
   @Test
   void sshPublicKeyIsBoxResolvedNeverPrompted() throws Exception {
-    var id = resolver(boxWithKey("ssh-ed25519 AAAAKEY"), true);
+    var key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILDpT0mMcK mady@box";
+    var id = resolver(boxWithKey(key), true);
 
-    assertEquals("ssh-ed25519 AAAAKEY", id.apply(PlaceholderResolver.SSH_PUBLIC_KEY));
+    assertEquals(key, id.apply(PlaceholderResolver.SSH_PUBLIC_KEY));
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/LocalIdentityTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/LocalIdentityTest.java
@@ -25,7 +25,7 @@ class LocalIdentityTest {
 
   @BeforeEach
   void setUp() {
-    keyPath = dir.resolve("sync_ed25519.pub");
+    keyPath = dir.resolve("workstation_key.pub");
   }
 
   private LocalIdentity identity(Map<String, String> gitConfig) {
@@ -39,10 +39,21 @@ class LocalIdentityTest {
     assertEquals("mady@example.com", identity.valueFor("GIT_EMAIL"));
   }
 
+  private static final String VALID_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILDpT0mMcK mady@box";
+
   @Test
   void resolvesSshKeyFromTheBoxIdentityFile() throws IOException {
-    Files.writeString(keyPath, "ssh-ed25519 AAAAMADY mady@box\n");
-    assertEquals("ssh-ed25519 AAAAMADY mady@box", identity(Map.of()).valueFor("SSH_PUBLIC_KEY"));
+    Files.writeString(keyPath, VALID_KEY + "\n");
+    assertEquals(VALID_KEY, identity(Map.of()).valueFor("SSH_PUBLIC_KEY"));
+  }
+
+  @Test
+  void failsLoudRatherThanInjectingAnUnparseableKey() throws IOException {
+    Files.writeString(keyPath, "this is not a valid ssh key\n");
+    var error =
+        assertThrows(
+            IllegalStateException.class, () -> identity(Map.of()).valueFor("SSH_PUBLIC_KEY"));
+    assertTrue(error.getMessage().contains("sail host config set ssh-public-key"));
   }
 
   @Test
@@ -57,7 +68,10 @@ class LocalIdentityTest {
     var error =
         assertThrows(
             IllegalStateException.class, () -> identity(Map.of()).valueFor("SSH_PUBLIC_KEY"));
-    assertTrue(error.getMessage().contains("sail join"));
+    assertTrue(
+        error.getMessage().contains("sail host config set ssh-public-key"),
+        "must point at the workstation-key setter, not the machine sync key: "
+            + error.getMessage());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectDefinitionsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectDefinitionsTest.java
@@ -82,8 +82,9 @@ class ProjectDefinitionsTest {
 
   @Test
   void resolveForProvisioningFillsPlaceholdersFromTheLocalBox() throws Exception {
-    var keyPath = dir.resolve("sync_ed25519.pub");
-    Files.writeString(keyPath, "ssh-ed25519 AAAAMADY mady@box\n");
+    var workstationKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILDpT0mMcK mady@box";
+    var keyPath = dir.resolve("workstation_key.pub");
+    Files.writeString(keyPath, workstationKey + "\n");
     var identity = new LocalIdentity(gitConfig("Mady M", "mady@example.com"), keyPath);
 
     var config =
@@ -96,7 +97,7 @@ class ProjectDefinitionsTest {
 
     assertEquals("Mady M", config.git().name());
     assertEquals("mady@example.com", config.git().email());
-    assertEquals("ssh-ed25519 AAAAMADY mady@box", config.ssh().authorizedKeys().getFirst());
+    assertEquals(workstationKey, config.ssh().authorizedKeys().getFirst());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/WorkstationIdentityTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/WorkstationIdentityTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.ssh.SshPublicKey;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WorkstationIdentityTest {
+
+  private static final String ED25519 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILDpT0mMcK sumesh@mac";
+
+  @Test
+  void identityFileFollowsTheRegisteredKeysAlgorithm() {
+    assertEquals(
+        "~/.ssh/id_ed25519",
+        WorkstationIdentity.identityFileFor(Optional.of(SshPublicKey.parse(ED25519))));
+    assertEquals(
+        "~/.ssh/id_rsa",
+        WorkstationIdentity.identityFileFor(
+            Optional.of(new SshPublicKey("ssh-rsa", "", null, ""))));
+  }
+
+  @Test
+  void identityFileDefaultsToEd25519WhenNoKeyIsRegistered() {
+    assertEquals("~/.ssh/id_ed25519", WorkstationIdentity.identityFileFor(Optional.empty()));
+  }
+
+  @Test
+  void registeredReadsAValidKeyFromDisk(@TempDir Path dir) throws Exception {
+    var path = dir.resolve("workstation_key.pub");
+    Files.writeString(path, ED25519 + "\n");
+
+    var key = WorkstationIdentity.registeredAt(path);
+
+    assertTrue(key.isPresent());
+    assertEquals("ssh-ed25519", key.orElseThrow().type());
+  }
+
+  @Test
+  void registeredIsEmptyWhenMissingOrUnparseable(@TempDir Path dir) throws Exception {
+    assertTrue(WorkstationIdentity.registeredAt(dir.resolve("absent.pub")).isEmpty());
+    var garbage = dir.resolve("garbage.pub");
+    Files.writeString(garbage, "not a key at all\n");
+    assertTrue(WorkstationIdentity.registeredAt(garbage).isEmpty());
+  }
+}


### PR DESCRIPTION
## The bug (multi-machine, node-vs-main)

A fellow FDE (Sumesh) installed sail on his own bare-metal server, `sail sync`'d to main, created a project — but **couldn't SSH from his MacBook into the container** via the printed ProxyJump, even after adding the `sail project connect` snippet. His agent's `/root/.ssh/config` workaround "fixed" it only because it made him connect *from the server*.

**Root cause:** a container's `~dev/.ssh/authorized_keys` is filled from `${SSH_PUBLIC_KEY}`, which resolved to the box's **machine sync key** (`~/.sail/sync_ed25519.pub`) — generated by `sail join`, "separate from the engineer's personal keys." So a node's container trusted a key no laptop holds. It *appeared* to work on main only because those projects were authored with a concrete Mac key before catalog redaction (latent on main too — destroy + re-create from the catalog breaks identically).

## The fix (per-box, single-owner)

`${SSH_PUBLIC_KEY}` now resolves to the box owner's **workstation key** (`~/.sail/workstation_key.pub`). Each box has one owner, so one workstation key authorizes them into the box's containers.

- **Resolution + validation:** `LocalIdentity` reads *and validates* the workstation key (fail-loud; never injects an unparseable key into `authorized_keys`). The redact→placeholder→resolve sync lifecycle is unchanged — only the resolution *target* is corrected, so the shared catalog stays identity-free.
- **Capture:** `sail host config set ssh-public-key "<key>"` and `sail host init --ssh-public-key`.
- **Honest output:** `connect`/`create` snippets derive `IdentityFile` from the registered key's algorithm (`id_ed25519`/`id_rsa`/`id_ecdsa`) and inform when no key is registered.
- **Hardening:** `SshPublicKey.parse` rejects multi-line input (no `authorized_keys` line injection).
- The **sync key** is untouched (sync lane + gateway); we only stopped it leaking into containers.

## Rigor

Built the full key/auth matrix before changing anything (per-box single-owner ⇒ no roster/sync-layer churn needed). TDD throughout, then an **adversarial self-review** whose findings — a misplaced warning I'd introduced, an unvalidated-key injection path, test gaps, and DRY/text-block/parse cleanups — are all addressed.

Full suites green: **sail-core 1289 + sail-infra 1820, coverage gates met.**
