### PR TITLE
fix(dispatch): force branch checkout on --restart so a dirty tree can't abort it

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
@@ -554,9 +554,11 @@ public final class DispatchCommand implements Runnable {
 
   /**
    * The git checkout command for a dispatch's work branch. A fresh branch is created with {@code
-   * checkout -b}; on a restart an already-present branch is reused with a plain {@code checkout} so
-   * re-dispatch resumes onto the prior work instead of failing to recreate it. A collision on a
-   * non-restart dispatch is unexpected and fails loud, pointing the operator at {@code --restart}.
+   * checkout -b}; on a restart an already-present branch is reused with a <em>forced</em> {@code
+   * checkout -f} so re-dispatch lands on the prior branch even when the previous run left a dirty
+   * working tree (untracked scaffold that a plain {@code checkout} would refuse to overwrite),
+   * rather than resuming onto it and aborting. A collision on a non-restart dispatch is unexpected
+   * and fails loud, pointing the operator at {@code --restart}.
    */
   static List<String> branchCheckoutArgs(
       String repoDir, String branchName, boolean branchExists, boolean restart) {
@@ -567,7 +569,7 @@ public final class DispatchCommand implements Runnable {
               + "' already exists. Pass --restart to re-dispatch onto it, or delete it first.");
     }
     return branchExists
-        ? List.of("git", "-C", repoDir, "checkout", branchName)
+        ? List.of("git", "-C", repoDir, "checkout", "-f", branchName)
         : List.of("git", "-C", repoDir, "checkout", "-b", branchName);
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
@@ -325,12 +325,13 @@ class DispatchCommandTest {
   }
 
   @Test
-  void branchCheckoutReusesAnExistingBranchOnRestart() {
+  void branchCheckoutForceReusesAnExistingBranchOnRestart() {
     var args = DispatchCommand.branchCheckoutArgs("/w/mast", "agent/x", true, true);
     assertEquals(
-        List.of("git", "-C", "/w/mast", "checkout", "agent/x"),
+        List.of("git", "-C", "/w/mast", "checkout", "-f", "agent/x"),
         args,
-        "a restart must re-dispatch onto the existing branch, not fail trying to recreate it");
+        "a restart must land on the existing branch even over a dirty tree from the prior run "
+            + "(untracked scaffold that would otherwise abort a plain checkout)");
   }
 
   @Test


### PR DESCRIPTION
## Problem

`sail spec dispatch --restart` reuses an existing work branch with `git checkout <branch>` (shipped in #103). That aborts when the previous run left untracked files that collide with the branch's tracked files:

```
✗ Failed to check out branch 'agent/mast-app-shell': error: The following untracked
  working tree files would be overwritten by checkout:
        .gitattributes .gitignore AGENTS.md README.md
  Please move or remove them before you switch branches. Aborting
```

So a restart still failed on a dirty tree, which is exactly the state a killed/partial run leaves behind.

## Fix

Restart-reuse now forces the checkout (`git checkout -f <branch>`), so it lands on the branch and overwrites colliding untracked leftovers with the branch's versions. Fresh-branch creation (`checkout -b`) and the fail-loud guard for a non-restart collision are unchanged.

## Tests

`DispatchCommandTest.branchCheckoutForceReusesAnExistingBranchOnRestart` asserts the `-f`. Full reactor green (1832 tests), coverage gates met.

## Residual (not addressed)

`checkout -f` overwrites colliding untracked files but leaves non-colliding untracked leftovers in place. That is not fatal (the agent works over them), and auto-`git clean` is too destructive to make a default. A fully pristine restart is a larger, separate choice.
