### PR TITLE
Passkey lifecycle: list and revoke individual credentials

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -161,6 +161,11 @@ The three replicas are pure delegation adapters that implement both `LocalReplic
 `MainReplica`, so the same box acts as the node when it syncs up and as the authority when
 another node syncs to it.
 
+Passkeys stay box-local by design: identity crosses boxes via the roster pull, but a
+WebAuthn credential is an RP-scoped secret bound to one box's origin and never leaves it.
+Each box enrolls its own passkeys (`sail fde enroll`), and each box lists and revokes them
+on its own (`sail fde passkey list|rm`).
+
 ### The engine
 
 `SyncEngine.reconcile(local, main)` is entity-agnostic, order-independent, idempotent, and
@@ -409,8 +414,9 @@ and `Authorizer`:
 1. **Terminal: SSH key to FDE.** Each registered key is pinned in the `sail` user's
    `authorized_keys` to `command="…/sail _gateway --fde <handle>",restrict`, with no shell
    and no forwarding. Command classification is default-deny: only `spec`, `agent`, and
-   `events` reach the loopback API, `fde` is admin-gated at the gateway, `_sync` is admitted,
-   and everything else is refused. A short-lived session is minted per invocation. `sail fde
+   `events` reach the loopback API, `fde` is admin-gated at the gateway (with one
+   self-service carve-out: any active FDE may `fde passkey list|rm` its own pinned handle),
+   `_sync` is admitted, and everything else is refused. A short-lived session is minted per invocation. `sail fde
    add <handle> --key "<pubkey>"` is the whole enrollment, and removing the key revokes SSH
    and API access in one step.
 2. **Web, opt-in and off by default: passkeys and WebAuthn.** For Mast and browser clients

--- a/sail-core/src/main/java/ai/singlr/sail/auth/PasskeyService.java
+++ b/sail-core/src/main/java/ai/singlr/sail/auth/PasskeyService.java
@@ -5,6 +5,8 @@
 
 package ai.singlr.sail.auth;
 
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.store.AuthSessionStore;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.PendingChallengeStore;
@@ -91,7 +93,7 @@ public final class PasskeyService implements PasskeyCeremonies {
       throw new PasskeyException(
           PasskeyException.Kind.BAD_REQUEST, "This passkey is already registered.");
     }
-    credentials.save(credential, pending.fdeId(), label);
+    credentials.save(credential, pending.fdeId(), effectiveLabel(label, credential.aaguid()));
     return new Registration(handleOf(pending.fdeId()), credential.credentialId());
   }
 
