### PR TITLE
feat(host): one command to configure the daemon's Slack token

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostConfigSetCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostConfigSetCommand.java
@@ -10,8 +10,12 @@ import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SyncConfig;
 import ai.singlr.sail.config.WebauthnConfig;
 import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.DaemonSecretInstaller;
 import ai.singlr.sail.engine.NetworkDetector;
 import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.engine.SystemdServiceInstaller;
 import ai.singlr.sail.ssh.SshPublicKey;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -19,6 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -45,7 +50,8 @@ public final class HostConfigSetCommand implements Runnable {
           "webauthn-origin",
           "sync-role",
           "sync-main",
-          "sync-handle");
+          "sync-handle",
+          "slack-token");
   private static final Set<String> WEBAUTHN_KEYS =
       Set.of("webauthn-rp-id", "webauthn-rp-name", "webauthn-origin");
   private static final Pattern RP_ID = Pattern.compile("[a-z0-9]([a-z0-9.-]*[a-z0-9])?");
@@ -59,8 +65,15 @@ public final class HostConfigSetCommand implements Runnable {
       index = "1",
       arity = "0..1",
       description =
-          "Value to set. Omit for ssh-public-key to auto-detect it from your authorized_keys.")
+          "Value to set. Omit for ssh-public-key to auto-detect it from your authorized_keys."
+              + " Never pass a value for slack-token — it is read from a hidden prompt, a stdin"
+              + " pipe, or --token-file.")
   private String value;
+
+  @Option(
+      names = "--token-file",
+      description = "Read the slack-token value from this file instead of prompting.")
+  private Path tokenFile;
 
   @Option(names = "--dry-run", description = "Print what would change without writing.")
   private boolean dryRun;
