### PR TITLE
fix(dispatch): persist resolved target repos with the in_progress transition

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -243,6 +243,26 @@ public final class SpecStore implements ConflictResolver {
         });
   }
 
+  /**
+   * Status transition that also persists the spec's resolved target repos in the same transaction.
+   * Dispatch resolves repo overrides at launch time; recording them here keeps later store reads
+   * (the review pipeline builds its prompt from the stored repos) aligned with the checkouts the
+   * agent actually worked in.
+   */
+  public void updateReposAndStatus(String id, List<String> repos, SpecStatus status) {
+    db.transaction(
+        () -> {
+          db.execute(
+              "UPDATE specs SET status = ?, updated_at = ? WHERE id = ?",
+              status.wire(),
+              DateTimeUtils.now().toString(),
+              id);
+          db.execute("DELETE FROM spec_repos WHERE spec_id = ?", id);
+          insertRepos(id, repos);
+          recordRevision(id, "local", false);
+        });
+  }
+
   public void delete(String id) {
     db.transaction(
         () -> {

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
@@ -235,6 +235,17 @@ class SpecStoreTest {
   }
 
   @Test
+  void updateReposAndStatusReplacesReposWithTheStatusTransition() {
+    store.create(spec("a", "Test", "pending"));
+    store.updateReposAndStatus("a", List.of("api", "web"), SpecStatus.IN_PROGRESS);
+
+    var found = store.findById("a").orElseThrow();
+    assertEquals(SpecStatus.IN_PROGRESS, found.status());
+    assertEquals(List.of("api", "web"), found.repos());
+    assertEquals(2, store.history("a").size());
+  }
+
+  @Test
   void deleteSpec() {
     store.create(spec("a", "Doomed", "draft"));
     store.delete("a");

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -247,7 +247,7 @@ public final class SailApiOperations implements ApiOperations {
 
     var targetRepos = DispatchRepos.resolve(loaded.config(), nextSpec, request.repos());
     var taskSpec = DispatchRepos.withTargetRepos(nextSpec, targetRepos);
-    specStore.updateStatus(nextSpec.id(), SpecStatus.IN_PROGRESS);
+    specStore.updateReposAndStatus(nextSpec.id(), taskSpec.repos(), SpecStatus.IN_PROGRESS);
     if (reviewStore != null) {
       reviewStore.supersedeForSpec(nextSpec.id());
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
@@ -162,7 +162,7 @@ public final class DispatchCommand implements Runnable {
               + name);
     }
 
-    var prepared = prepareDispatch(name, specId, restart);
+    var prepared = prepareDispatch(name, specId, restart, config);
     if (prepared == null) {
       printNoSpecs();
       return;
@@ -173,8 +173,8 @@ public final class DispatchCommand implements Runnable {
     var specBody = prepared.body();
 
     var agentType = nextSpec.agent() != null ? nextSpec.agent() : config.agent().type();
-    var targetRepos = DispatchRepos.resolve(config, nextSpec, repoOverrides);
-    var taskSpec = DispatchRepos.withTargetRepos(nextSpec, targetRepos);
+    var targetRepos = prepared.targetRepos();
+    var taskSpec = prepared.taskSpec();
     var branchName = BranchPolicy.branchName(config, nextSpec);
 
     if (resolution.restarted()) {
@@ -369,16 +369,25 @@ public final class DispatchCommand implements Runnable {
     }
   }
 
-  /** What {@link #prepareDispatch} produces: the resolved spec and its body, both from the DB. */
-  record Prepared(SpecResolution resolution, String body) {}
+  /**
+   * What {@link #prepareDispatch} produces: the resolved spec with its target repos (persisted to
+   * the DB alongside the {@code in_progress} transition) and its body.
+   */
+  record Prepared(
+      SpecResolution resolution, Spec taskSpec, List<SailYaml.Repo> targetRepos, String body) {}
 
   /**
    * Reads the project's specs from the control-plane database — the source of truth — picks the one
-   * to dispatch, marks it {@code in_progress}, and returns it with its body. Returns {@code null}
-   * when the project has no specs or none are ready. The container is never read: a stopped or
-   * file-drifted project is irrelevant because the spec lives in the DB, replicated by sync.
+   * to dispatch, resolves its target repos (honoring {@code --repo} overrides), marks it {@code
+   * in_progress} with those repos persisted, and returns it with its body. Persisting the resolved
+   * repos keeps later store reads (the review pipeline's prompt) aligned with the checkouts the
+   * agent actually works in, and resolving before the status transition means an invalid override
+   * fails before the spec is marked {@code in_progress}. Returns {@code null} when the project has
+   * no specs or none are ready. The container is never read: a stopped or file-drifted project is
+   * irrelevant because the spec lives in the DB, replicated by sync.
    */
-  private Prepared prepareDispatch(String project, String specId, boolean restart) {
+  private Prepared prepareDispatch(
+      String project, String specId, boolean restart, SailYaml config) {
     var fde = HostSync.handle();
     if (fde == null) {
       throw new IllegalStateException(
@@ -403,11 +412,12 @@ public final class DispatchCommand implements Runnable {
       if (resolution.spec() == null) {
         return null;
       }
-      store.updateStatus(resolution.spec().id(), SpecStatus.IN_PROGRESS);
-      new ReviewStore(db).supersedeForSpec(resolution.spec().id());
-      var body =
-          store.getContent(resolution.spec().id()).map(SpecStore.SpecContent::body).orElse("");
-      return new Prepared(resolution, body);
+      var targetRepos = DispatchRepos.resolve(config, resolution.spec(), repoOverrides);
+      var taskSpec = DispatchRepos.withTargetRepos(resolution.spec(), targetRepos);
+      store.updateReposAndStatus(taskSpec.id(), taskSpec.repos(), SpecStatus.IN_PROGRESS);
+      new ReviewStore(db).supersedeForSpec(taskSpec.id());
+      var body = store.getContent(taskSpec.id()).map(SpecStore.SpecContent::body).orElse("");
+      return new Prepared(resolution, taskSpec, targetRepos, body);
     }
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
@@ -217,6 +217,30 @@ class SailApiOperationsTest {
   }
 
   @Test
+  void dispatchPersistsResolvedRepoOverridesOnTheSpec() throws Exception {
+    var stores = new SpecStore[1];
+    var operations =
+        operationsWithStore(
+            multiRepoYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sail/agent.pid", new ShellExec.Result(1, "", "missing")),
+            store -> {
+              stores[0] = store;
+              seedAuthBillingSetup(store);
+            });
+
+    var result =
+        operations.dispatch(
+            "acme", new DispatchRequest("auth", "background", true, List.of("web")));
+
+    assertEquals(true, get(result, "dispatched"));
+    var persisted = stores[0].findById("auth").orElseThrow();
+    assertEquals(SpecStatus.IN_PROGRESS, persisted.status());
+    assertEquals(List.of("web"), persisted.repos());
+  }
+
+  @Test
   void dispatchRejectsBlockedSpec() throws Exception {
     var operations =
         operationsWithStore(
@@ -1318,6 +1342,22 @@ class SailApiOperationsTest {
         name: acme
         ssh:
           user: dev
+        agent:
+          type: claude-code
+          specs_dir: specs
+        """;
+  }
+
+  private static String multiRepoYaml() {
+    return """
+        name: acme
+        ssh:
+          user: dev
+        repos:
+          - url: https://github.com/acme/app.git
+            path: app
+          - url: https://github.com/acme/web.git
+            path: web
         agent:
           type: claude-code
           specs_dir: specs


### PR DESCRIPTION
## Summary

Addresses the open review finding from review 019f217b (slack-token-config, iteration 1): after a dispatch with repo overrides, only the spec status was written back to the database, so `ReviewPipelineController` later rebuilt its review prompt from stale or empty stored repos and could point the reviewer at the wrong checkout.

## Changes

- `SpecStore.updateReposAndStatus(id, repos, status)`: persists the resolved target repos and the status transition in one transaction, journaling a revision so the change syncs like any other spec mutation.
- `SailApiOperations.dispatchValue` (HTTP dispatch) now persists `taskSpec.repos()` with the `in_progress` transition instead of only the status.
- `DispatchCommand.prepareDispatch` (CLI dispatch) had the same gap: repos were resolved after the status was already persisted. Resolution now happens inside `prepareDispatch` and is persisted with the transition. As a side effect, an invalid `--repo` override now fails before the spec is marked `in_progress` instead of leaving it stuck there.

## Testing

- New `SpecStoreTest.updateReposAndStatusReplacesReposWithTheStatusTransition` covering repo replacement, status change, and revision journaling.
- New `SailApiOperationsTest.dispatchPersistsResolvedRepoOverridesOnTheSpec` covering the end-to-end API path with a multi-repo project and a repo override.
- Full `mvn verify` green: 1940 tests, coverage checks met.