### PR TITLE
feat(dispatch): autonomous protocol requires green CI

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/engine/AgentTaskPrompt.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/AgentTaskPrompt.java
@@ -61,7 +61,12 @@ public final class AgentTaskPrompt {
 
         ## Autonomous Operation
         Execute without waiting for confirmation: plan, implement, test, commit. When complete, run
-        the tests, commit with a clear message, push the branch, and open a pull request.
+        the full local verification the project uses (including any coverage or lint gates), commit
+        with a clear message, push the branch, and open a pull request.
+
+        The spec is not complete until CI is green: after opening the pull request, watch its
+        checks (e.g. `gh pr checks <number> --watch`), and if any check fails, diagnose it, fix it
+        on the branch, push, and watch again until every check passes.
         """
         + multiRepo
         + "If the build fails repeatedly on the same error, or three different approaches fail, stop"

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
@@ -187,6 +187,10 @@ class DispatchCommandTest {
         prompt.contains("## Autonomous Operation"),
         "the autonomous protocol belongs in the dispatch prompt, not the always-loaded context");
     assertTrue(prompt.contains("open a pull request"));
+    assertTrue(
+        prompt.contains("not complete until CI is green"),
+        "the agent must watch the PR's checks and fix failures — a red-CI PR is unfinished work");
+    assertTrue(prompt.contains("gh pr checks"));
     assertFalse(prompt.contains("handoff.md"), "no context-handoff cruft");
   }
 


### PR DESCRIPTION
A dispatched spec shipped a red-CI PR (coverage gate) and completed anyway. The generated dispatch protocol now requires full local verification before pushing and watching PR checks to green, fixing on the branch until they pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NvxJbXoANxoarjX6A2aLZ