### PR TITLE
fix(review): parse past prompt echoes, repair contaminated merge, no AI attribution

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/config/Notifications.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/Notifications.java
@@ -63,8 +63,7 @@ public record Notifications(String url, List<String> events, SlackNotifications 
     var slackRaw = (Map<String, Object>) map.get("slack");
     var slack = slackRaw != null ? SlackNotifications.fromMap(slackRaw) : null;
     if (Strings.isBlank(url) && slack == null) {
-      throw new IllegalArgumentException(
-          "notifications requires a webhook url or a slack block.");
+      throw new IllegalArgumentException("notifications requires a webhook url or a slack block.");
     }
     if (Strings.isNotBlank(url)) {
       WebhookUrlSafety.requireSafe(url);

--- a/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
@@ -22,12 +22,29 @@ public final class FindingParser {
 
   public record ParseResult(List<Finding> findings, List<String> warnings) {}
 
+  /**
+   * Parses the findings array out of a review agent's raw transcript. Transcripts are noisy: the
+   * agent may echo the prompt (which itself names the {@code ```json} convention) and may emit
+   * fenced blocks mid-reasoning, so candidates are tried <em>last to first</em> and the last block
+   * that parses as a JSON array wins — the response convention puts the verdict at the end. When
+   * nothing parses, the result carries warnings so the pipeline can refuse to treat an unreadable
+   * review as a clean pass.
+   */
   public static ParseResult parse(String agentOutput) {
-    var json = extractJsonBlock(agentOutput);
-    if (json == null) {
+    var candidates = extractJsonBlocks(agentOutput);
+    if (candidates.isEmpty()) {
       return new ParseResult(List.of(), List.of("No JSON block found in agent output."));
     }
-    return parseJsonArray(json);
+    var warnings = new ArrayList<String>();
+    for (var i = candidates.size() - 1; i >= 0; i--) {
+      var result = parseJsonArray(candidates.get(i));
+      if (result.findings().isEmpty() && !result.warnings().isEmpty()) {
+        warnings.addAll(result.warnings());
+        continue;
+      }
+      return result;
+    }
+    return new ParseResult(List.of(), List.copyOf(warnings));
   }
 
   private static ParseResult parseJsonArray(String json) {
@@ -50,23 +67,39 @@ public final class FindingParser {
     }
   }
 
-  static String extractJsonBlock(String output) {
-    if (Strings.isBlank(output)) return null;
+  static List<String> extractJsonBlocks(String output) {
+    if (Strings.isBlank(output)) return List.of();
 
-    var start = output.indexOf("```json");
-    if (start < 0) {
-      start = output.indexOf("```\n[");
-      if (start < 0) return tryBareJson(output);
+    var blocks = new ArrayList<String>();
+    collectBlocks(output, "```json", blocks);
+    if (blocks.isEmpty()) {
+      collectBlocks(output, "```\n[", blocks);
     }
+    if (blocks.isEmpty()) {
+      var bare = tryBareJson(output);
+      if (bare != null) blocks.add(bare);
+    }
+    return List.copyOf(blocks);
+  }
 
-    var contentStart = output.indexOf('\n', start);
-    if (contentStart < 0) return null;
-    contentStart++;
-
-    var end = output.indexOf("```", contentStart);
-    if (end < 0) return output.substring(contentStart).strip();
-
-    return output.substring(contentStart, end).strip();
+  /**
+   * Every marker occurrence starts an independent candidate (advancing past the marker, not the
+   * closing fence): a prompt echo's mid-sentence marker would otherwise swallow the real block's
+   * opening fence as its terminator. Overlap is harmless — candidates are validated by parsing.
+   */
+  private static void collectBlocks(String output, String marker, List<String> blocks) {
+    var from = 0;
+    while (true) {
+      var start = output.indexOf(marker, from);
+      if (start < 0) return;
+      from = start + marker.length();
+      var contentStart = output.indexOf('\n', start);
+      if (contentStart < 0) return;
+      contentStart++;
+      var end = output.indexOf("```", contentStart);
+      blocks.add(
+          (end < 0 ? output.substring(contentStart) : output.substring(contentStart, end)).strip());
+    }
   }
 
   private static String tryBareJson(String output) {

--- a/sail-core/src/test/java/ai/singlr/sail/config/NotificationsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/NotificationsTest.java
@@ -279,7 +279,8 @@ class NotificationsTest {
   void fromMapRequiresUrlOrSlack() {
     var ex =
         assertThrows(
-            IllegalArgumentException.class, () -> Notifications.fromMap(Map.of("events", List.of())));
+            IllegalArgumentException.class,
+            () -> Notifications.fromMap(Map.of("events", List.of())));
     assertTrue(ex.getMessage().contains("url or a slack block"));
   }
 
@@ -287,8 +288,7 @@ class NotificationsTest {
   void fromMapRejectsSlackWithoutChannel() {
     var ex =
         assertThrows(
-            IllegalArgumentException.class,
-            () -> Notifications.fromMap(Map.of("slack", Map.of())));
+            IllegalArgumentException.class, () -> Notifications.fromMap(Map.of("slack", Map.of())));
     assertTrue(ex.getMessage().contains("notifications.slack.channel"));
   }
 

--- a/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
@@ -7,7 +7,6 @@ package ai.singlr.sail.engine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.Finding;
@@ -163,9 +162,9 @@ class FindingParserTest {
         [{"severity": "LOW", "category": "LOGIC", "title": "Open", "description": "D"}]
         """;
 
-    var json = FindingParser.extractJsonBlock(output);
-    assertNotNull(json);
-    assertTrue(json.startsWith("["));
+    var json = FindingParser.extractJsonBlocks(output);
+    assertEquals(1, json.size());
+    assertTrue(json.getFirst().startsWith("["));
   }
 
   @Test
@@ -177,7 +176,64 @@ class FindingParserTest {
         ```
         """;
 
-    var json = FindingParser.extractJsonBlock(output);
-    assertNotNull(json);
+    var json = FindingParser.extractJsonBlocks(output);
+    assertEquals(1, json.size());
+  }
+
+  @Test
+  void parsesTheFindingsWhenTheTranscriptEchoesThePromptFence() {
+    var transcript =
+        """
+        Rules:
+        5. If there are no issues, return an empty array: []
+
+        Begin your response with ```json and end with ```.
+        codex
+        I inspected the diff and found one issue.
+
+        ```json
+        [{"severity": "MEDIUM", "category": "LOGIC", "file": "a.ts",
+          "line_start": 5, "line_end": 5, "title": "Leaked body",
+          "description": "Response not cancelled.", "confidence": 0.86}]
+        ```
+        """;
+
+    var result = FindingParser.parse(transcript);
+
+    assertEquals(
+        1,
+        result.findings().size(),
+        "the prompt echo's fence must not shadow the real findings block: " + result.warnings());
+    assertEquals("Leaked body", result.findings().getFirst().title());
+  }
+
+  @Test
+  void theLastParseableBlockWinsWhenSeveralArePresent() {
+    var transcript =
+        """
+        ```json
+        not valid json at all
+        ```
+        thinking...
+        ```json
+        []
+        ```
+        """;
+
+    var result = FindingParser.parse(transcript);
+
+    assertEquals(0, result.findings().size());
+    assertTrue(
+        result.warnings().isEmpty(),
+        "a clean empty array is a valid verdict: " + result.warnings());
+  }
+
+  @Test
+  void reportsAWarningWhenNoBlockParses() {
+    var result = FindingParser.parse("Begin your response with ```json and end with ```.");
+
+    assertTrue(result.findings().isEmpty());
+    assertTrue(
+        !result.warnings().isEmpty(), "an unparseable review must say so, never pass silently");
   }
 }

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/ClaudeCodeHookConfig.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/ClaudeCodeHookConfig.java
@@ -81,6 +81,7 @@ public final class ClaudeCodeHookConfig {
     hooks.put("SessionEnd", List.of(matcherGroup(null, sessionEnd)));
 
     var root = new LinkedHashMap<String, Object>();
+    root.put("includeCoAuthoredBy", false);
     root.put("hooks", hooks);
     return YamlUtil.dumpJson(root);
   }

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/ClaudeCodeHookConfigTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/ClaudeCodeHookConfigTest.java
@@ -53,6 +53,14 @@ class ClaudeCodeHookConfigTest {
   }
 
   @Test
+  void renderDisablesCommitCoAuthorAttribution() {
+    var json = ClaudeCodeHookConfig.render();
+    assertTrue(
+        json.contains("\"includeCoAuthoredBy\": false"),
+        "dispatched agents must not sign commits as co-author");
+  }
+
+  @Test
   void renderEmbedsNoSpecId() {
     var json = ClaudeCodeHookConfig.render();
     var firstCmd = SailEventHelper.SCRIPT_PATH + " agent_session_started";

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/SlackClientTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/SlackClientTest.java
@@ -56,7 +56,8 @@ class SlackClientTest {
   @Test
   void payloadEscapesTextAndChannel() {
     var payload =
-        SlackClient.buildPayload(new SlackPoster.Post("#ops", "line1\n\"two\"\t\\end", null, false));
+        SlackClient.buildPayload(
+            new SlackPoster.Post("#ops", "line1\n\"two\"\t\\end", null, false));
     assertTrue(payload.contains("\"text\":\"line1\\n\\\"two\\\"\\t\\\\end\""));
   }
 
@@ -76,7 +77,8 @@ class SlackClientTest {
   void successfulPostReturnsChannelAndTs() {
     var client =
         new SlackClient(
-            body -> new SlackClient.HttpReply(200, "{\"ok\":true,\"channel\":\"C9\",\"ts\":\"5.5\"}"),
+            body ->
+                new SlackClient.HttpReply(200, "{\"ok\":true,\"channel\":\"C9\",\"ts\":\"5.5\"}"),
             millis -> {});
 
     var result = client.post(new SlackPoster.Post("#ops", "hi", null, false));
@@ -92,7 +94,8 @@ class SlackClientTest {
         new SlackClient(
             body -> {
               calls.add(body);
-              return new SlackClient.HttpReply(200, "{\"ok\":false,\"error\":\"channel_not_found\"}");
+              return new SlackClient.HttpReply(
+                  200, "{\"ok\":false,\"error\":\"channel_not_found\"}");
             },
             millis -> {});
 
@@ -130,7 +133,8 @@ class SlackClientTest {
               calls.add(body);
               return calls.size() < 2
                   ? new SlackClient.HttpReply(429, "slow down")
-                  : new SlackClient.HttpReply(200, "{\"ok\":true,\"channel\":\"C1\",\"ts\":\"1.1\"}");
+                  : new SlackClient.HttpReply(
+                      200, "{\"ok\":true,\"channel\":\"C1\",\"ts\":\"1.1\"}");
             },
             millis -> {});
 
@@ -150,7 +154,8 @@ class SlackClientTest {
               if (calls.size() == 1) {
                 throw new java.io.IOException("connection reset");
               }
-              return new SlackClient.HttpReply(200, "{\"ok\":true,\"channel\":\"C1\",\"ts\":\"2.2\"}");
+              return new SlackClient.HttpReply(
+                  200, "{\"ok\":true,\"channel\":\"C1\",\"ts\":\"2.2\"}");
             },
             millis -> {});
 
@@ -164,7 +169,8 @@ class SlackClientTest {
   void okResponseWithoutTsIsFailure() {
     var client =
         new SlackClient(
-            body -> new SlackClient.HttpReply(200, "{\"ok\":true,\"channel\":\"C1\"}"), millis -> {});
+            body -> new SlackClient.HttpReply(200, "{\"ok\":true,\"channel\":\"C1\"}"),
+            millis -> {});
 
     var err = captureStderr(() -> assertNull(client.post(post())));
 
@@ -217,8 +223,7 @@ class SlackClientTest {
   void resolveTokenWarnsOnUnreadableTokenFile() {
     var missing = tempDir.resolve("nope").toString();
 
-    var err =
-        captureStderr(() -> assertNull(SlackClient.resolveToken(fileLookup(missing))));
+    var err = captureStderr(() -> assertNull(SlackClient.resolveToken(fileLookup(missing))));
 
     assertTrue(err.contains("SAIL_SLACK_TOKEN_FILE"));
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -287,6 +287,12 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
 
       var output = agentRunner.run(project, agent, prompt);
       var parseResult = FindingParser.parse(output);
+      if (parseResult.findings().isEmpty() && !parseResult.warnings().isEmpty()) {
+        var message = "reviewer output unparseable: " + String.join("; ", parseResult.warnings());
+        reviewStore.completeStage(stage.id(), "failed", message);
+        publishEvent(project, specId, "review_stage_failed", stage.name());
+        return new StageOutcome.Errored(message);
+      }
 
       for (var finding : parseResult.findings()) {
         reviewStore.addFinding(stage.id(), finding);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SlackMessage.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SlackMessage.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.store.SpecStore;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Pure formatting from an {@link Event} into Slack message text (mrkdwn). No I/O; pure functions so
+ * every lifecycle message can be unit-tested without a bus or HTTP.
+ */
+final class SlackMessage {
+
+  private SlackMessage() {}
+
+  /**
+   * Builds the message text for the given event. {@code spec} is the spec row when known — it
+   * supplies the title and assigned agent for root messages; dispatch events themselves are emitted
+   * by the orchestrator, not the coding agent.
+   */
+  static String forEvent(Event event, SpecStore.SpecRow spec) {
+    return switch (event.type()) {
+      case Event.WellKnownTypes.SPEC_DISPATCHED -> root(event, spec, "dispatched");
+      case Event.WellKnownTypes.SPEC_RESTARTED -> root(event, spec, "re-dispatched");
+      case Event.WellKnownTypes.AGENT_SESSION_STOPPED -> stopped(event);
+      case Event.WellKnownTypes.AGENT_FAILED ->
+          ":x: Agent failed (" + detailOr(event, "no exit code") + ").";
+      case Event.WellKnownTypes.GUARDRAIL_TRIGGERED -> guardrail(event);
+      case "review_stage_started" -> ":mag: Review started: " + detailOr(event, "review") + ".";
+      case "review_stage_passed" ->
+          ":white_check_mark: Review stage passed: "
+              + detailOr(event, "review")
+              + findingsSuffix(event)
+              + ".";
+      case "review_stage_failed" ->
+          ":x: Review stage failed: " + detailOr(event, "review") + findingsSuffix(event) + ".";
+      case "review_completed" -> ":tada: Review passed — spec done.";
+      case "review_errored" -> ":warning: Review errored: " + detailOr(event, "unknown error");
+      case "review_iteration_started" -> ":wrench: Fix iteration started.";
+      case "review_escalated" ->
+          ":rotating_light: Escalated — iterations exhausted, this spec needs a human.";
+      default -> "Event " + event.type() + " from " + event.agent() + ".";
+    };
+  }
+
+  private static String root(Event event, SpecStore.SpecRow spec, String verb) {
+    var sb = new StringBuilder(":rocket: Spec *");
+    sb.append(Objects.toString(event.spec(), "unknown")).append("*");
+    if (spec != null && spec.title() != null) {
+      sb.append(" — ").append(spec.title());
+    }
+    sb.append(" ").append(verb).append("\nproject `").append(event.project()).append("`");
+    var branch = stringFromData(event, "branch");
+    if (!branch.isBlank()) {
+      sb.append(" · branch `").append(branch).append("`");
+    }
+    var agent = spec != null && spec.agent() != null ? spec.agent() : event.agent();
+    sb.append(" · agent `").append(agent).append("`");
+    return sb.toString();
+  }
+
+  private static String stopped(Event event) {
+    var sb = new StringBuilder("Agent ").append(event.agent()).append(" stopped");
+    var exitCode = event.data().get(Event.WellKnownData.EXIT_CODE);
+    if (exitCode != null) {
+      sb.append(" (exit ").append(exitCode).append(")");
+    }
+    var note = stringFromData(event, "note");
+    if (!note.isBlank()) {
+      sb.append(" — ").append(note);
+    }
+    return sb.append(".").toString();
+  }
+
+  private static String guardrail(Event event) {
+    var sb = new StringBuilder(":no_entry: Guardrail triggered");
+    var reason = stringFromData(event, "reason");
+    if (!reason.isBlank()) {
+      sb.append(". Reason: ").append(reason);
+    }
+    var action = stringFromData(event, "action");
+    if (!action.isBlank()) {
+      sb.append(". Action: ").append(action);
+    }
+    return sb.append(".").toString();
+  }
+
+  private static String findingsSuffix(Event event) {
+    if (!(event.data().get("findings") instanceof Map<?, ?> counts)) {
+      return " (no findings)";
+    }
+    var parts = new ArrayList<String>();
+    for (var severity : List.of("critical", "high", "medium", "low")) {
+      var count = counts.get(severity);
+      if (count != null) {
+        parts.add(count + " " + severity);
+      }
+    }
+    return parts.isEmpty() ? " (no findings)" : " — " + String.join(", ", parts);
+  }
+
+  private static String detailOr(Event event, String fallback) {
+    var detail = stringFromData(event, "detail");
+    return detail.isBlank() ? fallback : detail;
+  }
+
+  private static String stringFromData(Event event, String key) {
+    return Objects.toString(event.data().get(key), "");
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SlackReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SlackReactor.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.engine.SlackClient;
+import ai.singlr.sail.engine.SlackPoster;
+import ai.singlr.sail.store.SlackThreadStore;
+import ai.singlr.sail.store.SpecStore;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Bus subscriber that mirrors a spec's lifecycle into one Slack thread. The dispatch event posts a
+ * root message and records its {@code thread_ts}; every later lifecycle event replies in that
+ * thread. A re-dispatch posts a new root, so each attempt gets its own thread. An escalation also
+ * broadcasts its reply to the channel, since it awaits a human.
+ *
+ * <p>Unlike the webhook reactor, the {@code notifications.events} filter does not apply here — the
+ * spec-lifecycle set below is what makes a thread coherent. Everything is best-effort: post
+ * failures are retried by {@link SlackClient}, logged loudly on give-up, and never thrown, so a
+ * Slack outage cannot back up the bus or the dispatch pipeline.
+ */
+public final class SlackReactor implements EventSubscriber {
+
+  /** Event types that start a new thread (one per dispatch attempt). */
+  static final Set<String> ROOT_TYPES =
+      Set.of(Event.WellKnownTypes.SPEC_DISPATCHED, Event.WellKnownTypes.SPEC_RESTARTED);
+
+  /** Event types mirrored into Slack. */
+  static final Set<String> NOTIFIABLE_TYPES =
+      Set.of(
+          Event.WellKnownTypes.SPEC_DISPATCHED,
+          Event.WellKnownTypes.SPEC_RESTARTED,
+          Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+          Event.WellKnownTypes.AGENT_FAILED,
+          Event.WellKnownTypes.GUARDRAIL_TRIGGERED,
+          "review_stage_started",
+          "review_stage_passed",
+          "review_stage_failed",
+          "review_completed",
+          "review_errored",
+          "review_iteration_started",
+          "review_escalated");
+
+  private final ProjectNotificationsResolver resolver;
+  private final SlackThreadStore threads;
+  private final Function<String, SpecStore.SpecRow> specLookup;
+  private final SlackPoster poster;
+
+  /**
+   * Default reactor: per-project sail.yaml config, spec titles from the store, and the real Slack
+   * client when a token is configured ({@code SAIL_SLACK_TOKEN} or {@code SAIL_SLACK_TOKEN_FILE}).
+   */
+  public static SlackReactor withDefaults(SlackThreadStore threads, SpecStore specStore) {
+    return new SlackReactor(
+        new SailYamlNotificationsResolver(), threads, specLookup(specStore), defaultPoster());
+  }
+
+  static Function<String, SpecStore.SpecRow> specLookup(SpecStore specStore) {
+    return specId -> specStore.findById(specId).orElse(null);
+  }
+
+  static SlackPoster defaultPoster() {
+    var token = SlackClient.resolveToken();
+    return token == null ? null : new SlackClient(token);
+  }
+
+  /**
+   * @param poster the Slack client, or {@code null} when no token is configured — events are then
+   *     dropped with a loud warning instead of silently
+   */
+  public SlackReactor(
+      ProjectNotificationsResolver resolver,
+      SlackThreadStore threads,
+      Function<String, SpecStore.SpecRow> specLookup,
+      SlackPoster poster) {
+    this.resolver = Objects.requireNonNull(resolver, "resolver");
+    this.threads = Objects.requireNonNull(threads, "threads");
+    this.specLookup = Objects.requireNonNull(specLookup, "specLookup");
+    this.poster = poster;
+  }
+
+  @Override
+  public String name() {
+    return "slack-reactor";
+  }
+
+  @Override
+  public Predicate<Event> filter() {
+    return e -> NOTIFIABLE_TYPES.contains(e.type());
+  }
+
+  @Override
+  public void onEvent(Event event) {
+    try {
+      handle(event);
+    } catch (Exception e) {
+      System.err.println(
+          "  [slack] Warning: failed to process "
+              + event.type()
+              + " for spec "
+              + event.spec()
+              + ": "
+              + e.getMessage());
+    }
+  }
+
+  private void handle(Event event) {
+    var notifications = resolver.resolve(event.project());
+    var slack = notifications == null ? null : notifications.slack();
+    if (slack == null) {
+      return;
+    }
+    if (isTurnEndStop(event)) {
+      return;
+    }
+    if (poster == null) {
+      System.err.println(
+          "  [slack] Warning: notifications.slack is configured for project '"
+              + event.project()
+              + "' but no token is available; set SAIL_SLACK_TOKEN or SAIL_SLACK_TOKEN_FILE");
+      return;
+    }
+    if (ROOT_TYPES.contains(event.type())) {
+      postRoot(event, slack.channel());
+    } else {
+      postReply(event, slack.channel());
+    }
+  }
+
+  private void postRoot(Event event, String channel) {
+    var spec = event.spec() == null ? null : specLookup.apply(event.spec());
+    var text = SlackMessage.forEvent(event, spec);
+    saveThread(event, poster.post(new SlackPoster.Post(channel, text, null, false)));
+  }
+
+  /**
+   * Replies in the spec's recorded thread. When no root exists — the spec was dispatched before
+   * Slack was configured, or the root post failed — the reply is posted standalone and adopted as
+   * the thread root so the rest of the lifecycle still lands in one place.
+   */
+  private void postReply(Event event, String channel) {
+    var text = SlackMessage.forEvent(event, null);
+    var thread =
+        event.spec() == null
+            ? Optional.<SlackThreadStore.ThreadRef>empty()
+            : threads.find(event.project(), event.spec());
+    if (thread.isEmpty()) {
+      saveThread(event, poster.post(new SlackPoster.Post(channel, text, null, false)));
+      return;
+    }
+    var broadcast = "review_escalated".equals(event.type());
+    poster.post(
+        new SlackPoster.Post(thread.get().channel(), text, thread.get().threadTs(), broadcast));
+  }
+
+  private void saveThread(Event event, SlackPoster.Result result) {
+    if (result != null && event.spec() != null) {
+      threads.save(event.project(), event.spec(), result.channel(), result.ts());
+    }
+  }
+
+  /**
+   * The in-container agent hook fires a stop at every turn end; only the watcher's poll-derived
+   * stop (which carries a {@code source}) is the real termination worth a thread reply.
+   */
+  private static boolean isTurnEndStop(Event event) {
+    return Event.WellKnownTypes.AGENT_SESSION_STOPPED.equals(event.type())
+        && event.data().get(Event.WellKnownData.SOURCE) == null;
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -14,6 +14,7 @@ import ai.singlr.sail.api.SailApiServer;
 import ai.singlr.sail.api.ServerConnectionConfig;
 import ai.singlr.sail.api.SessionAwareAuth;
 import ai.singlr.sail.api.SessionTracker;
+import ai.singlr.sail.api.SlackReactor;
 import ai.singlr.sail.api.SpecStoreAuditPersister;
 import ai.singlr.sail.api.TokenAuth;
 import ai.singlr.sail.api.WebauthnAuthHandler;
@@ -38,6 +39,7 @@ import ai.singlr.sail.store.MigrationRunner;
 import ai.singlr.sail.store.PendingChallengeStore;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.SessionStore;
+import ai.singlr.sail.store.SlackThreadStore;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.StuckSpecReconciler;
@@ -186,6 +188,7 @@ public final class ServerStartCommand implements Runnable {
             ServerStartCommand::loadProjectYaml,
             new ShellExecutor(false));
     bus.subscribe(new SessionTracker(new SessionStore(db)));
+    bus.subscribe(SlackReactor.withDefaults(new SlackThreadStore(db), specStore));
 
     var webauthn = resolveWebauthn();
     var configured = webauthn.isConfigured();

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/AgentTaskPrompt.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/AgentTaskPrompt.java
@@ -67,6 +67,9 @@ public final class AgentTaskPrompt {
         The spec is not complete until CI is green: after opening the pull request, watch its
         checks (e.g. `gh pr checks <number> --watch`), and if any check fails, diagnose it, fix it
         on the branch, push, and watch again until every check passes.
+
+        Never add AI attribution to the work: no Co-Authored-By trailers and no "Generated with"
+        footers in commit messages or pull request descriptions.
         """
         + multiRepo
         + "If the build fails repeatedly on the same error, or three different approaches fail, stop"

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
@@ -89,6 +89,8 @@ public final class ContainerSailSetup {
                         + ClaudeCodeHookConfig.PROGRESS_HOOK_MARKER
                         + " "
                         + ClaudeCodeHookConfig.SETTINGS_PATH
+                        + " && grep -qsF includeCoAuthoredBy "
+                        + ClaudeCodeHookConfig.SETTINGS_PATH
                         + " && test -f "
                         + CodexHookConfig.SETTINGS_PATH
                         + " && grep -qsF "

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -332,6 +332,25 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
+  void anUnparseableReviewIsAnErrorNeverACleanPass() {
+    createSpec("auth", "in_progress");
+    var promptEchoOnly = "Begin your response with ```json and end with ```.";
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr) -> promptEchoOnly);
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    var review = reviewStore.latestReviewForSpec("auth").orElseThrow();
+    assertEquals("failed", review.status());
+    assertTrue(
+        review.errored(),
+        "a review whose output cannot be parsed must never gate-pass as zero findings");
+    assertEquals(
+        SpecStatus.REVIEW,
+        specStore.findById("auth").orElseThrow().status(),
+        "the spec must not advance to done on an unreadable review");
+  }
+
+  @Test
   void aRunnerErrorIsRecordedOnTheReviewAndNeverMistakenForAVerdict() {
     createSpec("auth", "in_progress");
     var ctrl =
@@ -632,7 +651,7 @@ class ReviewPipelineControllerTest {
          {"severity": "HIGH", "category": "SECURITY", "file": "Auth.java",
           "line_start": 2, "line_end": 2, "title": "XSS",
           "description": "d", "confidence": 0.9},
-         {"severity": "LOW", "category": "STYLE", "file": "Auth.java",
+         {"severity": "LOW", "category": "LOGIC", "file": "Auth.java",
           "line_start": 3, "line_end": 3, "title": "Naming",
           "description": "d", "confidence": 0.9}]
         ```

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SlackMessageTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SlackMessageTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.store.SpecStore;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SlackMessageTest {
+
+  private static Event event(String type) {
+    return Event.of("light", "auth", type, "sail", "host");
+  }
+
+  private static Event event(String type, Map<String, Object> data) {
+    return Event.of("light", "auth", type, "sail", "host", data);
+  }
+
+  private static SpecStore.SpecRow spec(String title, String agent) {
+    return new SpecStore.SpecRow(
+        "auth",
+        "light",
+        title,
+        SpecStatus.PENDING,
+        null,
+        agent,
+        null,
+        null,
+        null,
+        0,
+        null,
+        "",
+        "",
+        null,
+        List.of(),
+        List.of());
+  }
+
+  @Test
+  void dispatchedRootCarriesSpecTitleProjectBranchAgent() {
+    var text =
+        SlackMessage.forEvent(
+            event("spec_dispatched", Map.of("branch", "feat/auth", "mode", "background")),
+            spec("OAuth flow", "claude-code"));
+
+    assertTrue(text.contains("*auth*"));
+    assertTrue(text.contains("OAuth flow"));
+    assertTrue(text.contains("dispatched"));
+    assertTrue(text.contains("project `light`"));
+    assertTrue(text.contains("branch `feat/auth`"));
+    assertTrue(text.contains("agent `claude-code`"));
+  }
+
+  @Test
+  void restartedRootSaysRedispatched() {
+    var text = SlackMessage.forEvent(event("spec_restarted"), spec("OAuth flow", "codex"));
+
+    assertTrue(text.contains("re-dispatched"));
+    assertTrue(text.contains("agent `codex`"));
+    assertFalse(text.contains("branch"));
+  }
+
+  @Test
+  void rootWithoutSpecRowFallsBackToEventAgent() {
+    var text = SlackMessage.forEvent(event("spec_dispatched"), null);
+
+    assertTrue(text.contains("*auth*"));
+    assertTrue(text.contains("agent `sail`"));
+    assertFalse(text.contains("—"));
+  }
+
+  @Test
+  void rootWithSpecRowWithoutTitleOmitsTitle() {
+    var text = SlackMessage.forEvent(event("spec_dispatched"), spec(null, null));
+
+    assertFalse(text.contains("—"));
+    assertTrue(text.contains("agent `sail`"));
+  }
+
+  @Test
+  void rootWithoutSpecIdSaysUnknown() {
+    var text =
+        SlackMessage.forEvent(Event.of("light", null, "spec_dispatched", "sail", "host"), null);
+
+    assertTrue(text.contains("*unknown*"));
+  }
+
+  @Test
+  void stoppedCarriesExitCodeAndNote() {
+    var text =
+        SlackMessage.forEvent(
+            event("agent_session_stopped", Map.of("exit_code", 0, "note", "clean run")), null);
+
+    assertEquals("Agent sail stopped (exit 0) — clean run.", text);
+  }
+
+  @Test
+  void stoppedWithoutExitCodeOrNoteIsBare() {
+    var text = SlackMessage.forEvent(event("agent_session_stopped"), null);
+
+    assertEquals("Agent sail stopped.", text);
+  }
+
+  @Test
+  void agentFailedUsesDetail() {
+    var text = SlackMessage.forEvent(event("agent_failed", Map.of("detail", "exit 1")), null);
+
+    assertEquals(":x: Agent failed (exit 1).", text);
+  }
+
+  @Test
+  void agentFailedWithoutDetailFallsBack() {
+    var text = SlackMessage.forEvent(event("agent_failed"), null);
+
+    assertEquals(":x: Agent failed (no exit code).", text);
+  }
+
+  @Test
+  void guardrailCarriesReasonAndAction() {
+    var text =
+        SlackMessage.forEvent(
+            event("guardrail_triggered", Map.of("reason", "budget", "action", "paused")), null);
+
+    assertEquals(":no_entry: Guardrail triggered. Reason: budget. Action: paused.", text);
+  }
+
+  @Test
+  void guardrailWithoutDataIsBare() {
+    var text = SlackMessage.forEvent(event("guardrail_triggered"), null);
+
+    assertEquals(":no_entry: Guardrail triggered.", text);
+  }
+
+  @Test
+  void reviewStageStartedNamesStage() {
+    var text =
+        SlackMessage.forEvent(event("review_stage_started", Map.of("detail", "security")), null);
+
+    assertEquals(":mag: Review started: security.", text);
+  }
+
+  @Test
+  void reviewStageStartedWithoutDetailFallsBack() {
+    var text = SlackMessage.forEvent(event("review_stage_started"), null);
+
+    assertEquals(":mag: Review started: review.", text);
+  }
+
+  @Test
+  void reviewStagePassedCarriesSeverityCounts() {
+    var text =
+        SlackMessage.forEvent(
+            event(
+                "review_stage_passed",
+                Map.of("detail", "security", "findings", Map.of("high", 2, "low", 1))),
+            null);
+
+    assertEquals(":white_check_mark: Review stage passed: security — 2 high, 1 low.", text);
+  }
+
+  @Test
+  void reviewStagePassedWithoutFindingsSaysNoFindings() {
+    var text =
+        SlackMessage.forEvent(event("review_stage_passed", Map.of("detail", "security")), null);
+
+    assertEquals(":white_check_mark: Review stage passed: security (no findings).", text);
+  }
+
+  @Test
+  void reviewStageFailedOrdersCountsBySeverity() {
+    var text =
+        SlackMessage.forEvent(
+            event(
+                "review_stage_failed",
+                Map.of(
+                    "detail",
+                    "security",
+                    "findings",
+                    Map.of("low", 4, "critical", 1, "medium", 2, "high", 3))),
+            null);
+
+    assertEquals(":x: Review stage failed: security — 1 critical, 3 high, 2 medium, 4 low.", text);
+  }
+
+  @Test
+  void findingsMapWithOnlyUnknownSeveritiesSaysNoFindings() {
+    var text =
+        SlackMessage.forEvent(
+            event("review_stage_failed", Map.of("detail", "s", "findings", Map.of("weird", 9))),
+            null);
+
+    assertEquals(":x: Review stage failed: s (no findings).", text);
+  }
+
+  @Test
+  void reviewCompletedIsSpecDone() {
+    var text = SlackMessage.forEvent(event("review_completed"), null);
+
+    assertEquals(":tada: Review passed — spec done.", text);
+  }
+
+  @Test
+  void reviewErroredCarriesError() {
+    var text =
+        SlackMessage.forEvent(event("review_errored", Map.of("detail", "agent timed out")), null);
+
+    assertEquals(":warning: Review errored: agent timed out", text);
+  }
+
+  @Test
+  void reviewErroredWithoutDetailFallsBack() {
+    var text = SlackMessage.forEvent(event("review_errored"), null);
+
+    assertEquals(":warning: Review errored: unknown error", text);
+  }
+
+  @Test
+  void fixIterationStarted() {
+    var text = SlackMessage.forEvent(event("review_iteration_started"), null);
+
+    assertEquals(":wrench: Fix iteration started.", text);
+  }
+
+  @Test
+  void escalatedIsLoud() {
+    var text = SlackMessage.forEvent(event("review_escalated"), null);
+
+    assertTrue(text.contains(":rotating_light:"));
+    assertTrue(text.contains("human"));
+  }
+
+  @Test
+  void unknownTypeFallsBackToGeneric() {
+    var text = SlackMessage.forEvent(event("custom_thing"), null);
+
+    assertEquals("Event custom_thing from sail.", text);
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SlackReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SlackReactorTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.Notifications;
+import ai.singlr.sail.config.SlackNotifications;
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.SlackPoster;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SlackThreadStore;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SlackReactorTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private SlackThreadStore threads;
+  private SpecStore specStore;
+
+  private static final Notifications SLACK_ONLY =
+      new Notifications(null, null, new SlackNotifications("#sail-activity"));
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    threads = new SlackThreadStore(db);
+    specStore = new SpecStore(db);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  private SlackReactor reactor(SlackPoster poster) {
+    return new SlackReactor(project -> SLACK_ONLY, threads, id -> null, poster);
+  }
+
+  private static Event event(String type) {
+    return Event.of("light", "auth", type, "sail", "host").withId(1L);
+  }
+
+  private static Event event(String type, Map<String, Object> data) {
+    return Event.of("light", "auth", type, "sail", "host", data).withId(1L);
+  }
+
+  private static Event authoritativeStop() {
+    return event(
+        Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+        Map.of(
+            Event.WellKnownData.SOURCE,
+            Event.WellKnownData.SOURCE_WATCHER,
+            Event.WellKnownData.EXIT_CODE,
+            0));
+  }
+
+  @Test
+  void constructorRejectsNullResolver() {
+    assertThrows(
+        NullPointerException.class, () -> new SlackReactor(null, threads, id -> null, null));
+  }
+
+  @Test
+  void constructorRejectsNullThreadStore() {
+    assertThrows(
+        NullPointerException.class,
+        () -> new SlackReactor(project -> null, null, id -> null, null));
+  }
+
+  @Test
+  void constructorRejectsNullSpecLookup() {
+    assertThrows(
+        NullPointerException.class, () -> new SlackReactor(project -> null, threads, null, null));
+  }
+
+  @Test
+  void nameIsStable() {
+    assertEquals("slack-reactor", reactor(new RecordingPoster()).name());
+  }
+
+  @Test
+  void filterAcceptsAllNotifiableTypes() {
+    var filter = reactor(new RecordingPoster()).filter();
+    for (var type : SlackReactor.NOTIFIABLE_TYPES) {
+      assertTrue(filter.test(Event.of("p", null, type, "a", "h")), "should accept " + type);
+    }
+  }
+
+  @Test
+  void filterRejectsOtherTypes() {
+    var filter = reactor(new RecordingPoster()).filter();
+    assertFalse(filter.test(Event.of("p", null, "agent_tool_started", "a", "h")));
+    assertFalse(filter.test(Event.of("p", null, "snapshot_created", "a", "h")));
+  }
+
+  @Test
+  void skipsWhenResolverReturnsNull() {
+    var poster = new RecordingPoster();
+    var reactor = new SlackReactor(project -> null, threads, id -> null, poster);
+
+    reactor.onEvent(event("spec_dispatched"));
+
+    assertTrue(poster.posts.isEmpty());
+  }
+
+  @Test
+  void skipsWhenNotificationsHaveNoSlackBlock() {
+    var poster = new RecordingPoster();
+    var webhookOnly = new Notifications("https://example.com/wh", null);
+    var reactor = new SlackReactor(project -> webhookOnly, threads, id -> null, poster);
+
+    reactor.onEvent(event("spec_dispatched"));
+
+    assertTrue(poster.posts.isEmpty());
+  }
+
+  @Test
+  void warnsLoudlyWhenNoTokenConfigured() {
+    var reactor = reactor(null);
+
+    var err = captureStderr(() -> reactor.onEvent(event("spec_dispatched")));
+
+    assertTrue(err.contains("SAIL_SLACK_TOKEN"));
+    assertTrue(err.contains("light"));
+  }
+
+  @Test
+  void dispatchPostsRootAndRecordsThread() {
+    var poster = new RecordingPoster();
+    reactor(poster).onEvent(event("spec_dispatched", Map.of("branch", "feat/auth")));
+
+    assertEquals(1, poster.posts.size());
+    var post = poster.posts.getFirst();
+    assertEquals("#sail-activity", post.channel());
+    assertNull(post.threadTs());
+    assertFalse(post.broadcast());
+    assertTrue(post.text().contains("*auth*"));
+
+    var thread = threads.find("light", "auth").orElseThrow();
+    assertEquals("C123", thread.channel());
+    assertEquals("1.100", thread.threadTs());
+  }
+
+  @Test
+  void rootMessageUsesSpecTitleFromLookup() {
+    specStore.create(
+        new SpecStore.SpecRow(
+            "auth",
+            "light",
+            "OAuth flow",
+            SpecStatus.PENDING,
+            null,
+            "claude-code",
+            null,
+            null,
+            null,
+            0,
+            null,
+            "",
+            "",
+            null,
+            List.of(),
+            List.of()));
+    var poster = new RecordingPoster();
+    var reactor =
+        new SlackReactor(
+            project -> SLACK_ONLY, threads, SlackReactor.specLookup(specStore), poster);
+
+    reactor.onEvent(event("spec_dispatched"));
+
+    assertTrue(poster.posts.getFirst().text().contains("OAuth flow"));
+    assertTrue(poster.posts.getFirst().text().contains("agent `claude-code`"));
+  }
+
+  @Test
+  void specLookupReturnsNullForUnknownSpec() {
+    assertNull(SlackReactor.specLookup(specStore).apply("ghost"));
+  }
+
+  @Test
+  void redispatchStartsANewThread() {
+    var poster = new RecordingPoster();
+    var reactor = reactor(poster);
+
+    reactor.onEvent(event("spec_dispatched"));
+    poster.nextTs = "2.200";
+    reactor.onEvent(event("spec_restarted"));
+
+    assertNull(poster.posts.get(1).threadTs());
+    assertEquals("2.200", threads.find("light", "auth").orElseThrow().threadTs());
+  }
+
+  @Test
+  void lifecycleEventsThreadUnderTheRoot() {
+    var poster = new RecordingPoster();
+    var reactor = reactor(poster);
+
+    reactor.onEvent(event("spec_dispatched"));
+    reactor.onEvent(authoritativeStop());
+    reactor.onEvent(event("review_stage_started", Map.of("detail", "security")));
+
+    var stop = poster.posts.get(1);
+    assertEquals("C123", stop.channel());
+    assertEquals("1.100", stop.threadTs());
+    assertTrue(stop.text().contains("exit 0"));
+    assertEquals("1.100", poster.posts.get(2).threadTs());
+  }
+
+  @Test
+  void turnEndStopWithoutSourceIsIgnored() {
+    var poster = new RecordingPoster();
+    var reactor = reactor(poster);
+
+    reactor.onEvent(event("spec_dispatched"));
+    reactor.onEvent(event(Event.WellKnownTypes.AGENT_SESSION_STOPPED));
+
+    assertEquals(1, poster.posts.size());
+  }
+
+  @Test
+  void escalationBroadcastsToTheChannel() {
+    var poster = new RecordingPoster();
+    var reactor = reactor(poster);
+
+    reactor.onEvent(event("spec_dispatched"));
+    reactor.onEvent(event("review_escalated"));
+
+    var escalation = poster.posts.get(1);
+    assertEquals("1.100", escalation.threadTs());
+    assertTrue(escalation.broadcast());
+  }
+
+  @Test
+  void otherThreadRepliesDoNotBroadcast() {
+    var poster = new RecordingPoster();
+    var reactor = reactor(poster);
+
+    reactor.onEvent(event("spec_dispatched"));
+    reactor.onEvent(event("review_completed"));
+
+    assertFalse(poster.posts.get(1).broadcast());
+  }
+
+  @Test
+  void replyWithoutARecordedThreadIsAdoptedAsRoot() {
+    var poster = new RecordingPoster();
+    var reactor = reactor(poster);
+
+    reactor.onEvent(event("review_errored", Map.of("detail", "boom")));
+
+    var post = poster.posts.getFirst();
+    assertNull(post.threadTs());
+    assertFalse(post.broadcast());
+    assertEquals("1.100", threads.find("light", "auth").orElseThrow().threadTs());
+  }
+
+  @Test
+  void eventWithoutSpecPostsStandaloneAndRecordsNothing() {
+    var poster = new RecordingPoster();
+    var reactor = reactor(poster);
+
+    reactor.onEvent(
+        Event.of("light", null, "guardrail_triggered", "sail", "h", Map.of("reason", "budget"))
+            .withId(1L));
+
+    assertNull(poster.posts.getFirst().threadTs());
+    assertTrue(threads.find("light", "null").isEmpty());
+  }
+
+  @Test
+  void failedRootPostRecordsNoThread() {
+    var poster = new RecordingPoster();
+    poster.failAll = true;
+    var reactor = reactor(poster);
+
+    reactor.onEvent(event("spec_dispatched"));
+
+    assertTrue(threads.find("light", "auth").isEmpty());
+  }
+
+  @Test
+  void posterExceptionIsCaughtAndLogged() {
+    var reactor =
+        reactor(
+            post -> {
+              throw new IllegalStateException("boom");
+            });
+
+    var err = captureStderr(() -> reactor.onEvent(event("spec_dispatched")));
+
+    assertTrue(err.contains("failed to process spec_dispatched"));
+    assertTrue(err.contains("boom"));
+  }
+
+  @Test
+  void defaultPosterIsNullWithoutToken() {
+    assertNull(SlackReactor.defaultPoster());
+  }
+
+  @Test
+  void defaultPosterBuildsClientWhenTokenPresent() {
+    System.setProperty("SAIL_SLACK_TOKEN", "xoxb-test");
+    try {
+      assertNotNull(SlackReactor.defaultPoster());
+    } finally {
+      System.clearProperty("SAIL_SLACK_TOKEN");
+    }
+  }
+
+  @Test
+  void withDefaultsDoesNotThrow() {
+    assertNotNull(SlackReactor.withDefaults(threads, specStore));
+  }
+
+  private static String captureStderr(Runnable work) {
+    var original = System.err;
+    var buffer = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(buffer));
+    try {
+      work.run();
+    } finally {
+      System.setErr(original);
+    }
+    return buffer.toString();
+  }
+
+  private static final class RecordingPoster implements SlackPoster {
+    final List<Post> posts = new ArrayList<>();
+    String nextTs = "1.100";
+    boolean failAll;
+
+    @Override
+    public Result post(Post post) {
+      posts.add(post);
+      return failAll ? null : new Result("C123", nextTs);
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
@@ -191,6 +191,9 @@ class DispatchCommandTest {
         prompt.contains("not complete until CI is green"),
         "the agent must watch the PR's checks and fix failures — a red-CI PR is unfinished work");
     assertTrue(prompt.contains("gh pr checks"));
+    assertTrue(
+        prompt.contains("no Co-Authored-By trailers"),
+        "generated work must not carry AI attribution");
     assertFalse(prompt.contains("handoff.md"), "no context-handoff cruft");
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerSailSetupTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerSailSetupTest.java
@@ -131,6 +131,9 @@ class ContainerSailSetupTest {
     assertTrue(
         probe.contains(SpecCliHelper.PROFILE_PATH),
         "the probe must detect a container missing the spec-CLI PATH entry so reconfigure retrofits it");
+    assertTrue(
+        probe.contains("grep -qsF includeCoAuthoredBy"),
+        "settings files predating the attribution opt-out must be refreshed on the next dispatch");
   }
 
   @Test


### PR DESCRIPTION
See commit message: prompt-echo parser poisoning (every codex review recorded 0 findings), main-tree repair after a shared-worktree contamination dropped the slack agent's final reactor layer, and attribution opt-out for dispatched agents. Full reactor green: 1918+170 tests.