### PR TITLE
Expose caller identity, role, and capabilities (GET /v1/whoami)

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -23,6 +23,19 @@ record HealthResponse(String status) implements Mappable {
   }
 }
 
+record WhoamiResponse(String fde, String name, Role role, List<Capability> capabilities)
+    implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("fde", fde);
+    m.put("name", name);
+    m.put("role", role);
+    m.put("capabilities", capabilities);
+    return m;
+  }
+}
+
 record ProjectResponse(String name, String containerStatus, AgentConfigView agent)
     implements Mappable {
   @Override

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -29,6 +29,7 @@ public final class ApiRouter implements HttpHandler {
   private static final String DELETE = "DELETE";
   private static final String V1 = "v1";
   private static final String HEALTH = "health";
+  private static final String WHOAMI = "whoami";
   private static final String PROJECTS = "projects";
   private static final String SPECS = "specs";
   private static final String DISPATCH = "dispatch";
@@ -108,6 +109,10 @@ public final class ApiRouter implements HttpHandler {
     auth.require(exchange);
     requireWithinRateLimit(exchange);
     Authorizer.require(exchange, Authorizer.capabilityFor(request.method()));
+
+    if (request.matches(GET, V1, WHOAMI)) {
+      return whoami(exchange);
+    }
 
     if (request.hasEventsPrefix()) {
       return routeEvents(exchange, request);
@@ -372,6 +377,25 @@ public final class ApiRouter implements HttpHandler {
    */
   static String resolveAssignee(String assignee, String actor) {
     return "me".equals(assignee) && actor != null ? actor : assignee;
+  }
+
+  /**
+   * Reflects the authenticated caller's identity back from the exchange attributes stamped by
+   * {@link ApiAuth} — no store access. Mirrors {@link #actor}: {@code fde} is present only for
+   * FDE-owned credentials, {@code name} is the credential name. Capabilities are derived from the
+   * role so clients gate UI on a capability rather than a hardcoded role→power map. Marked {@code
+   * Cache-Control: no-store} because the response is per-credential session state.
+   */
+  private static ApiResponse whoami(HttpExchange exchange) {
+    var role = Role.fromAttribute(exchange.getAttribute("token.role"));
+    var capabilities = Arrays.stream(Capability.values()).filter(role::allows).toList();
+    var response =
+        new WhoamiResponse(
+            Objects.toString(exchange.getAttribute("token.fde"), null),
+            Objects.toString(exchange.getAttribute("token.name"), null),
+            role,
+            capabilities);
+    return ApiResponse.ok(response).withHeader("Cache-Control", "no-store");
   }
 
   /**

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WhoamiTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WhoamiTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.store.AuthSessionStore;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import ai.singlr.sail.store.TokenStore;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WhoamiTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private FdeStore fdes;
+  private AuthSessionStore sessions;
+  private TokenStore tokenStore;
+  private SailApiServer server;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    fdes = new FdeStore(db);
+    sessions = new AuthSessionStore(db);
+    tokenStore = new TokenStore(db);
+    var auth = new SessionAwareAuth(sessions, fdes, new TokenAuth(tokenStore));
+    server =
+        new SailApiServer(
+            "127.0.0.1", 0, new TestOperations(), auth, new EventBus(), null, null, null);
+    server.start();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (server != null) server.close();
+    if (db != null) db.close();
+  }
+
+  @Test
+  void adminPasskeySessionSeesFullIdentity() throws Exception {
+    var fde = fdes.add("uday", null, null, "admin");
+    var session = sessions.create(fde.id(), Duration.ofMinutes(30)).token();
+    var response = get(session);
+    assertEquals(200, response.statusCode());
+    assertEquals("no-store", response.headers().firstValue("Cache-Control").orElse(null));
+    var body = YamlUtil.parseMap(response.body());
+    assertEquals(1, body.get("schema_version"));
+    assertEquals("uday", body.get("fde"));
+    assertEquals("admin", body.get("role"));
+    assertEquals(List.of("read", "write", "admin"), body.get("capabilities"));
+  }
+
+  @Test
+  void fdeOwnedTokenCarriesFdeAndTokenName() throws Exception {
+    var fde = fdes.add("uday", null, null, "member");
+    var token = tokenStore.create("uday-laptop", "member", fde.id()).token();
+    var body = YamlUtil.parseMap(get(token).body());
+    assertEquals("uday", body.get("fde"));
+    assertEquals("uday-laptop", body.get("name"));
+    assertEquals("member", body.get("role"));
+    assertEquals(List.of("read", "write"), body.get("capabilities"));
+  }
+
+  @Test
+  void machineTokenOmitsFdeAndLacksAdminCapability() throws Exception {
+    var token = tokenStore.create("ci-bot", "member").token();
+    var body = YamlUtil.parseMap(get(token).body());
+    assertFalse(body.containsKey("fde"), body.toString());
+    assertEquals("ci-bot", body.get("name"));
+    assertEquals("member", body.get("role"));
+    assertEquals(List.of("read", "write"), body.get("capabilities"));
+  }
+
+  @Test
+  void viewerTokenGetsReadOnlyCapabilities() throws Exception {
+    var token = tokenStore.create("dashboard", "viewer").token();
+    var body = YamlUtil.parseMap(get(token).body());
+    assertEquals("viewer", body.get("role"));
+    assertEquals(List.of("read"), body.get("capabilities"));
+  }
+
+  @Test
+  void missingBearerIsUnauthorized() throws Exception {
+    var response = get(null);
+    assertEquals(401, response.statusCode());
+    assertTrue(response.body().contains("missing_bearer_token"), response.body());
+  }
+
+  @Test
+  void invalidTokenIsForbidden() throws Exception {
+    var response = get("sail_bogus");
+    assertEquals(403, response.statusCode());
+    assertTrue(response.body().contains("invalid_bearer_token"), response.body());
+  }
+
+  @Test
+  void expiredSessionIsForbidden() throws Exception {
+    var fde = fdes.add("uday", null, null, "admin");
+    var session = sessions.create(fde.id(), Duration.ofMinutes(-1)).token();
+    var response = get(session);
+    assertEquals(403, response.statusCode());
+    assertTrue(response.body().contains("invalid_bearer_token"), response.body());
+  }
+
+  private HttpResponse<String> get(String token) throws Exception {
+    var builder =
+        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + server.port() + "/v1/whoami"));
+    if (token != null) {
+      builder.header("Authorization", "Bearer " + token);
+    }
+    return HttpClient.newHttpClient()
+        .send(builder.GET().build(), HttpResponse.BodyHandlers.ofString());
+  }
+}


### PR DESCRIPTION
## Summary

Implements spec `api-whoami-identity`. Every authenticated request already carries the caller's identity on the exchange — `SessionAwareAuth`/`TokenAuth` stamp `token.fde`, `token.name`, and `token.role` — but nothing exposed it back to the client. Mast and other thin clients could not answer "who am I?", gate admin-only UI (dispatch, review approve/dismiss) before issuing a doomed request, or validate a stored session without a throwaway `board()` call.

`GET /v1/whoami` (authenticated, any role) reads the already-stamped exchange attributes — no store access — and returns:

- `fde` — the FDE handle; omitted for ownerless machine tokens (mirrors `ApiRouter.actor(...)` exactly)
- `name` — the credential name
- `role` — `admin` | `member` | `viewer` (the enum wire form)
- `capabilities` — derived from the role (`viewer` → `["read"]`, `member` → `["read","write"]`, `admin` → `["read","write","admin"]`) so clients check a capability instead of hardcoding a role→power map

Standard `schema_version:1` envelope, `Cache-Control: no-store`. Auth semantics match every other route — no bearer → 401 `missing_bearer_token`, bad/expired credential → 403 `invalid_bearer_token` — making this the canonical cheap session-validation probe.

## Testing

- New `WhoamiTest` runs against the in-process server: admin passkey session (full identity + `admin` capability), FDE-owned member token, machine token (`fde` absent), viewer token, missing bearer (401), invalid token (403), expired session (403), and the `no-store` header.
- `mvn clean verify` green: 1969 tests, coverage checks met.