### PR TITLE
fix(dispatch): reuse an existing branch on --restart instead of failing

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
@@ -227,18 +227,35 @@ public final class DispatchCommand implements Runnable {
         var repoExists =
             shell.exec(ContainerExec.asDevUser(name, List.of("test", "-d", repoDir + "/.git")));
         if (repoExists.ok()) {
+          var branchExists =
+              shell
+                  .exec(
+                      ContainerExec.asDevUser(
+                          name,
+                          List.of(
+                              "git",
+                              "-C",
+                              repoDir,
+                              "rev-parse",
+                              "--verify",
+                              "--quiet",
+                              "refs/heads/" + branchName)))
+                  .ok();
+          var args = branchCheckoutArgs(repoDir, branchName, branchExists, resolution.restarted());
           if (!json) {
+            var verb = branchExists ? "Reusing branch:" : "Creating branch:";
             System.out.println(
-                Ansi.AUTO.string(
-                    "  @|bold Creating branch:|@ " + branchName + " in " + repo.path() + "..."));
+                Ansi.AUTO.string("  @|bold " + verb + "|@ " + branchName + " in " + repo.path()));
           }
-          var branchCmd =
-              ContainerExec.asDevUser(
-                  name, List.of("git", "-C", repoDir, "checkout", "-b", branchName));
-          var result = shell.exec(branchCmd);
+          var result = shell.exec(ContainerExec.asDevUser(name, args));
           if (!result.ok()) {
             throw new IOException(
-                "Failed to create branch '" + branchName + "': " + result.stderr());
+                "Failed to "
+                    + (branchExists ? "check out" : "create")
+                    + " branch '"
+                    + branchName
+                    + "': "
+                    + result.stderr());
           }
           if (!json) {
             System.out.println(
@@ -533,6 +550,25 @@ public final class DispatchCommand implements Runnable {
 
   static String branchRepoDir(String workDir, List<SailYaml.Repo> targetRepos, SailYaml.Repo repo) {
     return targetRepos.size() == 1 ? workDir : workDir + "/" + repo.path();
+  }
+
+  /**
+   * The git checkout command for a dispatch's work branch. A fresh branch is created with {@code
+   * checkout -b}; on a restart an already-present branch is reused with a plain {@code checkout} so
+   * re-dispatch resumes onto the prior work instead of failing to recreate it. A collision on a
+   * non-restart dispatch is unexpected and fails loud, pointing the operator at {@code --restart}.
+   */
+  static List<String> branchCheckoutArgs(
+      String repoDir, String branchName, boolean branchExists, boolean restart) {
+    if (branchExists && !restart) {
+      throw new IllegalStateException(
+          "Branch '"
+              + branchName
+              + "' already exists. Pass --restart to re-dispatch onto it, or delete it first.");
+    }
+    return branchExists
+        ? List.of("git", "-C", repoDir, "checkout", branchName)
+        : List.of("git", "-C", repoDir, "checkout", "-b", branchName);
   }
 
   record DispatchPreview(String name, String specId, String specTitle, String mode, String task) {}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.Sail;
@@ -315,6 +316,37 @@ class DispatchCommandTest {
         DispatchCommand.branchRepoDir("/home/dev/workspace", List.of(sing, chorus), chorus);
 
     assertEquals("/home/dev/workspace/chorus", repoDir);
+  }
+
+  @Test
+  void branchCheckoutCreatesAFreshBranchWhenItDoesNotExist() {
+    var args = DispatchCommand.branchCheckoutArgs("/w/mast", "agent/x", false, false);
+    assertEquals(List.of("git", "-C", "/w/mast", "checkout", "-b", "agent/x"), args);
+  }
+
+  @Test
+  void branchCheckoutReusesAnExistingBranchOnRestart() {
+    var args = DispatchCommand.branchCheckoutArgs("/w/mast", "agent/x", true, true);
+    assertEquals(
+        List.of("git", "-C", "/w/mast", "checkout", "agent/x"),
+        args,
+        "a restart must re-dispatch onto the existing branch, not fail trying to recreate it");
+  }
+
+  @Test
+  void branchCheckoutStillCreatesWhenRestartingWithNoPriorBranch() {
+    var args = DispatchCommand.branchCheckoutArgs("/w/mast", "agent/x", false, true);
+    assertEquals(List.of("git", "-C", "/w/mast", "checkout", "-b", "agent/x"), args);
+  }
+
+  @Test
+  void branchCheckoutFailsLoudOnACollisionForAFreshDispatch() {
+    var ex =
+        assertThrows(
+            IllegalStateException.class,
+            () -> DispatchCommand.branchCheckoutArgs("/w/mast", "agent/x", true, false));
+    assertTrue(ex.getMessage().contains("--restart"), "must point the operator at --restart");
+    assertTrue(ex.getMessage().contains("agent/x"));
   }
 
   @TempDir Path dbDir;


### PR DESCRIPTION
## Problem

`sail spec dispatch` creates the work branch with `git checkout -b <branch>`, which fails if the branch already exists. So `sail spec dispatch --restart` — whose whole purpose is to re-run a spec — dies at branch creation whenever a prior run left the branch behind, and the only recovery was to delete the branch by hand first.

## Fix

`--restart` now **reuses** an existing branch (plain `git checkout <branch>`) so the re-dispatch resumes onto the prior work. A fresh branch is still created (`checkout -b`) when none exists. A branch collision on a **non-restart** dispatch stays an error, but now a helpful one that points the operator at `--restart` instead of surfacing git's raw stderr.

The decision is a pure, unit-tested helper `branchCheckoutArgs(repoDir, branch, branchExists, restart)`; the dispatch loop probes `git rev-parse --verify --quiet refs/heads/<branch>` to decide.

| branch exists | restart | result |
|---|---|---|
| no | any | `checkout -b` (create) |
| yes | yes | `checkout` (reuse) |
| yes | no | fail loud, "pass --restart or delete it first" |

## Tests (TDD, red then green)

`DispatchCommandTest`: the four rows above. Full reactor green (1830 tests), coverage gates met, spotless clean.
