### PR TITLE
fix(host): sudo-from-root broke workstation-key auto-detection

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostConfigSetCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostConfigSetCommand.java
@@ -203,11 +203,20 @@ public final class HostConfigSetCommand implements Runnable {
   }
 
   private static Path authorizedKeysPath() {
-    var sudoUser = System.getenv("SUDO_USER");
-    var home =
-        Strings.isNotBlank(sudoUser)
-            ? Path.of("/home", sudoUser)
-            : Path.of(System.getProperty("user.home"));
+    return authorizedKeysPath(System.getenv("SUDO_USER"), Path.of(System.getProperty("user.home")));
+  }
+
+  /**
+   * The invoking user's authorized_keys: the sudo caller's when elevated, else the process user's.
+   * Root's home is {@code /root}, not {@code /home/root} — a root shell running {@code sudo} sets
+   * {@code SUDO_USER=root}, and resolving that to {@code /home/root} finds nothing and made
+   * auto-detection falsely report no keys.
+   */
+  static Path authorizedKeysPath(String sudoUser, Path userHome) {
+    if (Strings.isBlank(sudoUser)) {
+      return userHome.resolve(".ssh").resolve("authorized_keys");
+    }
+    var home = "root".equals(sudoUser) ? Path.of("/root") : Path.of("/home", sudoUser);
     return home.resolve(".ssh").resolve("authorized_keys");
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/HostConfigSetCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/HostConfigSetCommandTest.java
@@ -254,6 +254,21 @@ class HostConfigSetCommandTest {
   }
 
   @Test
+  void authorizedKeysPathResolvesRootsHomeCorrectlyUnderSudo() {
+    assertEquals(
+        Path.of("/root/.ssh/authorized_keys"),
+        HostConfigSetCommand.authorizedKeysPath("root", Path.of("/ignored")),
+        "sudo from a root shell sets SUDO_USER=root; root's home is /root, not /home/root");
+    assertEquals(
+        Path.of("/home/uday/.ssh/authorized_keys"),
+        HostConfigSetCommand.authorizedKeysPath("uday", Path.of("/ignored")));
+    assertEquals(
+        Path.of("/root/.ssh/authorized_keys"),
+        HostConfigSetCommand.authorizedKeysPath(null, Path.of("/root")),
+        "no sudo: the process user's own home");
+  }
+
+  @Test
   void detectWorkstationKeysIsEmptyWhenTheFileIsMissing(@TempDir Path tmp) {
     assertTrue(HostConfigSetCommand.detectWorkstationKeys(tmp.resolve("absent")).isEmpty());
   }


### PR DESCRIPTION
SUDO_USER=root resolved to /home/root (nonexistent) instead of /root, so key auto-detection falsely found nothing on root-operated boxes. Pure-seam fix + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NvxJbXoANxoarjX6A2aLZ