### PR TITLE
Sync converges the schema before touching data

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncDatabase.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncDatabase.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Path;
+
+/**
+ * The only database handle a sync path may run on: constructing one converges the schema, so a sync
+ * that skips convergence is unrepresentable. Exists because of the in-sync self-update incident
+ * where a freshly-replaced binary kept syncing against the previous release's schema and aborted on
+ * a stale CHECK constraint — both sync entry points (the node's local-replica open and main's
+ * RPC-serving open) go through {@link #converge}. Migration is idempotent and cheap when the schema
+ * is already current, so converging unconditionally is safe.
+ */
+public final class SyncDatabase implements AutoCloseable {
+
+  private final Sqlite db;
+
+  private SyncDatabase(Sqlite db) {
+    this.db = db;
+  }
+
+  /**
+   * Opens the database at {@code dbPath} and converges its schema before returning. A convergence
+   * failure closes the handle and aborts with a message naming {@code box} — the box whose binary
+   * and schema disagree — so the operator knows where to run {@code sail upgrade}. No sync data has
+   * been touched at that point.
+   */
+  public static SyncDatabase converge(Path dbPath, String box) {
+    var db = Sqlite.open(dbPath);
+    try {
+      new SchemaManager(db).migrate();
+    } catch (RuntimeException e) {
+      db.close();
+      throw new IllegalStateException(
+          "Sync aborted before touching data: could not converge the database schema on '"
+              + box
+              + "': "
+              + e.getMessage()
+              + ". Run 'sail upgrade' on '"
+              + box
+              + "', then sync again.",
+          e);
+    }
+    return new SyncDatabase(db);
+  }
+
+  /** The converged handle; valid until {@link #close()}. */
+  public Sqlite db() {
+    return db;
+  }
+
+  @Override
+  public void close() {
+    db.close();
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/SyncSchemaConvergenceTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SyncSchemaConvergenceTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.sync.SpecReplica;
+import ai.singlr.sail.sync.SyncDatabase;
+import ai.singlr.sail.sync.SyncEngine;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression for the in-sync self-update incident: a node's binary was replaced mid-sync and the
+ * new code wrote {@code awaiting_merge} into a specs table still carrying the old narrow CHECK
+ * constraint. Every sync entry point now opens its database through {@link SyncDatabase#converge},
+ * which migrates before any data is touched. Lives in the store package to reach the
+ * package-private {@link SchemaManager#migrateTo} staging seam.
+ */
+class SyncSchemaConvergenceTest {
+
+  @TempDir Path tempDir;
+
+  private Path stagedAtNarrowStatusCheck(String name) {
+    var path = tempDir.resolve(name + ".db");
+    try (var db = Sqlite.open(path)) {
+      new SchemaManager(db).migrateTo(SchemaManager.LAST_VERSION_WITH_NARROW_STATUS_CHECK);
+    }
+    return path;
+  }
+
+  private static SpecReplica replica(String id, Sqlite db) {
+    return new SpecReplica(
+        id, new SpecStore(db), new ChangeLog(db), new SyncConflicts(db), new SyncState(db));
+  }
+
+  private static SpecStore.SpecRow spec(String id, String title, String status) {
+    return new SpecStore.SpecRow(
+        id,
+        "proj",
+        title,
+        SpecStatus.fromWire(status),
+        null,
+        null,
+        null,
+        null,
+        null,
+        0,
+        "uday",
+        "",
+        "",
+        "uday",
+        List.of(),
+        List.of());
+  }
+
+  @Test
+  void theStagedSchemaRejectsAwaitingMergeWithoutConvergence() {
+    var path = stagedAtNarrowStatusCheck("raw");
+    try (var db = Sqlite.open(path)) {
+      assertThrows(
+          SqliteException.class,
+          () ->
+              db.execute(
+                  "INSERT INTO specs (id, title, status, created_at, updated_at)"
+                      + " VALUES ('m', 'M', 'awaiting_merge', 't', 't')"));
+    }
+  }
+
+  @Test
+  void aPulledAwaitingMergeRevisionAppliesBecauseTheReplicaOpenConvergedFirst() {
+    var nodePath = stagedAtNarrowStatusCheck("node");
+    try (var main = SyncDatabase.converge(tempDir.resolve("main.db"), "main");
+        var node = SyncDatabase.converge(nodePath, "node")) {
+      new SpecStore(main.db()).create(spec("auth", "Auth", "awaiting_merge"));
+
+      var report =
+          new SyncEngine().reconcile(replica("node", node.db()), replica("main", main.db()));
+
+      assertEquals(1, report.pulled());
+      assertEquals(
+          "awaiting_merge",
+          new SpecStore(node.db()).findById("auth").orElseThrow().status().wire());
+    }
+  }
+
+  @Test
+  void mainAcceptsAPushedAwaitingMergeCommitBecauseTheServingOpenConvergedFirst() {
+    var mainPath = stagedAtNarrowStatusCheck("main");
+    try (var main = SyncDatabase.converge(mainPath, "main");
+        var node = SyncDatabase.converge(tempDir.resolve("node.db"), "node")) {
+      new SpecStore(node.db()).create(spec("auth", "Auth", "awaiting_merge"));
+
+      var report =
+          new SyncEngine().reconcile(replica("node", node.db()), replica("main", main.db()));
+
+      assertEquals(1, report.pushed());
+      assertEquals(
+          "awaiting_merge",
+          new SpecStore(main.db()).findById("auth").orElseThrow().status().wire());
+    }
+  }
+
+  @Test
+  void aConvergenceFailureNamesTheBoxThatNeedsUpgradeAndAborts() {
+    var path = tempDir.resolve("broken.db");
+    try (var db = Sqlite.open(path)) {
+      db.execute("CREATE TABLE specs (id TEXT PRIMARY KEY, project TEXT)");
+    }
+
+    var failure =
+        assertThrows(IllegalStateException.class, () -> SyncDatabase.converge(path, "devbox-7"));
+
+    assertTrue(failure.getMessage().contains("devbox-7"));
+    assertTrue(failure.getMessage().contains("sail upgrade"));
+  }
+
+  @Test
+  void convergeIsIdempotentOnACurrentDatabase() {
+    var path = tempDir.resolve("current.db");
+    int versionAfterFirst;
+    try (var first = SyncDatabase.converge(path, "box")) {
+      versionAfterFirst = new SchemaManager(first.db()).currentVersion();
+    }
+    try (var second = SyncDatabase.converge(path, "box")) {
+      assertEquals(versionAfterFirst, new SchemaManager(second.db()).currentVersion());
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
@@ -23,12 +23,12 @@ import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.SpecStore;
-import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.SyncConflicts;
 import ai.singlr.sail.store.SyncState;
 import ai.singlr.sail.sync.FileReplica;
 import ai.singlr.sail.sync.ProjectReplica;
 import ai.singlr.sail.sync.SpecReplica;
+import ai.singlr.sail.sync.SyncDatabase;
 import ai.singlr.sail.sync.SyncEngine;
 import ai.singlr.sail.sync.SyncSession;
 import java.io.IOException;
@@ -47,7 +47,10 @@ import picocli.CommandLine.Option;
  * engine runs here on the node and drives a {@link RemoteMainReplica} across the channel:
  * local-only work pushes (main mints the rev), main-only work pulls, disjoint edits auto-merge, and
  * same-field conflicts are parked locally for {@code sail conflicts} — the node's row is never
- * clobbered. The round is idempotent; running it again after it converges does nothing.
+ * clobbered. The round is idempotent; running it again after it converges does nothing. The local
+ * replica is opened through {@link SyncDatabase}, so the schema is converged before any revision is
+ * applied — a binary the auto-updater just replaced can never sync against the previous release's
+ * schema.
  *
  * <p>With {@code --watch} it loops on an interval, staying up through a transient main outage and
  * resuming from the checkpoint when main returns. Each round that brings remote work (or raises a
@@ -98,23 +101,34 @@ public final class SyncCommand implements Callable<Integer> {
       return 0;
     }
     var target = resolution.target();
-    try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
-      var host = HostInfo.hostname();
-      var changeLog = new ChangeLog(db);
-      var conflicts = new SyncConflicts(db);
-      var syncState = new SyncState(db);
-      var fileStore = new FileStore(db);
-      var projectStore = new ProjectStore(db);
-      var boxes =
-          new Boxes(
-              new SpecReplica(host, new SpecStore(db), changeLog, conflicts, syncState),
-              new FileReplica(host, fileStore, changeLog, conflicts, syncState),
-              new ProjectReplica(host, projectStore, changeLog, conflicts, syncState),
-              new FdeStore(db),
-              fileStore,
-              projectStore);
+    var host = HostInfo.hostname();
+    SyncDatabase replicaDb;
+    try {
+      replicaDb = SyncDatabase.converge(SailPaths.controlPlaneDb(), host);
+    } catch (RuntimeException e) {
+      System.err.println(Banner.errorLine(SyncCommand.reason(e), Ansi.AUTO));
+      return 1;
+    }
+    try (replicaDb) {
+      var boxes = boxes(replicaDb, host);
       return watch ? watchLoop(boxes, target) : runOnce(boxes, target);
     }
+  }
+
+  private static Boxes boxes(SyncDatabase converged, String host) {
+    var db = converged.db();
+    var changeLog = new ChangeLog(db);
+    var conflicts = new SyncConflicts(db);
+    var syncState = new SyncState(db);
+    var fileStore = new FileStore(db);
+    var projectStore = new ProjectStore(db);
+    return new Boxes(
+        new SpecReplica(host, new SpecStore(db), changeLog, conflicts, syncState),
+        new FileReplica(host, fileStore, changeLog, conflicts, syncState),
+        new ProjectReplica(host, projectStore, changeLog, conflicts, syncState),
+        new FdeStore(db),
+        fileStore,
+        projectStore);
   }
 
   private record Boxes(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
@@ -23,6 +23,7 @@ import ai.singlr.sail.sync.FileReplica;
 import ai.singlr.sail.sync.MainReplica;
 import ai.singlr.sail.sync.ProjectReplica;
 import ai.singlr.sail.sync.SpecReplica;
+import ai.singlr.sail.sync.SyncDatabase;
 import ai.singlr.sail.sync.SyncRpcServer;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -42,7 +43,8 @@ import picocli.CommandLine.Command;
  * this with {@code SAIL_TOKEN} set, and the {@link SyncRpcServer} then exchanges {@link
  * ai.singlr.sail.sync.SyncWire} over the channel's stdio. The token resolves to the FDE's role:
  * only {@code member}+ may push (write), so a read-only FDE can pull but its commits are refused.
- * Not meant to be run by hand.
+ * The serving database is opened through {@link SyncDatabase}, so main's schema is converged before
+ * any revision is served or committed. Not meant to be run by hand.
  */
 @Command(
     name = "_sync",
@@ -52,15 +54,25 @@ public final class SyncServerCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+    var host = HostInfo.hostname();
+    SyncDatabase mainDb;
+    try {
+      mainDb = SyncDatabase.converge(SailPaths.controlPlaneDb(), host);
+    } catch (RuntimeException e) {
+      System.err.println(SyncCommand.reason(e));
+      return 1;
+    }
+    try (mainDb) {
       var in = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
       var out = new OutputStreamWriter(System.out, StandardCharsets.UTF_8);
-      return serve(db, HostInfo.hostname(), System.getenv("SAIL_TOKEN"), in, out);
+      return serve(mainDb, host, System.getenv("SAIL_TOKEN"), in, out);
     }
   }
 
-  static int serve(Sqlite db, String mainId, String token, BufferedReader in, Writer out)
+  static int serve(
+      SyncDatabase converged, String mainId, String token, BufferedReader in, Writer out)
       throws IOException {
+    var db = converged.db();
     var changeLog = new ChangeLog(db);
     var conflicts = new SyncConflicts(db);
     var syncState = new SyncState(db);

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SyncServerCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SyncServerCommandTest.java
@@ -19,6 +19,7 @@ import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.SyncConflicts;
 import ai.singlr.sail.store.SyncState;
 import ai.singlr.sail.sync.SpecReplica;
+import ai.singlr.sail.sync.SyncDatabase;
 import ai.singlr.sail.sync.SyncEngine;
 import ai.singlr.sail.sync.SyncSession;
 import ai.singlr.sail.sync.SyncTransportException;
@@ -43,6 +44,7 @@ import org.junit.jupiter.api.io.TempDir;
 class SyncServerCommandTest {
 
   @TempDir Path tempDir;
+  private SyncDatabase mainReplicaDb;
   private Sqlite mainDb;
   private Sqlite nodeDb;
   private SpecStore mainSpecs;
@@ -51,7 +53,8 @@ class SyncServerCommandTest {
 
   @BeforeEach
   void setUp() {
-    mainDb = open("main");
+    mainReplicaDb = SyncDatabase.converge(tempDir.resolve("main.db"), "main");
+    mainDb = mainReplicaDb.db();
     nodeDb = open("node");
     mainSpecs = new SpecStore(mainDb);
     nodeSpecs = new SpecStore(nodeDb);
@@ -67,7 +70,7 @@ class SyncServerCommandTest {
   @AfterEach
   void tearDown() {
     nodeDb.close();
-    mainDb.close();
+    mainReplicaDb.close();
   }
 
   private Sqlite open(String name) {
@@ -112,7 +115,7 @@ class SyncServerCommandTest {
             .start(
                 () -> {
                   try {
-                    SyncServerCommand.serve(mainDb, "main", token, serverIn, toClient);
+                    SyncServerCommand.serve(mainReplicaDb, "main", token, serverIn, toClient);
                   } catch (IOException e) {
                     throw new UncheckedIOException(e);
                   }


### PR DESCRIPTION
## Incident

A node on 0.13.138 ran `sail sync`. The in-sync self-update replaced the binary with 0.13.140, re-execed, and the new code applied an `awaiting_merge` revision into a specs table still carrying the old narrow CHECK constraint — sqlite error 19, sync aborted. The re-exec mechanism (`AutoUpgrader.reExec`) already existed and worked; the gap was that no sync entry point ever converged the local schema, so the freshly-replaced binary ran new code against the previous release's schema.

## Fix

`SyncDatabase` (sail-core, sync package) is now the only database handle a sync path can run on. Constructing one — `SyncDatabase.converge(path, box)` — runs `SchemaManager.migrate()` before returning, so a sync that skips convergence is unrepresentable rather than merely discouraged:

- **Node side** (`SyncCommand`): the local replica set is built from a `SyncDatabase`; the raw `Sqlite.open` is gone.
- **Serving side** (`SyncServerCommand`): `serve()` now takes a `SyncDatabase`, so the RPC server cannot be handed an unconverged handle. This also covers the case where the auto-updater replaces the binary right before `sail _sync` serves a session on main.

A convergence failure aborts the sync **before any data is touched**, with a message naming the box whose binary and schema disagree and telling the operator to run `sail upgrade` there. Migration is idempotent and a version check when current, so converging unconditionally is safe and cheap.

### Why re-exec alone was not enough

The self-update already re-execs the new binary (`AutoUpgrader` sets `SAIL_AUTO_UPGRADED=1` and execs the original argv). Post-update, the code that syncs is the new code — but it synced against the old schema. With this change the re-execed `sail sync` converges the schema as its first database act, which is exactly the guarantee the spec asks for: the code that syncs is the code that matches the schema it just converged.

## Write-path audit (freshly-replaced binary, daemon not yet restarted)

**Converge schema before touching data:**
- `sail sync` and `sail _sync` — this PR, via `SyncDatabase`.
- `sail server start` / `sail server init` — `MigrationRunner.applyAll` on every daemon start.
- `sail migrate`, and `sail upgrade` (spawns the *new* binary's `sail migrate` as a sub-process).
- `ProjectCatalog`, `ProjectDefinitions`, `DemoSeeder`, `ProjectDemoCommand`, `ProjectRenameCommand`, `ProjectDestroyCommand` — already called `SchemaManager.migrate()` on open.

**Daemon-mediated, therefore safe:**
- The in-container `spec` CLI talks to `sail-api` over the socket. Until the daemon restarts it is old code writing to the old schema it matches; the restart that brings new code re-runs all migrations first (`ServerStartCommand`).

**Direct-open without convergence (audited, deliberately unchanged):**
- `ConflictsCommand` — writes resolutions of conflicts that a sync round parked; with this PR a conflict can only exist on a box whose schema that sync round already converged.
- `DispatchCommand`, `AgentLaunchCommand`, `AgentStatusCommand`, `RunCommand`, `ServerTokenCommand`, `FdeCommand`, `HostKeysCommand`, `HostSshIdentityCommand`, `JoinCommand`, `GatewayCommand`, `ProjectFilesCommand`, `ProjectConfigCommand`, `ContainerWorkspace` — local-actor reads/writes of long-stable columns, not appliers of remote revisions; none writes sync-borne statuses. `StuckSpecReconciler` / `ExpiredRowSweeper` run inside the daemon, covered by its start-time migration.

## Regression tests

`SyncSchemaConvergenceTest` (store package, to reach the package-private `SchemaManager.migrateTo` staging seam):
- Stages a database at `LAST_VERSION_WITH_NARROW_STATUS_CHECK` and proves it still rejects `awaiting_merge` when opened raw — the incident reproduced.
- Drives a real `SyncEngine` round where a node **pulls** an `awaiting_merge` revision into a staged narrow-schema replica opened via `converge` — applies cleanly.
- Drives the inverse: a staged narrow-schema **main** opened via `converge` accepts a **pushed** `awaiting_merge` commit.
- A convergence failure aborts with a message naming the box and `sail upgrade`.
- Converge is idempotent on a current database.

`mvn clean verify` green: 1962 infra tests + core suite, all coverage gates hold.
