### PR TITLE
Add display_name and email to GET /v1/whoami

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -23,13 +23,21 @@ record HealthResponse(String status) implements Mappable {
   }
 }
 
-record WhoamiResponse(String fde, String name, Role role, List<Capability> capabilities)
+record WhoamiResponse(
+    String fde,
+    String name,
+    String displayName,
+    String email,
+    Role role,
+    List<Capability> capabilities)
     implements Mappable {
   @Override
   public Map<String, Object> toMap() {
     var m = new LinkedHashMap<String, Object>();
     m.put("fde", fde);
     m.put("name", name);
+    m.put("display_name", displayName);
+    m.put("email", email);
     m.put("role", role);
     m.put("capabilities", capabilities);
     return m;

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -382,9 +382,12 @@ public final class ApiRouter implements HttpHandler {
   /**
    * Reflects the authenticated caller's identity back from the exchange attributes stamped by
    * {@link ApiAuth} — no store access. Mirrors {@link #actor}: {@code fde} is present only for
-   * FDE-owned credentials, {@code name} is the credential name. Capabilities are derived from the
-   * role so clients gate UI on a capability rather than a hardcoded role→power map. Marked {@code
-   * Cache-Control: no-store} because the response is per-credential session state.
+   * FDE-owned credentials, {@code name} is the credential name. {@code display_name} and {@code
+   * email} are present only on passkey/session logins (the {@link SessionAwareAuth} path resolves
+   * the FDE record); they are omitted for machine/CI tokens, which carry no personal identity.
+   * Capabilities are derived from the role so clients gate UI on a capability rather than a
+   * hardcoded role→power map. Marked {@code Cache-Control: no-store} because the response is
+   * per-credential session state.
    */
   private static ApiResponse whoami(HttpExchange exchange) {
     var role = Role.fromAttribute(exchange.getAttribute("token.role"));
@@ -393,6 +396,8 @@ public final class ApiRouter implements HttpHandler {
         new WhoamiResponse(
             Objects.toString(exchange.getAttribute("token.fde"), null),
             Objects.toString(exchange.getAttribute("token.name"), null),
+            Objects.toString(exchange.getAttribute("token.displayName"), null),
+            Objects.toString(exchange.getAttribute("token.email"), null),
             role,
             capabilities);
     return ApiResponse.ok(response).withHeader("Cache-Control", "no-store");

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SessionAwareAuth.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SessionAwareAuth.java
@@ -61,5 +61,11 @@ public final class SessionAwareAuth implements ApiAuth {
     exchange.setAttribute("token.name", fde.handle());
     exchange.setAttribute("token.fde", fde.handle());
     exchange.setAttribute("token.role", fde.role());
+    if (fde.displayName() != null) {
+      exchange.setAttribute("token.displayName", fde.displayName());
+    }
+    if (fde.email() != null) {
+      exchange.setAttribute("token.email", fde.email());
+    }
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WhoamiTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WhoamiTest.java
@@ -58,7 +58,7 @@ class WhoamiTest {
 
   @Test
   void adminPasskeySessionSeesFullIdentity() throws Exception {
-    var fde = fdes.add("uday", null, null, "admin");
+    var fde = fdes.add("uday", "Uday K", "uday@singlr.ai", "admin");
     var session = sessions.create(fde.id(), Duration.ofMinutes(30)).token();
     var response = get(session);
     assertEquals(200, response.statusCode());
@@ -66,8 +66,20 @@ class WhoamiTest {
     var body = YamlUtil.parseMap(response.body());
     assertEquals(1, body.get("schema_version"));
     assertEquals("uday", body.get("fde"));
+    assertEquals("Uday K", body.get("display_name"));
+    assertEquals("uday@singlr.ai", body.get("email"));
     assertEquals("admin", body.get("role"));
     assertEquals(List.of("read", "write", "admin"), body.get("capabilities"));
+  }
+
+  @Test
+  void passkeySessionOmitsUnsetNameAndEmail() throws Exception {
+    var fde = fdes.add("uday", null, null, "member");
+    var session = sessions.create(fde.id(), Duration.ofMinutes(30)).token();
+    var body = YamlUtil.parseMap(get(session).body());
+    assertEquals("uday", body.get("fde"));
+    assertFalse(body.containsKey("display_name"), body.toString());
+    assertFalse(body.containsKey("email"), body.toString());
   }
 
   @Test


### PR DESCRIPTION
Passkey/session logins now return the FDE's display name and email, so a desktop client (Mast) can show a real identity instead of just the handle.

## What
- `WhoamiResponse` gains `display_name` and `email`.
- `SessionAwareAuth` already resolves the FDE record when validating a `sess_` token, so it stamps `token.displayName` / `token.email` (both nullable — omitted when unset).
- The whoami handler reflects the two new attributes; nulls serialize away exactly like `fde` does today.
- Machine/CI tokens carry no personal identity, so both fields are absent for them.

## Why
Mast's passkey login lands a `sess_` session; the user menu wants to show who you are (name + email), but `/v1/whoami` only exposed `fde` (handle) + token name + role. This is the smallest change that surfaces the identity already stored in `fdes.display_name` / `fdes.email`.

## Tests
- `WhoamiTest`: passkey session with name+email returns them; a session whose FDE has neither omits both keys. Machine-token omission already covered.
- Full `sail-infra` verify green: 1970 tests, jacoco `coverage-check` (api.* 100%) passes.