### PR TITLE
A spec is done when its work is merged, not when the gate passes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -362,6 +362,14 @@ stage's gate fails, a fix agent addresses the open findings on the same branch a
 reviewer runs again, bounded by `max_iterations`, after which the spec `escalates` and parks
 in `review` for a human.
 
+A gate pass is not completion: the PR is still open on whatever forge hosts the repo, so the
+spec parks in `awaiting_merge`. Sail never talks to the forge — the FDE reviews and merges
+the PR there, then closes the loop with `sail spec edit <id> --status done`. Deciding about
+escalated findings (parks in `review`) and merging a passed PR (parks in `awaiting_merge`)
+are different human acts and get distinct states. Because only `done` satisfies
+`depends_on`, a dependent spec never dispatches against a main that lacks its parent's
+unmerged work.
+
 Reviewer and fix agents run on the same agent command and log handling as dispatch, but not
 its process wrapper. Dispatch is fire-and-forget (it launches a detached `systemd-run --user`
 unit and an external `sail agent watch` monitors it); a review blocks the pipeline until it

--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ reviewer checks the branch, a fix agent addresses its findings, and the loop rep
 `max_iterations` before escalating to a human. `sail agent review <project>` shows every
 attempt's iterations and findings; `sail agent log <project> --review` follows the
 negotiation live. Guardrails combine a `max_duration` and an action, so a runaway agent is
-stopped and rolled back to the pre-launch snapshot.
+stopped and rolled back to the pre-launch snapshot. A passing review parks the spec in
+`awaiting_merge` — sail never talks to the forge, so you merge the PR there and close the
+loop with `sail spec edit <id> --status done`.
 
 Findings the gate let ship don't die in the review store: `sail spec create --from-review
 <spec-id>` drafts a follow-up spec from the latest review's open findings — one actionable

--- a/sail-core/src/main/java/ai/singlr/sail/config/SpecDirectory.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/SpecDirectory.java
@@ -20,7 +20,12 @@ public final class SpecDirectory {
 
   /** Statuses an engineer may assign by hand via {@code sail spec status}. */
   public static final Set<SpecStatus> CLI_SETTABLE =
-      Set.of(SpecStatus.PENDING, SpecStatus.IN_PROGRESS, SpecStatus.REVIEW, SpecStatus.DONE);
+      Set.of(
+          SpecStatus.PENDING,
+          SpecStatus.IN_PROGRESS,
+          SpecStatus.REVIEW,
+          SpecStatus.AWAITING_MERGE,
+          SpecStatus.DONE);
 
   public record Summary(
       Map<String, Integer> counts, int readyCount, int blockedCount, String nextReadyId) {
@@ -169,12 +174,16 @@ public final class SpecDirectory {
         statusCounts(specs), readyCount, blockedCount, nextReady != null ? nextReady.id() : null);
   }
 
-  /** Returns a map of status counts: {pending: N, in_progress: N, review: N, done: N}. */
+  /**
+   * Returns a map of status counts: {pending: N, in_progress: N, review: N, awaiting_merge: N,
+   * done: N}.
+   */
   public static Map<String, Integer> statusCounts(List<Spec> specs) {
     var counts = new LinkedHashMap<String, Integer>();
     counts.put(SpecStatus.PENDING.wire(), 0);
     counts.put(SpecStatus.IN_PROGRESS.wire(), 0);
     counts.put(SpecStatus.REVIEW.wire(), 0);
+    counts.put(SpecStatus.AWAITING_MERGE.wire(), 0);
     counts.put(SpecStatus.DONE.wire(), 0);
     for (var spec : specs) {
       counts.merge(spec.status().wire(), 1, Integer::sum);
@@ -196,6 +205,11 @@ public final class SpecDirectory {
     }
   }
 
+  /**
+   * Only {@code done} satisfies a dependency. {@code awaiting_merge} deliberately does not: the
+   * work exists on an unmerged branch, so a dependent spec building on it would branch from a main
+   * that lacks it.
+   */
   private static Set<String> doneIds(List<Spec> specs) {
     return specs.stream()
         .filter(s -> s.status() == SpecStatus.DONE)

--- a/sail-core/src/main/java/ai/singlr/sail/config/SpecStatus.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/SpecStatus.java
@@ -14,15 +14,19 @@ import java.util.stream.Collectors;
  * persisted, serialized, and compared as its {@link #wire()} form (the lowercased name, e.g. {@code
  * IN_PROGRESS} → {@code "in_progress"}).
  *
- * <p>{@link #DRAFT} is the bucket for imported specs whose status is unknown or absent; {@link
- * #ARCHIVED} is hidden from the default board. Only {@link #CLI_SETTABLE} statuses may be assigned
- * by hand via {@code sail spec status}.
+ * <p>{@link #AWAITING_MERGE} sits between the review gate and completion: the review passed, the
+ * pull request is open, and a human still has to merge it on the forge and mark the spec {@link
+ * #DONE}. {@link #DRAFT} is the bucket for imported specs whose status is unknown or absent —
+ * including a status synced from a newer peer that this binary does not know yet, which lands in
+ * the draft column instead of crashing; {@link #ARCHIVED} is hidden from the default board. Only
+ * {@link SpecDirectory#CLI_SETTABLE} statuses may be assigned by hand via {@code sail spec status}.
  */
 public enum SpecStatus {
   DRAFT,
   PENDING,
   IN_PROGRESS,
   REVIEW,
+  AWAITING_MERGE,
   DONE,
   ARCHIVED;
 

--- a/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
@@ -255,9 +255,10 @@ public final class AgentContextGenerator {
         auto-create a branch.
 
         ### Status Lifecycle
-        `pending` → `in_progress` → `review` → `done`
+        `pending` → `in_progress` → `review` → `awaiting_merge` → `done`
         Status is managed by `sail`, not by you. Do not change a spec's status during autonomous
-        execution.
+        execution. `awaiting_merge` means the review passed and the PR waits for a human to merge
+        it; only the engineer marks a spec `done`.
 
         ### Dependencies
         `--depends-on` lists spec ids that must be `done` before a spec can start. Never start a

--- a/sail-core/src/main/java/ai/singlr/sail/gen/SpecSkillGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/SpecSkillGenerator.java
@@ -105,15 +105,15 @@ public final class SpecSkillGenerator {
         `--status pending` or `--assignee me` to filter). Render the result as status columns:
 
         ```