@@ -148,6 +150,14 @@ public final class PasskeyService implements PasskeyCeremonies {
       return true;
     }
     return Arrays.equals(userHandle, fdeId.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * A skipped label prompt falls back to a device-descriptive default (authenticator name plus
+   * enrollment date) so {@code sail fde passkey list} can still tell the FDE's credentials apart.
+   */
+  private static String effectiveLabel(String label, byte[] aaguid) {
+    return Strings.isBlank(label) ? Passkeys.defaultLabel(aaguid, DateTimeUtils.now()) : label;
   }
 
   private static PasskeyException loginFailed() {

--- a/sail-core/src/main/java/ai/singlr/sail/auth/Passkeys.java
+++ b/sail-core/src/main/java/ai/singlr/sail/auth/Passkeys.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.auth;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.store.WebauthnCredentialStore.Credential;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Pure helpers for managing an FDE's registered passkeys. Naming: a label tells apart multiple
+ * credentials of the same FDE (never the FDE's own name), so when enrollment skips the label prompt
+ * the default is device-descriptive — the authenticator's well-known AAGUID name plus the
+ * enrollment date, e.g. {@code "iCloud Keychain · 2026-07-06"}. Selection: {@link #resolveByPrefix}
+ * resolves a credential from a git-style unambiguous id prefix and reports ambiguity rather than
+ * guessing.
+ */
+public final class Passkeys {
+
+  private static final Base64.Encoder URL = Base64.getUrlEncoder().withoutPadding();
+  private static final int SHORT_ID_LENGTH = 12;
+  private static final String UNKNOWN_AUTHENTICATOR = "passkey";
+
+  private static final Map<String, String> WELL_KNOWN_AAGUIDS =
+      Map.ofEntries(
+          Map.entry("fbfc3007-154e-4ecc-8c0b-6e020557d7bd", "iCloud Keychain"),
+          Map.entry("dd4ec289-e01d-41c9-bb89-70fa845d4bf2", "iCloud Keychain (Managed)"),
+          Map.entry("ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4", "Google Password Manager"),
+          Map.entry("adce0002-35bc-c60a-648b-0b25f1f05503", "Chrome on Mac"),
+          Map.entry("08987058-cadc-4b81-b6e1-30de50dcbe96", "Windows Hello"),
+          Map.entry("9ddd1817-af5a-4672-a2b9-3e3dd95000a9", "Windows Hello"),
+          Map.entry("6028b017-b1d4-4c02-b4b3-afcdafc96bb2", "Windows Hello"),
+          Map.entry("bada5566-a7aa-401f-bd96-45619a55120d", "1Password"),
+          Map.entry("d548826e-79b4-db40-a3d8-11116f7e8349", "Bitwarden"),
+          Map.entry("531126d6-e717-415c-9320-3d9aa6981239", "Dashlane"),
+          Map.entry("ee882879-721c-4913-9775-3dfcce97072a", "YubiKey 5"),
+          Map.entry("cb69481e-8ff7-4039-93ec-0a2729a154a8", "YubiKey 5"),
+          Map.entry("fa2b99dc-9e39-4257-8f92-4a30d23c4118", "YubiKey 5 NFC"),
+          Map.entry("2fc0579f-8113-47ea-b116-bb5a8db9202a", "YubiKey 5 NFC"));
+
+  private Passkeys() {}
+
+  /** How a credential id prefix resolved against an FDE's registered passkeys. */
+  public sealed interface Resolution permits Match, NotFound, Ambiguous {}
+
+  /** Exactly one credential matched. */
+  public record Match(Credential credential) implements Resolution {}
+
+  /** No credential matched. */
+  public record NotFound() implements Resolution {}
+
+  /** More than one credential matched; a longer prefix is needed. */
+  public record Ambiguous(List<Credential> candidates) implements Resolution {}
+
+  /** The credential id in its canonical CLI form: base64url without padding. */
+  public static String encodeId(byte[] credentialId) {
+    return URL.encodeToString(credentialId);
+  }
+
+  /** A display-length prefix of the encoded credential id, long enough to be unambiguous. */
+  public static String shortId(byte[] credentialId) {
+    var encoded = encodeId(credentialId);
+    return encoded.length() <= SHORT_ID_LENGTH ? encoded : encoded.substring(0, SHORT_ID_LENGTH);
+  }
+
+  /** Resolves a non-blank id prefix against {@code credentials}, git-style. */
+  public static Resolution resolveByPrefix(List<Credential> credentials, String prefix) {
+    if (Strings.isBlank(prefix)) {
+      throw new IllegalArgumentException("Credential id prefix must not be blank.");
+    }
+    var matches =
+        credentials.stream()
+            .filter(credential -> encodeId(credential.credentialId()).startsWith(prefix))
+            .toList();
+    return switch (matches.size()) {
+      case 0 -> new NotFound();
+      case 1 -> new Match(matches.getFirst());
+      default -> new Ambiguous(matches);
+    };
+  }
+
+  /** The authenticator's well-known name for {@code aaguid}, or {@code "passkey"}. */
+  public static String authenticatorName(byte[] aaguid) {
+    if (aaguid == null || aaguid.length != 16) {
+      return UNKNOWN_AUTHENTICATOR;
+    }
+    var buffer = ByteBuffer.wrap(aaguid);
+    var uuid = new UUID(buffer.getLong(), buffer.getLong());
+    return WELL_KNOWN_AAGUIDS.getOrDefault(uuid.toString(), UNKNOWN_AUTHENTICATOR);
+  }
+
+  /** The label stored when enrollment skips the prompt: authenticator name plus enrollment date. */
+  public static String defaultLabel(byte[] aaguid, Instant enrolledAt) {
+    return authenticatorName(aaguid) + " · " + enrolledAt.toString().substring(0, 10);
+  }
+
+  /** The stored label, or the device-descriptive default for rows enrolled before labels. */
+  public static String displayLabel(Credential credential) {
+    return Strings.isBlank(credential.label())
+        ? defaultLabel(credential.aaguid(), Instant.parse(credential.createdAt()))
+        : credential.label();
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/ssh/SshGateway.java
+++ b/sail-core/src/main/java/ai/singlr/sail/ssh/SshGateway.java
@@ -25,7 +25,8 @@ import java.util.Set;
  *   <li>{@link #API_COMMANDS} run for every active FDE — they talk to the loopback API, where the
  *       FDE's role decides what each request may do.
  *   <li>{@link #ADMIN_COMMANDS} are database-direct, so no downstream check exists; the gateway
- *       itself requires the {@code admin} role.
+ *       itself requires the {@code admin} role — except {@code fde passkey list|rm} on the caller's
+ *       own pinned handle, which any active FDE may run.
  *   <li>Everything else ({@code project}, {@code host}, {@code server}, {@code migrate}, …) runs
  *       with host privileges the {@code sail} user must never have, and is refused.
  * </ul>
@@ -90,10 +91,35 @@ public final class SshGateway {
     if (fde.isEmpty() || !"active".equals(fde.get().status())) {
       return new Rejected("Unknown or disabled FDE.");
     }
-    if (ADMIN_COMMANDS.contains(subcommand) && !"admin".equals(fde.get().role())) {
-      return new Rejected("'" + subcommand + "' requires the admin role.");
+    if (ADMIN_COMMANDS.contains(subcommand)
+        && !"admin".equals(fde.get().role())
+        && !isOwnPasskeyCommand(tokens, fdeHandle)) {
+      return new Rejected(
+          isPasskeyCommand(tokens)
+              ? "Managing another FDE's passkeys requires the admin role. You may manage your"
+                  + " own: sail fde passkey list "
+                  + fdeHandle
+              : "'" + subcommand + "' requires the admin role.");
     }
     var session = sessions.create(fde.get().id(), SESSION_TTL);
     return new Authorized(List.copyOf(tokens), session.token());
+  }
+
+  /**
+   * The one self-service carve-out in the admin-gated {@code fde} family: an FDE may list and
+   * revoke its own passkeys ({@code fde passkey list|rm <handle>}). The target handle is compared
+   * against the handle pinned to the calling key on the {@code authorized_keys} line, so a
+   * non-admin can never reach another FDE's credentials — and only when the handle sits directly
+   * after the verb, so an option-first spelling fails closed to the admin gate.
+   */
+  private static boolean isOwnPasskeyCommand(List<String> tokens, String fdeHandle) {
+    return isPasskeyCommand(tokens)
+        && tokens.size() >= 4
+        && Set.of("list", "rm").contains(tokens.get(2))
+        && tokens.get(3).equals(fdeHandle);
+  }
+
+  private static boolean isPasskeyCommand(List<String> tokens) {
+    return tokens.size() >= 2 && tokens.get(0).equals("fde") && tokens.get(1).equals("passkey");
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/store/WebauthnCredentialStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/WebauthnCredentialStore.java
@@ -77,6 +77,14 @@ public final class WebauthnCredentialStore {
         SELECT + " WHERE fde_id = ? ORDER BY created_at", WebauthnCredentialStore::map, fdeId);
   }
 
+  /** Deletes a single credential; returns whether a row was removed. */
+  public boolean delete(byte[] credentialId) {
+    db.execute(
+        "DELETE FROM webauthn_credentials WHERE credential_id = ?",
+        URL.encodeToString(credentialId));
+    return db.changes() > 0;
+  }
+
   /** Records a successful assertion: advances the signature counter and stamps last-used. */
   public void recordUse(byte[] credentialId, long signCount) {
     db.execute(

--- a/sail-core/src/test/java/ai/singlr/sail/auth/PasskeyServiceTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/auth/PasskeyServiceTest.java
@@ -98,6 +98,56 @@ class PasskeyServiceTest {
   }
 
   @Test
+  void providedLabelIsStored() {
+    enroll("uday");
+    var stored = credentials.findByCredentialId(authenticator.credentialId()).orElseThrow();
+    assertEquals("laptop", stored.label());
+  }
+
+  @Test
+  void skippedLabelDefaultsToAuthenticatorAndEnrollmentDate() {
+    var ceremony = service.startRegistration("uday");
+    var response = authenticator.register(challengeOf(ceremony), ORIGIN);
+    service.finishRegistration(
+        ceremony.challengeId(), response.clientDataJson(), response.attestationObject(), " ");
+    var stored = credentials.findByCredentialId(authenticator.credentialId()).orElseThrow();
+    assertTrue(
+        stored.label().matches("passkey · \\d{4}-\\d{2}-\\d{2}"),
+        "unexpected default label: " + stored.label());
+  }
+
+  @Test
+  void deletingACredentialDoesNotInvalidateSessionsItMinted() {
+    enroll("uday");
+    var login = service.startLogin();
+    var assertion = authenticator.assertResponse(challengeOf(login), ORIGIN);
+    var result =
+        service.finishLogin(
+            login.challengeId(),
+            assertion.credentialId(),
+            assertion.clientDataJson(),
+            assertion.authenticatorData(),
+            assertion.signature(),
+            null);
+
+    assertTrue(credentials.delete(authenticator.credentialId()));
+
+    assertTrue(sessions.validate(result.sessionToken()).isPresent());
+    var retry = service.startLogin();
+    var replay = authenticator.assertResponse(challengeOf(retry), ORIGIN);
+    assertThrows(
+        PasskeyException.class,
+        () ->
+            service.finishLogin(
+                retry.challengeId(),
+                replay.credentialId(),
+                replay.clientDataJson(),
+                replay.authenticatorData(),
+                replay.signature(),
+                null));
+  }
+
+  @Test
   void twoLoginsAdvanceSignCounter() {
     enroll("uday");
     for (var i = 0; i < 2; i++) {

--- a/sail-core/src/test/java/ai/singlr/sail/auth/PasskeysTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/auth/PasskeysTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ai.singlr.sail.store.WebauthnCredentialStore.Credential;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class PasskeysTest {
+
+  private static final byte[] ICLOUD_KEYCHAIN = aaguid("fbfc3007-154e-4ecc-8c0b-6e020557d7bd");
+
+  private static byte[] aaguid(String uuid) {
+    var parsed = UUID.fromString(uuid);
+    return ByteBuffer.allocate(16)
+        .putLong(parsed.getMostSignificantBits())
+        .putLong(parsed.getLeastSignificantBits())
+        .array();
+  }
+
+  private static Credential credential(String id, String label) {
+    return new Credential(
+        id.getBytes(StandardCharsets.UTF_8),
+        "fde-1",
+        new byte[] {1},
+        -7,
+        0,
+        null,
+        false,
+        false,
+        label,
+        "2026-07-06T10:15:30Z",
+        null);
+  }
+
+  @Test
+  void encodeIdIsUrlSafeWithoutPadding() {
+    assertEquals("_-8", Passkeys.encodeId(new byte[] {(byte) 0xff, (byte) 0xef}));
+  }
+
+  @Test
+  void shortIdTruncatesLongIdsAndKeepsShortOnes() {
+    assertEquals("AAAAAAAAAAAA", Passkeys.shortId(new byte[12]));
+    assertEquals(12, Passkeys.shortId(new byte[32]).length());
+    assertEquals(Passkeys.encodeId(new byte[3]), Passkeys.shortId(new byte[3]));
+  }
+
+  @Test
+  void resolvesUniquePrefixToMatch() {
+    var credentials = List.of(credential("alpha", "a"), credential("bravo", "b"));
+    var prefix = Passkeys.encodeId("alpha".getBytes(StandardCharsets.UTF_8)).substring(0, 3);
+    var match =
+        assertInstanceOf(Passkeys.Match.class, Passkeys.resolveByPrefix(credentials, prefix));
+    assertEquals("a", match.credential().label());
+  }
+
+  @Test
+  void resolvesFullIdToMatch() {
+    var credentials = List.of(credential("alpha", "a"));
+    var full = Passkeys.encodeId("alpha".getBytes(StandardCharsets.UTF_8));
+    assertInstanceOf(Passkeys.Match.class, Passkeys.resolveByPrefix(credentials, full));
+  }
+
+  @Test
+  void unknownPrefixResolvesToNotFound() {
+    var credentials = List.of(credential("alpha", "a"));
+    assertInstanceOf(Passkeys.NotFound.class, Passkeys.resolveByPrefix(credentials, "zzzz"));
+  }
+
+  @Test
+  void sharedPrefixResolvesToAmbiguousWithAllCandidates() {
+    var credentials = List.of(credential("alpha-one", "a"), credential("alpha-two", "b"));
+    var ambiguous =
+        assertInstanceOf(
+            Passkeys.Ambiguous.class,
+            Passkeys.resolveByPrefix(
+                credentials, Passkeys.encodeId("alpha".getBytes(StandardCharsets.UTF_8))));
+    assertEquals(2, ambiguous.candidates().size());
+  }
+
+  @Test
+  void blankPrefixIsRejected() {
+    var credentials = List.of(credential("alpha", "a"));
+    assertThrows(IllegalArgumentException.class, () -> Passkeys.resolveByPrefix(credentials, "  "));
+    assertThrows(IllegalArgumentException.class, () -> Passkeys.resolveByPrefix(credentials, null));
+  }
+
+  @Test
+  void wellKnownAaguidMapsToAuthenticatorName() {
+    assertEquals("iCloud Keychain", Passkeys.authenticatorName(ICLOUD_KEYCHAIN));
+    assertEquals(
+        "YubiKey 5", Passkeys.authenticatorName(aaguid("ee882879-721c-4913-9775-3dfcce97072a")));
+  }
+
+  @Test
+  void unknownNullAndMalformedAaguidsFallBackToPasskey() {
+    assertEquals("passkey", Passkeys.authenticatorName(new byte[16]));
+    assertEquals("passkey", Passkeys.authenticatorName(null));
+    assertEquals("passkey", Passkeys.authenticatorName(new byte[4]));
+  }
+
+  @Test
+  void defaultLabelJoinsAuthenticatorNameAndEnrollmentDate() {
+    assertEquals(
+        "iCloud Keychain · 2026-07-06",
+        Passkeys.defaultLabel(ICLOUD_KEYCHAIN, Instant.parse("2026-07-06T23:59:59Z")));
+    assertEquals(
+        "passkey · 2026-01-02", Passkeys.defaultLabel(null, Instant.parse("2026-01-02T00:00:00Z")));
+  }
+
+  @Test
+  void displayLabelPrefersStoredLabel() {
+    assertEquals("uday's macbook", Passkeys.displayLabel(credential("alpha", "uday's macbook")));
+  }
+
+  @Test
+  void displayLabelFallsBackToDefaultForUnlabeledRows() {
+    assertEquals("passkey · 2026-07-06", Passkeys.displayLabel(credential("alpha", null)));
+    assertEquals("passkey · 2026-07-06", Passkeys.displayLabel(credential("alpha", " ")));
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/ssh/SshGatewayTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/ssh/SshGatewayTest.java
@@ -77,6 +77,53 @@ class SshGatewayTest {
   }
 
   @Test
+  void memberManagesItsOwnPasskeys() {
+    for (var command :
+        List.of(
+            "sail fde passkey list uday",
+            "sail fde passkey rm uday --credential abc123 --revoke-sessions")) {
+      var authorized = assertInstanceOf(SshGateway.Authorized.class, authorize(command, "uday"));
+      assertEquals("fde", authorized.args().getFirst());
+      assertTrue(sessions.validate(authorized.sessionToken()).isPresent());
+    }
+  }
+
+  @Test
+  void memberCannotManageAnotherFdesPasskeys() {
+    fdes.add("ada", null, null, "member");
+    for (var command :
+        List.of("sail fde passkey list ada", "sail fde passkey rm ada --credential abc123")) {
+      var rejected = assertInstanceOf(SshGateway.Rejected.class, authorize(command, "uday"));
+      assertTrue(rejected.reason().contains("admin role"));
+      assertTrue(rejected.reason().contains("sail fde passkey list uday"));
+    }
+  }
+
+  @Test
+  void memberPasskeyCarveOutDoesNotLeakIntoOtherFdeSubcommands() {
+    for (var command :
+        List.of(
+            "sail fde passkey",
+            "sail fde passkey list",
+            "sail fde passkey add uday",
+            "sail fde passkey rm --credential abc123 uday",
+            "sail fde enroll uday",
+            "sail fde rm uday")) {
+      var rejected = assertInstanceOf(SshGateway.Rejected.class, authorize(command, "uday"));
+      assertTrue(rejected.reason().contains("admin role"));
+    }
+  }
+
+  @Test
+  void adminManagesAnyFdesPasskeys() {
+    fdes.add("ada", null, null, "admin");
+    var authorized =
+        assertInstanceOf(
+            SshGateway.Authorized.class, authorize("sail fde passkey list uday", "ada"));
+    assertEquals(List.of("fde", "passkey", "list", "uday"), authorized.args());
+  }
+
+  @Test
   void rejectsHostPrivilegedCommandsEvenForAdmins() {
     fdes.add("ada", null, null, "admin");
     for (var handle : List.of("uday", "ada")) {

--- a/sail-core/src/test/java/ai/singlr/sail/store/WebauthnCredentialStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/WebauthnCredentialStoreTest.java
@@ -99,6 +99,32 @@ class WebauthnCredentialStoreTest {
   }
 
   @Test
+  void deleteRemovesOnlyTheGivenCredential() {
+    store.save(cred(new byte[] {1}, 0, null), fdeId, "keep");
+    store.save(cred(new byte[] {2}, 0, null), fdeId, "drop");
+
+    assertTrue(store.delete(new byte[] {2}));
+
+    var remaining = store.listForFde(fdeId);
+    assertEquals(1, remaining.size());
+    assertEquals("keep", remaining.getFirst().label());
+    assertTrue(store.findByCredentialId(new byte[] {2}).isEmpty());
+  }
+
+  @Test
+  void deleteReturnsFalseForUnknownCredential() {
+    assertFalse(store.delete(new byte[] {9, 9, 9}));
+  }
+
+  @Test
+  void deletingTheLastCredentialLeavesTheFdeIntact() {
+    store.save(cred(new byte[] {1}, 0, null), fdeId, null);
+    assertTrue(store.delete(new byte[] {1}));
+    assertTrue(store.listForFde(fdeId).isEmpty());
+    assertTrue(new FdeStore(db).byHandle("uday").isPresent());
+  }
+
+  @Test
   void recordUseAdvancesSignCountAndStampsLastUsed() {
     var credId = new byte[] {5};
     store.save(cred(credId, 5, null), fdeId, null);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/WebauthnPageHandler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/WebauthnPageHandler.java
@@ -146,6 +146,8 @@ public final class WebauthnPageHandler implements HttpHandler {
         const ticket = params.get('ticket');
         if (!ticket) { fail('Missing enrollment ticket in the URL.'); return; }
         const headers = { 'X-Enrollment-Ticket': ticket };
+        const button = document.getElementById('enroll');
+        button.disabled = true;
         try {
           setStatus('Starting enrollment…');
           const start = await postJson('/v1/auth/register/start', '{}', headers);
@@ -159,24 +161,38 @@ public final class WebauthnPageHandler implements HttpHandler {
           setStatus('Touch your authenticator to create a passkey…');
           const cred = await navigator.credentials.create({ publicKey: pk });
           const r = cred.response;
+          const label = document.getElementById('label').value.trim();
           const out = await postJson('/v1/auth/register/finish', JSON.stringify({
             challenge_id: start.challenge_id,
             client_data_json: bufToB64url(r.clientDataJSON),
             attestation_object: bufToB64url(r.attestationObject),
+            label: label || null,
           }), headers);
           setStatus('Passkey registered for ' + out.fde + '. You can close this tab.');
           handBack('');
         } catch (e) {
           fail('Enrollment failed: ' + e.message);
+          button.disabled = false;
         }
       }
-      window.addEventListener('load', run);
+      window.addEventListener('load', () => {
+        document.getElementById('enroll').addEventListener('click', run);
+        setStatus('Name this passkey so you can tell your devices apart, then create it.');
+      });
       """;
 
-  private static final String LOGIN_PAGE = page("Sign in to Sail", LOGIN_SCRIPT);
-  private static final String ENROLL_PAGE = page("Enroll a Sail passkey", ENROLL_SCRIPT);
+  private static final String ENROLL_FORM =
+      """
+      <label for="label">Passkey name (optional)</label>
+      <input id="label" placeholder="e.g. MacBook Pro" maxlength="64">
+      <button id="enroll">Create passkey</button>
+      """;
 
-  private static String page(String title, String script) {
+  private static final String LOGIN_PAGE = page("Sign in to Sail", "", LOGIN_SCRIPT);
+  private static final String ENROLL_PAGE =
+      page("Enroll a Sail passkey", ENROLL_FORM, ENROLL_SCRIPT);
+
+  private static String page(String title, String form, String script) {
     return """
         <!doctype html>
         <html lang="en">
@@ -191,10 +207,14 @@ public final class WebauthnPageHandler implements HttpHandler {
             #status { margin-top: 1rem; padding: 0.75rem 1rem; border-radius: 0.5rem;
                       background: #f1f5f9; }
             #status.err { background: #fee2e2; color: #991b1b; }
+            label { display: block; margin-top: 1rem; }
+            input { width: 100%; padding: 0.5rem; margin-top: 0.25rem; box-sizing: border-box; }
+            button { margin-top: 1rem; padding: 0.5rem 1rem; }
           </style>
         </head>
         <body>
           <h1>%TITLE%</h1>
+        %FORM%
           <p id="status">Loading…</p>
           <script>
         %SHARED%
@@ -204,6 +224,7 @@ public final class WebauthnPageHandler implements HttpHandler {
         </html>
         """
         .replace("%TITLE%", title)
+        .replace("%FORM%", form)
         .replace("%SHARED%", SHARED_SCRIPT)
         .replace("%SCRIPT%", script);
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
@@ -6,20 +6,25 @@
 package ai.singlr.sail.commands;
 
 import ai.singlr.sail.auth.EnrollmentService;
+import ai.singlr.sail.auth.Passkeys;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.AuthorizedKeysSync;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.ssh.SshPublicKey;
+import ai.singlr.sail.store.AuthSessionStore;
 import ai.singlr.sail.store.EnrollmentTicketStore;
 import ai.singlr.sail.store.FdeSshKeyStore;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.SqliteException;
+import ai.singlr.sail.store.WebauthnCredentialStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -41,7 +46,8 @@ import picocli.CommandLine.Spec;
       FdeCommand.Update.class,
       FdeCommand.Remove.class,
       FdeCommand.Enroll.class,
-      FdeCommand.Key.class
+      FdeCommand.Key.class,
+      FdeCommand.Passkey.class
     })
 public final class FdeCommand implements Runnable {
 
@@ -506,6 +512,180 @@ public final class FdeCommand implements Runnable {
           return Optional.empty();
         }
         return Optional.of(keys.getFirst().fingerprint());
+      }
+    }
+  }
+
+  @Command(
+      name = "passkey",
+      description = "Manage the passkeys an FDE signs in to the web door with.",
+      mixinStandardHelpOptions = true,
+      subcommands = {Passkey.ListPasskeys.class, Passkey.Remove.class})
+  static final class Passkey implements Runnable {
+
+    @Override
+    public void run() {
+      new picocli.CommandLine(this).usage(System.out);
+    }
+
+    private static FdeStore.Fde requireFde(Sqlite db, String handle) {
+      return new FdeStore(db)
+          .byHandle(handle)
+          .orElseThrow(() -> new IllegalArgumentException("Unknown FDE '" + handle + "'."));
+    }
+
+    static String noMatchMessage(
+        String handle, String prefix, List<WebauthnCredentialStore.Credential> credentials) {
+      if (credentials.isEmpty()) {
+        return "'"
+            + handle
+            + "' has no passkeys. Enroll one with 'sail fde enroll "
+            + handle
+            + "'.";
+      }
+      return "No passkey of '"
+          + handle
+          + "' matches '"
+          + prefix
+          + "'. Registered passkeys:\n"
+          + candidateLines(credentials);
+    }
+
+    static String ambiguousMessage(
+        String handle, String prefix, List<WebauthnCredentialStore.Credential> candidates) {
+      return "'"
+          + prefix
+          + "' matches "
+          + candidates.size()
+          + " passkeys of '"
+          + handle
+          + "'; use a longer prefix:\n"
+          + candidateLines(candidates);
+    }
+
+    private static String candidateLines(List<WebauthnCredentialStore.Credential> credentials) {
+      return credentials.stream()
+          .map(
+              credential ->
+                  "    "
+                      + Passkeys.encodeId(credential.credentialId())
+                      + "  "
+                      + Passkeys.displayLabel(credential))
+          .collect(Collectors.joining("\n"));
+    }
+
+    @Command(
+        name = "list",
+        description = "List an FDE's registered passkeys.",
+        mixinStandardHelpOptions = true)
+    static final class ListPasskeys implements Runnable {
+
+      @Parameters(index = "0", description = "FDE handle.")
+      private String handle;
+
+      @Spec private CommandSpec spec;
+
+      @Override
+      public void run() {
+        CliCommand.run(
+            spec,
+            () -> {
+              try (var db = Sqlite.open(dbPath())) {
+                var fde = requireFde(db, handle);
+                var credentials = new WebauthnCredentialStore(db).listForFde(fde.id());
+                if (credentials.isEmpty()) {
+                  System.out.println(
+                      "  No passkeys for '"
+                          + handle
+                          + "'. Enroll one with 'sail fde enroll "
+                          + handle
+                          + "'.");
+                  return;
+                }
+                Banner.printFdePasskeyTable(credentials, handle, System.out, Ansi.AUTO);
+              }
+            });
+      }
+    }
+
+    @Command(
+        name = "rm",
+        description =
+            "Revoke one of an FDE's passkeys by credential id prefix. Sessions it minted stay"
+                + " valid unless --revoke-sessions is passed.",
+        mixinStandardHelpOptions = true)
+    static final class Remove implements Runnable {
+
+      @Parameters(index = "0", description = "FDE handle.")
+      private String handle;
+
+      @Option(
+          names = "--credential",
+          required = true,
+          description =
+              "Credential id or an unambiguous prefix; see 'sail fde passkey list <handle>'.")
+      private String credential;
+
+      @Option(
+          names = "--revoke-sessions",
+          description = "Also end the FDE's active web sessions (the lost-device case).")
+      private boolean revokeSessions;
+
+      @Spec private CommandSpec spec;
+
+      @Override
+      public void run() {
+        CliCommand.run(
+            spec,
+            () -> {
+              try (var db = Sqlite.open(dbPath())) {
+                var fde = requireFde(db, handle);
+                var store = new WebauthnCredentialStore(db);
+                var credentials = store.listForFde(fde.id());
+                var match =
+                    switch (Passkeys.resolveByPrefix(credentials, credential)) {
+                      case Passkeys.Match m -> m.credential();
+                      case Passkeys.NotFound _ ->
+                          throw new IllegalArgumentException(
+                              noMatchMessage(handle, credential, credentials));
+                      case Passkeys.Ambiguous a ->
+                          throw new IllegalArgumentException(
+                              ambiguousMessage(handle, credential, a.candidates()));
+                    };
+                store.delete(match.credentialId());
+                System.out.println(
+                    Ansi.AUTO.string(
+                        "  @|green ✓|@ Revoked passkey '"
+                            + Passkeys.displayLabel(match)
+                            + "' ("
+                            + Passkeys.shortId(match.credentialId())
+                            + ") of "
+                            + handle));
+                if (revokeSessions) {
+                  var revoked = new AuthSessionStore(db).revokeForFde(fde.id());
+                  System.out.println(
+                      Ansi.AUTO.string(
+                          "  @|green ✓|@ Revoked "
+                              + revoked
+                              + " active web session(s) of "
+                              + handle));
+                } else {
+                  System.out.println(
+                      Ansi.AUTO.string(
+                          "  @|faint Sessions this passkey minted stay valid until they expire;"
+                              + " pass --revoke-sessions to end them now.|@"));
+                }
+                if (credentials.size() == 1) {
+                  System.out.println(
+                      Ansi.AUTO.string(
+                          "  @|faint '"
+                              + handle
+                              + "' has no passkeys left. Re-enroll with 'sail fde enroll "
+                              + handle
+                              + "'.|@"));
+                }
+              }
+            });
       }
     }
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.engine;
 
 import ai.singlr.sail.SailVersion;
+import ai.singlr.sail.auth.Passkeys;
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.HostYaml;
@@ -15,6 +16,7 @@ import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.store.FdeSshKeyStore;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.FileStore;
+import ai.singlr.sail.store.WebauthnCredentialStore;
 import java.io.PrintStream;
 import java.text.NumberFormat;
 import java.time.Duration;
@@ -641,6 +643,32 @@ public final class Banner {
       table.addRow(key.fdeHandle(), orDash(key.comment()), key.fingerprint());
     }
     table.render(out, ansi);
+  }
+
+  /** Prints a bordered table of an FDE's registered passkeys. */
+  public static void printFdePasskeyTable(
+      List<WebauthnCredentialStore.Credential> credentials,
+      String handle,
+      PrintStream out,
+      Ansi ansi) {
+    var table =
+        new TableFormatter(
+            " Passkeys: " + handle + " ",
+            List.of("ID", "LABEL", "AUTHENTICATOR", "CREATED", "LAST USED", "SYNCED"));
+    for (var credential : credentials) {
+      table.addRow(
+          Passkeys.shortId(credential.credentialId()),
+          Passkeys.displayLabel(credential),
+          Passkeys.authenticatorName(credential.aaguid()),
+          datePart(credential.createdAt()),
+          datePart(credential.lastUsedAt()),
+          credential.backupState() ? "yes" : "no");
+    }
+    table.render(out, ansi);
+  }
+
+  private static String datePart(String instant) {
+    return instant == null || instant.length() < 10 ? "-" : instant.substring(0, 10);
   }
 
   /** Prints a bordered table of a project's shared files. */

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WebauthnPageHandlerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WebauthnPageHandlerTest.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.SchemaManager;
@@ -70,6 +71,20 @@ class WebauthnPageHandlerTest {
     assertTrue(response.body().contains("navigator.credentials.create"));
     assertTrue(response.body().contains("X-Enrollment-Ticket"));
     assertTrue(response.body().contains("/v1/auth/register/finish"));
+  }
+
+  @Test
+  void enrollPagePromptsForAnOptionalPasskeyLabel() throws Exception {
+    var body = request("GET", "/enroll").body();
+    assertTrue(body.contains("id=\"label\""));
+    assertTrue(body.contains("Passkey name (optional)"));
+    assertTrue(body.contains("Create passkey"));
+    assertTrue(body.contains("label: label || null"));
+  }
+
+  @Test
+  void loginPageHasNoLabelPrompt() throws Exception {
+    assertFalse(request("GET", "/login").body().contains("id=\"label\""));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/FdeCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/FdeCommandTest.java
@@ -7,9 +7,28 @@ package ai.singlr.sail.commands;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.singlr.sail.auth.Passkeys;
+import ai.singlr.sail.store.WebauthnCredentialStore;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class FdeCommandTest {
+
+  private static WebauthnCredentialStore.Credential credential(String id, String label) {
+    return new WebauthnCredentialStore.Credential(
+        id.getBytes(StandardCharsets.UTF_8),
+        "fde-1",
+        new byte[] {1},
+        -7,
+        0,
+        null,
+        false,
+        false,
+        label,
+        "2026-07-06T10:15:30Z",
+        null);
+  }
 
   @Test
   void rosterEditOnNodeMessageNamesTheActionAndPointsAtMain() {
@@ -18,5 +37,34 @@ class FdeCommandTest {
     assertTrue(message.contains("main devbox"));
     assertTrue(message.contains("Run this on main"));
     assertTrue(message.contains("overwritten on the next sync"));
+  }
+
+  @Test
+  void passkeyNoMatchMessageListsRegisteredCredentials() {
+    var credentials = List.of(credential("alpha", "macbook"), credential("bravo", null));
+    var message = FdeCommand.Passkey.noMatchMessage("uday", "zz", credentials);
+    assertTrue(message.contains("No passkey of 'uday' matches 'zz'"));
+    assertTrue(message.contains(Passkeys.encodeId("alpha".getBytes(StandardCharsets.UTF_8))));
+    assertTrue(message.contains("macbook"));
+    assertTrue(message.contains("passkey · 2026-07-06"), "unlabeled rows show the default label");
+  }
+
+  @Test
+  void passkeyNoMatchMessagePointsAtEnrollWhenNoneRegistered() {
+    var message = FdeCommand.Passkey.noMatchMessage("uday", "zz", List.of());
+    assertTrue(message.contains("'uday' has no passkeys"));
+    assertTrue(message.contains("sail fde enroll uday"));
+  }
+
+  @Test
+  void passkeyAmbiguousMessageListsEveryCandidate() {
+    var candidates = List.of(credential("alpha-one", "a"), credential("alpha-two", "b"));
+    var message = FdeCommand.Passkey.ambiguousMessage("uday", "YWxwaGE", candidates);
+    assertTrue(message.contains("'YWxwaGE' matches 2 passkeys of 'uday'"));
+    assertTrue(message.contains("use a longer prefix"));
+    assertTrue(
+        message.contains(Passkeys.encodeId("alpha-one".getBytes(StandardCharsets.UTF_8))),
+        "candidates list full ids so one is always copy-pasteable");
+    assertTrue(message.contains(Passkeys.encodeId("alpha-two".getBytes(StandardCharsets.UTF_8))));
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/BannerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/BannerTest.java
@@ -15,6 +15,7 @@ import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.store.FdeSshKeyStore;
 import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.WebauthnCredentialStore;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
@@ -85,6 +86,53 @@ class BannerTest {
     assertTrue(text.contains("laptop"));
     assertTrue(text.contains("SHA256:abc"));
     assertTrue(text.contains("-"), "a missing comment renders as a dash");
+  }
+
+  @Test
+  void fdePasskeyTableShowsIdLabelAuthenticatorDatesAndSyncState() {
+    var out = new ByteArrayOutputStream();
+    var credentials =
+        List.of(
+            new WebauthnCredentialStore.Credential(
+                "alpha".getBytes(StandardCharsets.UTF_8),
+                "id1",
+                new byte[] {1},
+                -7,
+                0,
+                null,
+                true,
+                true,
+                "uday's macbook",
+                "2026-07-06T10:15:30Z",
+                "2026-07-07T08:00:00Z"),
+            new WebauthnCredentialStore.Credential(
+                "bravo".getBytes(StandardCharsets.UTF_8),
+                "id1",
+                new byte[] {1},
+                -7,
+                0,
+                null,
+                false,
+                false,
+                null,
+                "2026-01-02T00:00:00Z",
+                null));
+
+    Banner.printFdePasskeyTable(
+        credentials, "uday", new PrintStream(out, true, StandardCharsets.UTF_8), Ansi.OFF);
+    var text = out.toString(StandardCharsets.UTF_8);
+
+    assertTrue(text.contains("Passkeys: uday"));
+    assertTrue(text.contains("LABEL"));
+    assertTrue(text.contains("AUTHENTICATOR"));
+    assertTrue(text.contains("SYNCED"));
+    assertTrue(text.contains("uday's macbook"));
+    assertTrue(text.contains("passkey · 2026-01-02"), "unlabeled rows show the default label");
+    assertTrue(text.contains("2026-07-06"));
+    assertTrue(text.contains("2026-07-07"));
+    assertTrue(text.contains("yes"));
+    assertTrue(text.contains("no"));
+    assertTrue(text.contains("-"), "a never-used passkey renders last-used as a dash");
   }
 
   @Test


### PR DESCRIPTION
## Problem

`webauthn_credentials` had no management surface: no delete in the store, nothing lists an FDE's passkeys, and the only revocation was `sail fde rm` — whose cascade destroys the whole identity (keys, tokens, sessions). "I lost my MacBook" must not require deleting the FDE.

## What this adds

**CLI only — no new HTTP routes.** From the Mac thin client the commands ride the existing SSH command-forwarding lane.

- `sail fde passkey list <handle>` — bordered table with id prefix, label, authenticator (well-known AAGUID name), created, last used, and backup/sync state.
- `sail fde passkey rm <handle> --credential <id-prefix> [--revoke-sessions]` — git-style unambiguous prefix match. Unknown or ambiguous prefixes fail listing the candidates with **full** credential ids, so the error is always copy-pasteable. Deleting the last credential is allowed and prints the re-enroll hint.
- **Session semantics, pinned by tests:** deleting a credential does NOT invalidate sessions it minted (they hang off the fde and expire on their own TTL). `--revoke-sessions` purges the FDE's sessions for the lost-device case; the output states exactly which of the two happened.
- **Authorization on the pinned gateway handle:** `fde` remains admin-gated over SSH, with one self-service carve-out — any active FDE may `fde passkey list|rm` its **own** handle (compared against the `_gateway --fde` handle pinned to the calling key; option-first spellings fail closed). Direct host-CLI use stays unrestricted as today.
- **Device-descriptive labels:** the enroll page now prompts for an optional passkey name and the ceremony is button-gated; a skipped prompt defaults to authenticator + enrollment date (`iCloud Keychain · 2026-07-06`) so a list of one FDE's credentials can answer "which one is the lost laptop?". The WebAuthn user entity (handle / display name / rp "Sail") is untouched.
- **Store:** `WebauthnCredentialStore.delete(credentialId)`; the existing `Credential` view already carries label, created_at, last_used_at, aaguid, backup_state end to end.
- **Docs:** ARCHITECTURE.md notes passkeys are box-local by design — identity syncs via the roster; credentials are RP-scoped and never leave the box.

## Verification

- `mvn clean verify` green (1995 tests in sail-infra reactor, all jacoco gates met, including 100% line/method on `ai.singlr.sail.api.*`).
- New pure domain class `Passkeys` (AAGUID naming, default labels, prefix resolution) at 100% line+method.
- Exercised end-to-end against a scratch control-plane DB: list table rendering, ambiguous-prefix error with full-id candidates, unknown-prefix error, lost-device `rm --revoke-sessions` (session count reported), last-credential re-enroll hint, empty-list hint.

No new dependencies.