### PR TITLE
Consistent current-project scoping: spec list defaults + CLI audit

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -364,7 +364,7 @@ in `review` for a human.
 
 A gate pass is not completion: the PR is still open on whatever forge hosts the repo, so the
 spec parks in `awaiting_merge`. Sail never talks to the forge — the FDE reviews and merges
-the PR there, then closes the loop with `sail spec edit <id> --status done`. Deciding about
+the PR there, then closes the loop with `sail spec update <id> --status done`. Deciding about
 escalated findings (parks in `review`) and merging a passed PR (parks in `awaiting_merge`)
 are different human acts and get distinct states. Because only `done` satisfies
 `depends_on`, a dependent spec never dispatches against a main that lacks its parent's
@@ -389,7 +389,7 @@ guardrail-killed or failed dispatch leaves the work committed, so `sail spec dis
 --restart` resumes on the branch; an escalated review parks in `review` with its findings (in
 the review store), its negotiation (`review.log`), and every fix commit intact, so the FDE
 reads it with `sail agent review <project>` plus `sail agent log <project> --review`, then
-resolves with `sail spec edit <id> --status done` (accept the work as-is) or `--status
+resolves with `sail spec update <id> --status done` (accept the work as-is) or `--status
 pending` (send it back to be re-dispatched). Nothing is deleted along the way.
 
 **Events:** an in-process `EventBus` (lock-light, with bounded per-subscriber queues that

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ attempt's iterations and findings; `sail agent log <project> --review` follows t
 negotiation live. Guardrails combine a `max_duration` and an action, so a runaway agent is
 stopped and rolled back to the pre-launch snapshot. A passing review parks the spec in
 `awaiting_merge` — sail never talks to the forge, so you merge the PR there and close the
-loop with `sail spec edit <id> --status done`.
+loop with `sail spec update <id> --status done`.
 
 Findings the gate let ship don't die in the review store: `sail spec create --from-review
 <spec-id>` drafts a follow-up spec from the latest review's open findings — one actionable

--- a/docs/E2E_JOIN_RUNBOOK.md
+++ b/docs/E2E_JOIN_RUNBOOK.md
@@ -131,9 +131,9 @@ sail spec list                       # expect push-demo present
 ### 3. Auto-merge (disjoint fields)
 ```bash
 # MAIN
-sail spec edit pull-demo --assignee alice
+sail spec update pull-demo --assignee alice
 # NODE  (edit a DIFFERENT field on the same spec, before syncing)
-sail spec edit pull-demo --title "Pull works (node-edited)"
+sail spec update pull-demo --title "Pull works (node-edited)"
 sail sync                            # expect merged ≥ 1, conflicts = 0
 sail spec show pull-demo             # expect BOTH: assignee=alice AND the node title
 ```
@@ -141,9 +141,9 @@ sail spec show pull-demo             # expect BOTH: assignee=alice AND the node 
 ### 4. Conflict (same field), node row not clobbered
 ```bash
 # MAIN
-sail spec edit push-demo --title "Main's title"
+sail spec update push-demo --title "Main's title"
 # NODE  (same field, different value, before syncing)
