### PR TITLE
feat(spec): turn review findings into follow-up specs (spec create --from-review)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ attempt's iterations and findings; `sail agent log <project> --review` follows t
 negotiation live. Guardrails combine a `max_duration` and an action, so a runaway agent is
 stopped and rolled back to the pre-launch snapshot.
 
+Findings the gate let ship don't die in the review store: `sail spec create --from-review
+<spec-id>` drafts a follow-up spec from the latest review's open findings — one actionable
+section per finding, priority derived from the highest severity, repos copied from the
+original. The draft stays in `draft` until you promote it, and when it reaches `done` the
+findings it was created from are marked resolved. `sail spec show` and the board flag done
+specs that still carry open findings (`· N open findings`), so completion-with-residue is
+distinguishable from clean completion.
+
 Specs and projects edited on two boxes merge automatically when the changes touch different
 fields. A true same-field clash parks for `sail conflicts` instead of overwriting either
 side.

--- a/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
@@ -295,6 +295,57 @@ public final class ReviewStore {
         "UPDATE review_findings SET resolution = ? WHERE id = ?", resolution.name(), findingId);
   }
 
+  /**
+   * Records which review findings a follow-up spec was drafted from, so completing the spec can
+   * resolve exactly those findings. Idempotent: re-linking an already-linked finding is a no-op.
+   */
+  public void linkSourceFindings(String specId, List<String> findingIds) {
+    db.transaction(
+        () -> {
+          for (var findingId : findingIds) {
+            db.execute(
+                "INSERT OR IGNORE INTO spec_source_findings (spec_id, finding_id) VALUES (?, ?)",
+                specId,
+                findingId);
+          }
+        });
+  }
+
+  /** The finding ids a follow-up spec was drafted from, or empty for a regular spec. */
+  public List<String> sourceFindingIds(String specId) {
+    return db.query(
+        "SELECT finding_id FROM spec_source_findings WHERE spec_id = ? ORDER BY rowid ASC",
+        row -> row.text(0),
+        specId);
+  }
+
+  /**
+   * Marks every still-open finding linked to the follow-up spec {@code FIXED}, returning how many
+   * changed. Called when the follow-up spec reaches {@code done}; findings already dismissed or
+   * fixed by other means are left untouched.
+   */
+  public int resolveSourceFindings(String specId) {
+    db.execute(
+        """
+        UPDATE review_findings SET resolution = 'FIXED'
+        WHERE resolution = 'OPEN'
+        AND id IN (SELECT finding_id FROM spec_source_findings WHERE spec_id = ?)""",
+        specId);
+    return db.changes();
+  }
+
+  /**
+   * Open findings the spec shipped with: the latest non-superseded review's open findings, but only
+   * when that review passed. A failed or still-running review is in-flight work, not residue, so it
+   * contributes nothing here.
+   */
+  public List<Finding> openFindingsAfterPass(String specId) {
+    return latestReviewForSpec(specId)
+        .filter(review -> "passed".equals(review.status()))
+        .map(review -> openFindingsForReview(review.id()))
+        .orElse(List.of());
+  }
+
   private ReviewRow mapReview(Sqlite.Row row) {
     return new ReviewRow(
         row.text(0),

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -308,7 +308,13 @@ public final class SchemaManager {
           "ALTER TABLE agent_sessions ADD COLUMN exit_code INTEGER",
           "ALTER TABLE reviews ADD COLUMN superseded_at TEXT",
           "ALTER TABLE reviews ADD COLUMN error TEXT",
-          "ALTER TABLE review_stages ADD COLUMN error TEXT");
+          "ALTER TABLE review_stages ADD COLUMN error TEXT",
+          """
+          CREATE TABLE IF NOT EXISTS spec_source_findings (
+              spec_id TEXT NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
+              finding_id TEXT NOT NULL REFERENCES review_findings(id) ON DELETE CASCADE,
+              PRIMARY KEY (spec_id, finding_id)
+          )""");
 
   private final Sqlite db;
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
@@ -56,6 +56,129 @@ class ReviewStoreTest {
     if (db != null) db.close();
   }
 
+  private void createSpec(String id) {
+    specStore.create(
+        new SpecStore.SpecRow(
+            id,
+            "test-project",
+            "Follow-up",
+            SpecStatus.DRAFT,
+            null,
+            null,
+            null,
+            null,
+            null,
+            0,
+            null,
+            "",
+            "",
+            null,
+            List.of(),
+            List.of()));
+  }
+
+  private Finding addOpenFinding(String stageId, Finding.Severity severity, String title) {
+    var finding =
+        Finding.create(
+            severity,
+            Finding.Category.SECURITY,
+            "src/Auth.java",
+            10,
+            12,
+            title,
+            "Description",
+            "Evidence",
+            new Finding.Suggestion("bad", "good", "why"),
+            0.8);
+    store.addFinding(stageId, finding);
+    return finding;
+  }
+
+  @Test
+  void linkSourceFindingsRecordsAndReturnsIds() {
+    var reviewId = store.createReview("auth", 1);
+    var stageId = store.createStage(reviewId, "security", "agent");
+    var finding = addOpenFinding(stageId, Finding.Severity.HIGH, "Issue");
+    createSpec("auth-followup");
+
+    store.linkSourceFindings("auth-followup", List.of(finding.id()));
+    store.linkSourceFindings("auth-followup", List.of(finding.id()));
+
+    assertEquals(List.of(finding.id()), store.sourceFindingIds("auth-followup"));
+  }
+
+  @Test
+  void resolveSourceFindingsMarksOnlyLinkedOpenFindingsFixed() {
+    var reviewId = store.createReview("auth", 1);
+    var stageId = store.createStage(reviewId, "security", "agent");
+    var linked = addOpenFinding(stageId, Finding.Severity.HIGH, "Linked");
+    var dismissed = addOpenFinding(stageId, Finding.Severity.LOW, "Dismissed");
+    var unlinked = addOpenFinding(stageId, Finding.Severity.MEDIUM, "Unlinked");
+    store.resolveFinding(dismissed.id(), Finding.Resolution.DISMISSED);
+    createSpec("auth-followup");
+    store.linkSourceFindings("auth-followup", List.of(linked.id(), dismissed.id()));
+
+    assertEquals(1, store.resolveSourceFindings("auth-followup"));
+
+    var byId = store.findingsForReview(reviewId);
+    assertEquals(
+        Finding.Resolution.FIXED,
+        byId.stream()
+            .filter(f -> f.id().equals(linked.id()))
+            .findFirst()
+            .orElseThrow()
+            .resolution());
+    assertEquals(
+        Finding.Resolution.DISMISSED,
+        byId.stream()
+            .filter(f -> f.id().equals(dismissed.id()))
+            .findFirst()
+            .orElseThrow()
+            .resolution());
+    assertEquals(
+        Finding.Resolution.OPEN,
+        byId.stream()
+            .filter(f -> f.id().equals(unlinked.id()))
+            .findFirst()
+            .orElseThrow()
+            .resolution());
+  }
+
+  @Test
+  void openFindingsAfterPassReturnsOpenFindingsOfLatestPassedReview() {
+    var reviewId = store.createReview("auth", 1);
+    var stageId = store.createStage(reviewId, "security", "agent");
+    var open = addOpenFinding(stageId, Finding.Severity.HIGH, "Open");
+    var fixed = addOpenFinding(stageId, Finding.Severity.LOW, "Fixed");
+    store.resolveFinding(fixed.id(), Finding.Resolution.FIXED);
+    store.updateReviewStatus(reviewId, "passed");
+
+    var findings = store.openFindingsAfterPass("auth");
+    assertEquals(1, findings.size());
+    assertEquals(open.id(), findings.getFirst().id());
+  }
+
+  @Test
+  void openFindingsAfterPassEmptyWhenLatestReviewNotPassed() {
+    var reviewId = store.createReview("auth", 1);
+    var stageId = store.createStage(reviewId, "security", "agent");
+    addOpenFinding(stageId, Finding.Severity.HIGH, "Open");
+    store.updateReviewStatus(reviewId, "failed");
+
+    assertTrue(store.openFindingsAfterPass("auth").isEmpty());
+  }
+
+  @Test
+  void openFindingsAfterPassIgnoresSupersededReviews() {
+    var reviewId = store.createReview("auth", 1);
+    var stageId = store.createStage(reviewId, "security", "agent");
+    addOpenFinding(stageId, Finding.Severity.HIGH, "Open");
+    store.updateReviewStatus(reviewId, "passed");
+    store.supersedeForSpec("auth");
+
+    assertTrue(store.openFindingsAfterPass("auth").isEmpty());
+  }
+
   @Test
   void createAndFindReview() {
     var id = store.createReview("auth", 1);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -488,6 +488,34 @@ record SpecUpdateRequest(
   }
 }
 
+record FollowupCreateRequest(String id, String createdBy) {
+  static FollowupCreateRequest fromMap(Map<String, Object> map) {
+    return new FollowupCreateRequest((String) map.get("id"), null);
+  }
+
+  /**
+   * Returns a copy attributed to {@code actor}. {@code created_by} is set by the server from the
+   * authenticated principal, never from the request body, so a client cannot forge authorship.
+   */
+  FollowupCreateRequest withCreatedBy(String actor) {
+    return new FollowupCreateRequest(id, actor);
+  }
+}
+
+record FollowupSpecResponse(
+    GlobalSpecView spec, String sourceSpecId, String reviewId, int findingCount)
+    implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("spec", spec.toMap());
+    m.put("source_spec_id", sourceSpecId);
+    m.put("review_id", reviewId);
+    m.put("finding_count", findingCount);
+    return m;
+  }
+}
+
 record SpecContentRequest(String body, String plan) {
   static SpecContentRequest fromMap(Map<String, Object> map) {
     return new SpecContentRequest((String) map.get("body"), (String) map.get("plan"));
@@ -613,13 +641,15 @@ record GlobalSpecsListResponse(List<GlobalSpecView> specs, int total) implements
   }
 }
 
-record GlobalSpecDetailResponse(GlobalSpecView spec, String body, String plan) implements Mappable {
+record GlobalSpecDetailResponse(GlobalSpecView spec, String body, String plan, int openFindings)
+    implements Mappable {
   @Override
   public Map<String, Object> toMap() {
     var m = new LinkedHashMap<String, Object>();
     m.put("spec", spec.toMap());
     if (body != null) m.put("body", body);
     if (plan != null) m.put("plan", plan);
+    if (openFindings > 0) m.put("open_findings", openFindings);
     return m;
   }
 }
@@ -663,7 +693,7 @@ record GlobalSpecContentResponse(String specId, String body, String plan) implem
   }
 }
 
-record GlobalBoardResponse(SpecStore.BoardSummary board) implements Mappable {
+record GlobalBoardResponse(SpecStore.BoardSummary board, int doneOpenFindings) implements Mappable {
   @Override
   public Map<String, Object> toMap() {
     var m = new LinkedHashMap<String, Object>();
@@ -674,6 +704,7 @@ record GlobalBoardResponse(SpecStore.BoardSummary board) implements Mappable {
     m.put("done", board.done());
     m.put("archived", board.archived());
     m.put("next_ready_id", board.nextReadyId());
+    m.put("done_open_findings", doneOpenFindings);
     return m;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiOperations.java
@@ -50,6 +50,9 @@ public interface ApiOperations {
 
   Result<GlobalSpecCreatedResponse> createGlobalSpec(SpecCreateRequest request);
 
+  /** Drafts a follow-up spec from the open findings of a spec's latest non-superseded review. */
+  Result<FollowupSpecResponse> createFollowupSpec(String specId, FollowupCreateRequest request);
+
   Result<GlobalSpecUpdatedResponse> updateGlobalSpec(String specId, SpecUpdateRequest request);
 
   Result<GlobalSpecDeletedResponse> deleteGlobalSpec(String specId);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -49,6 +49,7 @@ public final class ApiRouter implements HttpHandler {
   private static final String SESSIONS = "sessions";
   private static final String APPROVE = "approve";
   private static final String DISMISS = "dismiss";
+  private static final String FOLLOWUP = "followup";
   private static final int DEFAULT_TAIL = 200;
   private static final int MIN_TAIL = 1;
   private static final int MAX_TAIL = 5000;
@@ -262,6 +263,14 @@ public final class ApiRouter implements HttpHandler {
         return ApiResponse.from(
             operations.restoreGlobalSpec(
                 specId, SpecRestoreRequest.fromMap(JsonBody.readMap(exchange))));
+      }
+      if (FOLLOWUP.equals(sub)) {
+        requireMethod(request, POST);
+        return ApiResponse.fromCreated(
+            operations.createFollowupSpec(
+                specId,
+                FollowupCreateRequest.fromMap(JsonBody.readMap(exchange))
+                    .withCreatedBy(actor(exchange))));
       }
     }
     throw notFound();

--- a/sail-infra/src/main/java/ai/singlr/sail/api/FollowupDraft.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/FollowupDraft.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.store.Finding;
+import ai.singlr.sail.store.ReviewStore;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Renders a follow-up spec draft from a review's open findings: the derived title, a markdown body
+ * with one actionable section per finding (ordered by severity), and a priority derived from the
+ * highest severity present. Pure functions over {@link Finding}s — no store access, no I/O.
+ */
+final class FollowupDraft {
+
+  private FollowupDraft() {}
+
+  static String title(String sourceTitle) {
+    return "Address review findings: " + sourceTitle;
+  }
+
+  static int priority(List<Finding> findings) {
+    var top =
+        findings.stream()
+            .map(Finding::severity)
+            .min(Comparator.naturalOrder())
+            .orElseThrow(() -> new IllegalArgumentException("At least one finding is required."));
+    return switch (top) {
+      case CRITICAL -> 4;
+      case HIGH -> 3;
+      case MEDIUM -> 2;
+      case LOW -> 1;
+    };
+  }
+
+  static String body(String sourceSpecId, ReviewStore.ReviewRow review, List<Finding> findings) {
+    var sb = new StringBuilder();
+    sb.append("# Follow-up: open review findings for `")
+        .append(sourceSpecId)
+        .append("`\n\n")
+        .append("Drafted from review `")
+        .append(review.id())
+        .append("` (iteration ")
+        .append(review.iteration())
+        .append("). Each section below is one open finding, ordered by severity.\n")
+        .append("The linked findings are marked resolved automatically when this spec")
+        .append(" reaches `done`.\n");
+    var index = 1;
+    for (var finding : findings) {
+      appendFinding(sb, index++, finding);
+    }
+    return sb.toString();
+  }
+
+  private static void appendFinding(StringBuilder sb, int index, Finding finding) {
+    sb.append("\n## ")
+        .append(index)
+        .append(". [")
+        .append(finding.severity())
+        .append("] ")
+        .append(finding.title())
+        .append("\n\n");
+    sb.append("- **Severity:** ").append(finding.severity()).append('\n');
+    sb.append("- **Category:** ").append(finding.category()).append('\n');
+    if (Strings.isNotBlank(finding.file())) {
+      sb.append("- **Location:** `").append(location(finding)).append("`\n");
+    }
+    sb.append("- **Confidence:** ").append(finding.confidence()).append('\n');
+    sb.append('\n').append(finding.description()).append('\n');
+    if (Strings.isNotBlank(finding.evidence())) {
+      sb.append("\n**Evidence:**\n\n").append(finding.evidence()).append('\n');
+    }
+    appendSuggestion(sb, finding.suggestion());
+  }
+
+  private static void appendSuggestion(StringBuilder sb, Finding.Suggestion suggestion) {
+    if (suggestion == null) {
+      return;
+    }
+    var hasDiff = Strings.isNotBlank(suggestion.before()) || Strings.isNotBlank(suggestion.after());
+    if (!hasDiff && Strings.isBlank(suggestion.rationale())) {
+      return;
+    }
+    sb.append("\n**Suggested fix:**\n");
+    if (Strings.isNotBlank(suggestion.before())) {
+      sb.append("\nBefore:\n\n```\n").append(suggestion.before()).append("\n```\n");
+    }
+    if (Strings.isNotBlank(suggestion.after())) {
+      sb.append("\nAfter:\n\n```\n").append(suggestion.after()).append("\n```\n");
+    }
+    if (Strings.isNotBlank(suggestion.rationale())) {
+      sb.append("\nRationale: ").append(suggestion.rationale()).append('\n');
+    }
+  }
+
+  private static String location(Finding finding) {
+    var lines =
+        finding.lineEnd() > finding.lineStart()
+            ? finding.lineStart() + "-" + finding.lineEnd()
+            : String.valueOf(finding.lineStart());
+    return finding.file() + ":" + lines;
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.api;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.engine.NameValidator;
+import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.SpecStore;
 import java.util.Objects;
 
@@ -20,9 +21,15 @@ import java.util.Objects;
 final class GlobalSpecOperations {
 
   private final SpecStore specStore;
+  private final ReviewStore reviewStore;
 
   GlobalSpecOperations(SpecStore specStore) {
+    this(specStore, null);
+  }
+
+  GlobalSpecOperations(SpecStore specStore, ReviewStore reviewStore) {
     this.specStore = specStore;
+    this.reviewStore = reviewStore;
   }
 
   GlobalSpecsListResponse list(SpecStore.SpecFilter filter) {
@@ -42,7 +49,8 @@ final class GlobalSpecOperations {
     return new GlobalSpecDetailResponse(
         GlobalSpecView.from(row),
         content != null ? content.body() : null,
-        content != null ? content.plan() : null);
+        content != null ? content.plan() : null,
+        openFindingCount(specId));
   }
 
   GlobalSpecCreatedResponse create(SpecCreateRequest request) {
@@ -114,6 +122,11 @@ final class GlobalSpecOperations {
             request.dependsOn() != null ? request.dependsOn() : existing.dependsOn(),
             request.repos() != null ? request.repos() : existing.repos());
     specStore.update(updated);
+    if (updated.status() == SpecStatus.DONE
+        && existing.status() != SpecStatus.DONE
+        && reviewStore != null) {
+      reviewStore.resolveSourceFindings(specId);
+    }
     var result = specStore.findById(specId).orElseThrow();
     return new GlobalSpecUpdatedResponse(GlobalSpecView.from(result));
   }
@@ -165,7 +178,27 @@ final class GlobalSpecOperations {
 
   GlobalBoardResponse board(String project) {
     requireStore();
-    return new GlobalBoardResponse(specStore.board(project));
+    return new GlobalBoardResponse(specStore.board(project), doneOpenFindings(project));
+  }
+
+  /**
+   * Open findings still attached to {@code done} specs — residual work the gate let ship. Shown
+   * next to the board's done column so completion-with-residue is distinguishable from clean
+   * completion.
+   */
+  private int doneOpenFindings(String project) {
+    if (reviewStore == null) {
+      return 0;
+    }
+    return specStore
+        .list(new SpecStore.SpecFilter(project, SpecStatus.DONE.wire(), null, null, null))
+        .stream()
+        .mapToInt(spec -> openFindingCount(spec.id()))
+        .sum();
+  }
+
+  private int openFindingCount(String specId) {
+    return reviewStore == null ? 0 : reviewStore.openFindingsAfterPass(specId).size();
   }
 
   GlobalSpecHistoryResponse history(String specId) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewOperations.java
@@ -6,9 +6,11 @@
 package ai.singlr.sail.api;
 
 import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.store.Finding;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.SpecStore;
+import java.util.List;
 
 /**
  * Review-workflow operations against the {@link ReviewStore}. Split out of {@code
@@ -68,7 +70,92 @@ final class ReviewOperations {
     reviewStore.completeStage(humanStage.id(), "passed");
     reviewStore.approve(reviewId, actor);
     specStore.updateStatus(review.specId(), SpecStatus.DONE);
+    reviewStore.resolveSourceFindings(review.specId());
     return new ReviewApproveResponse(reviewId, true);
+  }
+
+  /**
+   * Drafts a follow-up spec from the open findings of {@code sourceSpecId}'s latest non-superseded
+   * review. The draft copies the source spec's project and repos, derives its priority from the
+   * highest severity present, and starts in {@code draft} so a human reviews and edits it before
+   * promotion — generated work is never auto-dispatched. The findings it was drafted from are
+   * linked, so they are marked resolved when the follow-up reaches {@code done}.
+   */
+  FollowupSpecResponse createFollowup(String sourceSpecId, FollowupCreateRequest request) {
+    requireStore();
+    var source =
+        specStore
+            .findById(sourceSpecId)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.SPEC_NOT_FOUND, "Spec '" + sourceSpecId + "' was not found."));
+    var review =
+        reviewStore.latestReviewForSpec(sourceSpecId).orElseThrow(() -> noReview(sourceSpecId));
+    var findings = reviewStore.openFindingsForReview(review.id());
+    if (findings.isEmpty()) {
+      throw new ApiException(
+          ErrorCode.INVALID_REQUEST,
+          "The latest review of spec '" + sourceSpecId + "' has no open findings.",
+          "Every finding is already fixed or dismissed — there is nothing to follow up on.");
+    }
+    var followupId = followupId(sourceSpecId, request.id());
+    if (specStore.findById(followupId).isPresent()) {
+      throw new ApiException(
+          ErrorCode.CONFLICT,
+          "Spec '" + followupId + "' already exists.",
+          "Pass --id <id> to choose a different id for the follow-up spec.");
+    }
+    specStore.create(
+        new SpecStore.SpecRow(
+            followupId,
+            source.project(),
+            FollowupDraft.title(source.title()),
+            SpecStatus.DRAFT,
+            null,
+            null,
+            null,
+            null,
+            null,
+            FollowupDraft.priority(findings),
+            request.createdBy(),
+            "",
+            "",
+            request.createdBy(),
+            List.of(),
+            source.repos()));
+    specStore.setContent(followupId, FollowupDraft.body(sourceSpecId, review, findings), "");
+    reviewStore.linkSourceFindings(followupId, findings.stream().map(Finding::id).toList());
+    var created = specStore.findById(followupId).orElseThrow();
+    return new FollowupSpecResponse(
+        GlobalSpecView.from(created), sourceSpecId, review.id(), findings.size());
+  }
+
+  private ApiException noReview(String sourceSpecId) {
+    if (reviewStore.reviewsForSpec(sourceSpecId).isEmpty()) {
+      return new ApiException(
+          ErrorCode.NOT_FOUND,
+          "Spec '" + sourceSpecId + "' has no reviews.",
+          "Dispatch the spec with a review pipeline configured, let the review finish,"
+              + " then re-run this command.");
+    }
+    return new ApiException(
+        ErrorCode.CONFLICT,
+        "Every review of spec '"
+            + sourceSpecId
+            + "' was superseded by a re-dispatch — there is no current review to draw findings"
+            + " from.",
+        "Let the current dispatch attempt finish its review, then re-run this command.");
+  }
+
+  private static String followupId(String sourceSpecId, String requestedId) {
+    var followupId = requestedId != null ? requestedId : sourceSpecId + "-followup";
+    try {
+      NameValidator.requireValidSpecId(followupId);
+    } catch (IllegalArgumentException e) {
+      throw new ApiException(ErrorCode.INVALID_REQUEST, e.getMessage());
+    }
+    return followupId;
   }
 
   FindingDismissResponse dismissFinding(String reviewId, String findingId) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiClient.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiClient.java
@@ -82,6 +82,10 @@ public final class SailApiClient implements AutoCloseable {
       if (response.statusCode() >= 400) {
         var error = (Map<String, Object>) body.get("error");
         var message = error != null ? (String) error.get("message") : "API request failed";
+        var action = error != null ? (String) error.get("action") : null;
+        if (action != null && !action.isBlank()) {
+          message = message + " " + action;
+        }
         throw new IOException(message + " (HTTP " + response.statusCode() + ")");
       }
       return body;

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -141,7 +141,7 @@ public final class SailApiOperations implements ApiOperations {
     this.specStore = specStore;
     this.reviewStore = reviewStore;
     this.sessionStore = sessionStore;
-    this.globalSpecOps = new GlobalSpecOperations(specStore);
+    this.globalSpecOps = new GlobalSpecOperations(specStore, reviewStore);
     this.reviewOps = new ReviewOperations(reviewStore, specStore);
   }
 
@@ -793,6 +793,12 @@ public final class SailApiOperations implements ApiOperations {
   @Override
   public Result<GlobalSpecCreatedResponse> createGlobalSpec(SpecCreateRequest request) {
     return safe(() -> globalSpecOps.create(request));
+  }
+
+  @Override
+  public Result<FollowupSpecResponse> createFollowupSpec(
+      String specId, FollowupCreateRequest request) {
+    return safe(() -> reviewOps.createFollowup(specId, request));
   }
 
   @Override

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecBoardCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecBoardCommand.java
@@ -58,7 +58,13 @@ public final class ApiSpecBoardCommand implements Runnable {
       System.out.println(
           Ansi.AUTO.string("    @|blue In Progress:|@ " + result.get("in_progress")));
       System.out.println(Ansi.AUTO.string("    @|yellow Review:|@      " + result.get("review")));
-      System.out.println(Ansi.AUTO.string("    @|green Done:|@        " + result.get("done")));
+      var doneOpenFindings = result.get("done_open_findings");
+      var doneSuffix =
+          doneOpenFindings instanceof Number n && n.intValue() > 0
+              ? " @|yellow · " + n + " open findings|@"
+              : "";
+      System.out.println(
+          Ansi.AUTO.string("    @|green Done:|@        " + result.get("done") + doneSuffix));
 
       var nextReady = result.get("next_ready_id");
       if (nextReady != null) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCreateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCreateCommand.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Mixin;
@@ -24,11 +25,20 @@ import picocli.CommandLine.Spec;
 @Command(name = "create", description = "Create a new spec.", mixinStandardHelpOptions = true)
 public final class ApiSpecCreateCommand implements Runnable {
 
-  @Option(names = "--id", required = true, description = "Spec ID.")
+  @Option(names = "--id", description = "Spec ID. Required unless --from-review is used.")
   private String id;
 
-  @Option(names = "--title", required = true, description = "Spec title.")
+  @Option(names = "--title", description = "Spec title. Required unless --from-review is used.")
   private String title;
+
+  @Option(
+      names = "--from-review",
+      paramLabel = "<spec-id>",
+      description =
+          "Draft a follow-up spec from the open findings of the given spec's latest review."
+              + " Title, body, priority, project, and repos are derived; the draft stays in"
+              + " 'draft' status until you promote it.")
+  private String fromReview;
 
   @Option(
       names = "--project",
@@ -77,6 +87,15 @@ public final class ApiSpecCreateCommand implements Runnable {
 
   private void execute() throws Exception {
     SpecSync.freshenIfNode(syncOptions.noSync());
+    if (fromReview != null) {
+      executeFromReview();
+      return;
+    }
+    if (id == null || title == null) {
+      throw new IllegalArgumentException(
+          "--id and --title are required. To draft a follow-up spec from review findings"
+              + " instead, use --from-review <spec-id>.");
+    }
     NameValidator.requireValidSpecId(id);
     var config = connection.resolve();
     var resolvedProject = project != null ? project : projectFromCwd();
@@ -108,6 +127,59 @@ public final class ApiSpecCreateCommand implements Runnable {
             Ansi.AUTO.string(
                 "  @|green ✓|@ Spec created: " + id + " @|faint (" + resolvedProject + ")|@"));
       }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void executeFromReview() throws Exception {
+    NameValidator.requireValidSpecId(fromReview);
+    requireNoDerivedOptions();
+    var config = connection.resolve();
+    var body = new LinkedHashMap<String, Object>();
+    if (id != null) {
+      NameValidator.requireValidSpecId(id);
+      body.put("id", id);
+    }
+    try (var client = new SailApiClient(config.serverUrl(), config.token())) {
+      var result = client.post("/v1/specs/" + fromReview + "/followup", body);
+
+      if (json) {
+        System.out.println(YamlUtil.dumpJson(new LinkedHashMap<>(result)));
+        return;
+      }
+      var spec = (Map<String, Object>) result.get("spec");
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|green ✓|@ Follow-up spec drafted: "
+                  + spec.get("id")
+                  + " @|faint ("
+                  + result.get("finding_count")
+                  + " open findings from the latest review of "
+                  + fromReview
+                  + ")|@"));
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|faint Review and edit it, then promote: sail spec edit "
+                  + spec.get("id")
+                  + " --status pending|@"));
+    }
+  }
+
+  private void requireNoDerivedOptions() {
+    var derived =
+        title != null
+            || bodyFile != null
+            || planFile != null
+            || assignee != null
+            || agent != null
+            || branch != null
+            || dependsOn != null
+            || repos != null
+            || !"draft".equals(status);
+    if (derived) {
+      throw new IllegalArgumentException(
+          "--from-review derives title, body, priority, project, and repos from the review;"
+              + " only --id may be combined with it.");
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecShowCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecShowCommand.java
@@ -62,7 +62,13 @@ public final class ApiSpecShowCommand implements Runnable {
         System.out.println(Ansi.AUTO.string("  @|bold Project:|@ " + spec.get("project")));
       }
       System.out.println(Ansi.AUTO.string("  @|bold Title:|@ " + spec.get("title")));
-      System.out.println(Ansi.AUTO.string("  @|bold Status:|@ " + spec.get("status")));
+      var openFindings = result.get("open_findings");
+      var findingsSuffix =
+          openFindings instanceof Number n && n.intValue() > 0
+              ? " @|yellow · " + n + " open findings|@"
+              : "";
+      System.out.println(
+          Ansi.AUTO.string("  @|bold Status:|@ " + spec.get("status") + findingsSuffix));
       if (spec.get("assignee") != null) {
         System.out.println(Ansi.AUTO.string("  @|bold Assignee:|@ " + spec.get("assignee")));
       }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -687,6 +687,35 @@ class ApiRouterTest {
   }
 
   @Test
+  void followupPostReturns201WithDraftedSpec() throws Exception {
+    try (var server = server()) {
+      var response = post(server, "/v1/specs/auth-flow/followup", "token", "{}");
+      assertEquals(201, response.statusCode());
+      assertTrue(response.body().contains("\"id\": \"auth-flow-followup\""));
+      assertTrue(response.body().contains("\"source_spec_id\": \"auth-flow\""));
+      assertTrue(response.body().contains("\"finding_count\": 2"));
+    }
+  }
+
+  @Test
+  void followupHonorsRequestedId() throws Exception {
+    try (var server = server()) {
+      var response =
+          post(server, "/v1/specs/auth-flow/followup", "token", "{\"id\": \"auth-round2\"}");
+      assertEquals(201, response.statusCode());
+      assertTrue(response.body().contains("\"id\": \"auth-round2\""));
+    }
+  }
+
+  @Test
+  void followupRejectsNonPost() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/specs/auth-flow/followup", "token");
+      assertEquals(405, response.statusCode());
+    }
+  }
+
+  @Test
   void specReviewsListReturns200() throws Exception {
     try (var server = server()) {
       var response = get(server, "/v1/specs/auth-flow/reviews", "token");
@@ -1053,7 +1082,34 @@ class ApiRouterTest {
                   "",
                   null),
               null,
-              null));
+              null,
+              0));
+    }
+
+    @Override
+    public Result<FollowupSpecResponse> createFollowupSpec(
+        String specId, FollowupCreateRequest request) {
+      return Result.success(
+          new FollowupSpecResponse(
+              new GlobalSpecView(
+                  request.id() != null ? request.id() : specId + "-followup",
+                  "test-project",
+                  "Address review findings: Test",
+                  "draft",
+                  null,
+                  null,
+                  null,
+                  null,
+                  3,
+                  java.util.List.of(),
+                  java.util.List.of(),
+                  request.createdBy(),
+                  "",
+                  "",
+                  request.createdBy()),
+              specId,
+              "r1",
+              2));
     }
 
     @Override
