### PR TITLE
feat(banner): stroke-drawn sigma matching the wordmark font

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
@@ -66,7 +66,7 @@ public final class Banner {
     var r = useColor ? RESET : "";
     out.println();
     var mark =
-        List.of("█████████", "▜███▙    ", "  ▜██▙   ", "  ▟██▛   ", "▟███▛    ", "█████████");
+        List.of("██████████", " ╚███╗    ", "   ╚███╗  ", "   ███╔╝  ", " ███╔╝    ", "██████████");
     var wordmark =
         List.of(
             "███████╗  █████╗  ██╗ ██╗",

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/BannerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/BannerTest.java
@@ -172,7 +172,7 @@ class BannerTest {
     Banner.printBranding(new PrintStream(out), Ansi.OFF);
     var output = out.toString(StandardCharsets.UTF_8);
 
-    assertTrue(output.contains("▜███▙"), "the Standard Applied sigma mark leads the wordmark");
+    assertTrue(output.contains("╚███╗"), "the stroke-drawn sigma mark leads the wordmark");
     assertTrue(output.contains("███████"), "the SAIL wordmark");
     assertTrue(output.contains("standardapplied/sail"));
   }


### PR DESCRIPTION
Replaces the solid chevron with a sigma drawn in the SAIL wordmark's own ANSI-shadow stroke style, picked from rendered candidates:

```
  ██████████  ███████╗  █████╗  ██╗ ██╗
   ╚███╗      ██╔════╝ ██╔══██╗ ██║ ██║
     ╚███╗    ███████╗ ███████║ ██║ ██║
     ███╔╝    ╚════██║ ██╔══██║ ██║ ██║
   ███╔╝      ███████║ ██║  ██║ ██║ ███████╗
  ██████████  ╚══════╝ ╚═╝  ╚═╝ ╚═╝ ╚══════╝
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NvxJbXoANxoarjX6A2aLZ