### PR TITLE
fix(dispatch): emit tool-progress hooks so the stall guardrail sees a busy agent

### DIFF
--- a/sail-harness/src/main/java/ai/singlr/sail/engine/ClaudeCodeHookConfig.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/ClaudeCodeHookConfig.java
@@ -23,9 +23,16 @@ import java.util.concurrent.TimeoutException;
  *
  * <ul>
  *   <li>{@code SessionStart} ({@code matcher: startup}) → {@code agent_session_started}
+ *   <li>{@code PreToolUse} → {@code agent_tool_started}
+ *   <li>{@code PostToolUse} → {@code agent_tool_finished}
  *   <li>{@code Stop} → {@code agent_session_stopped}
  *   <li>{@code SessionEnd} → {@code agent_session_completed}
  * </ul>
+ *
+ * <p>The tool hooks are the dispatch watcher's liveness signal: {@code AgentWatchCommand} resets
+ * its stall timer on {@code agent_tool_started}/{@code agent_tool_finished}, so a working agent
+ * pushes the {@code max_idle} deadline out on every tool call. Without them the stall timer counts
+ * from launch and kills even a busy agent at {@code max_idle}.
  *
  * <p>Spec attribution flows in via the {@code SAIL_SPEC_ID} env var that sail sets at launch — no
  * spec id is baked into the hook commands, so the file is install-once at provision/sync time