-        ┌─────────────┬─────────────────┬──────────────┬──────────────┐
-        │ Pending (3)  │ In Progress (1) │ Review (0)   │ Done (2)     │
-        ├─────────────┼─────────────────┼──────────────┼──────────────┤
-        │ search-api   │ oauth-flow      │              │ data-model   │
-        │  └─ depends: │                 │              │ auth-setup   │
-        │     oauth    │                 │              │              │
-        │ payments     │                 │              │              │
-        │ notifications│                 │              │              │
-        └─────────────┴─────────────────┴──────────────┴──────────────┘
+        ┌─────────────┬─────────────────┬──────────────┬────────────────────┬──────────────┐
+        │ Pending (3)  │ In Progress (1) │ Review (0)   │ Awaiting Merge (1) │ Done (2)     │
+        ├─────────────┼─────────────────┼──────────────┼────────────────────┼──────────────┤
+        │ search-api   │ oauth-flow      │              │ billing-hooks      │ data-model   │
+        │  └─ depends: │                 │              │                    │ auth-setup   │
+        │     oauth    │                 │              │                    │              │
+        │ payments     │                 │              │                    │              │
+        │ notifications│                 │              │                    │              │
+        └─────────────┴─────────────────┴──────────────┴────────────────────┴──────────────┘
         ```
 
         Show the title under each id. The board marks the next ready spec; flag specs whose \
@@ -153,7 +153,7 @@ public final class SpecSkillGenerator {
 
   private static String updateInstructions() {
     return """
-        Valid statuses: `pending`, `in_progress`, `review`, `done`.
+        Valid statuses: `pending`, `in_progress`, `review`, `awaiting_merge`, `done`.
 
         ```sh
         spec update <id> --status <new-status>
