### PR TITLE
fix(review): prompt targets spec repos with a missing-branch fallback

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/engine/ReviewPromptBuilder.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/ReviewPromptBuilder.java
@@ -16,12 +16,21 @@ public final class ReviewPromptBuilder {
 
   private ReviewPromptBuilder() {}
 
-  public static String build(String branch, String repo, List<String> categories) {
+  /**
+   * @param repos the spec's target repository directory names inside the workspace — the actual
+   *     checkouts to review, never the project name (a multi-repo workspace root contains several
+   *     repos, and a wrong name sends the reviewer into an unrelated codebase)
+   */
+  public static String build(String branch, List<String> repos, List<String> categories) {
     var categoryList =
         categories.isEmpty() ? "any relevant category" : String.join(", ", categories);
+    var repoList = repos.isEmpty() ? "the repository in the workspace" : String.join(", ", repos);
 
     return """
-        Review the changes on branch %s in repository %s.
+        Review the changes on branch %s in the following repository director%s inside this
+        workspace: %s. Review only those checkouts — ignore any other repositories present.
+        If that branch no longer exists, review the spec's changes as merged on the default
+        branch instead; do not go hunting for the missing ref.
 
         Focus on these categories: %s
 
@@ -46,6 +55,6 @@ public final class ReviewPromptBuilder {
 
         Begin your response with ```json and end with ```.
         """
-        .formatted(branch, repo, categoryList);
+        .formatted(branch, repos.size() == 1 ? "y" : "ies", repoList, categoryList);
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/engine/ReviewPromptBuilderTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/ReviewPromptBuilderTest.java
@@ -14,40 +14,41 @@ class ReviewPromptBuilderTest {
 
   @Test
   void includesBranchAndRepo() {
-    var prompt = ReviewPromptBuilder.build("feat/auth", "backend", List.of());
+    var prompt = ReviewPromptBuilder.build("feat/auth", List.of("backend"), List.of());
     assertTrue(prompt.contains("feat/auth"));
     assertTrue(prompt.contains("backend"));
   }
 
   @Test
   void includesCategories() {
-    var prompt = ReviewPromptBuilder.build("main", "app", List.of("security", "injection"));
+    var prompt =
+        ReviewPromptBuilder.build("main", List.of("app"), List.of("security", "injection"));
     assertTrue(prompt.contains("security, injection"));
   }
 
   @Test
   void emptyCategoriesToDefaultsToAny() {
-    var prompt = ReviewPromptBuilder.build("main", "app", List.of());
+    var prompt = ReviewPromptBuilder.build("main", List.of("app"), List.of());
     assertTrue(prompt.contains("any relevant category"));
   }
 
   @Test
   void instructsJsonOutput() {
-    var prompt = ReviewPromptBuilder.build("main", "app", List.of());
+    var prompt = ReviewPromptBuilder.build("main", List.of("app"), List.of());
     assertTrue(prompt.contains("```json"));
     assertTrue(prompt.contains("JSON array"));
   }
 
   @Test
   void requiresEvidenceInFindings() {
-    var prompt = ReviewPromptBuilder.build("main", "app", List.of());
+    var prompt = ReviewPromptBuilder.build("main", List.of("app"), List.of());
     assertTrue(prompt.contains("evidence"));
     assertTrue(prompt.contains("If you cannot prove it, do not report it"));
   }
 
   @Test
   void includesSeverityLevels() {
-    var prompt = ReviewPromptBuilder.build("main", "app", List.of());
+    var prompt = ReviewPromptBuilder.build("main", List.of("app"), List.of());
     assertTrue(prompt.contains("CRITICAL"));
     assertTrue(prompt.contains("HIGH"));
     assertTrue(prompt.contains("MEDIUM"));
@@ -56,10 +57,21 @@ class ReviewPromptBuilderTest {
 
   @Test
   void includesSuggestionFormat() {
-    var prompt = ReviewPromptBuilder.build("main", "app", List.of());
+    var prompt = ReviewPromptBuilder.build("main", List.of("app"), List.of());
     assertTrue(prompt.contains("suggestion"));
     assertTrue(prompt.contains("before"));
     assertTrue(prompt.contains("after"));
     assertTrue(prompt.contains("rationale"));
+  }
+
+  @Test
+  void namesTheSpecReposNotTheProjectAndCoversTheMissingBranchCase() {
+    var prompt = ReviewPromptBuilder.build("agent/x", List.of("sail", "mast"), List.of());
+
+    assertTrue(prompt.contains("directories inside this\nworkspace: sail, mast"), prompt);
+    assertTrue(
+        prompt.contains("If that branch no longer exists"),
+        "a deleted work branch must not send the reviewer hunting: " + prompt);
+    assertTrue(prompt.contains("ignore any other repositories"), prompt);
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -283,7 +283,8 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     try {
       var spec = specStore.findById(specId);
       var branch = spec.map(SpecStore.SpecRow::branch).orElse("main");
-      var prompt = ReviewPromptBuilder.build(branch, project, stageConfig.categories());
+      var repos = spec.map(SpecStore.SpecRow::repos).orElse(List.of());
+      var prompt = ReviewPromptBuilder.build(branch, repos, stageConfig.categories());
 
       var output = agentRunner.run(project, agent, prompt);
       var parseResult = FindingParser.parse(output);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopIT.java
@@ -90,7 +90,7 @@ class ReviewAgentLoopIT extends AbstractIncusIT {
 
   @Test
   void theRealRunnerInvokesTheAgentInTheContainerAndParsesItsFindings() throws Exception {
-    var prompt = ReviewPromptBuilder.build("feat/test", CONTAINER, List.of("security"));
+    var prompt = ReviewPromptBuilder.build("feat/test", List.of("sail"), List.of("security"));
 
     var output = new ContainerReviewAgentRunner(shell).run(CONTAINER, "codex", prompt);
 


### PR DESCRIPTION
Re-review prompts named the project (not the repo) and a possibly-deleted branch, sending the reviewer into the wrong codebase. Prompts now name spec.repos(), scope the reviewer to them, and fall back to reviewing the merged changes when the branch is gone. Full reactor green (1918+170).