-sail spec edit push-demo --title "Node's title"
+sail spec update push-demo --title "Node's title"
 sail sync                            # expect conflicts ≥ 1
 sail spec show push-demo             # expect STILL "Node's title" — local not clobbered
 sail conflicts                       # expect push-demo listed; resolve it (take main or local)

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/SpecCliHelper.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/SpecCliHelper.java
@@ -94,7 +94,7 @@ public final class SpecCliHelper {
         spec create --id <id> --title <title> [--body-file F] [--status pending]
                     [--depends-on a,b] [--repos a,b] [--agent A] [--model M]
                     [--reasoning-effort none|low|medium|high|xhigh] [--priority N] [--plan-file F]
-        spec update <id> [--status S] [--title T] [--assignee H] [--force] [--repos a,b] [...]
+        spec update <id> [--status S] [--title T] [--assignee H] [--force] [...]  (alias: edit)
         spec content <id> --body-file F [--plan-file F]   revise the body
         spec archive <id>
       USAGE
@@ -114,7 +114,7 @@ public final class SpecCliHelper {
         create)
           collect_fields "$@"
           api -X POST --data-urlencode "project=$PROJECT" "${FIELDS[@]}" "$BASE";;
-        update)
+        update|edit)
           [ $# -ge 1 ] || die "update needs a spec id"
           id="$1"; shift
           collect_fields "$@"

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/SpecCliHelperTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/SpecCliHelperTest.java
@@ -41,7 +41,9 @@ class SpecCliHelperTest {
   void scriptHandlesEverySubcommand() {
     var content = SpecCliHelper.scriptContent();
     for (var sub :
-        new String[] {"board)", "list)", "show)", "create)", "update)", "content)", "archive)"}) {
+        new String[] {
+          "board)", "list)", "show)", "create)", "update|edit)", "content)", "archive)"
+        }) {
       assertTrue(content.contains(sub), "missing subcommand: " + sub);
     }
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentAttachCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentAttachCommand.java
@@ -35,7 +35,10 @@ import picocli.CommandLine.Spec;
     mixinStandardHelpOptions = true)
 public final class AgentAttachCommand implements Runnable {
 
-  @Parameters(index = "0", description = "Project name.")
+  @Parameters(
+      index = "0",
+      arity = "0..1",
+      description = "Project name (default: the current project).")
   private String name;
 
   @Option(
@@ -52,6 +55,7 @@ public final class AgentAttachCommand implements Runnable {
   }
 
   private void execute() throws Exception {
+    name = CurrentProject.require(name);
     NameValidator.requireValidProjectName(name);
     var shell = new ShellExecutor(false);
     var state = new ContainerManager(shell).queryState(name);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentContextRegenCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentContextRegenCommand.java
@@ -33,7 +33,10 @@ import picocli.CommandLine.Spec;
     mixinStandardHelpOptions = true)
 public final class AgentContextRegenCommand implements Runnable {
 
-  @Parameters(index = "0", description = "Project name.")
+  @Parameters(
+      index = "0",
+      arity = "0..1",
+      description = "Project name (default: the current project).")
   private String name;
 
   @Option(
@@ -56,6 +59,7 @@ public final class AgentContextRegenCommand implements Runnable {
   }
 
   private void execute() throws Exception {
+    name = CurrentProject.require(name);
     NameValidator.requireValidProjectName(name);
 
     var singYamlPath = SailPaths.resolveSailYaml(name, file);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLaunchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLaunchCommand.java
@@ -44,7 +44,10 @@ public final class AgentLaunchCommand implements Runnable {
 
   private static final Pattern SAFE_PATH = Pattern.compile("^[a-zA-Z0-9._/\\-]+$");
 
-  @Parameters(index = "0", description = "Project name.")
+  @Parameters(
+      index = "0",
+      arity = "0..1",
+      description = "Project name (default: the current project).")
   private String name;
 
   @Option(names = "--task", description = "Task description for headless mode.")
@@ -87,6 +90,7 @@ public final class AgentLaunchCommand implements Runnable {
   }
 
   private void execute() throws Exception {
+    name = CurrentProject.require(name);
     NameValidator.requireValidProjectName(name);
 
     if (!json) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLogCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLogCommand.java
@@ -34,7 +34,10 @@ import picocli.CommandLine.Spec;
     mixinStandardHelpOptions = true)
 public final class AgentLogCommand implements Runnable {
 
-  @Parameters(index = "0", description = "Project name.")
+  @Parameters(
+      index = "0",
+      arity = "0..1",
+      description = "Project name (default: the current project).")
   private String name;
 
   @Option(
@@ -61,6 +64,7 @@ public final class AgentLogCommand implements Runnable {
   }
 
   private void execute() throws Exception {
+    name = CurrentProject.require(name);
     NameValidator.requireValidProjectName(name);
     var shell = new ShellExecutor(false);
     var mgr = new ContainerManager(shell);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentReportCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentReportCommand.java
@@ -32,7 +32,10 @@ import picocli.CommandLine.Parameters;
     mixinStandardHelpOptions = true)
 public final class AgentReportCommand implements Runnable {
 
-  @Parameters(index = "0", description = "Project name.")
+  @Parameters(
+      index = "0",
+      arity = "0..1",
+      description = "Project name (default: the current project).")
   private String name;
 
   @Option(names = "--json", description = "Output in JSON format.")
@@ -62,6 +65,7 @@ public final class AgentReportCommand implements Runnable {
   }
 
   private void execute() throws Exception {
+    name = CurrentProject.require(name);
     NameValidator.requireValidProjectName(name);
     var shell = new ShellExecutor(false);
     var mgr = new ContainerManager(shell);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentReviewCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentReviewCommand.java
@@ -34,7 +34,10 @@ import picocli.CommandLine.Spec;
     mixinStandardHelpOptions = true)
 public final class AgentReviewCommand implements Runnable {
 
-  @Parameters(index = "0", description = "Project name.")
+  @Parameters(
+      index = "0",
+      arity = "0..1",
+      description = "Project name (default: the current project).")
   private String project;
 
   @Option(names = "--spec", description = "Only this spec (also prints its findings).")
@@ -54,6 +57,7 @@ public final class AgentReviewCommand implements Runnable {
 
   @SuppressWarnings("unchecked")
   private void execute() throws Exception {
+    project = CurrentProject.require(project);
     NameValidator.requireValidProjectName(project);
     var config = connection.resolve();
     try (var client = new SailApiClient(config.serverUrl(), config.token())) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentSessionsCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentSessionsCommand.java
@@ -25,7 +25,10 @@ import picocli.CommandLine.Spec;
     mixinStandardHelpOptions = true)
 public final class AgentSessionsCommand implements Runnable {
 
-  @Parameters(index = "0", description = "Project name.")
+  @Parameters(
+      index = "0",
+      arity = "0..1",
+      description = "Project name (default: the current project).")
   private String project;
 
   @Mixin private ConnectionOptions connection;
@@ -42,6 +45,7 @@ public final class AgentSessionsCommand implements Runnable {
 
   @SuppressWarnings("unchecked")
   private void execute() throws Exception {
+    project = CurrentProject.require(project);
     var config = connection.resolve();
     try (var client = new SailApiClient(config.serverUrl(), config.token())) {
       var result = client.get("/v1/projects/" + project + "/agent/sessions");

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStopCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStopCommand.java
@@ -25,7 +25,10 @@ import picocli.CommandLine.Spec;
     mixinStandardHelpOptions = true)
 public final class AgentStopCommand implements Runnable {
 
-  @Parameters(index = "0", description = "Project name.")
+  @Parameters(
+      index = "0",
+      arity = "0..1",
+      description = "Project name (default: the current project).")
   private String name;
 
   @Option(names = "--dry-run", description = "Print commands instead of executing them.")
@@ -42,6 +45,7 @@ public final class AgentStopCommand implements Runnable {
   }
 
   private void execute() throws Exception {
+    name = CurrentProject.require(name);
     NameValidator.requireValidProjectName(name);
     var shell = new ShellExecutor(dryRun);
     var mgr = new ContainerManager(shell);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStreamCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStreamCommand.java
@@ -30,7 +30,10 @@ import picocli.CommandLine.Spec;
     mixinStandardHelpOptions = true)
 public final class AgentStreamCommand implements Runnable {
 
-  @Parameters(index = "0", description = "Project name.")
+  @Parameters(
+      index = "0",
+      arity = "0..1",
+      description = "Project name (default: the current project).")
   private String project;
 
   @Option(names = "--since", description = "Resume from line number.", defaultValue = "0")
@@ -46,6 +49,7 @@ public final class AgentStreamCommand implements Runnable {
   }
 
   private void execute() throws Exception {
+    project = CurrentProject.require(project);
     var config = connection.resolve();
     var path = "/v1/projects/" + project + "/agent/stream" + (since > 0 ? "?since=" + since : "");
     var uri = URI.create(config.serverUrl() + path);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentSweepCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentSweepCommand.java
@@ -51,7 +51,10 @@ public final class AgentSweepCommand implements Runnable {
 
       When done, write a summary to ~/sweep-report.md listing what was found and fixed.""";
 
-  @Parameters(index = "0", description = "Project name.")
+  @Parameters(
+      index = "0",
+      arity = "0..1",
+      description = "Project name (default: the current project).")
   private String name;
 
   @Option(
@@ -74,6 +77,7 @@ public final class AgentSweepCommand implements Runnable {
   }
 
   private void execute() throws Exception {
+    name = CurrentProject.require(name);
     NameValidator.requireValidProjectName(name);
 
     var shell = new ShellExecutor(dryRun);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
@@ -65,7 +65,10 @@ public final class AgentWatchCommand implements Runnable {
    */
   private static final long LIVENESS_POLL_MS = 15_000;
 
-  @Parameters(index = "0", description = "Project name.")
+  @Parameters(
+      index = "0",
+      arity = "0..1",
+      description = "Project name (default: the current project).")
   private String name;
 
   @Option(names = "--dry-run", description = "Print actions instead of executing them.")
@@ -94,6 +97,7 @@ public final class AgentWatchCommand implements Runnable {
   }
 
   private void execute() throws Exception {
+    name = CurrentProject.require(name);
     NameValidator.requireValidProjectName(name);
     var shell = new ShellExecutor(dryRun);
     requireRunning(shell);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecBoardCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecBoardCommand.java
@@ -19,9 +19,14 @@ import picocli.CommandLine.Spec;
 public final class ApiSpecBoardCommand implements Runnable {
 
   @Option(
-      names = "--project",
-      description = "Scope the board to one client project. Inferred from cwd's sail.yaml.")
+      names = {"-p", "--project"},
+      description =
+          "Scope the board to one client project ('*' = all projects). Defaults to the current"
+              + " project, inferred from cwd's sail.yaml or 'sail project switch'.")
   private String project;
+
+  @Option(names = "--all-projects", description = "Show the board across all projects.")
+  private boolean allProjects;
 
   @Mixin private SyncOptions syncOptions;
 
@@ -40,7 +45,7 @@ public final class ApiSpecBoardCommand implements Runnable {
   private void execute() throws Exception {
     SpecSync.freshenIfNode(syncOptions.noSync());
     var config = connection.resolve();
-    var resolvedProject = project != null ? project : ApiSpecCreateCommand.projectFromCwd();
+    var resolvedProject = CurrentProject.scope(project, allProjects).orElse(null);
     var path =
         resolvedProject != null ? "/v1/specs/board?project=" + resolvedProject : "/v1/specs/board";
     try (var client = new SailApiClient(config.serverUrl(), config.token())) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCreateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCreateCommand.java
@@ -6,10 +6,8 @@
 package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.SailApiClient;
-import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.NameValidator;
-import ai.singlr.sail.engine.SailPaths;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -41,10 +39,10 @@ public final class ApiSpecCreateCommand implements Runnable {
   private String fromReview;
 
   @Option(
-      names = "--project",
+      names = {"-p", "--project"},
       description =
-          "Client project this spec belongs to. Inferred from sail.yaml in the current"
-              + " directory tree when omitted.")
+          "Client project this spec belongs to. Defaults to the current project, inferred from"
+              + " cwd's sail.yaml or 'sail project switch'.")
   private String project;
 
   @Option(names = "--status", description = "Initial status.", defaultValue = "draft")
@@ -98,11 +96,7 @@ public final class ApiSpecCreateCommand implements Runnable {
     }
     NameValidator.requireValidSpecId(id);
     var config = connection.resolve();
-    var resolvedProject = project != null ? project : projectFromCwd();
-    if (resolvedProject == null) {
-      throw new IllegalStateException(
-          "--project is required: no sail.yaml found in the current directory tree.");
-    }
+    var resolvedProject = CurrentProject.require(project);
 
     var body = new LinkedHashMap<String, Object>();
     body.put("id", id);
@@ -159,7 +153,7 @@ public final class ApiSpecCreateCommand implements Runnable {
                   + ")|@"));
       System.out.println(
           Ansi.AUTO.string(
-              "  @|faint Review and edit it, then promote: sail spec edit "
+              "  @|faint Review and edit it, then promote: sail spec update "
                   + spec.get("id")
                   + " --status pending|@"));
     }
@@ -180,19 +174,6 @@ public final class ApiSpecCreateCommand implements Runnable {
       throw new IllegalArgumentException(
           "--from-review derives title, body, priority, project, and repos from the review;"
               + " only --id may be combined with it.");
-    }
-  }
-
-  static String projectFromCwd() {
-    var yaml = SailPaths.findSailYamlUpward(Path.of(".")).orElse(null);
-    if (yaml == null) {
-      return null;
-    }
-    try {
-      var name = (String) YamlUtil.parseFile(yaml).get("name");
-      return Strings.isBlank(name) ? null : name;
-    } catch (Exception e) {
-      return null;
     }
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecEditCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecEditCommand.java
@@ -18,13 +18,19 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Spec;
 
-@Command(name = "edit", description = "Update a spec's metadata.", mixinStandardHelpOptions = true)
+@Command(
+    name = "update",
+    aliases = {"edit"},
+    description = "Update a spec's metadata.",
+    mixinStandardHelpOptions = true)
 public final class ApiSpecEditCommand implements Runnable {
 
   @Parameters(index = "0", description = "Spec ID.")
   private String specId;
 
-  @Option(names = "--project", description = "Move the spec to a different client project.")
+  @Option(
+      names = {"-p", "--project"},
+      description = "Move the spec to a different client project.")
   private String project;
 
   @Option(names = "--title", description = "New title.")

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecListCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecListCommand.java
@@ -24,13 +24,28 @@ import picocli.CommandLine.Spec;
     mixinStandardHelpOptions = true)
 public final class ApiSpecListCommand implements Runnable {
 
+  static final String ACTIVE_STATUSES = "draft,pending,in_progress,review,awaiting_merge";
+
   @Option(
-      names = "--project",
-      description = "Filter by client project. Inferred from cwd's sail.yaml when omitted.")
+      names = {"-p", "--project"},
+      description =
+          "Filter by client project ('*' = all projects). Defaults to the current project,"
+              + " inferred from cwd's sail.yaml or 'sail project switch'.")
   private String project;
 
-  @Option(names = "--status", description = "Filter by status (comma-separated).")
+  @Option(names = "--all-projects", description = "List specs across all projects.")
+  private boolean allProjects;
+
+  @Option(
+      names = "--status",
+      description =
+          "Filter by status (comma-separated). Defaults to the active statuses: "
+              + ACTIVE_STATUSES
+              + ".")
   private String status;
+
+  @Option(names = "--all", description = "Include every status (done and archived too).")
+  private boolean allStatuses;
 
   @Option(names = "--assignee", description = "Filter by assignee ('me' = your own FDE).")
   private String assignee;
@@ -61,11 +76,12 @@ public final class ApiSpecListCommand implements Runnable {
   private void execute() throws Exception {
     SpecSync.freshenIfNode(syncOptions.noSync());
     var config = connection.resolve();
-    var resolvedProject = project != null ? project : ApiSpecCreateCommand.projectFromCwd();
+    var resolvedProject = CurrentProject.scope(project, allProjects).orElse(null);
+    var resolvedStatus = statusFilter(status, allStatuses);
     try (var client = new SailApiClient(config.serverUrl(), config.token())) {
       var params = new StringBuilder("/v1/specs?");
       if (resolvedProject != null) params.append("project=").append(resolvedProject).append("&");
-      if (status != null) params.append("status=").append(status).append("&");
+      if (resolvedStatus != null) params.append("status=").append(resolvedStatus).append("&");
       if (assignee != null) params.append("assignee=").append(assignee).append("&");
       if (repo != null) params.append("repo=").append(repo).append("&");
       if (query != null) params.append("q=").append(query).append("&");
@@ -83,7 +99,11 @@ public final class ApiSpecListCommand implements Runnable {
       var specs = (List<Map<String, Object>>) result.get("specs");
       if (specs == null || specs.isEmpty()) {
         var scope = resolvedProject != null ? " for project '" + resolvedProject + "'" : "";
-        System.out.println(Ansi.AUTO.string("  @|faint No specs found" + scope + ".|@"));
+        var hint =
+            ACTIVE_STATUSES.equals(resolvedStatus)
+                ? " (active statuses only; pass --all to include done and archived)"
+                : "";
+        System.out.println(Ansi.AUTO.string("  @|faint No specs found" + scope + hint + ".|@"));
         return;
       }
 
@@ -91,10 +111,26 @@ public final class ApiSpecListCommand implements Runnable {
     }
   }
 
+  /**
+   * The status filter {@code list} sends to the server: an explicit {@code --status} verbatim,
+   * every status under {@code --all}, and the active set — which by definition includes {@code
+   * awaiting_merge}, the human merge queue — by default.
+   */
+  static String statusFilter(String status, boolean allStatuses) {
+    if (allStatuses) {
+      if (status != null) {
+        throw new IllegalArgumentException(
+            "--all lists every status; pass either --all or --status, not both.");
+      }
+      return null;
+    }
+    return status != null ? status : ACTIVE_STATUSES;
+  }
+
   @SuppressWarnings("unchecked")
   static void printGroupedByProjectAndStatus(List<Map<String, Object>> specs) {
     var statusOrder =
-        List.of("draft", "pending", "in_progress", "review", "awaiting_merge", "done");
+        List.of("draft", "pending", "in_progress", "review", "awaiting_merge", "done", "archived");
     var byProject = new LinkedHashMap<String, List<Map<String, Object>>>();
     for (var spec : specs) {
       var proj = (String) spec.getOrDefault("project", "unassigned");
@@ -146,6 +182,7 @@ public final class ApiSpecListCommand implements Runnable {
       case "review" -> "Review";
       case "awaiting_merge" -> "Awaiting Merge";
       case "done" -> "Done";
+      case "archived" -> "Archived";
       default -> status;
     };
   }
@@ -158,6 +195,7 @@ public final class ApiSpecListCommand implements Runnable {
       case "review" -> "yellow";
       case "awaiting_merge" -> "magenta";
       case "done" -> "green";
+      case "archived" -> "faint";
       default -> "white";
     };
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ClientInitCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ClientInitCommand.java
@@ -54,7 +54,7 @@ public final class ClientInitCommand implements Runnable {
                 + ClientConfig.GATEWAY_USER
                 + "' gateway user"));
     System.out.println();
-    System.out.println(Ansi.AUTO.string("  Test with: @|bold sail spec list|@"));
+    System.out.println(Ansi.AUTO.string("  Test with: @|bold sail spec list --all-projects|@"));
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/CurrentProject.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/CurrentProject.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.commands;
 
 import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.SailPaths;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -14,10 +15,11 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 /**
- * The current project — the one {@code sail project switch} last selected — so project commands
- * need neither a name argument nor a {@code cd} into a descriptor directory. It is a single line
- * under {@code ~/.sail}; the project catalog itself lives in the database, this is only the
- * pointer.
+ * The current project, resolved the same way by every command: an explicit flag or positional
+ * always wins, then the {@code sail.yaml} found upward from the working directory, then the project
+ * {@code sail project switch} last selected (a single line under {@code ~/.sail}; the project
+ * catalog itself lives in the database, this is only the pointer). Commands that need a project
+ * fail with guidance naming both options when none of the three yields one.
  */
 final class CurrentProject {
 
@@ -58,23 +60,75 @@ final class CurrentProject {
     }
   }
 
-  /**
-   * Resolves the project a command should act on: the explicit name when given, otherwise the
-   * current project. Throws with actionable guidance when neither is available.
-   */
-  static String require(String explicit) {
-    return require(explicit, file());
+  /** The project named by the {@code sail.yaml} found upward from the working directory. */
+  static Optional<String> fromCwd() {
+    var yaml = SailPaths.findSailYamlUpward(Path.of(".")).orElse(null);
+    if (yaml == null) {
+      return Optional.empty();
+    }
+    try {
+      var name = (String) YamlUtil.parseFile(yaml).get("name");
+      return Strings.isBlank(name) ? Optional.<String>empty() : Optional.of(name);
+    } catch (Exception unreadable) {
+      return Optional.empty();
+    }
   }
 
-  static String require(String explicit, Path stateFile) {
+  static Optional<String> infer(String cwdProject, Path stateFile) {
+    return Optional.ofNullable(cwdProject).or(() -> get(stateFile));
+  }
+
+  /**
+   * Resolves the project a command should act on: the explicit name when given, otherwise the cwd's
+   * {@code sail.yaml}, otherwise the current project. Throws with actionable guidance when none is
+   * available.
+   */
+  static String require(String explicit) {
+    return require(explicit, fromCwd().orElse(null), file());
+  }
+
+  static String require(String explicit, String cwdProject, Path stateFile) {
     if (Strings.isNotBlank(explicit)) {
       return explicit;
     }
-    return get(stateFile)
+    return infer(cwdProject, stateFile)
         .orElseThrow(
             () ->
                 new IllegalStateException(
-                    "No current project. Run 'sail project switch <project>' first, or pass"
-                        + " --project <project>."));
+                    "No project given and none could be inferred (no sail.yaml in the current"
+                        + " directory tree, no current project). Name the project on the command"
+                        + " line (-p/--project or the <project> argument), or run 'sail project"
+                        + " switch <project>' first."));
+  }
+
+  /**
+   * Resolves the project filter for listing commands: empty means every project (requested with
+   * {@code --all-projects} or {@code --project '*'}), otherwise {@link #require} semantics apply.
+   */
+  static Optional<String> scope(String explicit, boolean allProjects) {
+    return scope(explicit, allProjects, fromCwd().orElse(null), file());
+  }
+
+  static Optional<String> scope(
+      String explicit, boolean allProjects, String cwdProject, Path stateFile) {
+    if (allProjects && Strings.isNotBlank(explicit) && !"*".equals(explicit)) {
+      throw new IllegalArgumentException("Pass either --project or --all-projects, not both.");
+    }
+    if (allProjects || "*".equals(explicit)) {
+      return Optional.empty();
+    }
+    if (Strings.isNotBlank(explicit)) {
+      return Optional.of(explicit);
+    }
+    var inferred =
+        infer(cwdProject, stateFile)
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "No project given and none could be inferred (no sail.yaml in the current"
+                            + " directory tree, no current project). Pass -p/--project <project>"
+                            + " (or --all-projects for every project), or run 'sail project switch"
+                            + " <project>' first."));
+    return Optional.of(inferred);
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
@@ -60,8 +60,8 @@ public final class DispatchCommand implements Runnable {
   @Option(
       names = {"-p", "--project"},
       description =
-          "Project whose container runs the agent (default: the current project from 'sail"
-              + " project switch').")
+          "Project whose container runs the agent (default: the current project, inferred from"
+              + " cwd's sail.yaml or 'sail project switch').")
   private String project;
 
   private String name;

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/EventsCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/EventsCommand.java
@@ -49,7 +49,9 @@ public final class EventsCommand implements Runnable {
       defaultValue = "100")
   private int lines;
 
-  @Option(names = "--project", description = "Only show events for this project.")
+  @Option(
+      names = {"-p", "--project"},
+      description = "Only show events for this project.")
   private String projectFilter;
 
   @Option(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
@@ -51,7 +51,10 @@ public final class RunCommand implements Runnable {
 
   private static final Pattern SAFE_PATH = Pattern.compile("^[a-zA-Z0-9._/\\-]+$");
 
-  @Parameters(index = "0", description = "Project name.")
+  @Parameters(
+      index = "0",
+      arity = "0..1",
+      description = "Project name (default: the current project).")
   private String name;
 
   @Option(names = "--task", description = "Task description for headless mode.")
@@ -99,6 +102,7 @@ public final class RunCommand implements Runnable {
   }
 
   private void execute() throws Exception {
+    name = CurrentProject.require(name);
     NameValidator.requireValidProjectName(name);
 
     if (!json) {

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ApiSpecCommandsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ApiSpecCommandsTest.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -83,12 +84,14 @@ class ApiSpecCommandsTest {
     }
   }
 
+  private static final Set<String> PROJECT_SCOPED = Set.of("create", "list", "board");
+
   private static String[] withDefaultProject(String[] args) {
-    if (args.length == 0 || !"create".equals(args[0])) {
+    if (args.length == 0 || !PROJECT_SCOPED.contains(args[0])) {
       return args;
     }
     for (var arg : args) {
-      if ("--project".equals(arg)) {
+      if ("--project".equals(arg) || "--all-projects".equals(arg)) {
         return args;
       }
     }
@@ -230,6 +233,61 @@ class ApiSpecCommandsTest {
     var output = run("board", "--json");
     assertTrue(output.contains("\"draft\": 1"));
     assertTrue(output.contains("\"pending\": 2"));
+  }
+
+  @Test
+  void listDefaultsToActiveStatusesIncludingAwaitingMerge() {
+    run("create", "--id", "queued", "--title", "Queued", "--status", "pending");
+    run("create", "--id", "merge-me", "--title", "Merge queue", "--status", "awaiting_merge");
+    run("create", "--id", "shipped", "--title", "Shipped", "--status", "done");
+    run("create", "--id", "buried", "--title", "Buried", "--status", "archived");
+
+    var output = run("list", "--json");
+    assertTrue(output.contains("\"id\": \"queued\""));
+    assertTrue(output.contains("\"id\": \"merge-me\""));
+    assertFalse(output.contains("\"id\": \"shipped\""));
+    assertFalse(output.contains("\"id\": \"buried\""));
+  }
+
+  @Test
+  void listAllIncludesDoneAndArchived() {
+    run("create", "--id", "shipped", "--title", "Shipped", "--status", "done");
+    run("create", "--id", "buried", "--title", "Buried", "--status", "archived");
+
+    var output = run("list", "--all", "--json");
+    assertTrue(output.contains("\"id\": \"shipped\""));
+    assertTrue(output.contains("\"id\": \"buried\""));
+  }
+
+  @Test
+  void listExplicitDoneStatusShowsDoneSpecs() {
+    run("create", "--id", "shipped", "--title", "Shipped", "--status", "done");
+
+    var output = run("list", "--status", "done", "--json");
+    assertTrue(output.contains("\"id\": \"shipped\""));
+  }
+
+  @Test
+  void listScopesToTheRequestedProjectOnly() {
+    run("create", "--id", "mine", "--title", "Mine", "--project", "test");
+    run("create", "--id", "theirs", "--title", "Theirs", "--project", "other");
+
+    var scoped = run("list", "--project", "test", "--json");
+    assertTrue(scoped.contains("\"id\": \"mine\""));
+    assertFalse(scoped.contains("\"id\": \"theirs\""));
+
+    var everywhere = run("list", "--all-projects", "--json");
+    assertTrue(everywhere.contains("\"id\": \"mine\""));
+    assertTrue(everywhere.contains("\"id\": \"theirs\""));
+  }
+
+  @Test
+  void updateIsAnAcceptedVerbForEdit() {
+    run("create", "--id", "renamed", "--title", "Original");
+    run("update", "renamed", "--title", "Via update verb");
+
+    var output = run("show", "renamed", "--json");
+    assertTrue(output.contains("\"title\": \"Via update verb\""));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
@@ -90,6 +90,7 @@ class CommandTaxonomyTest {
             "list",
             "show",
             "create",
+            "update",
             "edit",
             "content",
             "delete",
@@ -98,6 +99,13 @@ class CommandTaxonomyTest {
             "restore",
             "dispatch"),
         spec.getSubcommands().keySet());
+  }
+
+  @Test
+  void specUpdateKeepsEditAsAlias() {
+    var spec = new CommandLine(new SpecCommand());
+
+    assertSame(spec.getSubcommands().get("update"), spec.getSubcommands().get("edit"));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CurrentProjectTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CurrentProjectTest.java
@@ -36,16 +36,61 @@ class CurrentProjectTest {
   }
 
   @Test
-  void requireFavoursTheExplicitNameThenTheCurrent() {
+  void requireFavoursTheExplicitNameThenCwdThenTheCurrent() {
     CurrentProject.set(state(), "acme");
-    assertEquals("globex", CurrentProject.require("globex", state()), "explicit wins");
-    assertEquals("acme", CurrentProject.require(null, state()), "falls back to current");
-    assertEquals("acme", CurrentProject.require("  ", state()), "blank is not explicit");
+    assertEquals("globex", CurrentProject.require("globex", "initech", state()), "explicit wins");
+    assertEquals("initech", CurrentProject.require(null, "initech", state()), "cwd beats current");
+    assertEquals("acme", CurrentProject.require(null, null, state()), "falls back to current");
+    assertEquals("acme", CurrentProject.require("  ", null, state()), "blank is not explicit");
   }
 
   @Test
-  void requireFailsWithGuidanceWhenNeitherIsAvailable() {
-    var e = assertThrows(IllegalStateException.class, () -> CurrentProject.require(null, state()));
+  void requireFailsWithGuidanceNamingBothOptionsWhenNothingIsAvailable() {
+    var e =
+        assertThrows(
+            IllegalStateException.class, () -> CurrentProject.require(null, null, state()));
+    assertTrue(e.getMessage().contains("sail project switch"), e.getMessage());
+    assertTrue(e.getMessage().contains("--project"), e.getMessage());
+  }
+
+  @Test
+  void inferPrefersCwdOverCurrent() {
+    CurrentProject.set(state(), "acme");
+    assertEquals("initech", CurrentProject.infer("initech", state()).orElseThrow());
+    assertEquals("acme", CurrentProject.infer(null, state()).orElseThrow());
+    assertTrue(CurrentProject.infer(null, tempDir.resolve("missing")).isEmpty());
+  }
+
+  @Test
+  void scopeResolvesExplicitThenInferred() {
+    CurrentProject.set(state(), "acme");
+    assertEquals("globex", CurrentProject.scope("globex", false, "initech", state()).orElseThrow());
+    assertEquals("initech", CurrentProject.scope(null, false, "initech", state()).orElseThrow());
+    assertEquals("acme", CurrentProject.scope(null, false, null, state()).orElseThrow());
+  }
+
+  @Test
+  void scopeIsUnboundedForAllProjectsOrStar() {
+    assertTrue(CurrentProject.scope(null, true, "initech", state()).isEmpty());
+    assertTrue(CurrentProject.scope("*", false, "initech", state()).isEmpty());
+    assertTrue(CurrentProject.scope("*", true, null, state()).isEmpty());
+  }
+
+  @Test
+  void scopeRejectsAProjectCombinedWithAllProjects() {
+    var e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> CurrentProject.scope("globex", true, null, state()));
+    assertTrue(e.getMessage().contains("--all-projects"), e.getMessage());
+  }
+
+  @Test
+  void scopeFailsWithGuidanceWhenNothingIsAvailable() {
+    var e =
+        assertThrows(
+            IllegalStateException.class, () -> CurrentProject.scope(null, false, null, state()));
+    assertTrue(e.getMessage().contains("--all-projects"), e.getMessage());
     assertTrue(e.getMessage().contains("sail project switch"), e.getMessage());
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/LifecycleCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/LifecycleCommandTest.java
@@ -294,12 +294,12 @@ class LifecycleCommandTest {
   }
 
   @Test
-  void agentLaunchWithNoNameShowsError() {
+  void agentLaunchWithInvalidNameShowsError() {
     var cmd = new CommandLine(new Sail());
     cmd.setOut(new PrintWriter(new StringWriter()));
     cmd.setErr(new PrintWriter(new StringWriter()));
 
-    var exitCode = cmd.execute("agent", "start");
+    var exitCode = cmd.execute("agent", "start", "INVALID NAME!");
 
     assertNotEquals(0, exitCode);
   }
@@ -636,12 +636,12 @@ class LifecycleCommandTest {
   }
 
   @Test
-  void agentContextRegenMissingArgsFails() {
+  void agentContextRegenInvalidNameFails() {
     var cmd = new CommandLine(new Sail());
     var sw = new StringWriter();
     cmd.setErr(new PrintWriter(sw));
 
-    var exitCode = cmd.execute("agent", "context", "regen");
+    var exitCode = cmd.execute("agent", "context", "regen", "INVALID NAME!");
 
     assertNotEquals(0, exitCode);
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SpecListCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SpecListCommandTest.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.Sail;
@@ -144,6 +145,96 @@ class SpecListCommandTest {
   @Test
   void parseSnapshotTimeReturnsNullForGarbage() {
     assertNull(SnapsPruneCommand.parseSnapshotTime("not-a-date"));
+  }
+
+  @Test
+  void defaultStatusFilterIsTheActiveSetIncludingAwaitingMerge() {
+    var filter = ApiSpecListCommand.statusFilter(null, false);
+
+    assertEquals("draft,pending,in_progress,review,awaiting_merge", filter);
+    assertTrue(List.of(filter.split(",")).contains("awaiting_merge"));
+  }
+
+  @Test
+  void explicitStatusOverridesTheDefaultSet() {
+    assertEquals("done", ApiSpecListCommand.statusFilter("done", false));
+    assertEquals("done,archived", ApiSpecListCommand.statusFilter("done,archived", false));
+  }
+
+  @Test
+  void allFlagLiftsTheStatusFilterEntirely() {
+    assertNull(ApiSpecListCommand.statusFilter(null, true));
+  }
+
+  @Test
+  void allFlagRejectsAnExplicitStatus() {
+    var e =
+        assertThrows(
+            IllegalArgumentException.class, () -> ApiSpecListCommand.statusFilter("done", true));
+    assertTrue(e.getMessage().contains("--all"), e.getMessage());
+  }
+
+  @Test
+  void specListHelpDocumentsScopingFlags() {
+    var cmd = new CommandLine(new Sail());
+    var sw = new StringWriter();
+    cmd.setOut(new PrintWriter(sw));
+
+    var exitCode = cmd.execute("spec", "list", "--help");
+
+    assertEquals(0, exitCode);
+    var help = sw.toString();
+    assertTrue(help.contains("-p, --project"));
+    assertTrue(help.contains("--all-projects"));
+    assertTrue(help.contains("--all"));
+  }
+
+  @Test
+  void projectOptionAcceptsShortAliasOnEveryCarryingCommand() {
+    for (var args :
+        List.of(
+            new String[] {"spec", "list", "-p", "acme"},
+            new String[] {"spec", "board", "-p", "acme"},
+            new String[] {"spec", "create", "-p", "acme"},
+            new String[] {"spec", "update", "some-spec", "-p", "acme"},
+            new String[] {"spec", "dispatch", "-p", "acme"},
+            new String[] {"events", "-p", "acme"})) {
+      var parsed = new CommandLine(new Sail()).parseArgs(args);
+      var leaf = parsed.asCommandLineList().getLast();
+      assertEquals(
+          "acme",
+          leaf.getParseResult().matchedOptionValue("--project", null),
+          String.join(" ", args));
+    }
+  }
+
+  @Test
+  void specUpdateIsTheCanonicalVerbAndEditRemainsAnAlias() {
+    assertNotNull(
+        new CommandLine(new Sail()).getSubcommands().get("spec").getSubcommands().get("update"));
+    new CommandLine(new Sail()).parseArgs("spec", "update", "some-spec", "--status", "pending");
+    new CommandLine(new Sail()).parseArgs("spec", "edit", "some-spec", "--status", "pending");
+  }
+
+  @Test
+  void agentCommandsAcceptAnOmittedProjectArgument() {
+    for (var args :
+        List.of(
+            new String[] {"agent", "launch"},
+            new String[] {"agent", "run"},
+            new String[] {"agent", "attach"},
+            new String[] {"agent", "stream"},
+            new String[] {"agent", "sessions"},
+            new String[] {"agent", "stop"},
+            new String[] {"agent", "log"},
+            new String[] {"agent", "review"},
+            new String[] {"agent", "sweep"},
+            new String[] {"agent", "watch"},
+            new String[] {"agent", "report"},
+            new String[] {"agent", "context", "regen"},
+            new String[] {"spec", "dispatch"})) {
+      new CommandLine(new Sail()).parseArgs(args);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Problem

`sail spec list` showed everything, everywhere, in every status; current-project inference was applied inconsistently (some commands inferred from cwd's sail.yaml, some from `sail project switch`, some required the project outright); and `--project` was declared long-only on five commands while six others accepted `-p`.

## What changed

One resolution rule, implemented once in `CurrentProject` and used everywhere it applies:

**explicit flag/positional → cwd `sail.yaml` → `sail project switch` pointer → fail with a message naming both options.**

- `sail spec list` defaults to the current project and the **active statuses** (`draft, pending, in_progress, review, awaiting_merge` — `awaiting_merge` is the human merge queue and stays visible by default). `--all` lifts the status filter (and the renderer now has an Archived column, which the status order previously dropped); `--status done` works explicitly; `--all-projects` or `--project '*'` lists across projects.
- `sail spec board` gets the same scoping; the global board is an explicit `--all-projects`, not a silent fallback.
- Every command carrying a project option now declares `names = {"-p", "--project"}`, and `-p` means nothing else anywhere.
- Verb unification with the in-container `spec` wrapper: `sail spec update` is now the canonical verb (`edit` kept as an alias), and the wrapper accepts `edit` as an alias for `update`. Docs updated to the canonical verb.

## Audit: project resolution per command

| Command | Before | After | Project flag shape |
|---|---|---|---|
| `spec list` | all projects, all statuses; inferred from cwd sail.yaml only | current project + active statuses; `--all` / `--all-projects` / `-p '*'` escapes; fails naming both options | `-p, --project` (was long-only) |
| `spec board` | cwd sail.yaml only; silently global when not inferable | explicit → cwd → switch → fail; global board via `--all-projects` or `-p '*'` | `-p, --project` (was long-only) |
| `spec create` | cwd sail.yaml only, else "no sail.yaml" error | explicit → cwd → switch → fail naming both options | `-p, --project` (was long-only) |
| `spec update` (was `edit`) | host verb `edit` vs wrapper verb `update`; long-only flag | canonical `update`, alias `edit`; `--project` here moves a spec (still a project option, so it carries `-p`) | `-p, --project` (was long-only) |
| `spec show` / `content` / `delete` / `history` / `restore` | address a spec by globally unique id; no project option | unchanged — rule not applicable | — |
| `spec dispatch` | explicit → `sail project switch` only | explicit → cwd sail.yaml → switch → fail | `-p, --project` (unchanged) |
| `agent start/launch`, `run`, `attach`, `stream`, `sessions`, `stop`, `logs/log`, `review`, `sweep`, `watch`, `report`, `context regen` | required positional `<project>`, no inference | optional positional; explicit → cwd → switch → fail naming both options | positional (unchanged) |
| `agent status` | optional positional; omitted = all projects | unchanged — fleet overview; project is an optional filter, not a scoping requirement | positional (unchanged) |
| `events` | long-only `--project`; optional filter over the whole event bus | filter semantics unchanged (bus-wide observability); gains the short alias | `-p, --project` (was long-only) |
| `project files list/get/put/rm/sync` | explicit → switch pointer | now also infers cwd sail.yaml via the shared resolver | `-p, --project` (unchanged) |

Precedence note: cwd `sail.yaml` beats the switch pointer because it is the more local signal — `cd` into a project's descriptor directory and commands act on that project, matching what `spec create` always did.

## Compatibility

- `--json` shapes are untouched (the server response passes through; the default filters only narrow which rows are requested).
- `sail spec edit`, `agent start`/`agent launch`, `agent logs`/`agent log` all keep working via aliases.
- Behavior deliberately narrowed: bare `sail spec list` on a box with no inferable project now fails with guidance instead of dumping every spec in every status; `sail spec board` no longer silently falls back to the global board.

## Testing

- `CurrentProjectTest`: full precedence chain, `scope()` semantics (`'*'`, `--all-projects`, conflict, failure guidance).
- `SpecListCommandTest`: exact default filter set asserted (`draft,pending,in_progress,review,awaiting_merge`, including `awaiting_merge` membership), `--all`/`--status` interaction, `-p` alias parse on every carrying command, `update`/`edit` alias, omitted positional on every agent command.
- `ApiSpecCommandsTest` (against a real `SailApiServer`): default list excludes done/archived and includes awaiting_merge; `--all` includes them; `--status done` and `--all-projects` behave; `update` verb round-trips.
- `mvn clean verify` green (1962 tests, spotless, jacoco ratchet), plus a manual smoke of the built CLI: inference failure message, cwd inference, `agent stop` with no argument.