@@ -70,20 +83,32 @@ public final class HostConfigSetCommand implements Runnable {
 
   @Spec private CommandSpec spec;
 
+  ShellExec shell;
+  Path userHome;
+  SystemdServiceInstaller.Mode serviceMode;
+
   @Override
   public void run() {
     CliCommand.run(spec, this::execute);
   }
 
   private void execute() throws Exception {
-    if (!dryRun && !ConsoleHelper.isRoot()) {
-      throw new IllegalStateException(
-          "Root privileges required. Run with: sudo sail host config set " + key + " " + value);
-    }
-
     if (!SETTABLE_KEYS.contains(key)) {
       throw new IllegalArgumentException(
           "Unknown config key: '" + key + "'. Settable keys: " + String.join(", ", SETTABLE_KEYS));
+    }
+
+    if ("slack-token".equals(key)) {
+      applySlackToken();
+      return;
+    }
+    if (tokenFile != null) {
+      throw new IllegalArgumentException("The --token-file option applies only to 'slack-token'.");
+    }
+
+    if (!dryRun && !ConsoleHelper.isRoot()) {
+      throw new IllegalStateException(
+          "Root privileges required. Run with: sudo sail host config set " + key + " " + value);
     }
 
     if ("ssh-public-key".equals(key)) {
@@ -125,6 +150,125 @@ public final class HostConfigSetCommand implements Runnable {
       System.out.println(
           Ansi.AUTO.string("  @|faint Restart to apply: sudo systemctl restart sail-api|@"));
     }
+  }
+
+  /**
+   * Sets the daemon's Slack bot token: owner-only token file, systemd drop-in publishing {@code
+   * SAIL_SLACK_TOKEN_FILE}, service restart. The token is never accepted as an argument so it
+   * cannot leak into shell history or the process list. Package-private so the full flow is
+   * unit-tested with an injected shell, home, and mode instead of root and a live systemd.
+   */
+  void applySlackToken() throws Exception {
+    if (Strings.isNotBlank(value)) {
+      throw new IllegalArgumentException(
+          "Never pass the token as an argument — it would land in shell history and the process"
+              + " list. Run without a value for a hidden prompt, pipe the token on stdin, or use"
+              + " --token-file <path>.");
+    }
+    var secret = DaemonSecretInstaller.SLACK_TOKEN;
+    var mode = resolvedServiceMode();
+    var installer = new DaemonSecretInstaller(resolvedShell(), mode, resolvedUserHome());
+
+    if (dryRun) {
+      var systemctl = mode == SystemdServiceInstaller.Mode.USER ? "systemctl --user" : "systemctl";
+      System.out.println(
+          "[dry-run] Would write the Slack bot token to "
+              + installer.secretFilePath(secret)
+              + " (mode 0600)");
+      System.out.println(
+          "[dry-run] Would write "
+              + installer.dropInPath(secret)
+              + " (Environment="
+              + secret.envVar()
+              + "="
+              + installer.secretFilePath(secret)
+              + ")");
+      System.out.println(
+          "[dry-run] Would run: "
+              + systemctl
+              + " daemon-reload (only if the drop-in changed) && "
+              + systemctl
+              + " restart "
+              + SystemdServiceInstaller.UNIT_NAME);
+      return;
+    }
+
+    var token = acquireSlackToken();
+    var warning = slackTokenWarning(token);
+    var applied = installer.install(secret, token);
+
+    if (json) {
+      var map = new LinkedHashMap<String, Object>();
+      map.put("key", key);
+      map.put("tokenFile", applied.secretFile().toString());
+      map.put("dropIn", applied.dropIn().toString());
+      map.put("dropInChanged", applied.dropInChanged());
+      map.put("restarted", true);
+      map.put("status", "updated");
+      if (warning != null) {
+        map.put("warning", warning);
+      }
+      System.out.println(YamlUtil.dumpJson(map));
+      return;
+    }
+
+    if (warning != null) {
+      System.out.println(Ansi.AUTO.string("  @|yellow ⚠|@ " + warning));
+    }
+    System.out.println(
+        Ansi.AUTO.string("  @|bold,green ✓|@ slack-token set (" + applied.secretFile() + ")"));
+    System.out.println(
+        Ansi.AUTO.string("  @|bold,green ✓|@ sail-api restarted with " + secret.envVar() + " set"));
+    System.out.println(
+        Ansi.AUTO.string(
+            "  @|faint Invite the bot to the configured Slack channel or posts will fail.|@"));
+  }
+
+  private String acquireSlackToken() throws IOException {
+    var token = Objects.toString(readRawSlackToken(), "").strip();
+    if (token.isEmpty()) {
+      throw new IllegalArgumentException(
+          "No token provided. Enter it at the prompt, pipe it on stdin, or pass --token-file"
+              + " <path>.");
+    }
+    return token;
+  }
+
+  private String readRawSlackToken() throws IOException {
+    if (tokenFile != null) {
+      if (!Files.isRegularFile(tokenFile)) {
+        throw new IllegalArgumentException("Token file not found: " + tokenFile);
+      }
+      return Files.readString(tokenFile);
+    }
+    if (ConsoleHelper.hasConsole()) {
+      return ConsoleHelper.readPassword("  Slack bot token (input hidden): ");
+    }
+    return ConsoleHelper.readLine();
+  }
+
+  static String slackTokenWarning(String token) {
+    return token.startsWith("xoxb-")
+        ? null
+        : "Token does not start with 'xoxb-' (a Slack bot token). Setting it anyway — if it is"
+            + " wrong, the first post will fail loudly in the sail-api journal.";
+  }
+
+  private ShellExec resolvedShell() {
+    return Objects.requireNonNullElseGet(shell, () -> new ShellExecutor(false));
+  }
+
+  private Path resolvedUserHome() {
+    return Objects.requireNonNullElseGet(userHome, () -> Path.of(System.getProperty("user.home")));
+  }
+
+  private SystemdServiceInstaller.Mode resolvedServiceMode() {
+    if (serviceMode != null) {
+      return serviceMode;
+    }
+    return ConsoleHelper.isRoot()
+        ? SystemdServiceInstaller.Mode.SYSTEM
+        : SystemdServiceInstaller.Mode.USER;
   }
 
   private void applyWorkstationKey() throws IOException {

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/DaemonSecretInstaller.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/DaemonSecretInstaller.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import ai.singlr.sail.common.Strings;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Objects;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Installs a secret the {@code sail-api} daemon reads from a file named by an environment variable:
+ * writes the value to an owner-only ({@code 0600}) file under {@code ~/.sail}, points the unit at
+ * it through a systemd drop-in, and restarts the service so the daemon picks it up. The name → env
+ * var → file path mapping in {@link DaemonSecret} is the whole seam — the next daemon secret is a
+ * new constant, not a new mechanism.
+ *
+ * <p>Idempotent: the secret file is replaced in place, the drop-in is reconciled the same way
+ * {@link SystemdServiceInstaller#reconcile()} treats the unit file (rewrite plus {@code
+ * daemon-reload} only on drift), and re-running leaves exactly one drop-in.
+ */
+public final class DaemonSecretInstaller {
+
+  /** A secret the daemon reads from a file whose path is published via {@code envVar}. */
+  public record DaemonSecret(String name, String envVar) {
+    public DaemonSecret {
+      if (Strings.isBlank(name) || Strings.isBlank(envVar)) {
+        throw new IllegalArgumentException("name and envVar are required");
+      }
+    }
+  }
+
+  /** The Slack bot token the reactor resolves through {@code SAIL_SLACK_TOKEN_FILE}. */
+  public static final DaemonSecret SLACK_TOKEN =
+      new DaemonSecret("slack-token", "SAIL_SLACK_TOKEN_FILE");
+
+  /** What {@link #install} changed on disk. */
+  public record Applied(Path secretFile, Path dropIn, boolean dropInChanged) {}
+
+  private static final String OWNER_ONLY = "rw-------";
+
+  private final ShellExec shell;
+  private final SystemdServiceInstaller.Mode mode;
+  private final Path secretDir;
+  private final Path dropInDir;
+
+  /**
+   * @param shell the shell executor (real or scripted for tests)
+   * @param mode scope of the {@code sail-api} unit the drop-in targets — {@link
+   *     SystemdServiceInstaller.Mode#SYSTEM} puts it under {@code /etc/systemd/system}, {@link
+   *     SystemdServiceInstaller.Mode#USER} under {@code ~/.config/systemd/user}
+   * @param userHome the daemon user's home directory; secrets live in its {@code .sail}
+   */
+  public DaemonSecretInstaller(ShellExec shell, SystemdServiceInstaller.Mode mode, Path userHome) {
+    this(
+        shell,
+        mode,
+        Objects.requireNonNull(userHome, "userHome").resolve(".sail"),
+        mode == SystemdServiceInstaller.Mode.SYSTEM
+            ? Path.of("/etc/systemd/system", SystemdServiceInstaller.UNIT_NAME + ".d")
+            : userHome
+                .resolve(".config/systemd/user")
+                .resolve(SystemdServiceInstaller.UNIT_NAME + ".d"));
+  }
+
+  DaemonSecretInstaller(
+      ShellExec shell, SystemdServiceInstaller.Mode mode, Path secretDir, Path dropInDir) {
+    this.shell = Objects.requireNonNull(shell, "shell");
+    this.mode = Objects.requireNonNull(mode, "mode");
+    this.secretDir = Objects.requireNonNull(secretDir, "secretDir");
+    this.dropInDir = Objects.requireNonNull(dropInDir, "dropInDir");
+  }
+
+  /** Where the secret value is stored: {@code <secretDir>/<name>}, mode {@code 0600}. */
+  public Path secretFilePath(DaemonSecret secret) {
+    return secretDir.resolve(secret.name());
+  }
+
+  /** The drop-in that points the unit at {@link #secretFilePath}. */
+  public Path dropInPath(DaemonSecret secret) {
+    return dropInDir.resolve("20-" + secret.name() + ".conf");
+  }
+
+  /** Contents of the drop-in. Pure function — no I/O. */
+  public String renderDropIn(DaemonSecret secret) {
+    return "[Service]\nEnvironment=" + secret.envVar() + "=" + secretFilePath(secret) + "\n";
+  }
+
+  /**
+   * Writes the secret file ({@code 0600}), reconciles the drop-in ({@code daemon-reload} only on
+   * drift), and restarts {@code sail-api} so the daemon reads the new value.
+   */
+  public Applied install(DaemonSecret secret, String value)
+      throws IOException, InterruptedException, TimeoutException {
+    if (Strings.isBlank(value)) {
+      throw new IllegalArgumentException("A non-blank value is required for " + secret.name());
+    }
+    var secretFile = writeSecretFile(secret, value);
+    var dropInChanged = reconcileDropIn(secret);
+    restart();
+    return new Applied(secretFile, dropInPath(secret), dropInChanged);
+  }
+
+  private Path writeSecretFile(DaemonSecret secret, String value) throws IOException {
+    var file = secretFilePath(secret);
+    SailPaths.ensureDataDir(secretDir);
+    if (Files.notExists(file)) {
+      Files.createFile(
+          file, PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString(OWNER_ONLY)));
+    }
+    Files.setPosixFilePermissions(file, PosixFilePermissions.fromString(OWNER_ONLY));
+    Files.writeString(file, value + "\n");
+    return file;
+  }
+
+  private boolean reconcileDropIn(DaemonSecret secret)
+      throws IOException, InterruptedException, TimeoutException {
+    var dropIn = dropInPath(secret);
+    var expected = renderDropIn(secret);
+    String onDisk;
+    try {
+      onDisk = Files.readString(dropIn);
+    } catch (NoSuchFileException nsf) {
+      onDisk = null;
+    }
+    if (expected.equals(onDisk)) {
+      return false;
+    }
+    Files.createDirectories(dropInDir);
+    Files.writeString(dropIn, expected);
+    var reload = shell.exec(SystemdServiceInstaller.systemctl(mode, "daemon-reload"));
+    if (!reload.ok()) {
+      throw new IOException("Failed to reload systemd units: " + reload.stderr());
+    }
+    return true;
+  }
+
+  private void restart() throws IOException, InterruptedException, TimeoutException {
+    var unit = SystemdServiceInstaller.UNIT_NAME;
+    var restart = shell.exec(SystemdServiceInstaller.systemctl(mode, "restart", unit));
+    if (!restart.ok()) {
+      throw new IOException(
+          "Failed to restart "
+              + unit
+              + ": "
+              + restart.stderr().strip()
+              + ". The secret file and drop-in are in place. If the daemon is not installed yet,"
+              + " run 'sail host service install'; if it runs as a system service, rerun this"
+              + " command with sudo.");
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/SystemdServiceInstaller.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/SystemdServiceInstaller.java
@@ -324,6 +324,10 @@ public final class SystemdServiceInstaller {
   }
 
   private List<String> systemctl(String... args) {
+    return systemctl(mode, args);
+  }
+
+  static List<String> systemctl(Mode mode, String... args) {
     var cmd = new ArrayList<String>();
     cmd.add("systemctl");
     if (mode == Mode.USER) {

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/HostConfigSetCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/HostConfigSetCommandTest.java
@@ -14,13 +14,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.singlr.sail.Sail;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.ScriptedShellExecutor;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.SystemdServiceInstaller;
 import ai.singlr.sail.ssh.SshPublicKey;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -354,5 +359,152 @@ class HostConfigSetCommandTest {
         cmd.execute("host", "config", "set", "ssh-public-key", "not-a-real-key", "--dry-run");
 
     assertNotEquals(0, exit, "a malformed key must be rejected");
+  }
+
+  @Test
+  void slackTokenPassedAsArgumentIsRejectedBeforeAnythingElse() {
+    var cmd = new CommandLine(new Sail());
+    cmd.setErr(new PrintWriter(new StringWriter()));
+
+    var exit = cmd.execute("host", "config", "set", "slack-token", "xoxb-leaked");
+
+    assertNotEquals(0, exit);
+    assertTrue(
+        capturedErr.toString().contains("shell history"),
+        "must explain why the token cannot be an argument");
+  }
+
+  @Test
+  void slackTokenDryRunPrintsThePlanWithoutRootOrPrompting() {
+    var cmd = new CommandLine(new Sail());
+    cmd.setErr(new PrintWriter(new StringWriter()));
+
+    var exit = cmd.execute("host", "config", "set", "slack-token", "--dry-run");
+
+    assertEquals(0, exit);
+    var output = capturedOut.toString();
+    assertTrue(output.contains("0600"), "plan must mention the owner-only token file");
+    assertTrue(output.contains("SAIL_SLACK_TOKEN_FILE"), "plan must mention the drop-in env var");
+    assertTrue(output.contains("restart"), "plan must mention the service restart");
+  }
+
+  @Test
+  void tokenFileOptionIsRejectedForOtherKeys() {
+    var cmd = new CommandLine(new Sail());
+    cmd.setErr(new PrintWriter(new StringWriter()));
+
+    var exit =
+        cmd.execute(
+            "host",
+            "config",
+            "set",
+            "server-ip",
+            "10.0.0.1",
+            "--token-file",
+            "/tmp/x",
+            "--dry-run");
+
+    assertNotEquals(0, exit);
+    assertTrue(capturedErr.toString().contains("slack-token"));
+  }
+
+  @Test
+  void slackTokenWarningFlagsNonBotPrefixesButNeverBlocks() {
+    assertEquals(null, HostConfigSetCommand.slackTokenWarning("xoxb-real-bot-token"));
+    assertNotNull(HostConfigSetCommand.slackTokenWarning("xoxp-user-token"));
+    assertTrue(HostConfigSetCommand.slackTokenWarning("garbage").contains("xoxb-"));
+  }
+
+  @Test
+  void slackTokenFromTokenFileInstallsEverythingAndReportsJsonWithoutTheToken(@TempDir Path tmp)
+      throws Exception {
+    var source = tmp.resolve("source-token");
+    Files.writeString(source, "xoxb-secret-value\n");
+    var home = tmp.resolve("home");
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
+    var cmd = slackTokenCommand(shell, home);
+    injectFields(cmd, "tokenFile", source);
+    injectFields(cmd, "json", true);
+
+    cmd.applySlackToken();
+
+    var output = capturedOut.toString();
+    assertTrue(output.contains("updated"));
+    assertTrue(output.contains("slack-token"));
+    assertTrue(!output.contains("xoxb-secret-value"), "the token must never be printed");
+    var written = home.resolve(".sail/slack-token");
+    assertEquals("xoxb-secret-value\n", Files.readString(written));
+    assertEquals(
+        PosixFilePermissions.fromString("rw-------"), Files.getPosixFilePermissions(written));
+    assertTrue(
+        Files.readString(
+                home.resolve(".config/systemd/user/sail-api.service.d/20-slack-token.conf"))
+            .contains("SAIL_SLACK_TOKEN_FILE=" + written));
+    assertEquals(
+        List.of("systemctl --user daemon-reload", "systemctl --user restart sail-api.service"),
+        shell.invocations());
+  }
+
+  @Test
+  void slackTokenFromStdinWarnsOnUnexpectedPrefixAndRemindsAboutTheChannel(@TempDir Path tmp)
+      throws Exception {
+    var originalIn = System.in;
+    var originalConsole = ConsoleHelper.consoleSupplier;
+    try {
+      ConsoleHelper.consoleSupplier = () -> null;
+      System.setIn(new ByteArrayInputStream("xoxp-not-a-bot\n".getBytes()));
+      ConsoleHelper.resetStdin();
+      var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
+      var cmd = slackTokenCommand(shell, tmp.resolve("home"));
+
+      cmd.applySlackToken();
+
+      var output = capturedOut.toString();
+      assertTrue(output.contains("xoxb-"), "must warn about the unexpected token prefix");
+      assertTrue(output.contains("Invite the bot"), "must remind about the channel invite");
+      assertEquals(
+          "xoxp-not-a-bot\n", Files.readString(tmp.resolve("home").resolve(".sail/slack-token")));
+    } finally {
+      System.setIn(originalIn);
+      ConsoleHelper.consoleSupplier = originalConsole;
+      ConsoleHelper.resetStdin();
+    }
+  }
+
+  @Test
+  void slackTokenFailsLoudWhenStdinIsEmpty(@TempDir Path tmp) {
+    var originalIn = System.in;
+    var originalConsole = ConsoleHelper.consoleSupplier;
+    try {
+      ConsoleHelper.consoleSupplier = () -> null;
+      System.setIn(new ByteArrayInputStream(new byte[0]));
+      ConsoleHelper.resetStdin();
+      var cmd = slackTokenCommand(new ScriptedShellExecutor(), tmp.resolve("home"));
+
+      var ex = assertThrows(IllegalArgumentException.class, cmd::applySlackToken);
+      assertTrue(ex.getMessage().contains("--token-file"));
+    } finally {
+      System.setIn(originalIn);
+      ConsoleHelper.consoleSupplier = originalConsole;
+      ConsoleHelper.resetStdin();
+    }
+  }
+
+  @Test
+  void slackTokenFailsLoudWhenTheTokenFileIsMissing(@TempDir Path tmp) {
+    var cmd = slackTokenCommand(new ScriptedShellExecutor(), tmp.resolve("home"));
+    injectFields(cmd, "tokenFile", tmp.resolve("absent"));
+
+    var ex = assertThrows(IllegalArgumentException.class, cmd::applySlackToken);
+    assertTrue(ex.getMessage().contains("not found"));
+  }
+
+  private static HostConfigSetCommand slackTokenCommand(ShellExec shell, Path home) {
+    var cmd = new HostConfigSetCommand();
+    injectFields(cmd, "key", "slack-token");
+    injectFields(cmd, "shell", shell);
+    injectFields(cmd, "userHome", home);
+    injectFields(cmd, "serviceMode", SystemdServiceInstaller.Mode.USER);
+    return cmd;
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/DaemonSecretInstallerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/DaemonSecretInstallerTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.engine.DaemonSecretInstaller.DaemonSecret;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DaemonSecretInstallerTest {
+
+  private static final DaemonSecret SECRET = DaemonSecretInstaller.SLACK_TOKEN;
+
+  @Test
+  void slackTokenSecretMapsNameToEnvVar() {
+    assertEquals("slack-token", SECRET.name());
+    assertEquals("SAIL_SLACK_TOKEN_FILE", SECRET.envVar());
+  }
+
+  @Test
+  void secretRequiresNameAndEnvVar() {
+    assertThrows(IllegalArgumentException.class, () -> new DaemonSecret(" ", "ENV"));
+    assertThrows(IllegalArgumentException.class, () -> new DaemonSecret("name", ""));
+  }
+
+  @Test
+  void userModePathsResolveUnderTheHome(@TempDir Path home) {
+    var installer = userInstaller(home, new ScriptedShellExecutor());
+
+    assertEquals(home.resolve(".sail/slack-token"), installer.secretFilePath(SECRET));
+    assertEquals(
+        home.resolve(".config/systemd/user/sail-api.service.d/20-slack-token.conf"),
+        installer.dropInPath(SECRET));
+  }
+
+  @Test
+  void systemModeDropInLivesUnderEtcSystemd(@TempDir Path home) {
+    var installer =
+        new DaemonSecretInstaller(
+            new ScriptedShellExecutor(), SystemdServiceInstaller.Mode.SYSTEM, home);
+
+    assertEquals(home.resolve(".sail/slack-token"), installer.secretFilePath(SECRET));
+    assertEquals(
+        Path.of("/etc/systemd/system/sail-api.service.d/20-slack-token.conf"),
+        installer.dropInPath(SECRET));
+  }
+
+  @Test
+  void renderDropInPointsTheEnvVarAtTheSecretFile(@TempDir Path home) {
+    var installer = userInstaller(home, new ScriptedShellExecutor());
+
+    assertEquals(
+        "[Service]\nEnvironment=SAIL_SLACK_TOKEN_FILE=" + home.resolve(".sail/slack-token") + "\n",
+        installer.renderDropIn(SECRET));
+  }
+
+  @Test
+  void installWritesTheSecretOwnerOnlyAndTheDropInThenReloadsAndRestarts(@TempDir Path home)
+      throws Exception {
+    var shell = okShell();
+    var installer = userInstaller(home, shell);
+
+    var applied = installer.install(SECRET, "xoxb-token-1");
+
+    assertEquals("xoxb-token-1\n", Files.readString(applied.secretFile()));
+    assertEquals(
+        PosixFilePermissions.fromString("rw-------"),
+        Files.getPosixFilePermissions(applied.secretFile()));
+    assertEquals(installer.renderDropIn(SECRET), Files.readString(applied.dropIn()));
+    assertTrue(applied.dropInChanged());
+    assertEquals(
+        List.of("systemctl --user daemon-reload", "systemctl --user restart sail-api.service"),
+        shell.invocations());
+  }
+
+  @Test
+  void reinstallReplacesTheTokenSkipsDaemonReloadAndStillRestarts(@TempDir Path home)
+      throws Exception {
+    var shell = okShell();
+    var installer = userInstaller(home, shell);
+
+    installer.install(SECRET, "xoxb-token-1");
+    var applied = installer.install(SECRET, "xoxb-token-2");
+
+    assertEquals("xoxb-token-2\n", Files.readString(applied.secretFile()));
+    assertFalse(applied.dropInChanged());
+    assertEquals(1, shell.invocations().stream().filter(c -> c.contains("daemon-reload")).count());
+    assertEquals(2, shell.invocations().stream().filter(c -> c.contains("restart")).count());
+    try (var entries = Files.list(applied.dropIn().getParent())) {
+      assertEquals(1, entries.count(), "reruns must leave exactly one drop-in");
+    }
+  }
+
+  @Test
+  void driftedDropInIsRewrittenAndReloaded(@TempDir Path home) throws Exception {
+    var shell = okShell();
+    var installer = userInstaller(home, shell);
+    installer.install(SECRET, "xoxb-token-1");
+    Files.writeString(installer.dropInPath(SECRET), "stale drop-in from an old binary\n");
+
+    var applied = installer.install(SECRET, "xoxb-token-1");
+
+    assertTrue(applied.dropInChanged());
+    assertEquals(installer.renderDropIn(SECRET), Files.readString(applied.dropIn()));
+    assertEquals(2, shell.invocations().stream().filter(c -> c.contains("daemon-reload")).count());
+  }
+
+  @Test
+  void preExistingSecretFileIsTightenedToOwnerOnly(@TempDir Path home) throws Exception {
+    var installer = userInstaller(home, okShell());
+    var file = installer.secretFilePath(SECRET);
+    Files.createDirectories(file.getParent());
+    Files.writeString(file, "old\n");
+    Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-r--r--"));
+
+    installer.install(SECRET, "xoxb-token-1");
+
+    assertEquals(PosixFilePermissions.fromString("rw-------"), Files.getPosixFilePermissions(file));
+  }
+
+  @Test
+  void systemModeSystemctlCommandsOmitTheUserFlag(@TempDir Path tmp) throws Exception {
+    var shell = okShell();
+    var installer =
+        new DaemonSecretInstaller(
+            shell,
+            SystemdServiceInstaller.Mode.SYSTEM,
+            tmp.resolve(".sail"),
+            tmp.resolve("sail-api.service.d"));
+
+    installer.install(SECRET, "xoxb-token-1");
+
+    assertEquals(
+        List.of("systemctl daemon-reload", "systemctl restart sail-api.service"),
+        shell.invocations());
+  }
+
+  @Test
+  void restartFailureExplainsWhatToDo(@TempDir Path home) {
+    var shell = new ScriptedShellExecutor().onOk("daemon-reload").onFail("restart", "no D-Bus");
+    var installer = userInstaller(home, shell);
+
+    var ex = assertThrows(IOException.class, () -> installer.install(SECRET, "xoxb-token-1"));
+
+    assertTrue(ex.getMessage().contains("no D-Bus"));
+    assertTrue(ex.getMessage().contains("sail host service install"));
+  }
+
+  @Test
+  void daemonReloadFailurePropagates(@TempDir Path home) {
+    var shell = new ScriptedShellExecutor().onFail("daemon-reload", "no D-Bus");
+    var installer = userInstaller(home, shell);
+
+    var ex = assertThrows(IOException.class, () -> installer.install(SECRET, "xoxb-token-1"));
+    assertTrue(ex.getMessage().contains("no D-Bus"));
+  }
+
+  @Test
+  void blankValueIsRejectedBeforeTouchingDisk(@TempDir Path home) {
+    var installer = userInstaller(home, okShell());
+
+    assertThrows(IllegalArgumentException.class, () -> installer.install(SECRET, "  "));
+    assertFalse(Files.exists(installer.secretFilePath(SECRET)));
+  }
+
+  private static ScriptedShellExecutor okShell() {
+    return new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
+  }
+
+  private static DaemonSecretInstaller userInstaller(Path home, ShellExec shell) {
+    return new DaemonSecretInstaller(shell, SystemdServiceInstaller.Mode.USER, home);
+  }
+}


### PR DESCRIPTION
## Problem

Wiring the Slack bot token was four manual host steps: write a token file, chmod 600, `systemctl edit sail-api` to add the env var, then daemon-reload and restart. Exactly the class of surgery sail exists to remove.

## Solution

`sudo sail host config set slack-token` — a new settable key:

- Reads the token from a hidden interactive prompt; a stdin pipe or `--token-file <path>` for non-interactive use. Passing the token as an argument is rejected with an explanation, so it can never land in argv, shell history, or sail.yaml.
- Writes `~/.sail/slack-token` with mode 0600.
- Publishes `Environment=SAIL_SLACK_TOKEN_FILE=<path>` to the `sail-api` unit via a systemd drop-in (SYSTEM scope under `/etc/systemd/system`, USER scope under `~/.config/systemd/user`), reconciled the same way `SystemdServiceInstaller.reconcile()` treats the unit file — rewrite plus daemon-reload only on drift — then restarts the service so the reactor picks it up.
- Idempotent: reruns replace the token and leave exactly one drop-in. `--dry-run` prints the steps; `--json` reports what changed (never the token).
- Warns loudly on non-`xoxb-` prefixes without blocking, and reminds the operator to invite the bot to the configured channel.

## Design

The mechanism is a small daemon-secret seam, `DaemonSecretInstaller`, mapping name → env var → file path, with `SLACK_TOKEN` as its first user — the next daemon secret is a new constant, not a new command. No new dependencies, no Slack API call at set-time (the reactor's first post surfaces a bad token in the journal).

## Testing

- `DaemonSecretInstallerTest`: file perms, drop-in reconcile/drift, idempotency, SYSTEM vs USER systemctl invocations, actionable failure messages.
- `HostConfigSetCommandTest`: argv rejection, dry-run plan, stdin/token-file/blank-input paths, prefix warning, full flow with injected shell/home/mode asserting the token never appears in output.
- Verified end-to-end against the built CLI: piped token, idempotent rerun, and every error path; `mvn clean verify` green (1939 tests, coverage gates met).