### PR TITLE
feat(host): auto-detect workstation key for 'host config set ssh-public-key'

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostConfigSetCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostConfigSetCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SyncConfig;
 import ai.singlr.sail.config.WebauthnConfig;
@@ -18,8 +19,10 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -52,7 +55,11 @@ public final class HostConfigSetCommand implements Runnable {
   @Parameters(index = "0", description = "Configuration key (e.g. 'server-ip', 'webauthn-rp-id').")
   private String key;
 
-  @Parameters(index = "1", description = "Value to set.")
+  @Parameters(
+      index = "1",
+      arity = "0..1",
+      description =
+          "Value to set. Omit for ssh-public-key to auto-detect it from your authorized_keys.")
   private String value;
 
   @Option(names = "--dry-run", description = "Print what would change without writing.")
@@ -79,12 +86,15 @@ public final class HostConfigSetCommand implements Runnable {
           "Unknown config key: '" + key + "'. Settable keys: " + String.join(", ", SETTABLE_KEYS));
     }
 
-    validate(key, value);
-
     if ("ssh-public-key".equals(key)) {
       applyWorkstationKey();
       return;
     }
+
+    if (Strings.isBlank(value)) {
+      throw new IllegalArgumentException("A value is required for '" + key + "'.");
+    }
+    validate(key, value);
 
     var hostYamlPath = SailPaths.hostConfigPath();
     if (!Files.exists(hostYamlPath)) {
@@ -119,29 +129,97 @@ public final class HostConfigSetCommand implements Runnable {
 
   private void applyWorkstationKey() throws IOException {
     var dest = SailPaths.workstationPublicKeyPath();
+    var chosen = resolveWorkstationKey(value, detectWorkstationKeys(authorizedKeysPath()));
     if (dryRun) {
-      System.out.println("[dry-run] Would set ssh-public-key in " + dest);
+      System.out.println(
+          "[dry-run] Would set ssh-public-key (" + chosen.fingerprint() + ") in " + dest);
       return;
     }
-    var written = writeWorkstationKey(dest, value);
+    writeKey(dest, chosen);
     if (json) {
       var map = new LinkedHashMap<String, Object>();
       map.put("key", key);
-      map.put("value", written.line());
+      map.put("value", chosen.line());
       map.put("status", "updated");
       System.out.println(YamlUtil.dumpJson(map));
       return;
     }
     System.out.println(
-        Ansi.AUTO.string("  @|bold,green ✓|@ ssh-public-key set (" + written.fingerprint() + ")"));
+        Ansi.AUTO.string("  @|bold,green ✓|@ ssh-public-key set (" + chosen.fingerprint() + ")"));
   }
 
   /**
-   * Validates and writes the box owner's workstation public key, returning the parsed key.
+   * The box owner's workstation key: the explicit value if given, else the sole key already
+   * authorized to SSH into this box (their laptop key). Fails loud when none or several are found
+   * so the owner is never guessed for.
+   */
+  static SshPublicKey resolveWorkstationKey(String explicitValue, List<SshPublicKey> detected) {
+    if (Strings.isNotBlank(explicitValue)) {
+      return SshPublicKey.parse(explicitValue);
+    }
+    if (detected.size() == 1) {
+      return detected.getFirst();
+    }
+    if (detected.isEmpty()) {
+      throw new IllegalArgumentException(
+          "No workstation public key found in your authorized_keys. Pass the one you connect"
+              + " with:\n  sudo sail host config set ssh-public-key \"<your public key>\"");
+    }
+    var options =
+        detected.stream()
+            .map(
+                k ->
+                    "  - "
+                        + k.fingerprint()
+                        + (Strings.isBlank(k.comment()) ? "" : " " + k.comment()))
+            .collect(Collectors.joining("\n"));
+    throw new IllegalArgumentException(
+        "Multiple keys are authorized on this box; pass the one you connect with:\n" + options);
+  }
+
+  /** The keys already authorized to SSH into this box (the invoking user's authorized_keys). */
+  static List<SshPublicKey> detectWorkstationKeys(Path authorizedKeys) {
+    if (!Files.isRegularFile(authorizedKeys)) {
+      return List.of();
+    }
+    try {
+      return Files.readAllLines(authorizedKeys).stream()
+          .map(String::strip)
+          .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+          .map(HostConfigSetCommand::parseQuietly)
+          .flatMap(Optional::stream)
+          .toList();
+    } catch (IOException e) {
+      return List.of();
+    }
+  }
+
+  private static Optional<SshPublicKey> parseQuietly(String line) {
+    try {
+      return Optional.of(SshPublicKey.parse(line));
+    } catch (RuntimeException e) {
+      return Optional.empty();
+    }
+  }
+
+  private static Path authorizedKeysPath() {
+    var sudoUser = System.getenv("SUDO_USER");
+    var home =
+        Strings.isNotBlank(sudoUser)
+            ? Path.of("/home", sudoUser)
+            : Path.of(System.getProperty("user.home"));
+    return home.resolve(".ssh").resolve("authorized_keys");
+  }
+
+  /**
+   * Validates and writes an explicit workstation key value, returning the parsed key.
    * Package-private so the parse/write behaviour is unit-tested without root or a real host.
    */
   static SshPublicKey writeWorkstationKey(Path dest, String value) throws IOException {
-    var key = SshPublicKey.parse(value);
+    return writeKey(dest, SshPublicKey.parse(value));
+  }
+
+  private static SshPublicKey writeKey(Path dest, SshPublicKey key) throws IOException {
     SailPaths.ensureDataDir(dest.getParent());
     Files.writeString(dest, key.line() + "\n");
     Files.setPosixFilePermissions(
@@ -162,7 +240,6 @@ public final class HostConfigSetCommand implements Runnable {
               "Invalid IPv4 address: '" + value + "'. Expected format: 192.168.1.100");
         }
       }
-      case "ssh-public-key" -> SshPublicKey.parse(value);
       case "webauthn-rp-id" -> {
         if (!RP_ID.matcher(value).matches()) {
           throw new IllegalArgumentException(

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/LocalIdentity.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/LocalIdentity.java
@@ -92,7 +92,7 @@ public final class LocalIdentity {
     return """
         This box has no valid workstation SSH key set (%s), so a container here can't authorize \
         you to connect from your laptop.
-          Set it once with the public key you SSH with:
+          Register it (auto-detected from this box's authorized_keys, or pass the key):
             %s"""
         .formatted(sshPublicKeyPath, WorkstationIdentity.SET_KEY_HINT);
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/WorkstationIdentity.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/WorkstationIdentity.java
@@ -22,8 +22,7 @@ public final class WorkstationIdentity {
   /**
    * The one command that registers a box's workstation key — shared so the guidance can't drift.
    */
-  public static final String SET_KEY_HINT =
-      "sail host config set ssh-public-key \"$(cat ~/.ssh/id_ed25519.pub)\"";
+  public static final String SET_KEY_HINT = "sudo sail host config set ssh-public-key";
 
   private WorkstationIdentity() {}
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/HostConfigSetCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/HostConfigSetCommandTest.java
@@ -14,11 +14,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.singlr.sail.Sail;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.ssh.SshPublicKey;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -238,11 +241,64 @@ class HostConfigSetCommandTest {
     assertTrue(thrown.getMessage().contains("trailing slash"));
   }
 
+  private static final String KEY_A = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILDpT0mMcK alice@mac";
+  private static final String KEY_B = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILDpT0mMcX bob@laptop";
+
   @Test
-  void validateRejectsAMalformedSshPublicKey() {
+  void detectWorkstationKeysParsesValidLinesAndSkipsCommentsAndGarbage(@TempDir Path tmp)
+      throws Exception {
+    var ak = tmp.resolve("authorized_keys");
+    Files.writeString(ak, "# a comment\n\n" + KEY_A + "\nnot a key line\n" + KEY_B + "\n");
+
+    assertEquals(2, HostConfigSetCommand.detectWorkstationKeys(ak).size());
+  }
+
+  @Test
+  void detectWorkstationKeysIsEmptyWhenTheFileIsMissing(@TempDir Path tmp) {
+    assertTrue(HostConfigSetCommand.detectWorkstationKeys(tmp.resolve("absent")).isEmpty());
+  }
+
+  @Test
+  void resolveWorkstationKeyPrefersAnExplicitValueOverDetection() {
+    assertEquals(
+        KEY_A,
+        HostConfigSetCommand.resolveWorkstationKey(KEY_A, List.of(SshPublicKey.parse(KEY_B)))
+            .line());
+  }
+
+  @Test
+  void resolveWorkstationKeyAutoPicksTheSoleDetectedKey() {
+    assertEquals(
+        KEY_A,
+        HostConfigSetCommand.resolveWorkstationKey(null, List.of(SshPublicKey.parse(KEY_A)))
+            .line());
+  }
+
+  @Test
+  void resolveWorkstationKeyFailsWhenNoneCanBeFound() {
+    var error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> HostConfigSetCommand.resolveWorkstationKey(null, List.of()));
+    assertTrue(error.getMessage().contains("public key"));
+  }
+
+  @Test
+  void resolveWorkstationKeyFailsWhenMultipleAreDetectedSoTheOwnerMustChoose() {
+    var error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                HostConfigSetCommand.resolveWorkstationKey(
+                    null, List.of(SshPublicKey.parse(KEY_A), SshPublicKey.parse(KEY_B))));
+    assertTrue(error.getMessage().toLowerCase().contains("multiple"));
+  }
+
+  @Test
+  void resolveWorkstationKeyRejectsAMalformedExplicitValue() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> HostConfigSetCommand.validate("ssh-public-key", "not a real key"));
+        () -> HostConfigSetCommand.resolveWorkstationKey("not a real key", List.of()));
   }
 
   @Test


### PR DESCRIPTION
## What

`sail host config set ssh-public-key` no longer requires you to paste the key. Omit the value and it auto-detects the sole key already authorized to SSH into this box (the box owner's laptop key), from the invoking user's `authorized_keys` (SUDO_USER-aware).

- Sole authorized key → used automatically.
- Several authorized keys → fails loud with a fingerprint list so the owner picks the one they connect with (never guessed).
- None found → fails loud with the explicit `... ssh-public-key "<your public key>"` form.
- An explicit value still wins and is validated as before.

## Why

The prior onboarding hint was `sail host config set ssh-public-key "$(cat ~/.ssh/id_ed25519.pub)"` — but that `cat` runs on the **server**, which has no `~/.ssh/id_ed25519.pub`; the key lives on the engineer's laptop. The hint was inert. Since the laptop key is already in the box's `authorized_keys` (that's how the FDE SSHes in), the box can find it itself. Per-box trust: each box is owned by one FDE, so a single detected key is unambiguous.

## Tests

TDD, red→green. `HostConfigSetCommandTest` covers detect (parses valid lines, skips comments/garbage, empty when missing), resolve (explicit wins, sole auto-picked, none→loud, multiple→choose, malformed rejected), and write. Full `sail-infra` verify green (1826 tests) with coverage gates met.