@@ -190,10 +190,12 @@ public final class SpecSkillGenerator {
         ```
 
         ### Status Lifecycle
-        `pending` → `in_progress` → `review` → `done`
+        `pending` → `in_progress` → `review` → `awaiting_merge` → `done`
         - **pending**: ready to be picked up
         - **in_progress**: an agent is actively working on it (set by `sail spec dispatch`)
         - **review**: PR created, waiting for human review (set by `sail`)
+        - **awaiting_merge**: review passed; the PR waits for a human to merge it on the forge
+          (set by `sail`)
         - **done**: PR merged, work complete (set by the engineer via `sail`)
 
         During autonomous execution Sail manages status itself — do not change it. The engineer's
@@ -202,7 +204,7 @@ public final class SpecSkillGenerator {
         ### Fields (set at create or via `spec update`)
         - **id** (required): stable identifier, lowercase with hyphens
         - **title** (required): short human-readable description
-        - **status**: one of pending, in_progress, review, done
+        - **status**: one of pending, in_progress, review, awaiting_merge, done
         - **assignee**: agent type or engineer name
         - **depends-on**: spec ids that must be done first
         - **repos**: target repository paths from `sail.yaml` `repos[].path`

--- a/sail-core/src/main/java/ai/singlr/sail/store/MissedStops.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MissedStops.java
@@ -21,7 +21,9 @@ import java.util.function.Function;
  *
  * <p>Only {@code in_progress} specs are considered. A clean replay advances the spec out of {@code
  * in_progress} so it is not re-picked on the next start; a crash leaves it {@code in_progress} (its
- * failure already recorded on the session) where it is correctly still unresolved.
+ * failure already recorded on the session) where it is correctly still unresolved. A spec already
+ * past the gate ({@code review}, {@code awaiting_merge}, {@code done}) is never replayed — a replay
+ * would re-run a review it already passed.
  */
 public final class MissedStops {
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -323,7 +323,57 @@ public final class SchemaManager {
               thread_ts TEXT NOT NULL,
               created_at TEXT NOT NULL,
               PRIMARY KEY (project, spec_id)
-          )""");
+          )""",
+          """
+          CREATE TABLE specs_v2 (
+              id TEXT PRIMARY KEY,
+              title TEXT NOT NULL,
+              status TEXT NOT NULL DEFAULT 'draft'
+                  CHECK (status IN ('draft', 'pending', 'in_progress', 'review', 'awaiting_merge',
+                      'done', 'archived')),
+              assignee TEXT,
+              agent TEXT,
+              model TEXT,
+              reasoning_effort TEXT
+                  CHECK (reasoning_effort IS NULL OR reasoning_effort IN ('none', 'low', 'medium', 'high', 'xhigh')),
+              branch TEXT,
+              priority INTEGER NOT NULL DEFAULT 0,
+              created_by TEXT,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              project TEXT NOT NULL DEFAULT 'unassigned',
+              updated_by TEXT,
+              rev TEXT,
+              base_rev TEXT
+          )""",
+          """
+          INSERT INTO specs_v2 (id, title, status, assignee, agent, model, reasoning_effort,
+                  branch, priority, created_by, created_at, updated_at, project, updated_by,
+                  rev, base_rev)
+              SELECT id, title, status, assignee, agent, model, reasoning_effort,
+                  branch, priority, created_by, created_at, updated_at, project, updated_by,
+                  rev, base_rev FROM specs""",
+          "DROP TABLE specs",
+          "ALTER TABLE specs_v2 RENAME TO specs",
+          "CREATE INDEX IF NOT EXISTS idx_specs_project ON specs(project)");
+
+  /**
+   * The last schema version whose {@code specs.status} CHECK predates {@code awaiting_merge}. The
+   * five migrations after it rebuild the specs table to widen the constraint — SQLite cannot alter
+   * a CHECK in place. The rebuild only works because {@link #migrate()} disables foreign-key
+   * enforcement for the migration window: with it on, {@code DROP TABLE specs} would fire the
+   * children's {@code ON DELETE CASCADE} and wipe spec content, repos, and dependencies.
+   */
+  static final int LAST_VERSION_WITH_NARROW_STATUS_CHECK = versionBefore("CREATE TABLE specs_v2");
+
+  private static int versionBefore(String statementPrefix) {
+    for (var i = 0; i < MIGRATIONS.size(); i++) {
+      if (MIGRATIONS.get(i).startsWith(statementPrefix)) {
+        return i;
+      }
+    }
+    throw new IllegalStateException("No migration starts with: " + statementPrefix);
+  }
 
   private final Sqlite db;
 
@@ -332,18 +382,48 @@ public final class SchemaManager {
   }
 
   public void migrate() {
+    migrateTo(MIGRATIONS.size());
+  }
+
+  /**
+   * Applies pending migrations up to {@code targetVersion} (package-private so tests can stage a
+   * database at a historical version). Foreign-key enforcement is suspended for the migration
+   * window: table rebuilds must drop-and-recreate a parent table without firing the children's
+   * {@code ON DELETE CASCADE}. Referential integrity is verified with {@code PRAGMA
+   * foreign_key_check} before enforcement is restored — a violated rebuild fails loud, never
+   * silently ships a corrupted database.
+   */
+  void migrateTo(int targetVersion) {
     db.execute(MIGRATIONS.getFirst());
     var current = currentVersion();
-    for (var i = current; i < MIGRATIONS.size(); i++) {
-      var version = i + 1;
-      var sql = MIGRATIONS.get(i);
-      db.transaction(
-          () -> {
-            db.execute(sql);
-            db.execute(
-                "INSERT INTO schema_version (version, applied_at) VALUES (?, datetime('now'))",
-                version);
-          });
+    if (current >= targetVersion) {
+      return;
+    }
+    db.execute("PRAGMA foreign_keys = OFF");
+    try {
+      for (var i = current; i < targetVersion; i++) {
+        var version = i + 1;
+        var sql = MIGRATIONS.get(i);
+        db.transaction(
+            () -> {
+              db.execute(sql);
+              db.execute(
+                  "INSERT INTO schema_version (version, applied_at) VALUES (?, datetime('now'))",
+                  version);
+            });
+      }
+      requireForeignKeysIntact();
+    } finally {
+      db.execute("PRAGMA foreign_keys = ON");
+    }
+  }
+
+  private void requireForeignKeysIntact() {
+    var violations =
+        db.query("PRAGMA foreign_key_check", row -> row.text(0) + " row " + row.integer(1));
+    if (!violations.isEmpty()) {
+      throw new SqliteException(
+          "Migration broke referential integrity: " + String.join(", ", violations), 0);
     }
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -88,6 +88,7 @@ public final class SpecStore implements ConflictResolver {
       int pending,
       int inProgress,
       int review,
+      int awaitingMerge,
       int done,
       int archived,
       String nextReadyId) {}
@@ -771,6 +772,7 @@ public final class SpecStore implements ConflictResolver {
     var pending = 0;
     var inProgress = 0;
     var review = 0;
+    var awaitingMerge = 0;
     var done = 0;
     var archived = 0;
     for (var row : counts) {
@@ -780,6 +782,7 @@ public final class SpecStore implements ConflictResolver {
         case "pending" -> pending = count;
         case "in_progress" -> inProgress = count;
         case "review" -> review = count;
+        case "awaiting_merge" -> awaitingMerge = count;
         case "done" -> done = count;
         case "archived" -> archived = count;
         default -> {}
@@ -787,7 +790,8 @@ public final class SpecStore implements ConflictResolver {
     }
     var ready = readySpecs(projectFilter);
     var nextReadyId = ready.isEmpty() ? null : ready.getFirst().id();
-    return new BoardSummary(draft, pending, inProgress, review, done, archived, nextReadyId);
+    return new BoardSummary(
+        draft, pending, inProgress, review, awaitingMerge, done, archived, nextReadyId);
   }
 
   private SpecRow mapSpec(Sqlite.Row row) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/StrandedSpecs.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/StrandedSpecs.java
@@ -18,6 +18,10 @@ import java.util.Set;
  * active. Beyond a generous threshold (longer than the watchdog ceiling) a still-active spec means
  * something silently failed — a Stop hook that never fired, a watcher that died, a review that
  * crashed — and the spec needs surfacing rather than waiting forever.
+ *
+ * <p>{@code awaiting_merge} is deliberately not flagged: it is an explicit human queue (review
+ * passed, PR waiting to be merged on the forge), visible on the board, with no machinery left
+ * running that could have silently failed.
  */
 public final class StrandedSpecs {
 

--- a/sail-core/src/test/java/ai/singlr/sail/config/SpecDirectoryTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/SpecDirectoryTest.java
@@ -217,7 +217,8 @@ class SpecDirectoryTest {
             new Spec("c", "C", SpecStatus.IN_PROGRESS, null, List.of(), null),
             new Spec("d", "D", SpecStatus.PENDING, null, List.of(), null),
             new Spec("e", "E", SpecStatus.PENDING, null, List.of(), null),
-            new Spec("f", "F", SpecStatus.REVIEW, null, List.of(), null));
+            new Spec("f", "F", SpecStatus.REVIEW, null, List.of(), null),
+            new Spec("g", "G", SpecStatus.AWAITING_MERGE, null, List.of(), null));
 
     var counts = SpecDirectory.statusCounts(specs);
 
@@ -225,6 +226,7 @@ class SpecDirectoryTest {
     assertEquals(1, counts.get("in_progress"));
     assertEquals(2, counts.get("pending"));
     assertEquals(1, counts.get("review"));
+    assertEquals(1, counts.get("awaiting_merge"));
   }
 
   @Test
@@ -235,6 +237,28 @@ class SpecDirectoryTest {
     assertEquals(0, counts.get("in_progress"));
     assertEquals(0, counts.get("pending"));
     assertEquals(0, counts.get("review"));
+    assertEquals(0, counts.get("awaiting_merge"));
+  }
+
+  @Test
+  void awaitingMergeDependencyKeepsDependentBlocked() {
+    var specs =
+        List.of(
+            new Spec("base", "Base", SpecStatus.AWAITING_MERGE, null, List.of(), null),
+            new Spec("child", "Child", SpecStatus.PENDING, null, List.of("base"), null));
+
+    assertNull(SpecDirectory.nextReady(specs));
+    assertTrue(SpecDirectory.isBlocked(specs, specs.get(1)));
+    assertEquals(List.of("base"), SpecDirectory.unmetDependencies(specs, specs.get(1)));
+  }
+
+  @Test
+  void awaitingMergeIsCliSettable() {
+    var specs = List.of(new Spec("auth", "Auth", SpecStatus.REVIEW, null, List.of(), null));
+
+    var updated = SpecDirectory.updateStatus(specs, "auth", SpecStatus.AWAITING_MERGE);
+
+    assertEquals(SpecStatus.AWAITING_MERGE, updated.getFirst().status());
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/MissedStopsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/MissedStopsTest.java
@@ -89,6 +89,16 @@ class MissedStopsTest {
   }
 
   @Test
+  void neverReplaysASpecAlreadyPastTheGate() {
+    var replays =
+        MissedStops.find(
+            List.of(spec("parked", SpecStatus.AWAITING_MERGE)),
+            latest(Map.of("parked", session("parked", "stopped", 0))));
+
+    assertTrue(replays.isEmpty());
+  }
+
+  @Test
   void ignoresASpecWhoseSessionIsStillRunning() {
     var replays =
         MissedStops.find(

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -6,9 +6,11 @@
 package ai.singlr.sail.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,6 +71,94 @@ class SchemaManagerTest {
     var schema = new SchemaManager(db);
     schema.migrate();
     assertTrue(schema.currentVersion() > 0);
+  }
+
+  @Test
+  void statusCheckAcceptsAwaitingMergeAfterMigration() {
+    new SchemaManager(db).migrate();
+
+    db.execute(
+        "INSERT INTO specs (id, title, status, created_at, updated_at)"
+            + " VALUES ('m', 'M', 'awaiting_merge', 't', 't')");
+
+    assertEquals(
+        "awaiting_merge",
+        db.queryOne("SELECT status FROM specs WHERE id = 'm'", row -> row.text(0)).orElseThrow());
+  }
+
+  @Test
+  void statusCheckStillRejectsGarbageAfterMigration() {
+    new SchemaManager(db).migrate();
+
+    assertThrows(
+        SqliteException.class,
+        () ->
+            db.execute(
+                "INSERT INTO specs (id, title, status, created_at, updated_at)"
+                    + " VALUES ('m', 'M', 'bogus', 't', 't')"));
+  }
+
+  @Test
+  void specsRebuildPreservesRowsAndChildren() {
+    var schema = new SchemaManager(db);
+    schema.migrateTo(SchemaManager.LAST_VERSION_WITH_NARROW_STATUS_CHECK);
+    db.execute(
+        "INSERT INTO specs (id, title, status, priority, created_at, updated_at, project,"
+            + " updated_by, rev, base_rev)"
+            + " VALUES ('auth', 'OAuth', 'review', 7, 'c', 'u', 'acme', 'uday', 'r1', 'r0')");
+    db.execute(
+        "INSERT INTO spec_content (spec_id, body, plan, updated_at)"
+            + " VALUES ('auth', 'body', 'plan', 't')");
+    db.execute("INSERT INTO spec_repos (spec_id, repo) VALUES ('auth', 'api')");
+    db.execute("INSERT INTO spec_dependencies (spec_id, depends_on) VALUES ('auth', 'base')");
+    db.execute(
+        "INSERT INTO reviews (id, spec_id, iteration, status, created_at)"
+            + " VALUES ('rev-1', 'auth', 1, 'passed', 't')");
+
+    schema.migrate();
+
+    var row =
+        db.queryOne(
+                "SELECT title, status, priority, project, updated_by, rev, base_rev"
+                    + " FROM specs WHERE id = 'auth'",
+                r ->
+                    List.of(
+                        r.text(0),
+                        r.text(1),
+                        String.valueOf(r.integer(2)),
+                        r.text(3),
+                        r.text(4),
+                        r.text(5),
+                        r.text(6)))
+            .orElseThrow();
+    assertEquals(List.of("OAuth", "review", "7", "acme", "uday", "r1", "r0"), row);
+    assertEquals(
+        "body",
+        db.queryOne("SELECT body FROM spec_content WHERE spec_id = 'auth'", r -> r.text(0))
+            .orElseThrow());
+    assertEquals(
+        "api",
+        db.queryOne("SELECT repo FROM spec_repos WHERE spec_id = 'auth'", r -> r.text(0))
+            .orElseThrow());
+    assertTrue(db.query("PRAGMA foreign_key_check", r -> r.text(0)).isEmpty());
+  }
+
+  @Test
+  void specsRebuildKeepsChildCascadesWired() {
+    var schema = new SchemaManager(db);
+    schema.migrateTo(SchemaManager.LAST_VERSION_WITH_NARROW_STATUS_CHECK);
+    db.execute(
+        "INSERT INTO specs (id, title, status, created_at, updated_at)"
+            + " VALUES ('auth', 'OAuth', 'pending', 't', 't')");
+    db.execute(
+        "INSERT INTO spec_content (spec_id, body, plan, updated_at) VALUES ('auth', 'b', 'p', 't')");
+    schema.migrate();
+
+    db.execute("DELETE FROM specs WHERE id = 'auth'");
+
+    assertTrue(
+        db.queryOne("SELECT body FROM spec_content WHERE spec_id = 'auth'", r -> r.text(0))
+            .isEmpty());
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
@@ -338,15 +338,66 @@ class SpecStoreTest {
     store.create(spec("e", "E", "review"));
     store.create(spec("f", "F", "done"));
     store.create(spec("g", "G", "archived"));
+    store.create(spec("h", "H", "awaiting_merge"));
 
     var board = store.board();
     assertEquals(1, board.draft());
     assertEquals(2, board.pending());
     assertEquals(1, board.inProgress());
     assertEquals(1, board.review());
+    assertEquals(1, board.awaitingMerge());
     assertEquals(1, board.done());
     assertEquals(1, board.archived());
     assertEquals("b", board.nextReadyId());
+  }
+
+  @Test
+  void awaitingMergePersistsAndReadsBack() {
+    store.create(spec("gate-passed", "Gate passed", "review"));
+
+    store.updateStatus("gate-passed", SpecStatus.AWAITING_MERGE);
+
+    assertEquals(SpecStatus.AWAITING_MERGE, store.findById("gate-passed").get().status());
+  }
+
+  @Test
+  void awaitingMergeDependencyDoesNotUnblockDependents() {
+    store.create(spec("base", "Base", "awaiting_merge"));
+    var dependent =
+        new SpecStore.SpecRow(
+            "child",
+            "test-project",
+            "Child",
+            SpecStatus.PENDING,
+            null,
+            null,
+            null,
+            null,
+            null,
+            0,
+            null,
+            "",
+            "",
+            null,
+            List.of("base"),
+            List.of());
+    store.create(dependent);
+
+    assertTrue(store.readySpecs().isEmpty(), "unmerged work must not satisfy a dependency");
+  }
+
+  @Test
+  void applyRevisionToleratesUnknownStatusFromNewerPeer() {
+    var snapshot = new java.util.LinkedHashMap<String, Object>();
+    snapshot.put("title", "From the future");
+    snapshot.put("status", "warp_speed");
+    snapshot.put("project", "test-project");
+    snapshot.put("body", "");
+    snapshot.put("plan", "");
+
+    store.applyRevision("future-spec", snapshot, "rev-1");
+
+    assertEquals(SpecStatus.DRAFT, store.findById("future-spec").get().status());
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/StrandedSpecsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/StrandedSpecsTest.java
@@ -34,7 +34,8 @@ class StrandedSpecsTest {
             spec("stuck-rev", SpecStatus.REVIEW, old),
             spec("recent", SpecStatus.IN_PROGRESS, recent),
             spec("done", SpecStatus.DONE, old),
-            spec("pending", SpecStatus.PENDING, old));
+            spec("pending", SpecStatus.PENDING, old),
+            spec("waiting-on-human", SpecStatus.AWAITING_MERGE, old));
 
     var stranded = StrandedSpecs.find(specs, NOW, Duration.ofHours(6));
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -290,13 +290,15 @@ record AgentStatusView(
   }
 }
 
-record SpecSummaryView(int pending, int inProgress, int review, int done) implements Mappable {
+record SpecSummaryView(int pending, int inProgress, int review, int awaitingMerge, int done)
+    implements Mappable {
   @Override
   public Map<String, Object> toMap() {
     var m = new LinkedHashMap<String, Object>();
     m.put("pending", pending);
     m.put("in_progress", inProgress);
     m.put("review", review);
+    m.put("awaiting_merge", awaitingMerge);
     m.put("done", done);
     return m;
   }
@@ -701,6 +703,7 @@ record GlobalBoardResponse(SpecStore.BoardSummary board, int doneOpenFindings) i
     m.put("pending", board.pending());
     m.put("in_progress", board.inProgress());
     m.put("review", board.review());
+    m.put("awaiting_merge", board.awaitingMerge());
     m.put("done", board.done());
     m.put("archived", board.archived());
     m.put("next_ready_id", board.nextReadyId());

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewOperations.java
@@ -16,8 +16,8 @@ import java.util.List;
  * Review-workflow operations against the {@link ReviewStore}. Split out of {@code
  * SailApiOperations} so the review domain is one focused, fully-testable class. Methods return
  * their response value and throw {@link ApiException} on failure; the caller wraps them in a {@code
- * Result}. {@code specStore} is needed only to flip a spec to {@code done} when its human review is
- * approved.
+ * Result}. {@code specStore} is needed only to park a spec in {@code awaiting_merge} when its human
+ * review is approved — merging the PR and marking the spec {@code done} stays a human act.
  */
 final class ReviewOperations {
 
@@ -69,8 +69,7 @@ final class ReviewOperations {
                         ErrorCode.INVALID_REQUEST, "No human review stage awaiting approval."));
     reviewStore.completeStage(humanStage.id(), "passed");
     reviewStore.approve(reviewId, actor);
-    specStore.updateStatus(review.specId(), SpecStatus.DONE);
-    reviewStore.resolveSourceFindings(review.specId());
+    specStore.updateStatus(review.specId(), SpecStatus.AWAITING_MERGE);
     return new ReviewApproveResponse(reviewId, true);
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -34,7 +34,8 @@ import java.util.function.Predicate;
 /**
  * Orchestrates the review pipeline when an agent completes a spec. Subscribes to the event bus,
  * creates review records with stages, executes agent review stages sequentially, evaluates gates,
- * and triggers fix iterations or escalation.
+ * and triggers fix iterations or escalation. A pass parks the spec in {@code awaiting_merge} — the
+ * PR is open but unmerged, and only the human who merges it marks the spec {@code done}.
  *
  * <p>Agent execution is delegated to {@link ReviewAgentRunner}. This keeps the controller testable
  * without containers — tests inject a runner that returns canned agent output.
@@ -246,7 +247,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       }
 
       reviewStore.updateReviewStatus(reviewId, "passed");
-      specStore.updateStatus(specId, SpecStatus.DONE);
+      specStore.updateStatus(specId, SpecStatus.AWAITING_MERGE);
       publishEvent(project, specId, "review_completed", null);
 
     } catch (Exception e) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -703,6 +703,7 @@ public final class SailApiOperations implements ApiOperations {
         counts.getOrDefault("pending", 0),
         counts.getOrDefault("in_progress", 0),
         counts.getOrDefault("review", 0),
+        counts.getOrDefault("awaiting_merge", 0),
         counts.getOrDefault("done", 0));
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SlackMessage.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SlackMessage.java
@@ -37,7 +37,7 @@ final class SlackMessage {
           "Review stage passed: " + detailOr(event, "review") + findingsSuffix(event) + ".";
       case "review_stage_failed" ->
           "Review stage failed: " + detailOr(event, "review") + findingsSuffix(event) + ".";
-      case "review_completed" -> "Review passed. Spec done.";
+      case "review_completed" -> "Review passed. Awaiting merge.";
       case "review_errored" -> "Review errored: " + detailOr(event, "unknown error");
       case "review_iteration_started" -> "Fix iteration started.";
       case "review_escalated" ->

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecBoardCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecBoardCommand.java
@@ -53,18 +53,22 @@ public final class ApiSpecBoardCommand implements Runnable {
 
       var scope = resolvedProject != null ? " — " + resolvedProject : "";
       System.out.println(Ansi.AUTO.string("  @|bold Spec Board" + scope + "|@"));
-      System.out.println(Ansi.AUTO.string("    @|faint Draft:|@       " + result.get("draft")));
-      System.out.println(Ansi.AUTO.string("    @|white Pending:|@     " + result.get("pending")));
+      System.out.println(Ansi.AUTO.string("    @|faint Draft:|@           " + result.get("draft")));
       System.out.println(
-          Ansi.AUTO.string("    @|blue In Progress:|@ " + result.get("in_progress")));
-      System.out.println(Ansi.AUTO.string("    @|yellow Review:|@      " + result.get("review")));
+          Ansi.AUTO.string("    @|white Pending:|@         " + result.get("pending")));
+      System.out.println(
+          Ansi.AUTO.string("    @|blue In Progress:|@     " + result.get("in_progress")));
+      System.out.println(
+          Ansi.AUTO.string("    @|yellow Review:|@          " + result.get("review")));
+      System.out.println(
+          Ansi.AUTO.string("    @|magenta Awaiting Merge:|@  " + result.get("awaiting_merge")));
       var doneOpenFindings = result.get("done_open_findings");
       var doneSuffix =
           doneOpenFindings instanceof Number n && n.intValue() > 0
               ? " @|yellow · " + n + " open findings|@"
               : "";
       System.out.println(
-          Ansi.AUTO.string("    @|green Done:|@        " + result.get("done") + doneSuffix));
+          Ansi.AUTO.string("    @|green Done:|@            " + result.get("done") + doneSuffix));
 
       var nextReady = result.get("next_ready_id");
       if (nextReady != null) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecListCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecListCommand.java
@@ -93,7 +93,8 @@ public final class ApiSpecListCommand implements Runnable {
 
   @SuppressWarnings("unchecked")
   static void printGroupedByProjectAndStatus(List<Map<String, Object>> specs) {
-    var statusOrder = List.of("draft", "pending", "in_progress", "review", "done");
+    var statusOrder =
+        List.of("draft", "pending", "in_progress", "review", "awaiting_merge", "done");
     var byProject = new LinkedHashMap<String, List<Map<String, Object>>>();
     for (var spec : specs) {
       var proj = (String) spec.getOrDefault("project", "unassigned");
@@ -143,6 +144,7 @@ public final class ApiSpecListCommand implements Runnable {
       case "pending" -> "Pending";
       case "in_progress" -> "In Progress";
       case "review" -> "Review";
+      case "awaiting_merge" -> "Awaiting Merge";
       case "done" -> "Done";
       default -> status;
     };
@@ -154,6 +156,7 @@ public final class ApiSpecListCommand implements Runnable {
       case "pending" -> "white";
       case "in_progress" -> "blue";
       case "review" -> "yellow";
+      case "awaiting_merge" -> "magenta";
       case "done" -> "green";
       default -> "white";
     };

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/AgentTaskPrompt.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/AgentTaskPrompt.java
@@ -65,8 +65,10 @@ public final class AgentTaskPrompt {
         with a clear message, push the branch, and open a pull request.
 
         The spec is not complete until CI is green: after opening the pull request, watch its
-        checks (e.g. `gh pr checks <number> --watch`), and if any check fails, diagnose it, fix it
-        on the branch, push, and watch again until every check passes.
+        checks with the CLI of the forge hosting the repo (e.g. `gh pr checks <number> --watch`
+        on GitHub, `glab ci status --live` on GitLab, or the equivalent on your forge), and if any
+        check fails, diagnose it, fix it on the branch, push, and watch again until every check
+        passes.
 
         Never add AI attribution to the work: no Co-Authored-By trailers and no "Generated with"
         footers in commit messages or pull request descriptions.

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
@@ -1095,6 +1095,7 @@ public final class Banner {
               case DONE -> "@|green \u2713|@";
               case IN_PROGRESS -> "@|yellow \u25cb|@";
               case REVIEW -> "@|cyan \u25cb|@";
+              case AWAITING_MERGE -> "@|magenta \u25cb|@";
               default -> "@|faint \u25cb|@";
             };
         var idPad = String.format("%-16s", spec.id());

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -962,8 +962,8 @@ class ApiRouterTest {
           new SpecsResponse(
               project,
               java.util.List.of(),
-              new SpecSummaryView(0, 0, 0, 0),
-              new BoardSummaryView(new SpecSummaryView(0, 0, 0, 0), 0, 0, null)));
+              new SpecSummaryView(0, 0, 0, 0, 0),
+              new BoardSummaryView(new SpecSummaryView(0, 0, 0, 0, 0), 0, 0, null)));
     }
 
     @Override
@@ -1212,7 +1212,7 @@ class ApiRouterTest {
     public Result<GlobalBoardResponse> globalBoard(String project) {
       return Result.success(
           new GlobalBoardResponse(
-              new ai.singlr.sail.store.SpecStore.BoardSummary(0, 0, 0, 0, 0, 0, null), 0));
+              new ai.singlr.sail.store.SpecStore.BoardSummary(0, 0, 0, 0, 0, 0, 0, null), 0));
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -107,7 +107,7 @@ class MissedStopReconcilerTest {
   }
 
   @Test
-  void replaysACleanMissedStopAndDrivesTheSpecToDone() throws Exception {
+  void replaysACleanMissedStopAndDrivesTheSpecToAwaitingMerge() throws Exception {
     createInProgressSpec("auth");
     finishedSession("auth", "stopped", 0);
     var latch = new CountDownLatch(1);
@@ -117,7 +117,7 @@ class MissedStopReconcilerTest {
 
     assertEquals(1, replayed);
     BusTesting.awaitDelivery(latch);
-    assertEquals(SpecStatus.DONE, specStore.findById("auth").orElseThrow().status());
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
   }
 
   @Test
@@ -131,7 +131,7 @@ class MissedStopReconcilerTest {
 
     assertEquals(1, replayed);
     BusTesting.awaitDelivery(latch);
-    assertEquals(SpecStatus.DONE, specStore.findById("auth").orElseThrow().status());
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopIT.java
@@ -103,7 +103,7 @@ class ReviewAgentLoopIT extends AbstractIncusIT {
   }
 
   @Test
-  void theReviewLoopReachesDoneAgainstARealContainer() throws Exception {
+  void theReviewLoopReachesAwaitingMergeAgainstARealContainer() throws Exception {
     var stateDir = Files.createTempDirectory("review-loop-it");
     try (var db = Sqlite.open(stateDir.resolve("loop.db"))) {
       new SchemaManager(db).migrate();
@@ -163,7 +163,7 @@ class ReviewAgentLoopIT extends AbstractIncusIT {
               "host",
               Map.of(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_WATCHER)));
 
-      assertEquals(SpecStatus.DONE, specStore.findById("auth").orElseThrow().status());
+      assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
       assertEquals(2, reviewStore.reviewsForSpec("auth").size());
     } finally {
       deleteRecursively(stateDir);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopTest.java
@@ -129,7 +129,7 @@ class ReviewAgentLoopTest {
   }
 
   @Test
-  void aRealRunnerReviewFixReReviewLoopReachesDone() throws Exception {
+  void aRealRunnerReviewFixReReviewLoopReachesAwaitingMerge() throws Exception {
     createSpec("auth");
     var latch = new CountDownLatch(1);
     subscribe(config(3), new FakeAgentShell(List.of(CRITICAL_FINDING)), latch);
@@ -137,7 +137,7 @@ class ReviewAgentLoopTest {
     bus.publish(stop("auth"));
 
     BusTesting.awaitDelivery(latch);
-    assertEquals(SpecStatus.DONE, specStore.findById("auth").orElseThrow().status());
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
     assertEquals(2, reviewStore.reviewsForSpec("auth").size());
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewLoopIntegrationTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewLoopIntegrationTest.java
@@ -158,7 +158,7 @@ class ReviewLoopIntegrationTest {
   }
 
   @Test
-  void aCleanStopPublishedToTheBusAdvancesTheSpecToDone() throws Exception {
+  void aCleanStopPublishedToTheBusAdvancesTheSpecToAwaitingMerge() throws Exception {
     createSpec("auth");
     var latch = new CountDownLatch(1);
     subscribe(singleStage("no_critical"), (p, a, pr) -> "[]", latch);
@@ -166,7 +166,7 @@ class ReviewLoopIntegrationTest {
     bus.publish(stop("auth"));
 
     BusTesting.awaitDelivery(latch);
-    assertEquals(SpecStatus.DONE, specStore.findById("auth").orElseThrow().status());
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
     assertEquals("passed", reviewStore.latestReviewForSpec("auth").orElseThrow().status());
   }
 
@@ -184,7 +184,7 @@ class ReviewLoopIntegrationTest {
   }
 
   @Test
-  void theReviewFixReReviewLoopReachesDoneWhenAFixResolvesTheFindings() throws Exception {
+  void theReviewFixReReviewLoopReachesAwaitingMergeWhenAFixResolvesTheFindings() throws Exception {
     createSpec("auth");
     var latch = new CountDownLatch(1);
     subscribe(singleStage("no_critical"), cyclingRunner(List.of(CRITICAL_FINDING)), latch);
@@ -192,7 +192,7 @@ class ReviewLoopIntegrationTest {
     bus.publish(stop("auth"));
 
     BusTesting.awaitDelivery(latch);
-    assertEquals(SpecStatus.DONE, specStore.findById("auth").orElseThrow().status());
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
     assertEquals(
         2,
         reviewStore.reviewsForSpec("auth").size(),

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewOperationsTest.java
@@ -18,6 +18,7 @@ import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -105,7 +106,7 @@ class ReviewOperationsTest {
   }
 
   @Test
-  void approveCompletesHumanStageAndMarksSpecDone() {
+  void approveCompletesHumanStageAndParksSpecAwaitingMerge() {
     var reviewId = reviewStore.createReview("auth", 1);
     var stageId = reviewStore.createStage(reviewId, "human", "human");
     reviewStore.startStage(stageId, "uday");
@@ -116,6 +117,10 @@ class ReviewOperationsTest {
     var review = reviewStore.findReview(reviewId).orElseThrow();
     assertEquals("passed", review.status());
     assertEquals("uday", review.decidedBy());
+    assertEquals(
+        SpecStatus.AWAITING_MERGE,
+        specStore.findById("auth").orElseThrow().status(),
+        "approval decides the findings; merging the PR is a separate human act");
   }
 
   @Test
@@ -292,20 +297,28 @@ class ReviewOperationsTest {
   }
 
   @Test
-  void approveResolvesSourceFindingsOfTheApprovedSpec() {
+  void approveLeavesSourceFindingsOpenUntilTheSpecReachesDone() {
     seedPassedReviewWithOpenFindings();
     ops.createFollowup("auth", new FollowupCreateRequest(null, "uday"));
     var followupReview = reviewStore.createReview("auth-followup", 1);
     var humanStage = reviewStore.createStage(followupReview, "human", "human");
     reviewStore.startStage(humanStage, "uday");
+    var sourceReview = reviewStore.reviewsForSpec("auth").getFirst().id();
 
     ops.approve(followupReview, "uday");
 
-    var resolutions =
-        reviewStore.findingsForReview(reviewStore.reviewsForSpec("auth").getFirst().id()).stream()
-            .map(Finding::resolution)
-            .toList();
-    assertEquals(List.of(Finding.Resolution.FIXED, Finding.Resolution.FIXED), resolutions);
+    var afterApprove =
+        reviewStore.findingsForReview(sourceReview).stream().map(Finding::resolution).toList();
+    assertEquals(List.of(Finding.Resolution.OPEN, Finding.Resolution.OPEN), afterApprove);
+
+    new GlobalSpecOperations(specStore, reviewStore)
+        .update(
+            "auth-followup",
+            SpecUpdateRequest.fromMap(Map.of("status", "done")).withUpdatedBy("uday"));
+
+    var afterDone =
+        reviewStore.findingsForReview(sourceReview).stream().map(Finding::resolution).toList();
+    assertEquals(List.of(Finding.Resolution.FIXED, Finding.Resolution.FIXED), afterDone);
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -286,6 +286,17 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
+  void ignoresAStopForASpecAlreadyAwaitingMerge() {
+    createSpec("auth", "awaiting_merge");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr) -> "[]");
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    assertTrue(reviewStore.reviewsForSpec("auth").isEmpty());
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
   void transitionsSpecToReview() {
     createSpec("auth", "in_progress");
     var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr) -> "[]");
@@ -293,11 +304,11 @@ class ReviewPipelineControllerTest {
     ctrl.onEvent(agentStoppedEvent("auth"));
 
     var spec = specStore.findById("auth").orElseThrow();
-    assertEquals(SpecStatus.DONE, spec.status());
+    assertEquals(SpecStatus.AWAITING_MERGE, spec.status());
   }
 
   @Test
-  void cleanReviewPassesAndTransitionsSpecToDone() {
+  void cleanReviewPassesAndParksSpecAwaitingMerge() {
     createSpec("auth", "in_progress");
     var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr) -> "[]");
 
@@ -306,7 +317,10 @@ class ReviewPipelineControllerTest {
     var review = reviewStore.latestReviewForSpec("auth").orElseThrow();
     assertEquals("passed", review.status());
     assertEquals(1, review.iteration());
-    assertEquals(SpecStatus.DONE, specStore.findById("auth").orElseThrow().status());
+    assertEquals(
+        SpecStatus.AWAITING_MERGE,
+        specStore.findById("auth").orElseThrow().status(),
+        "a gate pass leaves the PR unmerged — done is the human's call after merging");
   }
 
   @Test
@@ -392,7 +406,7 @@ class ReviewPipelineControllerTest {
         "an infrastructure error must not consume a review iteration — the retry runs as the"
             + " same iteration, so quota outages can never exhaust max_iterations");
     assertEquals("passed", review.status());
-    assertEquals(SpecStatus.DONE, specStore.findById("auth").orElseThrow().status());
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
   }
 
   @Test
@@ -427,7 +441,7 @@ class ReviewPipelineControllerTest {
     var review = reviewStore.latestReviewForSpec("auth").orElseThrow();
     assertEquals(1, review.iteration(), "a re-dispatch is a fresh attempt, not iteration 4");
     assertEquals("passed", review.status());
-    assertEquals(SpecStatus.DONE, specStore.findById("auth").orElseThrow().status());
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SlackMessageTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SlackMessageTest.java
@@ -223,10 +223,10 @@ class SlackMessageTest {
   }
 
   @Test
-  void reviewCompletedIsSpecDone() {
+  void reviewCompletedSaysAwaitingMerge() {
     var text = SlackMessage.forEvent(event("review_completed"), null);
 
-    assertEquals("Review passed. Spec done.", text);
+    assertEquals("Review passed. Awaiting merge.", text);
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -26,8 +26,8 @@ class TestOperations implements ApiOperations {
         new SpecsResponse(
             project,
             List.of(),
-            new SpecSummaryView(0, 0, 0, 0),
-            new BoardSummaryView(new SpecSummaryView(0, 0, 0, 0), 0, 0, null)));
+            new SpecSummaryView(0, 0, 0, 0, 0),
+            new BoardSummaryView(new SpecSummaryView(0, 0, 0, 0, 0), 0, 0, null)));
   }
 
   @Override
@@ -258,7 +258,7 @@ class TestOperations implements ApiOperations {
   @Override
   public Result<GlobalBoardResponse> globalBoard(String project) {
     return Result.success(
-        new GlobalBoardResponse(new SpecStore.BoardSummary(0, 0, 0, 0, 0, 0, null), 0));
+        new GlobalBoardResponse(new SpecStore.BoardSummary(0, 0, 0, 0, 0, 0, 0, null), 0));
   }
 
   @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandResolveSpecTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandResolveSpecTest.java
@@ -176,6 +176,7 @@ class DispatchCommandResolveSpecTest {
     var store = store();
     store.create(row("done-one", "done"));
     store.create(row("review-one", "review"));
+    store.create(row("parked-one", "awaiting_merge"));
     var specs = specsOf(store);
 
     assertThrows(
@@ -184,6 +185,9 @@ class DispatchCommandResolveSpecTest {
     assertThrows(
         IllegalStateException.class,
         () -> DispatchCommand.resolveSpec("review-one", false, specs, store, FDE));
+    assertThrows(
+        IllegalStateException.class,
+        () -> DispatchCommand.resolveSpec("parked-one", false, specs, store, FDE));
   }
 
   @Test
@@ -200,5 +204,17 @@ class DispatchCommandResolveSpecTest {
         resolution.previousStatus(),
         "previousStatus carries the pre-reset status so the caller can publish spec_restarted");
     assertEquals(SpecStatus.PENDING, store.findById("oauth-flow").orElseThrow().status());
+  }
+
+  @Test
+  void restartResetsAnAwaitingMergeSpecToo() {
+    var store = store();
+    store.create(row("parked", "awaiting_merge"));
+
+    var resolution = DispatchCommand.resolveSpec("parked", true, specsOf(store), store, FDE);
+
+    assertTrue(resolution.restarted());
+    assertEquals("awaiting_merge", resolution.previousStatus());
+    assertEquals(SpecStatus.PENDING, store.findById("parked").orElseThrow().status());
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
@@ -190,7 +190,11 @@ class DispatchCommandTest {
     assertTrue(
         prompt.contains("not complete until CI is green"),
         "the agent must watch the PR's checks and fix failures — a red-CI PR is unfinished work");
-    assertTrue(prompt.contains("gh pr checks"));
+    assertTrue(
+        prompt.contains("the CLI of the forge hosting the repo"),
+        "CI-watching guidance must be forge-neutral so GitLab/Bitbucket agents reach for their"
+            + " own forge CLI");
+    assertTrue(prompt.contains("gh pr checks"), "GitHub stays as one concrete example");
     assertTrue(
         prompt.contains("no Co-Authored-By trailers"),
         "generated work must not carry AI attribution");


### PR DESCRIPTION
Implements spec `done-means-merged`: the review gate passing no longer overclaims completion. A gate pass parks the spec in a new `awaiting_merge` status; the FDE merges the PR on whatever forge hosts the repo and closes the loop with `sail spec edit <id> --status done` (or the in-container `spec update` equivalent). Sail never talks to a forge — no reconciler, no merge auto-detection, no forge API/CLI dependency.

## Lifecycle change

`pending → in_progress → review → awaiting_merge → done`

- Agent pipeline pass (`ReviewPipelineController`) and human approval (`ReviewOperations.approve`) both transition to `awaiting_merge`. Approval decides the findings; merging is a distinct human act.
- Escalation still parks in `review` — deciding about findings and merging a PR stay distinct states.
- Slack reply on gate pass now reads **"Review passed. Awaiting merge."**
- Resolving a spec's linked source findings stays attached to *reaching `done`*: it moved out of `approve()` and fires only on the `done` transition (`GlobalSpecOperations.update`, existing behavior).
- Board, `spec list`, `spec show`, agent report, and the API responses render `awaiting_merge` as its own column/state. It is CLI-settable so a premature `done` can be walked back.

## Migration (why this was a spec, not a patch)

`specs.status` carries a CHECK constraint, and SQLite cannot alter a CHECK in place. The migration rebuilds the table (create `specs_v2` → copy → drop → rename → recreate index) as append-only migration entries. Two safety properties:

- **Foreign keys are suspended for the migration window** (`SchemaManager.migrateTo`). With them on, `DROP TABLE specs` fires the children's `ON DELETE CASCADE` and silently wipes spec content, repos, and dependencies. After migrating, `PRAGMA foreign_key_check` must come back clean or the migration fails loud — never silently ships a corrupt DB.
- **Crash-safe resume**: each entry commits its version in its own transaction, so a crash mid-rebuild resumes at the exact statement (data already copied to `specs_v2` is preserved).

Tests stage a database at the pre-rebuild version (`migrateTo`), seed specs with children and reviews, run the full migration, and assert rows, child rows, cascades, and referential integrity survive.

## Consumer audit (each decision, as the spec requires)

| Consumer | Decision |
|----------|----------|
| `depends_on` readiness | Only `done` satisfies a dependency. `awaiting_merge` work exists on an unmerged branch; a dependent would branch from a main that lacks it. Test: `awaitingMergeDependencyKeepsDependentBlocked`. |
| `nextReadyAssignedTo` / auto-select | Unchanged — selects only `pending`; a parked spec is never re-picked. |
| `dispatch --restart` | Works from `awaiting_merge` exactly like any non-pending status: resets to `pending`, records `spec_restarted`. Test: `restartResetsAnAwaitingMergeSpecToo`. |
| Stuck-spec reconciler | `awaiting_merge` is **not** swept as stranded. It is an explicit human queue, visible on the board, with no machinery running that could have silently failed (unlike `review`, where a crashed pipeline can strand a spec). Documented in `StrandedSpecs` javadoc + test. |
| Missed-stop replay | Unchanged (`in_progress` only) — a replay for a parked spec would re-run a review it already passed. Test: `neverReplaysASpecAlreadyPastTheGate`. |
| Review pipeline stop guard | A stop event for an `awaiting_merge` spec is ignored (`status != in_progress` guard). Test: `ignoresAStopForASpecAlreadyAwaitingMerge`. |
| Sync from a newer peer | An unknown status string never crashes: `SpecStatus.fromLegacy` buckets it into `draft`, so the spec stays visible on the board instead of disappearing. Test: `applyRevisionToleratesUnknownStatusFromNewerPeer`. Residual caveat: an older binary journals the coerced form, so a local edit on that box could push `draft` back — acceptable fail-soft, no data loss (change log keeps every revision). |

## Forge-neutral protocol wording

The autonomous protocol's CI example no longer assumes GitHub: agents are told to watch checks "with the CLI of the forge hosting the repo (e.g. `gh pr checks` on GitHub, `glab ci status --live` on GitLab, or the equivalent)". Context/skill generators and ARCHITECTURE/README describe the new lifecycle.

## Verification

`mvn verify` green: 3352 tests (1943 infra / 1239 core / 170 harness), 0 failures, spotless clean.