### PR TITLE
feat: review observability (agent log --review), recovery docs, dead-code cleanup (Brick 3)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -354,10 +354,35 @@ On a trip it snapshots or kills the agent and fires notifications. Rollback uses
 snapshots, which are instant on `zfs` and full copies on `dir`, and the pre-dispatch
 snapshot is the restore point.
 
-**Multi-agent review:** review is agent-agnostic across claude-code and codex. When enabled,
-a secondary agent runs the security audit or the code review at spec completion, falling back
-to self-audit when only one agent is installed. A per-spec `agent` overrides the project
-default. These stages are baked into the generated completion protocol and post-task hooks.
+**Multi-agent review loop:** review is agent-agnostic across claude-code and codex. When the
+coder's dispatch stops cleanly, the spec moves to `review` and a secondary reviewer runs at
+spec completion (falling back to self-review when only one agent is installed; a per-spec
+`agent` overrides the project default). The reviewer is read-only and emits findings; if a
+stage's gate fails, a fix agent addresses the open findings on the same branch and the
+reviewer runs again, bounded by `max_iterations`, after which the spec `escalates` and parks
+in `review` for a human.
+
+Reviewer and fix agents run on the same agent command and log handling as dispatch, but not
+its process wrapper. Dispatch is fire-and-forget (it launches a detached `systemd-run --user`
+unit and an external `sail agent watch` monitors it); a review blocks the pipeline until it
+has findings, so `ContainerReviewAgentRunner` runs it as a bounded foreground `shell.exec`
+(30-minute per-invocation timeout) that needs no systemd user manager or D-Bus session, so it
+works in any container. The output streams to `review.log` (appended, so an attempt's whole
+reviewer-and-fix negotiation lands in one live-followable log, reset per dispatch attempt),
+findings are parsed from the bytes that run appended (read by offset so a plain agent's
+re-review is never fed a prior iteration's findings) via `StreamJsonResult`. The reviewer runs
+clean (empty `SAIL_SPEC_ID`, no hooks) so its own completion never re-enters the pipeline.
+Follow it live with `sail agent log <project> --review`.
+
+**Recovery without losing work.** The git branch is the durable record: every coding agent
+(build and fix) commits before it stops, and neither a guardrail stop nor an escalation ever
+discards it. So an FDE always recovers by returning to the branch. When a spec is stuck: a
+guardrail-killed or failed dispatch leaves the work committed, so `sail spec dispatch
+--restart` resumes on the branch; an escalated review parks in `review` with its findings (in
+the review store), its negotiation (`review.log`), and every fix commit intact, so the FDE
+reads it with `sail agent review <project>` plus `sail agent log <project> --review`, then
+resolves with `sail spec edit <id> --status done` (accept the work as-is) or `--status
+pending` (send it back to be re-dispatched). Nothing is deleted along the way.
 
 **Events:** an in-process `EventBus` (lock-light, with bounded per-subscriber queues that
 are lossy by design so publishers never block) fans out to the SSE stream and to startup

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
@@ -279,50 +279,19 @@ public final class AgentSession {
       String reasoningEffort,
       String specId,
       String agentType) {
-    return buildBackgroundLaunchCommand(
-        containerName,
-        sshUser,
-        workDir,
-        fullPermissions,
-        agentCli,
-        model,
-        reasoningEffort,
-        specId,
-        agentType,
-        AgentUnit.BUILD);
-  }
-
-  /**
-   * Same as the 9-arg overload but launches under the given {@link AgentUnit}, so the reviewer and
-   * fix agent get their own systemd unit and streamed log instead of clobbering the build's. The
-   * unit name is interpolated (a trusted constant, never user input) rather than passed as a
-   * positional argument, so the {@code printf "%s"} in the launch script stays literal.
-   */
-  public static List<String> buildBackgroundLaunchCommand(
-      String containerName,
-      String sshUser,
-      String workDir,
-      boolean fullPermissions,
-      AgentCli agentCli,
-      String model,
-      String reasoningEffort,
-      String specId,
-      String agentType,
-      AgentUnit unit) {
     var cli = Objects.requireNonNullElse(agentCli, AgentCli.CLAUDE_CODE);
     var settingsPath = cli == AgentCli.CLAUDE_CODE ? ClaudeCodeHookConfig.SETTINGS_PATH : null;
     var agentCmd =
-        cli.headlessCommand(
-            unit.taskPath(), fullPermissions, model, reasoningEffort, settingsPath, true);
+        cli.headlessCommand(TASK_FILE, fullPermissions, model, reasoningEffort, settingsPath, true);
     var effectiveSpec = Objects.requireNonNullElse(specId, "");
     var effectiveAgent = agentType == null || agentType.isBlank() ? cli.yamlName() : agentType;
     var script =
         """
         mkdir -p "$1"
         rm -f "$5"
-        @RESET@
+        : > "$4"
         systemctl --user reset-failed @SERVICE@ >/dev/null 2>&1 || true
-        systemd-run --user --setenv "SAIL_SPEC_ID=$6" --setenv "SAIL_AGENT=$7" --unit @UNIT@ bash -lc 'printf "%s\\n" "$$" > "$4"; cd "$1" && exec bash -l -c "$2" @REDIR@ "$3" 2>&1' bash "$2" "$3" "$4" "$5"
+        systemd-run --user --setenv "SAIL_SPEC_ID=$6" --setenv "SAIL_AGENT=$7" --unit @UNIT@ bash -lc 'printf "%s\\n" "$$" > "$4"; cd "$1" && exec bash -l -c "$2" > "$3" 2>&1' bash "$2" "$3" "$4" "$5"
         for i in $(seq 1 25); do
           test -s "$5" && exit 0
           pid="$(systemctl --user show @SERVICE@ --property=MainPID --value 2>/dev/null || true)"
@@ -335,10 +304,8 @@ public final class AgentSession {
         systemctl --user status @SERVICE@ --no-pager || true
         exit 1
         """
-            .replace("@SERVICE@", unit.service())
-            .replace("@UNIT@", unit.unitName())
-            .replace("@RESET@", unit.appendsLog() ? "true" : ": > \"$4\"")
-            .replace("@REDIR@", unit.appendsLog() ? ">>" : ">");
+            .replace("@SERVICE@", AgentUnit.BUILD.service())
+            .replace("@UNIT@", AgentUnit.BUILD.unitName());
     return ContainerExec.asDevUser(
         containerName,
         List.of(
@@ -349,8 +316,8 @@ public final class AgentSession {
             SAIL_DIR,
             workDir,
             agentCmd,
-            unit.logPath(),
-            unit.pidPath(),
+            AgentUnit.BUILD.logPath(),
+            AgentUnit.BUILD.pidPath(),
             effectiveSpec,
             effectiveAgent));
   }

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/AgentUnit.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/AgentUnit.java
@@ -19,30 +19,26 @@ package ai.singlr.sail.engine;
  * AgentSession} and the watcher read them from here rather than hardcoding their own copies.
  */
 public record AgentUnit(
-    String unitName,
-    String logPath,
-    String pidPath,
-    String sessionPath,
-    String taskPath,
-    boolean appendsLog) {
+    String unitName, String logPath, String pidPath, String sessionPath, String taskPath) {
 
   private static final String DIR = "/home/dev/.sail";
 
-  /** The dispatched build. Truncates its log so each dispatch starts with a fresh transcript. */
+  /**
+   * The dispatched build: launched as a detached systemd unit and streamed to {@code agent.log}.
+   */
   public static final AgentUnit BUILD =
       new AgentUnit(
           "sail-agent",
           DIR + "/agent.log",
           DIR + "/agent.pid",
           DIR + "/agent-session.json",
-          DIR + "/agent-task.txt",
-          false);
+          DIR + "/agent-task.txt");
 
   /**
-   * The read-only reviewer and the fix agent, which share this unit's log. It <em>appends</em> so
-   * every reviewer↔fix turn within one dispatch attempt lands in a single {@code review.log}; the
-   * attempt boundary resets it (the dispatch clears it before the build), keeping the whole
-   * negotiation in one file without growing across attempts.
+   * The read-only reviewer and the fix agent. They share {@code review.log}, which the runner
+   * appends so a dispatch attempt's whole reviewer↔fix negotiation lands in one live-followable
+   * file (the attempt boundary resets it via {@link AgentSession#resetLog}). Review runs as a
+   * blocking foreground exec, not a systemd unit, so only its task file and log are used here.
    */
   public static final AgentUnit REVIEW =
       new AgentUnit(
@@ -50,8 +46,7 @@ public record AgentUnit(
           DIR + "/review.log",
           DIR + "/review.pid",
           DIR + "/review-session.json",
-          DIR + "/review-prompt.txt",
-          true);
+          DIR + "/review-prompt.txt");
 
   /** The systemd unit name with the {@code .service} suffix, as {@code systemctl} expects it. */
   public String service() {

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
@@ -208,29 +208,6 @@ class AgentSessionTest {
   }
 
   @Test
-  void buildBackgroundLaunchCommandUnderReviewUnitIsIsolatedFromBuild() {
-    var cmd =
-        AgentSession.buildBackgroundLaunchCommand(
-            "acme",
-            "dev",
-            "/home/dev/workspace",
-            false,
-            AgentCli.CLAUDE_CODE,
-            null,
-            null,
-            "",
-            "",
-            AgentUnit.REVIEW);
-
-    var joined = String.join(" ", cmd);
-    assertTrue(joined.contains("--unit sail-review"), "review runs under its own systemd unit");
-    assertTrue(joined.contains("review.log"), "review streams to its own log, not agent.log");
-    assertTrue(joined.contains("review.pid"));
-    assertFalse(joined.contains("sail-agent"), "must not touch the build unit");
-    assertFalse(joined.contains("/agent.log"), "must not clobber the build log");
-  }
-
-  @Test
   void resetLogTruncatesTheGivenRolesLog() throws Exception {
     var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
 
@@ -239,44 +216,6 @@ class AgentSessionTest {
     var cmd = shell.invocations().getFirst();
     assertTrue(cmd.contains(": > "), "reset truncates the log to empty");
     assertTrue(cmd.contains("/home/dev/.sail/review.log"), "resets the review negotiation log");
-  }
-
-  @Test
-  void reviewLaunchAppendsToItsLogWhileBuildTruncates() {
-    var build =
-        String.join(
-            " ",
-            AgentSession.buildBackgroundLaunchCommand(
-                "acme",
-                "dev",
-                "/w",
-                false,
-                AgentCli.CLAUDE_CODE,
-                null,
-                null,
-                "",
-                "",
-                AgentUnit.BUILD));
-    var review =
-        String.join(
-            " ",
-            AgentSession.buildBackgroundLaunchCommand(
-                "acme",
-                "dev",
-                "/w",
-                false,
-                AgentCli.CLAUDE_CODE,
-                null,
-                null,
-                "",
-                "",
-                AgentUnit.REVIEW));
-
-    assertTrue(build.contains(": > \"$4\""), "build truncates agent.log fresh each dispatch");
-    assertFalse(build.contains(">> \"$3\""), "build overwrites its log, not append");
-    assertTrue(review.contains(">> \"$3\""), "review appends so the negotiation accumulates");
-    assertFalse(
-        review.contains(": > \"$4\""), "review must not truncate the shared negotiation log");
   }
 
   @Test

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentUnitTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentUnitTest.java
@@ -6,9 +6,7 @@
 package ai.singlr.sail.engine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -33,13 +31,5 @@ class AgentUnitTest {
     assertNotEquals(AgentUnit.BUILD.taskPath(), AgentUnit.REVIEW.taskPath());
     assertEquals("sail-review", AgentUnit.REVIEW.unitName());
     assertEquals("/home/dev/.sail/review.log", AgentUnit.REVIEW.logPath());
-  }
-
-  @Test
-  void buildTruncatesItsLogWhileReviewAppendsTheNegotiation() {
-    assertFalse(AgentUnit.BUILD.appendsLog(), "each dispatch build starts a fresh agent.log");
-    assertTrue(
-        AgentUnit.REVIEW.appendsLog(),
-        "review.log accumulates the reviewer↔fix negotiation within an attempt");
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLogCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLogCommand.java
@@ -7,7 +7,7 @@ package ai.singlr.sail.commands;
 
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.AgentLogRenderer;
-import ai.singlr.sail.engine.AgentSession;
+import ai.singlr.sail.engine.AgentUnit;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerStateGuard;
@@ -45,6 +45,11 @@ public final class AgentLogCommand implements Runnable {
   @Option(names = "--tail", description = "Number of lines to show.", defaultValue = "50")
   private int tail;
 
+  @Option(
+      names = "--review",
+      description = "Show the review/fix negotiation log instead of the build log.")
+  private boolean review;
+
   @Option(names = "--json", description = "Output in JSON format.")
   private boolean json;
 
@@ -63,7 +68,7 @@ public final class AgentLogCommand implements Runnable {
     var state = mgr.queryState(name);
     ContainerStateGuard.requireRunning(state, name);
 
-    var logPath = AgentSession.logPath();
+    var logPath = logPathFor(review);
 
     if (follow) {
       var tailCmd = ContainerExec.asDevUser(name, List.of("tail", "-f", logPath));
@@ -118,6 +123,14 @@ public final class AgentLogCommand implements Runnable {
 
       System.out.print(renderLines(result.stdout()));
     }
+  }
+
+  /**
+   * The log to tail: the reviewer/fix negotiation ({@code review.log}) with {@code --review}, else
+   * the coder's build log ({@code agent.log}).
+   */
+  static String logPathFor(boolean review) {
+    return (review ? AgentUnit.REVIEW : AgentUnit.BUILD).logPath();
   }
 
   /**

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentLogCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentLogCommandTest.java
@@ -26,4 +26,16 @@ class AgentLogCommandTest {
   void humanOutputRendersStreamJsonToReadableText() {
     assertEquals("Reading.", AgentLogCommand.renderForLog(STREAM_EVENT, false));
   }
+
+  @Test
+  void reviewFlagSelectsTheReviewLogOtherwiseTheBuildLog() {
+    assertEquals(
+        "/home/dev/.sail/agent.log",
+        AgentLogCommand.logPathFor(false),
+        "default follows the coder's build log");
+    assertEquals(
+        "/home/dev/.sail/review.log",
+        AgentLogCommand.logPathFor(true),
+        "--review follows the reviewer/fix negotiation log");
+  }
 }


### PR DESCRIPTION
## Brick 3 — review observability, recovery, and cleanup

**Observability.** `sail agent log <project> --review` tails `review.log` (the reviewer↔fix negotiation) instead of the build's `agent.log`, so the now-streamed review is reachable from the CLI.

**Recovery without losing work** (documented, no new code). The branch is the durable record — every coding agent commits before it stops, and nothing on failure/escalation deletes it. An FDE resolves a stuck or escalated spec with existing commands: `sail agent review` (findings) + `sail agent log --review` (negotiation), then `sail spec edit <id> --status done` (accept) / `--status pending` (send back) or `sail spec dispatch --restart` (resume on the branch). Dedicated `accept`/`reopen` verbs were **dropped on purpose**: `spec edit --status` already does exactly that, so adding them would duplicate it (DRY/YAGNI).

**Cleanup** after the blocking-exec review pivot. `buildBackgroundLaunchCommand` is dispatch-only again (dropped the never-non-`BUILD` `AgentUnit` param and the prod-dead append branch), and `AgentUnit` loses the unused `appendsLog` field. The BUILD launch stays byte-identical (characterization test holds). `AgentSession` stays a coherent role-parameterized session manager (`writeTaskFile`/`resetLog` genuinely use `REVIEW`); I deliberately did **not** trim the `queryStatus`/`killAgent`/`queryExitStatus` role params — that touches the watcher's authoritative-stop path for marginal gain.

Full reactor green (1836 tests, coverage). ARCHITECTURE.md updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NvxJbXoANxoarjX6A2aLZ