@@ -1156,7 +1212,7 @@ class ApiRouterTest {
     public Result<GlobalBoardResponse> globalBoard(String project) {
       return Result.success(
           new GlobalBoardResponse(
-              new ai.singlr.sail.store.SpecStore.BoardSummary(0, 0, 0, 0, 0, 0, null)));
+              new ai.singlr.sail.store.SpecStore.BoardSummary(0, 0, 0, 0, 0, 0, null), 0));
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/FollowupDraftTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/FollowupDraftTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.store.Finding;
+import ai.singlr.sail.store.ReviewStore;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class FollowupDraftTest {
+
+  private static final ReviewStore.ReviewRow REVIEW =
+      new ReviewStore.ReviewRow("r1", "auth", 1, "passed", "t0", "t1", null, null, null);
+
+  private static Finding finding(Finding.Severity severity, Finding.Suggestion suggestion) {
+    return Finding.create(
+        severity,
+        Finding.Category.SECURITY,
+        "Auth.java",
+        10,
+        10,
+        "Issue",
+        "Description",
+        "Evidence",
+        suggestion,
+        0.8);
+  }
+
+  @Test
+  void priorityMapsTheHighestSeverityPresent() {
+    assertEquals(4, FollowupDraft.priority(List.of(finding(Finding.Severity.CRITICAL, null))));
+    assertEquals(3, FollowupDraft.priority(List.of(finding(Finding.Severity.HIGH, null))));
+    assertEquals(2, FollowupDraft.priority(List.of(finding(Finding.Severity.MEDIUM, null))));
+    assertEquals(1, FollowupDraft.priority(List.of(finding(Finding.Severity.LOW, null))));
+    assertEquals(
+        4,
+        FollowupDraft.priority(
+            List.of(finding(Finding.Severity.LOW, null), finding(Finding.Severity.CRITICAL, null))),
+        "the top severity wins regardless of order");
+  }
+
+  @Test
+  void priorityRequiresAtLeastOneFinding() {
+    assertThrows(IllegalArgumentException.class, () -> FollowupDraft.priority(List.of()));
+  }
+
+  @Test
+  void bodyOmitsTheSuggestedFixWhenTheSuggestionIsBlankOrAbsent() {
+    var blank = new Finding.Suggestion("", "", "");
+
+    var withBlank =
+        FollowupDraft.body("auth", REVIEW, List.of(finding(Finding.Severity.HIGH, blank)));
+    var withNull =
+        FollowupDraft.body("auth", REVIEW, List.of(finding(Finding.Severity.HIGH, null)));
+
+    assertFalse(withBlank.contains("Suggested fix"), withBlank);
+    assertFalse(withNull.contains("Suggested fix"), withNull);
+    assertTrue(withBlank.contains("Description"), "the finding itself still renders");
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
@@ -11,10 +11,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.singlr.sail.store.Finding;
+import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,13 +28,17 @@ class GlobalSpecOperationsTest {
 
   @TempDir Path tempDir;
   private Sqlite db;
+  private SpecStore specStore;
+  private ReviewStore reviewStore;
   private GlobalSpecOperations ops;
 
   @BeforeEach
   void setUp() {
     db = Sqlite.open(tempDir.resolve("test.db"));
     new SchemaManager(db).migrate();
-    ops = new GlobalSpecOperations(new SpecStore(db));
+    specStore = new SpecStore(db);
+    reviewStore = new ReviewStore(db);
+    ops = new GlobalSpecOperations(specStore, reviewStore);
   }
 
   @AfterEach
@@ -275,6 +282,74 @@ class GlobalSpecOperationsTest {
     var noStore = new GlobalSpecOperations(null);
     var ex = assertThrows(ApiException.class, () -> noStore.list(SpecStore.SpecFilter.all()));
     assertEquals(ErrorCode.INTERNAL, ex.failure().errorCode());
+  }
+
+  private String seedPassedReviewWithOpenFinding(String specId) {
+    var reviewId = reviewStore.createReview(specId, 1);
+    var stageId = reviewStore.createStage(reviewId, "security", "agent");
+    reviewStore.addFinding(
+        stageId,
+        Finding.create(
+            Finding.Severity.HIGH,
+            Finding.Category.SECURITY,
+            "Auth.java",
+            1,
+            1,
+            "Issue",
+            "Description",
+            "",
+            null,
+            0.9));
+    reviewStore.updateReviewStatus(reviewId, "passed");
+    return reviewId;
+  }
+
+  @Test
+  void getReportsOpenFindingsOfLatestPassedReview() {
+    ops.create(createReq(Map.of("status", "done")));
+    seedPassedReviewWithOpenFinding("auth");
+
+    assertEquals(1, ops.get("auth").openFindings());
+  }
+
+  @Test
+  void updateToDoneResolvesLinkedSourceFindings() {
+    ops.create(createReq(Map.of("status", "done")));
+    var reviewId = seedPassedReviewWithOpenFinding("auth");
+    var findingId = reviewStore.findingsForReview(reviewId).getFirst().id();
+    ops.create(createReq(Map.of("id", "auth-followup", "title", "Follow-up", "status", "pending")));
+    reviewStore.linkSourceFindings("auth-followup", List.of(findingId));
+
+    ops.update(
+        "auth-followup", SpecUpdateRequest.fromMap(Map.of("status", "done")).withUpdatedBy("uday"));
+
+    assertEquals(
+        Finding.Resolution.FIXED, reviewStore.findingsForReview(reviewId).getFirst().resolution());
+  }
+
+  @Test
+  void updateWithoutDoneTransitionLeavesFindingsOpen() {
+    ops.create(createReq(Map.of("status", "done")));
+    var reviewId = seedPassedReviewWithOpenFinding("auth");
+    var findingId = reviewStore.findingsForReview(reviewId).getFirst().id();
+    ops.create(createReq(Map.of("id", "auth-followup", "title", "Follow-up", "status", "pending")));
+    reviewStore.linkSourceFindings("auth-followup", List.of(findingId));
+
+    ops.update(
+        "auth-followup",
+        SpecUpdateRequest.fromMap(Map.of("title", "Renamed")).withUpdatedBy("uday"));
+
+    assertEquals(
+        Finding.Resolution.OPEN, reviewStore.findingsForReview(reviewId).getFirst().resolution());
+  }
+
+  @Test
+  void boardCountsOpenFindingsOnDoneSpecs() {
+    ops.create(createReq(Map.of("status", "done")));
+    seedPassedReviewWithOpenFinding("auth");
+    ops.create(createReq(Map.of("id", "clean", "title", "Clean", "status", "done")));
+
+    assertEquals(1, ops.board("manatee").doneOpenFindings());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
@@ -183,6 +183,53 @@ class GlobalSpecOperationsTest {
   }
 
   @Test
+  void getSurvivesASpecWhoseContentRowIsMissing() {
+    ops.create(createReq(Map.of()));
+    db.execute("DELETE FROM spec_content WHERE spec_id = ?", "auth");
+
+    var detail = ops.get("auth");
+
+    assertNull(detail.body());
+    assertNull(detail.plan());
+  }
+
+  @Test
+  void updateReplacesEveryProvidedField() {
+    ops.create(createReq(Map.of()));
+
+    var updated =
+        ops.update(
+            "auth",
+            SpecUpdateRequest.fromMap(
+                Map.of(
+                    "project", "zenith",
+                    "status", "pending",
+                    "agent", "codex",
+                    "model", "claude-opus-4",
+                    "branch", "feat/x",
+                    "priority", 9,
+                    "depends_on", List.of("other"),
+                    "repos", List.of("api", "web"))));
+
+    assertEquals("zenith", updated.spec().project());
+    assertEquals("codex", updated.spec().agent());
+    assertEquals("claude-opus-4", updated.spec().model());
+    assertEquals("feat/x", updated.spec().branch());
+    assertEquals(9, updated.spec().priority());
+    assertEquals(List.of("other"), updated.spec().dependsOn());
+    assertEquals(List.of("api", "web"), updated.spec().repos());
+  }
+
+  @Test
+  void boardCountsNoResidualFindingsWithoutAReviewStore() {
+    ops.create(createReq(Map.of("status", "done")));
+
+    var board = new GlobalSpecOperations(specStore, null).board(null);
+
+    assertEquals(0, board.doneOpenFindings());
+  }
+
+  @Test
   void updateMissingThrowsNotFound() {
     assertThrows(
         ApiException.class,

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewOperationsTest.java
@@ -28,6 +28,7 @@ class ReviewOperationsTest {
   @TempDir Path tempDir;
   private Sqlite db;
   private ReviewStore reviewStore;
+  private SpecStore specStore;
   private ReviewOperations ops;
 
   @BeforeEach
@@ -35,7 +36,7 @@ class ReviewOperationsTest {
     db = Sqlite.open(tempDir.resolve("test.db"));
     new SchemaManager(db).migrate();
     reviewStore = new ReviewStore(db);
-    var specStore = new SpecStore(db);
+    specStore = new SpecStore(db);
     specStore.create(
         new SpecStore.SpecRow(
             "auth",
@@ -53,7 +54,7 @@ class ReviewOperationsTest {
             "",
             null,
             List.of(),
-            List.of()));
+            List.of("api", "web")));
     ops = new ReviewOperations(reviewStore, specStore);
   }
 
@@ -147,6 +148,153 @@ class ReviewOperationsTest {
   @Test
   void dismissFindingMissingReviewThrowsNotFound() {
     assertThrows(ApiException.class, () -> ops.dismissFinding("nope", "f1"));
+  }
+
+  private String seedPassedReviewWithOpenFindings() {
+    var reviewId = reviewStore.createReview("auth", 1);
+    var stageId = reviewStore.createStage(reviewId, "security", "agent");
+    reviewStore.addFinding(
+        stageId,
+        Finding.create(
+            Finding.Severity.MEDIUM,
+            Finding.Category.EDGE_CASE,
+            "Flow.java",
+            5,
+            5,
+            "Unchecked null",
+            "Null flows through.",
+            "",
+            null,
+            0.6));
+    reviewStore.addFinding(
+        stageId,
+        Finding.create(
+            Finding.Severity.HIGH,
+            Finding.Category.SECURITY,
+            "Auth.java",
+            10,
+            12,
+            "Token leak",
+            "Token is logged.",
+            "log.info(token)",
+            new Finding.Suggestion("log.info(token)", "log.info(mask(token))", "Never log secrets"),
+            0.9));
+    reviewStore.updateReviewStatus(reviewId, "passed");
+    return reviewId;
+  }
+
+  @Test
+  void createFollowupDraftsSpecFromOpenFindings() {
+    var reviewId = seedPassedReviewWithOpenFindings();
+
+    var response = ops.createFollowup("auth", new FollowupCreateRequest(null, "uday"));
+
+    assertEquals("auth-followup", response.spec().id());
+    assertEquals("Address review findings: Auth", response.spec().title());
+    assertEquals("draft", response.spec().status());
+    assertEquals("manatee", response.spec().project());
+    assertEquals(List.of("api", "web"), response.spec().repos());
+    assertEquals(3, response.spec().priority());
+    assertEquals("uday", response.spec().createdBy());
+    assertEquals("auth", response.sourceSpecId());
+    assertEquals(reviewId, response.reviewId());
+    assertEquals(2, response.findingCount());
+    assertEquals(2, reviewStore.sourceFindingIds("auth-followup").size());
+
+    var body = specStore.getContent("auth-followup").orElseThrow().body();
+    assertTrue(body.indexOf("Token leak") < body.indexOf("Unchecked null"));
+    assertTrue(body.contains("HIGH"));
+    assertTrue(body.contains("SECURITY"));
+    assertTrue(body.contains("`Auth.java:10-12`"));
+    assertTrue(body.contains("Token is logged."));
+    assertTrue(body.contains("log.info(mask(token))"));
+    assertTrue(body.contains("Never log secrets"));
+  }
+
+  @Test
+  void createFollowupHonorsExplicitId() {
+    seedPassedReviewWithOpenFindings();
+
+    var response = ops.createFollowup("auth", new FollowupCreateRequest("auth-round2", "uday"));
+
+    assertEquals("auth-round2", response.spec().id());
+  }
+
+  @Test
+  void createFollowupMissingSpecThrowsSpecNotFound() {
+    var ex =
+        assertThrows(
+            ApiException.class,
+            () -> ops.createFollowup("nope", new FollowupCreateRequest(null, "uday")));
+    assertEquals(ErrorCode.SPEC_NOT_FOUND, ex.failure().errorCode());
+  }
+
+  @Test
+  void createFollowupWithoutReviewsExplainsItself() {
+    var ex =
+        assertThrows(
+            ApiException.class,
+            () -> ops.createFollowup("auth", new FollowupCreateRequest(null, "uday")));
+    assertEquals(ErrorCode.NOT_FOUND, ex.failure().errorCode());
+    assertTrue(ex.failure().errorMessage().contains("no reviews"));
+  }
+
+  @Test
+  void createFollowupWithOnlySupersededReviewsExplainsItself() {
+    seedPassedReviewWithOpenFindings();
+    reviewStore.supersedeForSpec("auth");
+
+    var ex =
+        assertThrows(
+            ApiException.class,
+            () -> ops.createFollowup("auth", new FollowupCreateRequest(null, "uday")));
+    assertEquals(ErrorCode.CONFLICT, ex.failure().errorCode());
+    assertTrue(ex.failure().errorMessage().contains("superseded"));
+  }
+
+  @Test
+  void createFollowupWithoutOpenFindingsExplainsItself() {
+    var reviewId = seedPassedReviewWithOpenFindings();
+    for (var finding : reviewStore.findingsForReview(reviewId)) {
+      reviewStore.resolveFinding(finding.id(), Finding.Resolution.DISMISSED);
+    }
+
+    var ex =
+        assertThrows(
+            ApiException.class,
+            () -> ops.createFollowup("auth", new FollowupCreateRequest(null, "uday")));
+    assertEquals(ErrorCode.INVALID_REQUEST, ex.failure().errorCode());
+    assertTrue(ex.failure().errorMessage().contains("no open findings"));
+  }
+
+  @Test
+  void createFollowupWithExistingIdThrowsConflict() {
+    seedPassedReviewWithOpenFindings();
+    ops.createFollowup("auth", new FollowupCreateRequest(null, "uday"));
+
+    var ex =
+        assertThrows(
+            ApiException.class,
+            () -> ops.createFollowup("auth", new FollowupCreateRequest(null, "uday")));
+    assertEquals(ErrorCode.CONFLICT, ex.failure().errorCode());
+    assertTrue(ex.failure().errorMessage().contains("auth-followup"));
+  }
+
+  @Test
+  void approveResolvesSourceFindingsOfTheApprovedSpec() {
+    seedPassedReviewWithOpenFindings();
+    ops.createFollowup("auth", new FollowupCreateRequest(null, "uday"));
+    var followupReview = reviewStore.createReview("auth-followup", 1);
+    var humanStage = reviewStore.createStage(followupReview, "human", "human");
+    reviewStore.startStage(humanStage, "uday");
+
+    ops.approve(followupReview, "uday");
+
+    var resolutions =
+        reviewStore.findingsForReview(reviewStore.reviewsForSpec("auth").getFirst().id()).stream()
+            .map(Finding::resolution)
+            .toList();
+    assertEquals(List.of(Finding.Resolution.FIXED, Finding.Resolution.FIXED), resolutions);
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewOperationsTest.java
@@ -212,6 +212,17 @@ class ReviewOperationsTest {
   }
 
   @Test
+  void createFollowupRejectsAnInvalidExplicitId() {
+    seedPassedReviewWithOpenFindings();
+
+    var ex =
+        assertThrows(
+            ApiException.class,
+            () -> ops.createFollowup("auth", new FollowupCreateRequest("../bad id!", "uday")));
+    assertEquals(ErrorCode.INVALID_REQUEST, ex.failure().errorCode());
+  }
+
+  @Test
   void createFollowupHonorsExplicitId() {
     seedPassedReviewWithOpenFindings();
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -133,7 +133,34 @@ class TestOperations implements ApiOperations {
                 "",
                 null),
             null,
-            null));
+            null,
+            0));
+  }
+
+  @Override
+  public Result<FollowupSpecResponse> createFollowupSpec(
+      String specId, FollowupCreateRequest request) {
+    return Result.success(
+        new FollowupSpecResponse(
+            new GlobalSpecView(
+                specId + "-followup",
+                "test-project",
+                "Address review findings: Test",
+                "draft",
+                null,
+                null,
+                null,
+                null,
+                3,
+                List.of(),
+                List.of(),
+                request.createdBy(),
+                "",
+                "",
+                request.createdBy()),
+            specId,
+            "r1",
+            2));
   }
 
   @Override
@@ -231,7 +258,7 @@ class TestOperations implements ApiOperations {
   @Override
   public Result<GlobalBoardResponse> globalBoard(String project) {
     return Result.success(
-        new GlobalBoardResponse(new SpecStore.BoardSummary(0, 0, 0, 0, 0, 0, null)));
+        new GlobalBoardResponse(new SpecStore.BoardSummary(0, 0, 0, 0, 0, 0, null), 0));
   }
 
   @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ApiSpecCommandsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ApiSpecCommandsTest.java
@@ -15,6 +15,8 @@ import ai.singlr.sail.api.SailApiServer;
 import ai.singlr.sail.api.SpecStoreAuditPersister;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.store.EventStore;
+import ai.singlr.sail.store.Finding;
+import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
@@ -35,6 +37,7 @@ class ApiSpecCommandsTest {
   private Sqlite db;
   private SailApiServer server;
   private String token;
+  private ReviewStore reviewStore;
 
   @BeforeEach
   void setUp() throws Exception {
@@ -46,8 +49,10 @@ class ApiSpecCommandsTest {
     var eventStore = new EventStore(db);
     var bus = new EventBus();
     var persister = new SpecStoreAuditPersister(eventStore);
+    reviewStore = new ReviewStore(db);
     var operations =
-        new SailApiOperations(new ShellExecutor(false), "sail.yaml", bus, persister, specStore);
+        new SailApiOperations(
+            new ShellExecutor(false), "sail.yaml", bus, persister, specStore, reviewStore);
     server = new SailApiServer("127.0.0.1", 0, operations, tokenStore, bus, persister);
     server.start();
   }
@@ -92,6 +97,75 @@ class ApiSpecCommandsTest {
     expanded[args.length] = "--project";
     expanded[args.length + 1] = "test";
     return expanded;
+  }
+
+  private void seedPassedReviewWithOpenFinding(String specId) {
+    var reviewId = reviewStore.createReview(specId, 1);
+    var stageId = reviewStore.createStage(reviewId, "security", "agent");
+    reviewStore.addFinding(
+        stageId,
+        Finding.create(
+            Finding.Severity.HIGH,
+            Finding.Category.SECURITY,
+            "Auth.java",
+            10,
+            12,
+            "Token leak",
+            "Token is logged.",
+            "log.info(token)",
+            new Finding.Suggestion("log.info(token)", "log.info(mask(token))", "Never log secrets"),
+            0.9));
+    reviewStore.updateReviewStatus(reviewId, "passed");
+  }
+
+  @Test
+  void createFromReviewDraftsFollowupSpec() {
+    run("create", "--id", "auth", "--title", "OAuth flow", "--status", "done");
+    seedPassedReviewWithOpenFinding("auth");
+
+    var output = run("create", "--from-review", "auth");
+    assertTrue(output.contains("Follow-up spec drafted: auth-followup"));
+    assertTrue(output.contains("1 open findings"));
+
+    var show = run("show", "auth-followup", "--json");
+    assertTrue(show.contains("\"status\": \"draft\""));
+    assertTrue(show.contains("Address review findings: OAuth flow"));
+    assertTrue(show.contains("Token leak"));
+  }
+
+  @Test
+  void createFromReviewHonorsExplicitId() {
+    run("create", "--id", "auth", "--title", "OAuth flow", "--status", "done");
+    seedPassedReviewWithOpenFinding("auth");
+
+    var output = run("create", "--from-review", "auth", "--id", "auth-round2");
+    assertTrue(output.contains("Follow-up spec drafted: auth-round2"));
+  }
+
+  @Test
+  void showAppendsOpenFindingsToStatus() {
+    run("create", "--id", "auth", "--title", "OAuth flow", "--status", "done");
+    seedPassedReviewWithOpenFinding("auth");
+
+    var output = run("show", "auth");
+    assertTrue(output.contains("1 open findings"));
+  }
+
+  @Test
+  void boardAppendsOpenFindingsToDoneColumn() {
+    run("create", "--id", "auth", "--title", "OAuth flow", "--status", "done");
+    seedPassedReviewWithOpenFinding("auth");
+
+    var output = run("board");
+    assertTrue(output.contains("1 open findings"));
+  }
+
+  @Test
+  void boardWithoutResidueShowsNoFindingsSuffix() {
+    run("create", "--id", "auth", "--title", "OAuth flow", "--status", "done");
+
+    var output = run("board");
+    assertFalse(output.contains("open findings"));
   }
 
   @Test


### PR DESCRIPTION
## Problem

The review pipeline records rich findings, but anything below the gate threshold is recorded and then never routed anywhere. Findings die in the review store unless an FDE happens to run `sail agent review`.

## Solution

Findings become specs — the board stays the single source of truth for work.

### `sail spec create --from-review <spec-id>`

Drafts a follow-up spec from the latest non-superseded review's open findings:

- **Title:** `Address review findings: <original title>`
- **Body:** one actionable markdown section per finding — severity, category, `file:line`, description, evidence, suggested before/after fix with rationale — ordered by severity
- **Priority** derived from the highest severity present (CRITICAL→4, HIGH→3, MEDIUM→2, LOW→1)
- **Project and repos** copied from the source spec
- **Status starts `draft`** so the FDE reviews and edits before promoting — generated work is never auto-dispatched
- Only `--id` may be combined with `--from-review`; everything else is derived and combining is rejected loudly
- Errors explain themselves and what to do next: missing spec, no reviews, only superseded reviews, no open findings, id conflict

### Finding lifecycle

Source finding ids are linked via a new append-only `spec_source_findings` table (migration 61). When the follow-up spec reaches `done` — via `spec edit --status done` or human review approval — the still-open linked findings are marked `FIXED`. Findings dismissed in the meantime are left untouched.

### Visibility nudge

`sail spec show <id>` and the board's done column append `· N open findings` for specs whose latest review **passed** with open findings, so completion-with-residue is distinguishable from clean completion. A failed/running review is in-flight work, not residue, and contributes nothing.

### Plumbing

- New endpoint `POST /v1/specs/{id}/followup` (201, actor attribution from the authenticated principal)
- `SailApiClient` now appends the server's `action` hint to error messages, so remediation guidance reaches the CLI instead of being dropped

## Testing

- TDD at each layer: `ReviewStoreTest` (link/resolve/openFindingsAfterPass), `ReviewOperationsTest` (draft content, priority, repos, every error path, approve→resolution), `GlobalSpecOperationsTest` (done-transition resolution, show/board counts), `ApiRouterTest` (route + method guards), `ApiSpecCommandsTest` (end-to-end CLI against a real server)
- Full suite: 1861 tests, 0 failures
- Manually verified end-to-end against a live `sail server`: draft creation, body rendering, done-transition resolution, nudge appearing/clearing, and all five error paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)