### PR TITLE
fix(review): infra errors durable + visible, never burn iterations

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
@@ -34,10 +34,15 @@ public final class ReviewStore {
       String createdAt,
       String completedAt,
       String decidedBy,
-      String supersededAt) {
+      String supersededAt,
+      String error) {
 
     public boolean superseded() {
       return supersededAt != null;
+    }
+
+    public boolean errored() {
+      return error != null;
     }
   }
 
@@ -49,7 +54,8 @@ public final class ReviewStore {
       String status,
       String reviewer,
       String startedAt,
-      String completedAt) {}
+      String completedAt,
+      String error) {}
 
   public String createReview(String specId, int iteration) {
     var id = DateTimeUtils.newId().toString();
@@ -65,7 +71,7 @@ public final class ReviewStore {
   public Optional<ReviewRow> findReview(String reviewId) {
     return db.queryOne(
         "SELECT id, spec_id, iteration, status, created_at, completed_at, decided_by,"
-            + " superseded_at FROM reviews WHERE id = ?",
+            + " superseded_at, error FROM reviews WHERE id = ?",
         this::mapReview,
         reviewId);
   }
@@ -80,7 +86,7 @@ public final class ReviewStore {
     return db.queryOne(
         """
         SELECT id, spec_id, iteration, status, created_at, completed_at, decided_by,
-          superseded_at
+          superseded_at, error
         FROM reviews WHERE spec_id = ? AND superseded_at IS NULL
         ORDER BY created_at DESC, rowid DESC LIMIT 1""",
         this::mapReview,
@@ -92,7 +98,7 @@ public final class ReviewStore {
     return db.query(
         """
         SELECT id, spec_id, iteration, status, created_at, completed_at, decided_by,
-          superseded_at
+          superseded_at, error
         FROM reviews WHERE spec_id = ? ORDER BY created_at ASC, rowid ASC""",
         this::mapReview,
         specId);
@@ -136,6 +142,18 @@ public final class ReviewStore {
     return db.changes();
   }
 
+  /**
+   * Marks the review failed by infrastructure error, not verdict; retried without burning an
+   * iteration.
+   */
+  public void failReviewWithError(String reviewId, String error) {
+    db.execute(
+        "UPDATE reviews SET status = 'failed', error = ?, completed_at = ? WHERE id = ?",
+        error,
+        DateTimeUtils.now().toString(),
+        reviewId);
+  }
+
   public void updateReviewStatus(String reviewId, String status) {
     var completedAt =
         "passed".equals(status) || "failed".equals(status) || "escalated".equals(status)
@@ -162,7 +180,7 @@ public final class ReviewStore {
   public Optional<StageRow> findStage(String stageId) {
     return db.queryOne(
         """
-        SELECT id, review_id, name, stage_type, status, reviewer, started_at, completed_at
+        SELECT id, review_id, name, stage_type, status, reviewer, started_at, completed_at, error
         FROM review_stages WHERE id = ?""",
         this::mapStage,
         stageId);
@@ -171,7 +189,7 @@ public final class ReviewStore {
   public List<StageRow> stagesForReview(String reviewId) {
     return db.query(
         """
-        SELECT id, review_id, name, stage_type, status, reviewer, started_at, completed_at
+        SELECT id, review_id, name, stage_type, status, reviewer, started_at, completed_at, error
         FROM review_stages WHERE review_id = ? ORDER BY rowid ASC""",
         this::mapStage,
         reviewId);
@@ -186,10 +204,21 @@ public final class ReviewStore {
   }
 
   public void completeStage(String stageId, String status) {
+    completeStage(stageId, status, null);
+  }
+
+  /**
+   * Completes a stage, optionally recording why it failed for reasons other than its gate — the
+   * reviewer process erroring (quota, exec failure) rather than findings tripping the gate. The
+   * error is what {@code sail agent review} shows, so an infrastructure failure is never mistaken
+   * for a genuine review verdict.
+   */
+  public void completeStage(String stageId, String status, String error) {
     db.execute(
-        "UPDATE review_stages SET status = ?, completed_at = ? WHERE id = ?",
+        "UPDATE review_stages SET status = ?, completed_at = ?, error = ? WHERE id = ?",
         status,
         DateTimeUtils.now().toString(),
+        error,
         stageId);
   }
 
@@ -275,7 +304,8 @@ public final class ReviewStore {
         row.text(4),
         row.text(5),
         row.text(6),
-        row.text(7));
+        row.text(7),
+        row.text(8));
   }
 
   private StageRow mapStage(Sqlite.Row row) {
@@ -287,7 +317,8 @@ public final class ReviewStore {
         row.text(4),
         row.text(5),
         row.text(6),
-        row.text(7));
+        row.text(7),
+        row.text(8));
   }
 
   private Finding mapFinding(Sqlite.Row row) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -306,7 +306,9 @@ public final class SchemaManager {
           "DROP TABLE spec_dependencies",
           "ALTER TABLE spec_dependencies_v2 RENAME TO spec_dependencies",
           "ALTER TABLE agent_sessions ADD COLUMN exit_code INTEGER",
-          "ALTER TABLE reviews ADD COLUMN superseded_at TEXT");
+          "ALTER TABLE reviews ADD COLUMN superseded_at TEXT",
+          "ALTER TABLE reviews ADD COLUMN error TEXT",
+          "ALTER TABLE review_stages ADD COLUMN error TEXT");
 
   private final Sqlite db;
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
@@ -366,6 +366,26 @@ class ReviewStoreTest {
   }
 
   @Test
+  void anErroredReviewRecordsWhyAndIsDistinguishableFromAVerdict() {
+    var review = store.createReview("auth", 1);
+    var stage = store.createStage(review, "security", "agent");
+
+    store.completeStage(stage, "failed", "Quota exceeded");
+    store.failReviewWithError(review, "Quota exceeded");
+
+    var reviewRow = store.findReview(review).orElseThrow();
+    assertEquals("failed", reviewRow.status());
+    assertTrue(reviewRow.errored());
+    assertEquals("Quota exceeded", reviewRow.error());
+    assertEquals("Quota exceeded", store.findStage(stage).orElseThrow().error());
+    var gateFailed = store.createReview("auth", 2);
+    store.updateReviewStatus(gateFailed, "failed");
+    assertTrue(
+        !store.findReview(gateFailed).orElseThrow().errored(),
+        "a gate failure carries no error; only infrastructure failures do");
+  }
+
+  @Test
   void supersedeForSpecClosesPriorAttemptsSoIterationsRestartOnRedispatch() {
     var first = store.createReview("auth", 2);
     store.updateReviewStatus(first, "escalated");

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -697,6 +697,7 @@ record ReviewView(
     String completedAt,
     String decidedBy,
     String supersededAt,
+    String error,
     List<StageView> stages)
     implements Mappable {
   static ReviewView from(ReviewStore.ReviewRow row, List<StageView> stages) {
@@ -709,6 +710,7 @@ record ReviewView(
         row.completedAt(),
         row.decidedBy(),
         row.supersededAt(),
+        row.error(),
         stages);
   }
 
@@ -723,6 +725,7 @@ record ReviewView(
     if (completedAt != null) m.put("completed_at", completedAt);
     if (decidedBy != null) m.put("decided_by", decidedBy);
     if (supersededAt != null) m.put("superseded_at", supersededAt);
+    if (error != null) m.put("error", error);
     m.put("stages", stages);
     return m;
   }
@@ -736,7 +739,8 @@ record StageView(
     String reviewer,
     String startedAt,
     String completedAt,
-    int findingCount)
+    int findingCount,
+    String error)
     implements Mappable {
   static StageView from(ReviewStore.StageRow row, int findingCount) {
     return new StageView(
@@ -747,7 +751,8 @@ record StageView(
         row.reviewer(),
         row.startedAt(),
         row.completedAt(),
-        findingCount);
+        findingCount,
+        row.error());
   }
 
   @Override
@@ -761,6 +766,7 @@ record StageView(
     if (startedAt != null) m.put("started_at", startedAt);
     if (completedAt != null) m.put("completed_at", completedAt);
     m.put("finding_count", findingCount);
+    if (error != null) m.put("error", error);
     return m;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -186,8 +186,14 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       return;
     }
 
-    var iteration = existing.map(r -> r.iteration() + 1).orElse(1);
+    var iteration = existing.map(ReviewPipelineController::nextIteration).orElse(1);
     if (iteration > config.maxIterations()) {
+      System.err.println(
+          "review-pipeline: spec "
+              + specId
+              + " escalated — iterations exhausted ("
+              + config.maxIterations()
+              + "); re-dispatch with --restart to start a fresh attempt");
       escalate(event.project(), specId, existing.get().id());
       return;
     }
@@ -226,8 +232,12 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
           return;
         }
 
-        var passed = executeAgentStage(stage, stageConfig, project, specId);
-        if (!passed) {
+        var outcome = executeAgentStage(stage, stageConfig, project, specId);
+        if (outcome instanceof StageOutcome.Errored errored) {
+          handleStageError(reviewId, project, specId, stage.name(), errored.message());
+          return;
+        }
+        if (outcome instanceof StageOutcome.GateFailed) {
           handleStageFailure(reviewId, config, project, specId);
           return;
         }
@@ -247,13 +257,23 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     }
   }
 
-  private boolean executeAgentStage(
+  /** How an agent stage ended: gate verdicts are review outcomes; errors are infrastructure. */
+  sealed interface StageOutcome {
+    record Passed() implements StageOutcome {}
+
+    record GateFailed() implements StageOutcome {}
+
+    record Errored(String message) implements StageOutcome {}
+  }
+
+  private StageOutcome executeAgentStage(
       ReviewStore.StageRow stage, StageConfig stageConfig, String project, String specId) {
     var agent = stageConfig.agent() != null ? stageConfig.agent() : reviewerResolver.apply(project);
     if (agent == null) {
-      reviewStore.completeStage(stage.id(), "failed");
+      var message = "no reviewer agent resolved; set stages[].agent or agent.install in sail.yaml";
+      reviewStore.completeStage(stage.id(), "failed", message);
       publishEvent(project, specId, "review_stage_failed", stage.name());
-      return false;
+      return new StageOutcome.Errored(message);
     }
     reviewStore.startStage(stage.id(), agent);
     publishEvent(project, specId, "review_stage_started", stage.name());
@@ -277,14 +297,40 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       publishEvent(
           project, specId, passed ? "review_stage_passed" : "review_stage_failed", stage.name());
 
-      return passed;
+      return passed ? new StageOutcome.Passed() : new StageOutcome.GateFailed();
 
     } catch (Exception e) {
       System.err.println(
-          "review-pipeline: agent stage '" + stage.name() + "' failed: " + e.getMessage());
-      reviewStore.completeStage(stage.id(), "failed");
-      return false;
+          "review-pipeline: agent stage '" + stage.name() + "' errored: " + e.getMessage());
+      reviewStore.completeStage(stage.id(), "failed", e.getMessage());
+      return new StageOutcome.Errored(e.getMessage());
     }
+  }
+
+  /**
+   * An errored stage is an infrastructure failure, not a review verdict: record why on the review,
+   * say so loudly, and stop — without a fix iteration (there are no findings to fix) and without
+   * counting against {@code max_iterations} (the next stop retries the same iteration; see {@link
+   * #nextIteration}).
+   */
+  private void handleStageError(
+      String reviewId, String project, String specId, String stageName, String message) {
+    reviewStore.failReviewWithError(reviewId, message);
+    System.err.println(
+        "review-pipeline: review "
+            + reviewId
+            + " for spec "
+            + specId
+            + " errored at stage '"
+            + stageName
+            + "': "
+            + message);
+    publishEvent(project, specId, "review_errored", message);
+  }
+
+  /** The iteration the next review runs as: errored iterations are retried, not burned. */
+  private static int nextIteration(ReviewStore.ReviewRow latest) {
+    return latest.errored() ? latest.iteration() : latest.iteration() + 1;
   }
 
   private void handleStageFailure(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentReviewCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentReviewCommand.java
@@ -135,6 +135,11 @@ public final class AgentReviewCommand implements Runnable {
       for (var stage : stagesOf(review)) {
         var reviewer = Objects.toString(stage.get("reviewer"), "-");
         var count = Objects.toString(stage.get("finding_count"), "0");
+        var error = stage.get("error");
+        var tail =
+            error != null
+                ? " @|red error:|@ " + firstLine(Objects.toString(error, ""))
+                : ", " + count + " finding(s)";
         lines.add(
             "      "
                 + stage.get("name")
@@ -142,9 +147,7 @@ public final class AgentReviewCommand implements Runnable {
                 + reviewer
                 + "] — "
                 + statusMarkup(Objects.toString(stage.get("status"), ""))
-                + ", "
-                + count
-                + " finding(s)");
+                + tail);
       }
     }
     return lines;
@@ -162,6 +165,11 @@ public final class AgentReviewCommand implements Runnable {
         + finding.get("line_start")
         + " "
         + finding.get("title");
+  }
+
+  private static String firstLine(String text) {
+    var newline = text.indexOf('\n');
+    return newline < 0 ? text : text.substring(0, newline);
   }
 
   @SuppressWarnings("unchecked")

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -531,7 +531,7 @@ class ApiRouterTest {
   void reviewModelsCoverConstruction() {
     var stageRow =
         new ai.singlr.sail.store.ReviewStore.StageRow(
-            "s1", "r1", "security", "agent", "passed", "codex", "t1", "t2");
+            "s1", "r1", "security", "agent", "passed", "codex", "t1", "t2", null);
     var stageView = StageView.from(stageRow, 3);
     assertEquals("security", stageView.name());
     assertEquals(3, stageView.findingCount());
@@ -540,7 +540,7 @@ class ApiRouterTest {
 
     var reviewRow =
         new ai.singlr.sail.store.ReviewStore.ReviewRow(
-            "r1", "auth", 1, "passed", "t0", "t1", null, null);
+            "r1", "auth", 1, "passed", "t0", "t1", null, null, null);
     var reviewView = ReviewView.from(reviewRow, java.util.List.of(stageView));
     assertEquals(1, reviewView.iteration());
     var rmap = reviewView.toMap();
@@ -1161,19 +1161,28 @@ class ApiRouterTest {
 
     @Override
     public Result<ReviewListResponse> reviewsForSpec(String specId) {
-      var stage = new StageView("s1", "security", "agent", "passed", "codex", "t1", "t2", 2);
+      var stage = new StageView("s1", "security", "agent", "passed", "codex", "t1", "t2", 2, null);
       var review =
           new ReviewView(
-              "r1", specId, 1, "passed", "t0", "t1", null, null, java.util.List.of(stage));
+              "r1", specId, 1, "passed", "t0", "t1", null, null, null, java.util.List.of(stage));
       return Result.success(new ReviewListResponse(specId, java.util.List.of(review)));
     }
 
     @Override
     public Result<ReviewDetailResponse> reviewDetail(String reviewId) {
-      var stage = new StageView("s1", "security", "agent", "passed", "codex", "t1", "t2", 1);
+      var stage = new StageView("s1", "security", "agent", "passed", "codex", "t1", "t2", 1, null);
       var review =
           new ReviewView(
-              reviewId, "spec", 1, "passed", "t0", "t1", null, null, java.util.List.of(stage));
+              reviewId,
+              "spec",
+              1,
+              "passed",
+              "t0",
+              "t1",
+              null,
+              null,
+              null,
+              java.util.List.of(stage));
       var finding =
           java.util.Map.<String, Object>of(
               "id", "f1", "severity", "HIGH", "title", "SQL injection");

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -332,6 +332,51 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
+  void aRunnerErrorIsRecordedOnTheReviewAndNeverMistakenForAVerdict() {
+    createSpec("auth", "in_progress");
+    var ctrl =
+        controller(
+            singleAgentStage("no_critical"),
+            (p, a, pr) -> {
+              throw new IllegalStateException("Quota exceeded");
+            });
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    var review = reviewStore.latestReviewForSpec("auth").orElseThrow();
+    assertEquals("failed", review.status());
+    assertEquals("Quota exceeded", review.error(), "why it failed is durable, not journal-only");
+    var stage = reviewStore.stagesForReview(review.id()).getFirst();
+    assertEquals("Quota exceeded", stage.error());
+  }
+
+  @Test
+  void erroredIterationsAreRetriedNotBurnedAgainstMaxIterations() {
+    createSpec("auth", "in_progress");
+    var broken =
+        controller(
+            singleAgentStage("no_critical"),
+            (p, a, pr) -> {
+              throw new IllegalStateException("Quota exceeded");
+            });
+    broken.onEvent(agentStoppedEvent("auth"));
+    assertEquals(1, reviewStore.latestReviewForSpec("auth").orElseThrow().iteration());
+
+    specStore.updateStatus("auth", SpecStatus.IN_PROGRESS);
+    var healthy = controller(singleAgentStage("no_critical"), (p, a, pr) -> "[]");
+    healthy.onEvent(agentStoppedEvent("auth"));
+
+    var review = reviewStore.latestReviewForSpec("auth").orElseThrow();
+    assertEquals(
+        1,
+        review.iteration(),
+        "an infrastructure error must not consume a review iteration — the retry runs as the"
+            + " same iteration, so quota outages can never exhaust max_iterations");
+    assertEquals("passed", review.status());
+    assertEquals(SpecStatus.DONE, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
   void aCriticalFindingThatIsNeverFixedEscalates() {
     createSpec("auth", "in_progress");
     var agentOutput =

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -236,16 +236,17 @@ class TestOperations implements ApiOperations {
 
   @Override
   public Result<ReviewListResponse> reviewsForSpec(String specId) {
-    var stage = new StageView("s1", "security", "agent", "passed", "codex", "t1", "t2", 0);
-    var review = new ReviewView("r1", specId, 1, "passed", "t0", "t1", null, null, List.of(stage));
+    var stage = new StageView("s1", "security", "agent", "passed", "codex", "t1", "t2", 0, null);
+    var review =
+        new ReviewView("r1", specId, 1, "passed", "t0", "t1", null, null, null, List.of(stage));
     return Result.success(new ReviewListResponse(specId, List.of(review)));
   }
 
   @Override
   public Result<ReviewDetailResponse> reviewDetail(String reviewId) {
-    var stage = new StageView("s1", "security", "agent", "passed", "codex", "t1", "t2", 0);
+    var stage = new StageView("s1", "security", "agent", "passed", "codex", "t1", "t2", 0, null);
     var review =
-        new ReviewView(reviewId, "spec", 1, "passed", "t0", "t1", null, null, List.of(stage));
+        new ReviewView(reviewId, "spec", 1, "passed", "t0", "t1", null, null, null, List.of(stage));
     return Result.success(new ReviewDetailResponse(review, List.of()));
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentReviewCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentReviewCommandTest.java
@@ -72,6 +72,31 @@ class AgentReviewCommandTest {
   }
 
   @Test
+  void rendersAStageErrorInsteadOfPretendingItWasAVerdict() {
+    var errored =
+        Map.of(
+            "iteration",
+            1,
+            "status",
+            "failed",
+            "stages",
+            List.of(
+                Map.of(
+                    "name", "codeandsecurity",
+                    "reviewer", "codex",
+                    "status", "failed",
+                    "finding_count", 0,
+                    "error", "Quota exceeded. Check your plan.\nsecond line")));
+
+    var out = String.join("\n", AgentReviewCommand.render("auth", "review", List.of(errored)));
+
+    assertTrue(out.contains("error:"), out);
+    assertTrue(out.contains("Quota exceeded. Check your plan."), out);
+    assertTrue(!out.contains("second line"), "only the first line, keep it scannable: " + out);
+    assertTrue(!out.contains("finding(s)"), "an errored stage reviewed nothing: " + out);
+  }
+
+  @Test
   void rendersFindingsWhenPresent() {
     var finding =
         Map.<String, Object>of(


### PR DESCRIPTION
## Never-silent, part 2: infrastructure errors in the review pipeline

Field run with an out-of-quota codex exposed the last silent class: a reviewer *process* failure looked identical to a review *verdict* ("failed, 0 findings"), its cause lived only in the journal, the iterations-exhausted escalation printed nothing, and errored runs burned `max_iterations` — the spec escalated after three attempts in which nothing was ever reviewed.

- **Sealed `StageOutcome`** (Passed / GateFailed / Errored): gate verdicts and infra errors take different paths.
- **Errors are durable**: nullable `error` columns on `reviews` and `review_stages` (append-only migrations); `sail agent review` renders `error: Quota exceeded…` instead of a phantom finding count; `review_errored` event published; escalation and error paths log loudly.
- **Errored iterations are retried, not burned**: the next stop reruns the same iteration number, so an outage can never exhaust `max_iterations`. Gate-failure escalation semantics unchanged.

TDD: store persistence, controller error path + retry-not-burn + loop tests, renderer. Full reactor green (146 + 1840 tests), `api.*` 100% coverage held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NvxJbXoANxoarjX6A2aLZ