@@ -42,6 +49,13 @@ public final class ClaudeCodeHookConfig {
   /** Container-side absolute path to the settings file. Used with {@code claude --settings}. */
   public static final String SETTINGS_PATH = SETTINGS_DIR + "/" + SETTINGS_FILE;
 
+  /**
+   * Event type of the {@code PreToolUse} heartbeat, and the marker {@link
+   * ai.singlr.sail.engine.ContainerSailSetup} greps for to detect a settings file written before
+   * the tool hooks existed, so a stale container is refreshed on the next dispatch.
+   */
+  public static final String PROGRESS_HOOK_MARKER = "agent_tool_started";
+
   private final ShellExec shell;
 
   public ClaudeCodeHookConfig(ShellExec shell) {
@@ -54,11 +68,15 @@ public final class ClaudeCodeHookConfig {
    */
   public static String render() {
     var sessionStart = hookCommand(SailEventHelper.SCRIPT_PATH, "agent_session_started");
+    var toolStarted = hookCommand(SailEventHelper.SCRIPT_PATH, PROGRESS_HOOK_MARKER);
+    var toolFinished = hookCommand(SailEventHelper.SCRIPT_PATH, "agent_tool_finished");
     var stop = hookCommand(SailEventHelper.SCRIPT_PATH, "agent_session_stopped");
     var sessionEnd = hookCommand(SailEventHelper.SCRIPT_PATH, "agent_session_completed");
 
     var hooks = new LinkedHashMap<String, Object>();
     hooks.put("SessionStart", List.of(matcherGroup("startup", sessionStart)));
+    hooks.put("PreToolUse", List.of(matcherGroup(null, toolStarted)));
+    hooks.put("PostToolUse", List.of(matcherGroup(null, toolFinished)));
     hooks.put("Stop", List.of(matcherGroup(null, stop)));
     hooks.put("SessionEnd", List.of(matcherGroup(null, sessionEnd)));
 

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/ClaudeCodeHookConfigTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/ClaudeCodeHookConfigTest.java
@@ -35,6 +35,24 @@ class ClaudeCodeHookConfigTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  void renderWiresToolHooksSoTheStallWatcherSeesProgress() {
+    var json = ClaudeCodeHookConfig.render();
+    var hooks = (Map<String, Object>) YamlUtil.parseMap(json).get("hooks");
+    assertTrue(
+        hooks.containsKey("PreToolUse"),
+        "PreToolUse must fire a progress heartbeat, or the stall guardrail counts a busy agent"
+            + " as idle and kills it at max_idle");
+    assertTrue(hooks.containsKey("PostToolUse"), "PostToolUse must fire a progress heartbeat");
+    assertTrue(
+        json.contains(SailEventHelper.SCRIPT_PATH + " agent_tool_started"),
+        "PreToolUse must emit agent_tool_started (the event AgentWatchCommand resets the stall on)");
+    assertTrue(
+        json.contains(SailEventHelper.SCRIPT_PATH + " agent_tool_finished"),
+        "PostToolUse must emit agent_tool_finished");
+  }
+
+  @Test
   void renderEmbedsNoSpecId() {
     var json = ClaudeCodeHookConfig.render();
     var firstCmd = SailEventHelper.SCRIPT_PATH + " agent_session_started";

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
@@ -22,7 +22,11 @@ import java.util.concurrent.TimeoutException;
  *   <li><b>Helper files in the container.</b> {@code sail-event.sh}, {@code claude-settings.json},
  *       and {@code codex hooks.json} are probed with a single {@code test -f} chain; if any is
  *       missing — or the {@code spec} script still references a stale socket path after the socket
- *       moved off {@code /run} — the installers re-run and rewrite them to the current path.
+ *       moved off {@code /run}, or {@code claude-settings.json} predates the tool-progress hooks —
+ *       the installers re-run and rewrite them. The hook-content check matters because the file is
+ *       install-once: without it, a container provisioned before the hooks existed would keep a
+ *       settings file the stall watcher gets no progress from, and its agents die at {@code
+ *       max_idle}.
  * </ol>
  *
  * Designed for the dispatch hot path: ensureEventSocket is one idempotent shell call, the
@@ -80,6 +84,10 @@ public final class ContainerSailSetup {
                         + " && test -f "
                         + SpecCliHelper.SCRIPT_PATH
                         + " && test -f "
+                        + ClaudeCodeHookConfig.SETTINGS_PATH
+                        + " && grep -qsF "
+                        + ClaudeCodeHookConfig.PROGRESS_HOOK_MARKER
+                        + " "
                         + ClaudeCodeHookConfig.SETTINGS_PATH
                         + " && test -f "
                         + CodexHookConfig.SETTINGS_PATH

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentWatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentWatchCommandTest.java
@@ -134,6 +134,22 @@ class AgentWatchCommandTest {
   }
 
   @Test
+  void toolProgressEventsTheWatcherResetsOnAreActuallyEmittedByTheHookConfig() {
+    var hookJson = ai.singlr.sail.engine.ClaudeCodeHookConfig.render();
+    assertTrue(
+        hookJson.contains(Event.WellKnownTypes.AGENT_TOOL_STARTED)
+            && AgentWatchCommand.isProgressEvent(
+                sampleEvent(Event.WellKnownTypes.AGENT_TOOL_STARTED)),
+        "the stall watcher resets on agent_tool_started, so the hook config must emit it — "
+            + "otherwise a busy agent is killed at max_idle");
+    assertTrue(
+        hookJson.contains(Event.WellKnownTypes.AGENT_TOOL_FINISHED)
+            && AgentWatchCommand.isProgressEvent(
+                sampleEvent(Event.WellKnownTypes.AGENT_TOOL_FINISHED)),
+        "the stall watcher resets on agent_tool_finished, so the hook config must emit it");
+  }
+
+  @Test
   void earlierReturnsTheSoonerInstant() {
     var soon = java.time.Instant.now();
     var later = soon.plusSeconds(3600);

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerSailSetupTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerSailSetupTest.java
@@ -58,6 +58,26 @@ class ContainerSailSetupTest {
   }
 
   @Test
+  void aHookFileMissingTheToolHeartbeatsForcesAReinstall() throws Exception {
+    var shell =
+        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+            .onOk("config device get " + CONTAINER, "/run/sail\n")
+            .onFail("grep -qsF " + ClaudeCodeHookConfig.PROGRESS_HOOK_MARKER, "");
+
+    var result = ContainerSailSetup.ensureInstalled(shell, CONTAINER);
+
+    assertEquals(
+        ContainerSailSetup.Result.BACKFILLED,
+        result,
+        "a claude-settings.json written before the tool hooks existed is stale and must be "
+            + "rewritten, or the stall watcher never sees progress and kills the agent at max_idle");
+    assertTrue(
+        shell.invocations().stream()
+            .anyMatch(c -> c.contains("grep -qsF " + ClaudeCodeHookConfig.PROGRESS_HOOK_MARKER)),
+        "the probe must verify the hook file carries the tool-progress heartbeats, not just exists");
+  }
+
+  @Test
   void refreshHappensEvenWhenSourcePathUnchanged() throws Exception {
     // Same source path on host and container — the bug class 0.12.5/0.12.6 missed.
     // refreshEventSocket must still tear down + re-add so the kernel re-resolves the inode.


### PR DESCRIPTION
## The bug

Every dispatched Claude Code agent was hard-killed at `max_idle` (20 min default) no matter how busy it was.

Proven from a real run: session started 02:19:41, killed 02:39:41 (exactly `started_at + 20m`), while the agent was maximally active — 261 tool calls, tool results every few seconds, the last one 4 seconds before the kill. Same signature as an earlier run whose watch.log said `Guardrail triggered: stall / No progress for 20m`.

## Root cause

`AgentWatchCommand` resets its stall timer only on `agent_tool_started`, `agent_tool_finished`, or `agent_log_chunk`. None were ever emitted:

- `agent_log_chunk` is defined but has **no publisher**.
- `ClaudeCodeHookConfig.render()` wired only `SessionStart`, `Stop`, and `SessionEnd`. There was **no `PreToolUse`/`PostToolUse` hook**, so no tool events reached the watcher.

So `lastProgressAt` was frozen at launch and the idle timer counted from launch. The v0.13.125 streaming fix made `agent log --follow` fill live but did not touch the guardrail, which reads events, not the log.

## The fix

1. `ClaudeCodeHookConfig` now wires `PreToolUse -> agent_tool_started` and `PostToolUse -> agent_tool_finished` — the exact events the watcher already resets on. A busy agent now pushes the `max_idle` deadline out on every tool call. Hooks stay gated by `SAIL_SPEC_ID`, so bare `claude` sessions are unaffected.
2. The hook file is install-once, so `ContainerSailSetup.ensureInstalled` now treats a `claude-settings.json` lacking the tool hooks (grep for the `agent_tool_started` marker) as stale and reinstalls it. Existing containers self-heal on the next dispatch instead of staying broken after `sail upgrade`.

## Tests (TDD, red then green)

- `ClaudeCodeHookConfigTest`: render wires the tool hooks and emits both event types.
- `AgentWatchCommandTest`: drift-pin — the progress events the watcher resets on are exactly the ones the hook config emits.
- `ContainerSailSetupTest`: a settings file missing the tool heartbeats forces a reinstall.

Full reactor green (1828 tests), coverage gates met, spotless clean.

## Known residual (not addressed here)

A single tool call that runs longer than `max_idle` (for example a >20m build in one Bash call) still trips the stall, since only start/finish fire for it. That is a much rarer case; a periodic in-tool heartbeat or a per-project `max_idle` bump can handle it later.
