### PR TITLE
Periodic missed-stop sweep: orphaned sessions reconcile without a restart

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/EventStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/EventStore.java
@@ -61,6 +61,16 @@ public final class EventStore {
         specId);
   }
 
+  public List<EventRow> forSpecAndType(String specId, String type) {
+    return db.query(
+        """
+        SELECT id, timestamp, type, project, spec_id, agent, host, data
+        FROM events WHERE spec_id = ? AND type = ? ORDER BY id ASC""",
+        this::mapEvent,
+        specId,
+        type);
+  }
+
   public List<EventRow> since(long afterId, int limit) {
     return db.query(
         """

--- a/sail-core/src/main/java/ai/singlr/sail/store/MissedStops.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MissedStops.java
@@ -5,51 +5,90 @@
 
 package ai.singlr.sail.store;
 
-import ai.singlr.sail.config.SpecStatus;
-import java.util.List;
-import java.util.Optional;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.Set;
-import java.util.function.Function;
 
 /**
- * Finds specs whose agent already finished but whose stop never advanced them — the {@code
- * agent_session_stopped} was lost because the control plane was down when the agent exited. The
- * authoritative signal is the session: a spec still {@code in_progress} whose latest session is
- * terminal ({@code stopped}/{@code completed}) means the run ended without the loop reacting.
- * Replaying a stop for it lets the normal review (or failure) path run at startup, rather than
- * waiting on the stranded-spec sweep.
+ * Decides whether an {@code in_progress} spec's latest agent session needs a stop replayed — the
+ * agent already finished but no live observer advanced the spec, so without intervention it strands
+ * until the very-long-horizon stuck-spec alarm. The session, not the spec, is the anchor: a
+ * terminal session means the run ended and the loop never reacted; a still-{@code running} session
+ * may hide an agent that died without any stop signal at all (watcher killed by a daemon restart,
+ * hook never fired), which only a systemd liveness probe can confirm.
  *
- * <p>Only {@code in_progress} specs are considered. A clean replay advances the spec out of {@code
- * in_progress} so it is not re-picked on the next start; a crash leaves it {@code in_progress} (its
- * failure already recorded on the session) where it is correctly still unresolved. A spec already
- * past the gate ({@code review}, {@code awaiting_merge}, {@code done}) is never replayed — a replay
- * would re-run a review it already passed.
+ * <p>A session already covered by an <em>authoritative</em> stop — one carrying a {@code source},
+ * i.e. from the watcher or an earlier reconciler pass — is always skipped: either the pipeline
+ * consumed it (a failure verdict deliberately leaves the spec {@code in_progress}, and a fix
+ * iteration legitimately re-enters {@code in_progress} mid-review), or it is still in flight.
+ * Replaying over it would duplicate failure events or spawn a competing review. A raw turn-end hook
+ * stop carries no {@code source} and never blocks a replay — losing exactly the authoritative
+ * signal is the failure being repaired.
  */
 public final class MissedStops {
 
   private static final Set<String> TERMINAL = Set.of("stopped", "completed");
 
-  /** A spec to replay a stop for, carrying the exit code its finished session recorded. */
-  public record Replay(SpecStore.SpecRow spec, Integer exitCode) {}
+  /** What one reconciliation pass should do for a spec's latest session. */
+  public sealed interface Outcome {
+
+    /** Replay the stop the loop missed, carrying the exit code the session recorded (nullable). */
+    record ReplayStop(Integer exitCode, String why) implements Outcome {}
+
+    /**
+     * The session still claims to be running: probe the agent's systemd unit and synthesize a stop
+     * only if the unit is inactive or absent. The exit code of a vanished transient unit is
+     * unrecoverable, so the synthesized stop carries none — the same decision {@link ReplayStop}
+     * expresses for a terminal session without a recorded exit code.
+     */
+    record ProbeUnit(String why) implements Outcome {}
+
+    /** Leave the session alone. */
+    record Skip(String why) implements Outcome {}
+  }
 
   private MissedStops() {}
 
   /**
-   * @param specs candidate specs (non-{@code in_progress} ones are ignored)
-   * @param latestSession resolves a spec id to its most recent session, if any
+   * Assesses the latest session of an {@code in_progress} spec. Callers must pass the spec's most
+   * recent session — superseded sessions from restarts are never replayed — and whether an
+   * authoritative ({@code source}-carrying) stop has been recorded since the session started.
+   *
+   * <p>{@code grace} shields the dispatch launch window: dispatch claims the spec seconds before
+   * the systemd unit exists, so a young running session is never probed, let alone declared dead.
    */
-  public static List<Replay> find(
-      List<SpecStore.SpecRow> specs,
-      Function<String, Optional<SessionStore.SessionRow>> latestSession) {
-    return specs.stream()
-        .filter(spec -> spec.status() == SpecStatus.IN_PROGRESS)
-        .flatMap(
-            spec ->
-                latestSession
-                    .apply(spec.id())
-                    .filter(session -> TERMINAL.contains(session.status()))
-                    .map(session -> new Replay(spec, session.exitCode()))
-                    .stream())
-        .toList();
+  public static Outcome assess(
+      SessionStore.SessionRow session,
+      boolean authoritativeStopObserved,
+      Instant now,
+      Duration grace) {
+    if (authoritativeStopObserved) {
+      return new Outcome.Skip("an authoritative stop is already recorded");
+    }
+    if (TERMINAL.contains(session.status())) {
+      return new Outcome.ReplayStop(session.exitCode(), "finished session never advanced its spec");
+    }
+    if (!"running".equals(session.status())) {
+      return new Outcome.Skip("session status is " + session.status());
+    }
+    var age = Duration.between(parseOr(session.startedAt(), now), now);
+    if (age.compareTo(grace) < 0) {
+      return new Outcome.Skip("session is inside the launch grace period");
+    }
+    return new Outcome.ProbeUnit(
+        "running session with no stop signal after " + age.toMinutes() + "m");
+  }
+
+  /** Parses an ISO instant, falling back when the value is missing or malformed. */
+  public static Instant parseOr(String iso, Instant fallback) {
+    if (iso == null || iso.isBlank()) {
+      return fallback;
+    }
+    try {
+      return Instant.parse(iso);
+    } catch (DateTimeParseException e) {
+      return fallback;
+    }
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -355,7 +355,8 @@ public final class SchemaManager {
                   rev, base_rev FROM specs""",
           "DROP TABLE specs",
           "ALTER TABLE specs_v2 RENAME TO specs",
-          "CREATE INDEX IF NOT EXISTS idx_specs_project ON specs(project)");
+          "CREATE INDEX IF NOT EXISTS idx_specs_project ON specs(project)",
+          "ALTER TABLE agent_sessions ADD COLUMN watcher_pid INTEGER");
 
   /**
    * The last schema version whose {@code specs.status} CHECK predates {@code awaiting_merge}. The

--- a/sail-core/src/main/java/ai/singlr/sail/store/SessionStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SessionStore.java
@@ -17,7 +17,8 @@ import java.util.Optional;
 public final class SessionStore {
 
   private static final String COLUMNS =
-      "id, project, spec_id, agent, branch, task, pid, status, started_at, completed_at, exit_code";
+      "id, project, spec_id, agent, branch, task, pid, status, started_at, completed_at,"
+          + " exit_code, watcher_pid";
 
   private final Sqlite db;
 
@@ -36,15 +37,28 @@ public final class SessionStore {
       String status,
       String startedAt,
       String completedAt,
-      Integer exitCode) {}
+      Integer exitCode,
+      Integer watcherPid) {}
 
   public String create(
       String project, String specId, String agent, String branch, String task, Integer pid) {
+    return create(project, specId, agent, branch, task, pid, null);
+  }
+
+  /** As the simpler overload, also recording the host-side guardrail watcher's pid (nullable). */
+  public String create(
+      String project,
+      String specId,
+      String agent,
+      String branch,
+      String task,
+      Integer pid,
+      Integer watcherPid) {
     var id = DateTimeUtils.newId().toString();
     db.execute(
         """
-        INSERT INTO agent_sessions (id, project, spec_id, agent, branch, task, pid, status, started_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, 'running', ?)""",
+        INSERT INTO agent_sessions (id, project, spec_id, agent, branch, task, pid, status, started_at, watcher_pid)
+        VALUES (?, ?, ?, ?, ?, ?, ?, 'running', ?, ?)""",
         id,
         project,
         specId,
@@ -52,7 +66,8 @@ public final class SessionStore {
         branch,
         task,
         pid != null ? pid.longValue() : null,
-        DateTimeUtils.now().toString());
+        DateTimeUtils.now().toString(),
+        watcherPid != null ? watcherPid.longValue() : null);
     return id;
   }
 
@@ -118,6 +133,14 @@ public final class SessionStore {
         id);
   }
 
+  /** Records the pid of the guardrail watcher currently covering this session. */
+  public void updateWatcherPid(String id, Integer watcherPid) {
+    db.execute(
+        "UPDATE agent_sessions SET watcher_pid = ? WHERE id = ?",
+        watcherPid != null ? watcherPid.longValue() : null,
+        id);
+  }
+
   private SessionRow mapSession(Sqlite.Row row) {
     return new SessionRow(
         row.text(0),
@@ -130,6 +153,7 @@ public final class SessionStore {
         row.text(7),
         row.text(8),
         row.text(9),
-        row.isNull(10) ? null : (int) row.integer(10));
+        row.isNull(10) ? null : (int) row.integer(10),
+        row.isNull(11) ? null : (int) row.integer(11));
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/store/EventStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/EventStoreTest.java
@@ -87,6 +87,19 @@ class EventStoreTest {
   }
 
   @Test
+  void forSpecAndTypeFiltersOnBothAndKeepsInsertionOrder() {
+    store.insert(event("stopped", "backend", "auth"));
+    store.insert(event("started", "backend", "auth"));
+    store.insert(event("stopped", "backend", "payment"));
+    store.insert(event("stopped", "backend", "auth"));
+
+    var events = store.forSpecAndType("auth", "stopped");
+    assertEquals(2, events.size());
+    assertTrue(events.getFirst().id() < events.getLast().id());
+    assertTrue(store.forSpecAndType("auth", "missing").isEmpty());
+  }
+
+  @Test
   void sinceReturnsEventsAfterGivenId() {
     var id1 = store.insert(event("first", "p", null));
     var id2 = store.insert(event("second", "p", null));

--- a/sail-core/src/test/java/ai/singlr/sail/store/MissedStopsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/MissedStopsTest.java
@@ -6,141 +6,116 @@
 package ai.singlr.sail.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import ai.singlr.sail.config.SpecStatus;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.time.Duration;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 class MissedStopsTest {
 
-  private static SpecStore.SpecRow spec(String id, SpecStatus status) {
-    return new SpecStore.SpecRow(
-        id,
-        "acme",
-        "T",
-        status,
-        null,
-        "claude-code",
-        null,
-        null,
-        null,
-        0,
-        "me",
-        null,
-        null,
-        "me",
-        List.of(),
-        List.of());
-  }
+  private static final Instant NOW = Instant.parse("2026-07-06T12:00:00Z");
+  private static final Duration GRACE = Duration.ofMinutes(2);
 
-  private static SessionStore.SessionRow session(String specId, String status, Integer exitCode) {
+  private static SessionStore.SessionRow session(
+      String status, Integer exitCode, String startedAt) {
     return new SessionStore.SessionRow(
-        "s-" + specId,
+        "s-auth",
         "acme",
-        specId,
+        "auth",
         "claude-code",
         null,
         null,
         null,
         status,
-        "t0",
-        "t1",
-        exitCode);
+        startedAt,
+        null,
+        exitCode,
+        null);
   }
 
-  private static java.util.function.Function<String, Optional<SessionStore.SessionRow>> latest(
-      Map<String, SessionStore.SessionRow> byId) {
-    return id -> Optional.ofNullable(byId.get(id));
+  private static MissedStops.Outcome assess(SessionStore.SessionRow session, boolean observed) {
+    return MissedStops.assess(session, observed, NOW, GRACE);
   }
 
   @Test
-  void replaysAnInProgressSpecWhoseSessionStoppedCleanly() {
-    var replays =
-        MissedStops.find(
-            List.of(spec("auth", SpecStatus.IN_PROGRESS)),
-            latest(Map.of("auth", session("auth", "stopped", 0))));
+  void replaysACleanlyStoppedSessionWithItsExitCode() {
+    var outcome = assess(session("stopped", 0, "2026-07-06T11:00:00Z"), false);
 
-    assertEquals(1, replays.size());
-    assertEquals("auth", replays.getFirst().spec().id());
-    assertEquals(0, replays.getFirst().exitCode());
+    var replay = assertInstanceOf(MissedStops.Outcome.ReplayStop.class, outcome);
+    assertEquals(0, replay.exitCode());
   }
 
   @Test
   void carriesTheExitCodeOfACrashedSession() {
-    var replays =
-        MissedStops.find(
-            List.of(spec("auth", SpecStatus.IN_PROGRESS)),
-            latest(Map.of("auth", session("auth", "stopped", 137))));
+    var outcome = assess(session("stopped", 137, "2026-07-06T11:00:00Z"), false);
 
-    assertEquals(137, replays.getFirst().exitCode());
+    assertEquals(137, assertInstanceOf(MissedStops.Outcome.ReplayStop.class, outcome).exitCode());
   }
 
   @Test
-  void treatsCompletedAsTerminalToo() {
-    var replays =
-        MissedStops.find(
-            List.of(spec("auth", SpecStatus.IN_PROGRESS)),
-            latest(Map.of("auth", session("auth", "completed", null))));
+  void treatsCompletedAsTerminalAndToleratesAMissingExitCode() {
+    var outcome = assess(session("completed", null, "2026-07-06T11:00:00Z"), false);
 
-    assertEquals(1, replays.size());
+    assertNull(assertInstanceOf(MissedStops.Outcome.ReplayStop.class, outcome).exitCode());
   }
 
   @Test
-  void neverReplaysASpecAlreadyPastTheGate() {
-    var replays =
-        MissedStops.find(
-            List.of(spec("parked", SpecStatus.AWAITING_MERGE)),
-            latest(Map.of("parked", session("parked", "stopped", 0))));
+  void anAuthoritativeStopAlreadyRecordedSkipsEvenATerminalSession() {
+    var outcome = assess(session("stopped", 137, "2026-07-06T11:00:00Z"), true);
 
-    assertTrue(replays.isEmpty());
+    assertInstanceOf(MissedStops.Outcome.Skip.class, outcome);
   }
 
   @Test
-  void ignoresASpecWhoseSessionIsStillRunning() {
-    var replays =
-        MissedStops.find(
-            List.of(spec("auth", SpecStatus.IN_PROGRESS)),
-            latest(Map.of("auth", session("auth", "running", null))));
+  void anAuthoritativeStopAlreadyRecordedSkipsARunningSession() {
+    var outcome = assess(session("running", null, "2026-07-06T11:00:00Z"), true);
 
-    assertTrue(replays.isEmpty());
+    assertInstanceOf(MissedStops.Outcome.Skip.class, outcome);
   }
 
   @Test
-  void ignoresASpecWithNoSession() {
-    var replays = MissedStops.find(List.of(spec("auth", SpecStatus.IN_PROGRESS)), latest(Map.of()));
+  void aRunningSessionPastTheGracePeriodIsProbed() {
+    var outcome = assess(session("running", null, "2026-07-06T11:57:59Z"), false);
 
-    assertTrue(replays.isEmpty());
+    assertInstanceOf(MissedStops.Outcome.ProbeUnit.class, outcome);
   }
 
   @Test
-  void ignoresSpecsThatAreNotInProgress() {
-    var replays =
-        MissedStops.find(
-            List.of(spec("auth", SpecStatus.REVIEW), spec("done", SpecStatus.DONE)),
-            latest(
-                Map.of(
-                    "auth", session("auth", "stopped", 0),
-                    "done", session("done", "stopped", 0))));
+  void aRunningSessionInsideTheGracePeriodIsLeftAlone() {
+    var outcome = assess(session("running", null, "2026-07-06T11:59:50Z"), false);
 
-    assertTrue(replays.isEmpty());
+    assertInstanceOf(MissedStops.Outcome.Skip.class, outcome);
   }
 
   @Test
-  void surfacesOnlyTheStrandedSpecAmongMany() {
-    var replays =
-        MissedStops.find(
-            List.of(
-                spec("stuck", SpecStatus.IN_PROGRESS),
-                spec("active", SpecStatus.IN_PROGRESS),
-                spec("fresh", SpecStatus.IN_PROGRESS)),
-            latest(
-                Map.of(
-                    "stuck", session("stuck", "stopped", 0),
-                    "active", session("active", "running", null))));
+  void aSessionExactlyAtTheGraceBoundaryIsProbed() {
+    var outcome = assess(session("running", null, "2026-07-06T11:58:00Z"), false);
 
-    assertEquals(List.of("stuck"), replays.stream().map(r -> r.spec().id()).toList());
+    assertInstanceOf(MissedStops.Outcome.ProbeUnit.class, outcome);
+  }
+
+  @Test
+  void aRunningSessionWithAnUnparseableStartIsTreatedAsFreshlyLaunched() {
+    var outcome = assess(session("running", null, "not-a-timestamp"), false);
+
+    assertInstanceOf(MissedStops.Outcome.Skip.class, outcome);
+  }
+
+  @Test
+  void aFailedStatusSessionIsNeverReplayed() {
+    var outcome = assess(session("failed", 1, "2026-07-06T11:00:00Z"), false);
+
+    assertInstanceOf(MissedStops.Outcome.Skip.class, outcome);
+  }
+
+  @Test
+  void parseOrFallsBackOnNullBlankAndGarbage() {
+    var fallback = Instant.EPOCH;
+    assertEquals(fallback, MissedStops.parseOr(null, fallback));
+    assertEquals(fallback, MissedStops.parseOr("  ", fallback));
+    assertEquals(fallback, MissedStops.parseOr("garbage", fallback));
+    assertEquals(NOW, MissedStops.parseOr("2026-07-06T12:00:00Z", fallback));
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/store/SessionStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SessionStoreTest.java
@@ -60,6 +60,30 @@ class SessionStoreTest {
     assertNull(session.branch());
     assertNull(session.task());
     assertNull(session.pid());
+    assertNull(session.watcherPid());
+  }
+
+  @Test
+  void createRecordsTheWatcherPid() {
+    var id = store.create("backend", "auth", "claude-code", null, null, 1234, 5678);
+
+    assertEquals(5678, store.findById(id).orElseThrow().watcherPid());
+  }
+
+  @Test
+  void updateWatcherPidReplacesTheRecordedWatcher() {
+    var id = store.create("backend", "auth", "claude-code", null, null, 1234, 5678);
+    store.updateWatcherPid(id, 9012);
+
+    assertEquals(9012, store.findById(id).orElseThrow().watcherPid());
+  }
+
+  @Test
+  void updateWatcherPidClearsWhenNull() {
+    var id = store.create("backend", "auth", "claude-code", null, null, 1234, 5678);
+    store.updateWatcherPid(id, null);
+
+    assertNull(store.findById(id).orElseThrow().watcherPid());
   }
 
   @Test

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentReporterTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentReporterTest.java
@@ -242,7 +242,8 @@ class AgentReporterTest {
             "completed",
             start.toString(),
             end.toString(),
-            0);
+            0,
+            null);
     var shell =
         new ScriptedShellExecutor()
             .onFail("cat /home/dev/.sail/agent.pid", "No such file")
@@ -274,7 +275,8 @@ class AgentReporterTest {
             "stopped",
             start.toString(),
             Instant.now().toString(),
-            137);
+            137,
+            null);
     var shell =
         new ScriptedShellExecutor()
             .onFail("cat /home/dev/.sail/agent.pid", "No such file")

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
@@ -96,11 +96,17 @@ public record Event(
     /** {@link #SOURCE} value: the guardrail watcher, which observed the process exit code. */
     public static final String SOURCE_WATCHER = "watcher";
 
-    /** {@link #SOURCE} value: startup replay of a stop missed while the control plane was down. */
-    public static final String SOURCE_STARTUP_RECONCILE = "startup-reconcile";
+    /**
+     * {@link #SOURCE} value: a reconciler replay of a stop the control plane missed — at daemon
+     * start or from the periodic missed-stop sweep. Marks the stop as reconstructed, not observed.
+     */
+    public static final String SOURCE_RECONCILE = "reconcile";
 
     /** The agent process's exit code, carried on an authoritative stop. */
     public static final String EXIT_CODE = "exit_code";
+
+    /** Host pid of the guardrail watcher covering a dispatched session, carried on its start. */
+    public static final String WATCHER_PID = "watcher_pid";
 
     private WellKnownData() {}
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -5,78 +5,233 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.HostInfo;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.store.EventStore;
 import ai.singlr.sail.store.MissedStops;
 import ai.singlr.sail.store.SessionStore;
 import ai.singlr.sail.store.SpecStore;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 /**
- * One-shot startup recovery: replays the stop events that were lost while the control plane was
- * down. For every {@code in_progress} spec whose latest session already finished (see {@link
- * MissedStops}), it publishes a synthetic {@code agent_session_stopped} — carrying the session's
- * exit code — onto the bus, so the same subscribers that handle a live stop ({@link
- * ReviewPipelineController}, {@link SessionTracker}) drive the spec to its real outcome instead of
- * leaving it parked until the stranded-spec sweep.
+ * Replays the {@code agent_session_stopped} events the control plane missed, so the subscribers
+ * that handle a live stop ({@link ReviewPipelineController}, {@link SessionTracker}) drive each
+ * orphaned spec to its real outcome instead of leaving it parked until the stranded-spec alarm. One
+ * routine serves two callers: the daemon start hook runs a pass immediately, and {@link #start}
+ * repeats the same pass periodically, so an agent that finishes unobserved mid-run (its watcher
+ * died with a daemon restart or crashed) is reconciled within a sweep interval instead of requiring
+ * another restart.
  *
- * <p>Run after the bus subscribers are wired, once, at server start.
+ * <p>Each pass walks the {@code in_progress} specs and applies {@link MissedStops#assess} to the
+ * latest session — database-only checks first, so a pass with nothing to reconcile issues no
+ * systemctl calls. A terminal session replays the stop with its recorded exit code. A running
+ * session past the launch grace period whose systemd unit is inactive or absent gets a synthesized
+ * stop with <em>no exit code</em>: the transient unit is garbage-collected on exit, so the real
+ * code is unrecoverable, and the replay path makes the same choice for a terminal session that
+ * never recorded one — the pipeline treats the absent code as not-a-failure and lets review judge
+ * the work. Every replayed stop carries {@code source=reconcile} so the event log shows it was
+ * reconstructed, not observed.
+ *
+ * <p>Best-effort by design: a failing spec is logged and skipped, a failing pass is logged and
+ * retried on the next tick, and passes never overlap. Run after the bus subscribers are wired.
  */
-public final class MissedStopReconciler {
+public final class MissedStopReconciler implements AutoCloseable {
+
+  /** Sweep cadence: prompt enough that an orphaned run resumes its lifecycle within a minute. */
+  public static final Duration DEFAULT_INTERVAL = Duration.ofSeconds(60);
+
+  /**
+   * How old a running session must be before its unit may be probed: dispatch claims the spec
+   * seconds before the unit exists, and a sweep landing in that window must not declare a
+   * never-started agent dead.
+   */
+  public static final Duration LAUNCH_GRACE = Duration.ofMinutes(2);
 
   private static final SpecStore.SpecFilter IN_PROGRESS =
       new SpecStore.SpecFilter(null, "in_progress", null, null, null);
 
+  /** Answers whether a project's agent systemd unit is still active. */
+  @FunctionalInterface
+  public interface UnitProbe {
+    boolean active(String project) throws Exception;
+  }
+
   private final SpecStore specStore;
   private final SessionStore sessionStore;
+  private final EventStore eventStore;
   private final EventBus bus;
+  private final UnitProbe unitProbe;
+  private final Supplier<Instant> clock;
+  private final ScheduledExecutorService scheduler;
+  private final AtomicBoolean sweeping = new AtomicBoolean();
 
-  public MissedStopReconciler(SpecStore specStore, SessionStore sessionStore, EventBus bus) {
+  public MissedStopReconciler(
+      SpecStore specStore,
+      SessionStore sessionStore,
+      EventStore eventStore,
+      EventBus bus,
+      UnitProbe unitProbe,
+      Supplier<Instant> clock) {
     this.specStore = specStore;
     this.sessionStore = sessionStore;
+    this.eventStore = eventStore;
     this.bus = bus;
+    this.unitProbe = unitProbe;
+    this.clock = clock;
+    this.scheduler =
+        Executors.newSingleThreadScheduledExecutor(
+            Thread.ofVirtual().name("sail-missed-stop-", 0).factory());
   }
 
   /**
-   * Replays a stop for each spec with a missed one. Best-effort: a store error is logged and
-   * swallowed so reconciliation can never block server startup — anything it misses is still caught
-   * by the stranded-spec sweep. Returns how many stops were replayed.
+   * Probes the agent unit through systemd — the authoritative liveness source. A transient unit
+   * vanishes after a clean exit, and systemd reports an absent unit as {@code inactive}, so absent
+   * counts as dead; conversely a probe that cannot reach the container reports active, biasing the
+   * sweep toward doing nothing when it cannot know.
    */
-  public int reconcile() {
+  public static UnitProbe systemdUnitProbe(ShellExec shell) {
+    var agentSession = new AgentSession(shell);
+    return project -> agentSession.queryExitStatus(project).active();
+  }
+
+  /** Starts the periodic sweep at the default cadence. */
+  public void start() {
+    start(DEFAULT_INTERVAL);
+  }
+
+  public void start(Duration interval) {
+    scheduler.scheduleAtFixedRate(
+        this::sweepIfIdle, interval.toMillis(), interval.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Runs one pass unless another is still in flight (a slow probe must not stack passes). Returns
+   * whether the pass ran; never throws, so the schedule survives any failure.
+   */
+  boolean sweepIfIdle() {
+    if (!sweeping.compareAndSet(false, true)) {
+      return false;
+    }
+    try {
+      sweep();
+    } finally {
+      sweeping.set(false);
+    }
+    return true;
+  }
+
+  /**
+   * Runs one reconciliation pass and returns how many stops were replayed. Errors are logged and
+   * swallowed — per spec so one broken project cannot shadow the rest, and around the pass so
+   * reconciliation can never block server startup; anything missed is retried on the next sweep and
+   * ultimately caught by the stranded-spec alarm.
+   */
+  public int sweep() {
     var replayed = 0;
     try {
-      var replays =
-          MissedStops.find(
-              specStore.list(IN_PROGRESS),
-              specId -> sessionStore.listForSpec(specId).stream().findFirst());
-      for (var replay : replays) {
-        var spec = replay.spec();
-        System.err.println(
-            "  [startup] replaying missed stop for "
-                + spec.project()
-                + "/"
-                + spec.id()
-                + (replay.exitCode() != null ? " (exit " + replay.exitCode() + ")" : ""));
-        bus.publish(stopEvent(replay));
-        replayed++;
+      for (var spec : specStore.list(IN_PROGRESS)) {
+        try {
+          replayed += reconcile(spec) ? 1 : 0;
+        } catch (Exception e) {
+          System.err.println(
+              "  [reconcile] failed for "
+                  + spec.project()
+                  + "/"
+                  + spec.id()
+                  + ": "
+                  + e.getMessage());
+        }
       }
     } catch (Exception e) {
-      System.err.println("  [startup] missed-stop reconciliation aborted: " + e.getMessage());
+      System.err.println("  [reconcile] missed-stop sweep aborted: " + e.getMessage());
     }
     return replayed;
   }
 
-  static Event stopEvent(MissedStops.Replay replay) {
-    var spec = replay.spec();
+  private boolean reconcile(SpecStore.SpecRow spec) throws Exception {
+    var latest = sessionStore.listForSpec(spec.id()).stream().findFirst();
+    if (latest.isEmpty()) {
+      return false;
+    }
+    var session = latest.get();
+    var observed = authoritativeStopObserved(spec.id(), session.startedAt());
+    var outcome = MissedStops.assess(session, observed, clock.get(), LAUNCH_GRACE);
+    return switch (outcome) {
+      case MissedStops.Outcome.ReplayStop replay -> {
+        publishStop(spec, session, replay.exitCode(), replay.why());
+        yield true;
+      }
+      case MissedStops.Outcome.ProbeUnit probe -> {
+        if (unitProbe.active(spec.project())) {
+          yield false;
+        }
+        publishStop(spec, session, null, "unit inactive or gone; " + probe.why());
+        yield true;
+      }
+      case MissedStops.Outcome.Skip ignored -> false;
+    };
+  }
+
+  /**
+   * Whether an authoritative ({@code source}-carrying) stop for this spec has been recorded since
+   * the session started. Such a stop means the watcher (or an earlier pass) already covered this
+   * session; replaying over it would duplicate its outcome. Unreadable rows count as covering — the
+   * sweep must prefer doing nothing over acting on data it cannot interpret.
+   */
+  private boolean authoritativeStopObserved(String specId, String startedAt) {
+    var since = MissedStops.parseOr(startedAt, Instant.MIN);
+    return eventStore.forSpecAndType(specId, Event.WellKnownTypes.AGENT_SESSION_STOPPED).stream()
+        .anyMatch(row -> carriesSource(row) && !timestampOf(row).isBefore(since));
+  }
+
+  private static boolean carriesSource(EventStore.EventRow row) {
+    try {
+      return YamlUtil.parseMap(row.data()).get(Event.WellKnownData.SOURCE) != null;
+    } catch (Exception e) {
+      return true;
+    }
+  }
+
+  private static Instant timestampOf(EventStore.EventRow row) {
+    return MissedStops.parseOr(row.timestamp(), Instant.MAX);
+  }
+
+  private void publishStop(
+      SpecStore.SpecRow spec, SessionStore.SessionRow session, Integer exitCode, String why) {
+    System.err.println(
+        "  [reconcile] replaying missed stop for "
+            + spec.project()
+            + "/"
+            + spec.id()
+            + " (session "
+            + session.id()
+            + ", exit "
+            + (exitCode != null ? exitCode : "unknown")
+            + "): "
+            + why);
+    bus.publish(stopEvent(spec, exitCode));
+  }
+
+  static Event stopEvent(SpecStore.SpecRow spec, Integer exitCode) {
     var agent = spec.agent() != null ? spec.agent() : Event.SAIL_AGENT;
     var data =
-        replay.exitCode() != null
+        exitCode != null
             ? Map.<String, Object>of(
                 Event.WellKnownData.EXIT_CODE,
-                replay.exitCode(),
+                exitCode,
                 Event.WellKnownData.SOURCE,
-                Event.WellKnownData.SOURCE_STARTUP_RECONCILE)
+                Event.WellKnownData.SOURCE_RECONCILE)
             : Map.<String, Object>of(
-                Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_STARTUP_RECONCILE);
+                Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_RECONCILE);
     return Event.of(
         spec.project(),
         spec.id(),
@@ -84,5 +239,10 @@ public final class MissedStopReconciler {
         agent,
         HostInfo.hostname(),
         data);
+  }
+
+  @Override
+  public void close() {
+    scheduler.close();
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -42,6 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.TreeMap;
 import java.util.function.Supplier;
 
@@ -380,11 +381,19 @@ public final class SailApiOperations implements ApiOperations {
     var branchCreated = createBranchIfNeeded(project, loaded.config(), targetRepos, branch);
 
     if (!request.dryRun()) {
-      launchAgent(
-          project, loaded.config(), targetRepos, task, branch, request.mode(), taskSpec, agentType);
+      var watcherPid =
+          launchAgent(
+              project,
+              loaded.config(),
+              targetRepos,
+              task,
+              branch,
+              request.mode(),
+              taskSpec,
+              agentType);
       var status = querySession(agentSession, project);
       if (status != null && status.running()) {
-        publishAgentSessionStarted(project, nextSpec.id(), agentType, status.pid());
+        publishAgentSessionStarted(project, nextSpec.id(), agentType, status.pid(), watcherPid);
       }
       return new DispatchResponse(
           project,
@@ -441,13 +450,16 @@ public final class SailApiOperations implements ApiOperations {
   }
 
   private void publishAgentSessionStarted(
-      String project, String specId, String agentType, Integer pid) {
+      String project, String specId, String agentType, Integer pid, OptionalLong watcherPid) {
     if (eventBus == null) {
       return;
     }
     var data = new LinkedHashMap<String, Object>();
     if (pid != null) {
       data.put("pid", pid);
+    }
+    if (watcherPid.isPresent()) {
+      data.put(Event.WellKnownData.WATCHER_PID, watcherPid.getAsLong());
     }
     eventBus.publish(
         Event.of(
@@ -665,7 +677,7 @@ public final class SailApiOperations implements ApiOperations {
     return created;
   }
 
-  private void launchAgent(
+  private OptionalLong launchAgent(
       String project,
       SailYaml config,
       List<SailYaml.Repo> targetRepos,
@@ -709,7 +721,7 @@ public final class SailApiOperations implements ApiOperations {
       if (!result.ok()) {
         throw new ApiException(ErrorCode.AGENT_LAUNCH_FAILED, "Failed to launch agent.");
       }
-      launchWatcherIfGuardrails(project, config);
+      return launchWatcherIfGuardrails(project, config);
     } catch (Exception e) {
       throw new ApiException(ErrorCode.AGENT_LAUNCH_FAILED, "Failed to launch agent.", e);
     }
@@ -727,9 +739,22 @@ public final class SailApiOperations implements ApiOperations {
     }
   }
 
-  private void launchWatcherIfGuardrails(String project, SailYaml config) throws IOException {
+  /**
+   * Relaunches the guardrail watcher for a project whose original watcher died (e.g. with a daemon
+   * restart mid-run). The relaunched {@code sail agent watch} recomputes its deadlines from the
+   * session's original {@code started_at} inside the container, so a re-armed agent keeps its
+   * remaining budget rather than getting a fresh one. Returns the new watcher pid, or empty when
+   * the project declares no guardrails (no watcher existed to re-arm).
+   */
+  public OptionalLong relaunchWatcher(String project) throws IOException {
+    var loaded = loadProject(project);
+    return launchWatcherIfGuardrails(project, loaded.config());
+  }
+
+  private OptionalLong launchWatcherIfGuardrails(String project, SailYaml config)
+      throws IOException {
     if (config.agent() == null || config.agent().guardrails() == null) {
-      return;
+      return OptionalLong.empty();
     }
     var cmd =
         List.of(
@@ -742,14 +767,15 @@ public final class SailApiOperations implements ApiOperations {
             SailPaths.resolveSailYaml(project, file).toAbsolutePath().toString());
     var watchLog = SailPaths.projectDir(project).resolve("watch.log");
     Files.createDirectories(watchLog.getParent());
-    watcherLauncher.launch(cmd, watchLog);
+    return OptionalLong.of(watcherLauncher.launch(cmd, watchLog));
   }
 
-  static void launchWatcherProcess(List<String> command, Path logPath) throws IOException {
-    new ProcessBuilder(command)
+  static long launchWatcherProcess(List<String> command, Path logPath) throws IOException {
+    return new ProcessBuilder(command)
         .redirectOutput(ProcessBuilder.Redirect.to(logPath.toFile()))
         .redirectErrorStream(true)
-        .start();
+        .start()
+        .pid();
   }
 
   private static boolean shouldSnapshot(SnapshotManager snapMgr, String project) {
@@ -994,8 +1020,9 @@ public final class SailApiOperations implements ApiOperations {
 
   private record LoadedProject(SailYaml config, ContainerState state) {}
 
+  /** Spawns the host-side guardrail watcher process and returns its pid. */
   @FunctionalInterface
   interface WatcherLauncher {
-    void launch(List<String> command, Path logPath) throws IOException;
+    long launch(List<String> command, Path logPath) throws IOException;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SessionTracker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SessionTracker.java
@@ -65,10 +65,12 @@ public final class SessionTracker implements EventSubscriber {
   private void handleStarted(Event event) {
     var data = event.data();
     var pid = extractInt(data, "pid");
+    var watcherPid = extractInt(data, Event.WellKnownData.WATCHER_PID);
     var task = (String) data.get("task");
     var branch = (String) data.get("branch");
     var sessionId =
-        sessionStore.create(event.project(), event.spec(), event.agent(), branch, task, pid);
+        sessionStore.create(
+            event.project(), event.spec(), event.agent(), branch, task, pid, watcherPid);
     activeSessionsByProject.put(event.project(), sessionId);
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/WatcherRearmer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/WatcherRearmer.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.store.SessionStore;
+import ai.singlr.sail.store.SpecStore;
+import java.util.OptionalLong;
+import java.util.function.LongPredicate;
+
+/**
+ * Daemon-start recovery for runs left unwatched: the guardrail watcher lives in the daemon's
+ * cgroup, so a restart mid-run kills it while the agent keeps going — no stall detection, no
+ * max-duration enforcement until the agent exits. For each {@code in_progress} spec whose latest
+ * session is still {@code running}, whose systemd unit is still active, and whose recorded watcher
+ * pid is dead, this relaunches the watcher against the existing unit. The relaunched {@code sail
+ * agent watch} reads the session's original {@code started_at} from the container and computes the
+ * wall-clock deadline from it, so an agent three hours into a four-hour budget gets the remaining
+ * hour, not a fresh four.
+ *
+ * <p>A session with no recorded watcher pid (a CLI-side dispatch, whose watcher is not tied to the
+ * daemon's lifetime, or a pre-upgrade row) cannot be verified as uncovered; re-arming it could
+ * stack a second watcher whose guardrail actions would fire twice, so it is skipped with a log line
+ * saying so. A session whose unit is already dead is the missed-stop sweep's job, not this one's.
+ */
+public final class WatcherRearmer {
+
+  private static final SpecStore.SpecFilter IN_PROGRESS =
+      new SpecStore.SpecFilter(null, "in_progress", null, null, null);
+
+  /** Relaunches a project's guardrail watcher; empty when the project declares no guardrails. */
+  @FunctionalInterface
+  public interface WatcherRelauncher {
+    OptionalLong relaunch(String project) throws Exception;
+  }
+
+  private final SpecStore specStore;
+  private final SessionStore sessionStore;
+  private final MissedStopReconciler.UnitProbe unitProbe;
+  private final LongPredicate watcherAlive;
+  private final WatcherRelauncher relauncher;
+
+  public WatcherRearmer(
+      SpecStore specStore,
+      SessionStore sessionStore,
+      MissedStopReconciler.UnitProbe unitProbe,
+      LongPredicate watcherAlive,
+      WatcherRelauncher relauncher) {
+    this.specStore = specStore;
+    this.sessionStore = sessionStore;
+    this.unitProbe = unitProbe;
+    this.watcherAlive = watcherAlive;
+    this.relauncher = relauncher;
+  }
+
+  /** Liveness of a host process by pid — how recorded watcher pids are checked in production. */
+  public static LongPredicate livingProcess() {
+    return pid -> ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false);
+  }
+
+  /**
+   * Runs one re-arm pass and returns how many watchers were relaunched. Best-effort: a failing spec
+   * is logged and skipped so one broken project cannot leave the rest unwatched, and a store error
+   * is logged and swallowed so re-arming can never block server startup.
+   */
+  public int rearm() {
+    var rearmed = 0;
+    try {
+      for (var spec : specStore.list(IN_PROGRESS)) {
+        try {
+          rearmed += rearm(spec) ? 1 : 0;
+        } catch (Exception e) {
+          System.err.println(
+              "  [rearm] failed for " + spec.project() + "/" + spec.id() + ": " + e.getMessage());
+        }
+      }
+    } catch (Exception e) {
+      System.err.println("  [rearm] watcher re-arm aborted: " + e.getMessage());
+    }
+    return rearmed;
+  }
+
+  private boolean rearm(SpecStore.SpecRow spec) throws Exception {
+    var latest = sessionStore.listForSpec(spec.id()).stream().findFirst();
+    if (latest.isEmpty() || !"running".equals(latest.get().status())) {
+      return false;
+    }
+    var session = latest.get();
+    if (session.watcherPid() == null) {
+      System.err.println(
+          "  [rearm] "
+              + spec.project()
+              + "/"
+              + spec.id()
+              + " (session "
+              + session.id()
+              + "): no watcher pid recorded, so coverage cannot be verified; not re-arming"
+              + " (a second watcher would double guardrail actions)");
+      return false;
+    }
+    if (watcherAlive.test(session.watcherPid())) {
+      return false;
+    }
+    if (!unitProbe.active(spec.project())) {
+      return false;
+    }
+    var pid = relauncher.relaunch(spec.project());
+    if (pid.isEmpty()) {
+      System.err.println(
+          "  [rearm] "
+              + spec.project()
+              + "/"
+              + spec.id()
+              + " (session "
+              + session.id()
+              + "): watcher pid "
+              + session.watcherPid()
+              + " is dead but the project declares no guardrails; nothing to re-arm");
+      return false;
+    }
+    sessionStore.updateWatcherPid(session.id(), (int) pid.getAsLong());
+    System.err.println(
+        "  [rearm] re-armed watcher for "
+            + spec.project()
+            + "/"
+            + spec.id()
+            + " (session "
+            + session.id()
+            + "): watcher pid "
+            + session.watcherPid()
+            + " died while the agent unit is still active; new watcher pid "
+            + pid.getAsLong()
+            + " resumes the original deadline from the session's started_at");
+    return true;
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
@@ -49,8 +49,12 @@ import picocli.CommandLine.Spec;
  * sail-api {@code /v1/events/stream} and, via {@code BlockingQueue.poll}, wakes the moment the next
  * deadline fires — the wall-clock deadline or the stall deadline (last progress event + {@code
  * max_idle}), whichever is sooner. Progress events (tool calls, log chunks) push the stall deadline
- * out, so a long but active build is never mistaken for a hung agent. Supervision is on by default
- * (see {@code Guardrails.defaults()}); sail.yaml overrides every threshold and the action.
+ * out, so a long but active build is never mistaken for a hung agent. The stall clock starts at
+ * watch launch, not session start: idleness the watcher never observed is not idleness, which
+ * matters when the daemon re-arms a watcher onto a session already hours into its run. The
+ * wall-clock deadline stays anchored to the session's {@code started_at}, so a re-armed agent keeps
+ * only its remaining budget. Supervision is on by default (see {@code Guardrails.defaults()});
+ * sail.yaml overrides every threshold and the action.
  */
 @Command(
     name = "watch",
@@ -194,7 +198,7 @@ public final class AgentWatchCommand implements Runnable {
       throws Exception {
     var guardrailFired = false;
     var maxIdle = Guardrails.parseDuration(guardrails.maxIdle());
-    var lastProgressAt = startedAt;
+    var lastProgressAt = DateTimeUtils.now();
     while (true) {
       var stallDeadline = maxIdle != null ? lastProgressAt.plus(maxIdle) : Instant.MAX;
       var deadlineAt = earlier(deadline, stallDeadline);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -17,9 +17,11 @@ import ai.singlr.sail.api.SessionTracker;
 import ai.singlr.sail.api.SlackReactor;
 import ai.singlr.sail.api.SpecStoreAuditPersister;
 import ai.singlr.sail.api.TokenAuth;
+import ai.singlr.sail.api.WatcherRearmer;
 import ai.singlr.sail.api.WebauthnAuthHandler;
 import ai.singlr.sail.auth.EnrollmentService;
 import ai.singlr.sail.auth.PasskeyService;
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.WebauthnConfig;
@@ -189,7 +191,8 @@ public final class ServerStartCommand implements Runnable {
             bus,
             ServerStartCommand::loadProjectYaml,
             new ShellExecutor(false));
-    bus.subscribe(new SessionTracker(new SessionStore(db)));
+    var sessionStore = new SessionStore(db);
+    bus.subscribe(new SessionTracker(sessionStore));
     bus.subscribe(SlackReactor.withDefaults(new SlackThreadStore(db), specStore));
 
     var webauthn = resolveWebauthn();
@@ -220,16 +223,36 @@ public final class ServerStartCommand implements Runnable {
     var reconciler =
         new StuckSpecReconciler(
             dbPath, StuckSpecReconciler.DEFAULT_THRESHOLD, stranded -> surface(bus, stranded));
-    shutdown.register(server).register(sweeper).register(reconciler);
+    var unitProbe = MissedStopReconciler.systemdUnitProbe(new ShellExecutor(false));
+    var missedStops =
+        new MissedStopReconciler(
+            specStore, sessionStore, eventStore, bus, unitProbe, DateTimeUtils::now);
+    shutdown.register(server).register(sweeper).register(reconciler).register(missedStops);
     try {
       server.start();
       sweeper.start();
       reconciler.start();
-      var replayed = new MissedStopReconciler(specStore, new SessionStore(db), bus).reconcile();
+      var replayed = missedStops.sweep();
       if (replayed > 0) {
         System.out.println(
             Ansi.AUTO.string(
                 "  @|green ✓|@ Replayed " + replayed + " agent stop(s) missed while offline"));
+      }
+      missedStops.start();
+      var rearmed =
+          new WatcherRearmer(
+                  specStore,
+                  sessionStore,
+                  unitProbe,
+                  WatcherRearmer.livingProcess(),
+                  operations::relaunchWatcher)
+              .rearm();
+      if (rearmed > 0) {
+        System.out.println(
+            Ansi.AUTO.string(
+                "  @|green ✓|@ Re-armed "
+                    + rearmed
+                    + " guardrail watcher(s) for agents still running unwatched"));
       }
       System.out.println(
           Ansi.AUTO.string(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -858,7 +858,8 @@ class ApiRouterTest {
             "completed",
             "t0",
             "t1",
-            7);
+            7,
+            null);
     var view = SessionView.from(row);
     assertEquals("s1", view.id());
     assertEquals("proj", view.project());

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -7,20 +7,32 @@ package ai.singlr.sail.api;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.ReviewPipelineConfig;
 import ai.singlr.sail.config.SpecStatus;
-import ai.singlr.sail.store.MissedStops;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.HostInfo;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.store.EventStore;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SessionStore;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,11 +40,15 @@ import org.junit.jupiter.api.io.TempDir;
 
 class MissedStopReconcilerTest {
 
+  private static final Supplier<Instant> PAST_GRACE =
+      () -> Instant.now().plus(Duration.ofMinutes(3));
+
   @TempDir Path tempDir;
   private Sqlite db;
   private SpecStore specStore;
   private ReviewStore reviewStore;
   private SessionStore sessionStore;
+  private EventStore eventStore;
   private EventBus bus;
 
   @BeforeEach
@@ -42,6 +58,7 @@ class MissedStopReconcilerTest {
     specStore = new SpecStore(db);
     reviewStore = new ReviewStore(db);
     sessionStore = new SessionStore(db);
+    eventStore = new EventStore(db);
     bus = new EventBus();
   }
 
@@ -49,6 +66,26 @@ class MissedStopReconcilerTest {
   void tearDown() {
     bus.close();
     if (db != null) db.close();
+  }
+
+  private static final class CountingProbe implements MissedStopReconciler.UnitProbe {
+    final AtomicInteger calls = new AtomicInteger();
+    volatile boolean active;
+
+    CountingProbe(boolean active) {
+      this.active = active;
+    }
+
+    @Override
+    public boolean active(String project) {
+      calls.incrementAndGet();
+      return active;
+    }
+  }
+
+  private MissedStopReconciler reconciler(
+      MissedStopReconciler.UnitProbe probe, Supplier<Instant> clock) {
+    return new MissedStopReconciler(specStore, sessionStore, eventStore, bus, probe, clock);
   }
 
   private void createInProgressSpec(String id) {
@@ -72,9 +109,51 @@ class MissedStopReconcilerTest {
             List.of()));
   }
 
-  private void finishedSession(String specId, String status, Integer exitCode) {
+  private String finishedSession(String specId, String status, Integer exitCode) {
     var id = sessionStore.create("test-project", specId, "claude-code", "feat/test", "task", 1);
     sessionStore.complete(id, status, exitCode);
+    return id;
+  }
+
+  private String runningSession(String specId) {
+    return sessionStore.create("test-project", specId, "claude-code", "feat/test", "task", 1);
+  }
+
+  private void recordStopEvent(String specId, String timestamp, Map<String, Object> data) {
+    eventStore.insert(
+        new EventStore.EventRow(
+            0,
+            timestamp,
+            Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+            "test-project",
+            specId,
+            "claude-code",
+            HostInfo.hostname(),
+            YamlUtil.dumpJson(data)));
+  }
+
+  private ConcurrentLinkedQueue<Event> captureStops(CountDownLatch latch) {
+    var captured = new ConcurrentLinkedQueue<Event>();
+    bus.subscribe(
+        BusTesting.latching(
+            new EventSubscriber() {
+              @Override
+              public String name() {
+                return "capture";
+              }
+
+              @Override
+              public Predicate<Event> filter() {
+                return e -> Event.WellKnownTypes.AGENT_SESSION_STOPPED.equals(e.type());
+              }
+
+              @Override
+              public void onEvent(Event event) {
+                captured.add(event);
+              }
+            },
+            latch));
+    return captured;
   }
 
   private void subscribeController(CountDownLatch latch) {
@@ -113,7 +192,7 @@ class MissedStopReconcilerTest {
     var latch = new CountDownLatch(1);
     subscribeController(latch);
 
-    var replayed = new MissedStopReconciler(specStore, sessionStore, bus).reconcile();
+    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
 
     assertEquals(1, replayed);
     BusTesting.awaitDelivery(latch);
@@ -127,7 +206,7 @@ class MissedStopReconcilerTest {
     var latch = new CountDownLatch(1);
     subscribeController(latch);
 
-    var replayed = new MissedStopReconciler(specStore, sessionStore, bus).reconcile();
+    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
 
     assertEquals(1, replayed);
     BusTesting.awaitDelivery(latch);
@@ -141,7 +220,7 @@ class MissedStopReconcilerTest {
     var latch = new CountDownLatch(1);
     subscribeController(latch);
 
-    new MissedStopReconciler(specStore, sessionStore, bus).reconcile();
+    reconciler(new CountingProbe(true), Instant::now).sweep();
 
     BusTesting.awaitDelivery(latch);
     assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
@@ -149,29 +228,258 @@ class MissedStopReconcilerTest {
   }
 
   @Test
-  void aStoreErrorIsSwallowedSoStartupIsNeverBlocked() {
+  void aStoreErrorIsSwallowedSoAPassNeverThrows() {
     createInProgressSpec("auth");
     finishedSession("auth", "stopped", 0);
-    var reconciler = new MissedStopReconciler(specStore, sessionStore, bus);
+    var reconciler = reconciler(new CountingProbe(true), Instant::now);
     db.close();
     db = null;
 
-    assertEquals(0, assertDoesNotThrow(reconciler::reconcile));
+    assertEquals(0, assertDoesNotThrow(reconciler::sweep));
   }
 
   @Test
-  void doesNothingWhenTheSessionIsStillRunning() {
+  void terminalReplaysAndSpecsWithoutSessionsNeverTouchSystemctl() {
     createInProgressSpec("auth");
-    sessionStore.create("test-project", "auth", "claude-code", "feat/test", "task", 1);
+    finishedSession("auth", "stopped", 0);
+    createInProgressSpec("billing");
+    var probe = new CountingProbe(true);
 
-    var replayed = new MissedStopReconciler(specStore, sessionStore, bus).reconcile();
+    var replayed = reconciler(probe, Instant::now).sweep();
+
+    assertEquals(1, replayed);
+    assertEquals(0, probe.calls.get());
+  }
+
+  @Test
+  void aRunningSessionInsideTheLaunchGraceIsNeverProbed() {
+    createInProgressSpec("auth");
+    runningSession("auth");
+    var probe = new CountingProbe(false);
+
+    var replayed = reconciler(probe, Instant::now).sweep();
 
     assertEquals(0, replayed);
+    assertEquals(0, probe.calls.get());
     assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
   }
 
   @Test
-  void stopEventCarriesExitCodeAndStartupSource() {
+  void aRunningSessionWithALiveUnitIsLeftAlone() {
+    createInProgressSpec("auth");
+    runningSession("auth");
+    var probe = new CountingProbe(true);
+
+    var replayed = reconciler(probe, PAST_GRACE).sweep();
+
+    assertEquals(0, replayed);
+    assertEquals(1, probe.calls.get());
+  }
+
+  @Test
+  void synthesizesAStopWithoutExitCodeWhenTheUnitDiedUnobserved() throws Exception {
+    createInProgressSpec("auth");
+    runningSession("auth");
+    var latch = new CountDownLatch(1);
+    var captured = captureStops(latch);
+
+    var replayed = reconciler(new CountingProbe(false), PAST_GRACE).sweep();
+
+    assertEquals(1, replayed);
+    BusTesting.awaitDelivery(latch);
+    var stop = captured.poll();
+    assertEquals("auth", stop.spec());
+    assertNull(stop.data().get(Event.WellKnownData.EXIT_CODE));
+    assertEquals(Event.WellKnownData.SOURCE_RECONCILE, stop.data().get(Event.WellKnownData.SOURCE));
+  }
+
+  @Test
+  void aRecordedAuthoritativeStopMakesTheSweepANoOpForeverAfter() {
+    createInProgressSpec("auth");
+    var sessionId = runningSession("auth");
+    recordStopEvent(
+        "auth",
+        Instant.now().plusSeconds(1).toString(),
+        Map.of(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_RECONCILE));
+    var probe = new CountingProbe(false);
+    var reconciler = reconciler(probe, PAST_GRACE);
+
+    assertEquals(0, reconciler.sweep());
+    assertEquals(0, reconciler.sweep());
+    assertEquals(0, probe.calls.get());
+    assertEquals("running", sessionStore.findById(sessionId).orElseThrow().status());
+  }
+
+  @Test
+  void aWatcherObservedCrashIsNeverReplayedAgain() {
+    createInProgressSpec("auth");
+    finishedSession("auth", "stopped", 137);
+    recordStopEvent(
+        "auth",
+        Instant.now().plusSeconds(1).toString(),
+        Map.of(
+            Event.WellKnownData.EXIT_CODE,
+            137,
+            Event.WellKnownData.SOURCE,
+            Event.WellKnownData.SOURCE_WATCHER));
+
+    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
+
+    assertEquals(0, replayed);
+  }
+
+  @Test
+  void aRawTurnEndStopDoesNotBlockTheReplay() {
+    createInProgressSpec("auth");
+    finishedSession("auth", "stopped", null);
+    recordStopEvent("auth", Instant.now().plusSeconds(1).toString(), Map.of());
+
+    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
+
+    assertEquals(1, replayed);
+  }
+
+  @Test
+  void anAuthoritativeStopFromASupersededSessionDoesNotBlockTheLatestOne() {
+    createInProgressSpec("auth");
+    recordStopEvent(
+        "auth",
+        Instant.now().minus(Duration.ofHours(2)).toString(),
+        Map.of(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_WATCHER));
+    finishedSession("auth", "stopped", 0);
+
+    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
+
+    assertEquals(1, replayed);
+  }
+
+  @Test
+  void anUnreadableStopEventCountsAsCoveringSoTheSweepStaysConservative() {
+    createInProgressSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    eventStore.insert(
+        new EventStore.EventRow(
+            0,
+            Instant.now().plusSeconds(1).toString(),
+            Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+            "test-project",
+            "auth",
+            "claude-code",
+            HostInfo.hostname(),
+            "{\"source\": "));
+
+    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
+
+    assertEquals(0, replayed);
+  }
+
+  @Test
+  void anAuthoritativeStopWithAMalformedTimestampCountsAsRecent() {
+    createInProgressSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    recordStopEvent(
+        "auth", "garbage", Map.of(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_WATCHER));
+
+    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
+
+    assertEquals(0, replayed);
+  }
+
+  @Test
+  void aFailingProbeIsLoggedAndDoesNotShadowOtherSpecs() {
+    createInProgressSpec("broken");
+    runningSession("broken");
+    createInProgressSpec("auth");
+    finishedSession("auth", "stopped", 0);
+
+    var replayed =
+        reconciler(
+                project -> {
+                  throw new IllegalStateException("container unreachable");
+                },
+                PAST_GRACE)
+            .sweep();
+
+    assertEquals(1, replayed);
+  }
+
+  @Test
+  void aPassNeverOverlapsAStillRunningOne() {
+    createInProgressSpec("auth");
+    runningSession("auth");
+    var overlapped = new AtomicBoolean(true);
+    var reconciler = new MissedStopReconciler[1];
+    reconciler[0] =
+        reconciler(
+            project -> {
+              overlapped.set(reconciler[0].sweepIfIdle());
+              return true;
+            },
+            PAST_GRACE);
+
+    assertTrue(reconciler[0].sweepIfIdle());
+    assertFalse(overlapped.get());
+  }
+
+  @Test
+  void theScheduledSweepFiresAndSurvivesFailingPasses() throws Exception {
+    createInProgressSpec("auth");
+    runningSession("auth");
+    var latch = new CountDownLatch(2);
+    try (var reconciler =
+        reconciler(
+            project -> {
+              latch.countDown();
+              throw new IllegalStateException("boom");
+            },
+            PAST_GRACE)) {
+      reconciler.start(Duration.ofMillis(5));
+      BusTesting.awaitDelivery(latch);
+    }
+  }
+
+  @Test
+  void startUsesTheDefaultCadence() {
+    try (var reconciler = reconciler(new CountingProbe(true), Instant::now)) {
+      reconciler.start();
+    }
+  }
+
+  @Test
+  void systemdProbeReadsUnitLivenessThroughTheShell() throws Exception {
+    ShellExec activeShell = shellReturning("ActiveState=active\nExecMainStatus=0\n");
+    ShellExec inactiveShell = shellReturning("ActiveState=inactive\nExecMainStatus=0\n");
+    ShellExec failedShell = shellReturning("ActiveState=failed\nExecMainStatus=137\n");
+
+    assertTrue(MissedStopReconciler.systemdUnitProbe(activeShell).active("acme"));
+    assertFalse(MissedStopReconciler.systemdUnitProbe(inactiveShell).active("acme"));
+    assertFalse(MissedStopReconciler.systemdUnitProbe(failedShell).active("acme"));
+  }
+
+  private static ShellExec shellReturning(String systemctlShow) {
+    return new ShellExec() {
+      @Override
+      public Result exec(List<String> command) {
+        if (String.join(" ", command).contains("systemctl")) {
+          return new Result(0, systemctlShow, "");
+        }
+        return new Result(1, "", "no such file");
+      }
+
+      @Override
+      public Result exec(List<String> command, Path workDir, Duration timeout) {
+        return exec(command);
+      }
+
+      @Override
+      public boolean isDryRun() {
+        return false;
+      }
+    };
+  }
+
+  @Test
+  void stopEventCarriesExitCodeAndReconcileSource() {
     var spec =
         new SpecStore.SpecRow(
             "auth",
@@ -191,13 +499,13 @@ class MissedStopReconcilerTest {
             List.of(),
             List.of());
 
-    var event = MissedStopReconciler.stopEvent(new MissedStops.Replay(spec, 137));
+    var event = MissedStopReconciler.stopEvent(spec, 137);
 
     assertEquals(Event.WellKnownTypes.AGENT_SESSION_STOPPED, event.type());
     assertEquals("auth", event.spec());
     assertEquals("codex", event.agent());
     assertEquals(137, event.data().get("exit_code"));
-    assertEquals("startup-reconcile", event.data().get("source"));
+    assertEquals("reconcile", event.data().get("source"));
   }
 
   @Test
@@ -221,10 +529,10 @@ class MissedStopReconcilerTest {
             List.of(),
             List.of());
 
-    var event = MissedStopReconciler.stopEvent(new MissedStops.Replay(spec, null));
+    var event = MissedStopReconciler.stopEvent(spec, null);
 
     assertEquals(Event.SAIL_AGENT, event.agent());
-    assertTrue(event.data().get("exit_code") == null);
-    assertEquals("startup-reconcile", event.data().get("source"));
+    assertNull(event.data().get("exit_code"));
+    assertEquals("reconcile", event.data().get("source"));
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -324,6 +324,46 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
+  void aWatcherStopAndAReconcilerReplayBackToBackProduceExactlyOneReview() {
+    createSpec("auth", "in_progress");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr) -> "[]");
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+    ctrl.onEvent(reconcilerStoppedEvent("auth"));
+
+    assertEquals(1, reviewStore.reviewsForSpec("auth").size());
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void aReconcilerReplayLandingMidPipelineIsShedByTheStatusGuard() {
+    createSpec("auth", "in_progress");
+    var ctrl = new AtomicReference<ReviewPipelineController>();
+    ctrl.set(
+        controller(
+            singleAgentStage("no_critical"),
+            (p, a, pr) -> {
+              ctrl.get().onEvent(reconcilerStoppedEvent("auth"));
+              return "[]";
+            }));
+
+    ctrl.get().onEvent(agentStoppedEvent("auth"));
+
+    assertEquals(1, reviewStore.reviewsForSpec("auth").size());
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
+  }
+
+  private Event reconcilerStoppedEvent(String specId) {
+    return Event.of(
+        "test-project",
+        specId,
+        Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+        "claude-code",
+        "host",
+        Map.of(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_RECONCILE));
+  }
+
+  @Test
   void findingsStoredInDatabase() {
     createSpec("auth", "in_progress");
     var agentOutput =

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
@@ -703,6 +703,7 @@ class SailApiOperationsTest {
             (command, logPath) -> {
               launched.put("command", command);
               launched.put("log_path", logPath.toString());
+              return 4242L;
             });
 
     operations.dispatch("acme", request("auth"));
@@ -733,12 +734,89 @@ class SailApiOperationsTest {
   }
 
   @Test
-  void watcherProcessLauncherStartsCommand() throws Exception {
+  void watcherProcessLauncherStartsCommandAndReturnsItsPid() throws Exception {
     var logPath = tempDir.resolve("watch.log");
 
-    SailApiOperations.launchWatcherProcess(List.of("sh", "-c", "true"), logPath);
+    var pid = SailApiOperations.launchWatcherProcess(List.of("sh", "-c", "true"), logPath);
 
+    assertTrue(pid > 0);
     assertTrue(Files.exists(logPath));
+  }
+
+  @Test
+  void dispatchRecordsTheWatcherPidOnTheSessionStartedEvent() throws Exception {
+    var yaml = tempDir.resolve("sail-watcher-pid.yaml");
+    Files.writeString(yaml, guardrailsYaml());
+    var db = Sqlite.open(tempDir.resolve("watcher-pid.db"));
+    new SchemaManager(db).migrate();
+    var store = new SpecStore(db);
+    seedAuthBillingSetup(store);
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("cat /home/dev/.sail/agent.pid", "123")
+            .onSequence(
+                "kill -0 123", new ShellExec.Result(1, "", ""), new ShellExec.Result(0, "", ""))
+            .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"work\"}")
+            .on("mkdir -p /home/dev/workspace/specs", "")
+            .on("printf '%s'", "")
+            .on("-- mkdir -p /home/dev/.sail", "")
+            .on("claude", "");
+    try (var bus = new EventBus()) {
+      var started = new java.util.concurrent.atomic.AtomicReference<Event>();
+      var latch = new java.util.concurrent.CountDownLatch(1);
+      bus.subscribe(
+          BusTesting.latching(
+              new EventSubscriber() {
+                @Override
+                public String name() {
+                  return "capture";
+                }
+
+                @Override
+                public Predicate<Event> filter() {
+                  return e -> Event.WellKnownTypes.AGENT_SESSION_STARTED.equals(e.type());
+                }
+
+                @Override
+                public void onEvent(Event event) {
+                  started.set(event);
+                }
+              },
+              latch));
+      var operations =
+          new SailApiOperations(
+              shell, yaml.toString(), (cmd, log) -> 4242L, bus, null, store, null);
+
+      operations.dispatch("acme", request("auth"));
+
+      BusTesting.awaitDelivery(latch);
+      assertEquals(4242L, started.get().data().get(Event.WellKnownData.WATCHER_PID));
+    } finally {
+      db.close();
+    }
+  }
+
+  @Test
+  void relaunchWatcherReturnsTheNewWatcherPid() throws Exception {
+    var operations =
+        operations(
+            guardrailsYaml(),
+            shell().on("incus list ^acme$", RUNNING_JSON),
+            (command, logPath) -> 4242L);
+
+    var pid = operations.relaunchWatcher("acme");
+
+    assertEquals(4242L, pid.orElseThrow());
+  }
+
+  @Test
+  void relaunchWatcherIsEmptyWhenTheProjectDeclaresNoGuardrails() throws Exception {
+    var operations =
+        operations(
+            baseYaml(), shell().on("incus list ^acme$", RUNNING_JSON), (command, logPath) -> 4242L);
+
+    assertTrue(operations.relaunchWatcher("acme").isEmpty());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SessionTrackerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SessionTrackerTest.java
@@ -90,6 +90,21 @@ class SessionTrackerTest {
     assertEquals("implement OAuth", session.get().task());
     assertEquals(1234, session.get().pid());
     assertEquals("running", session.get().status());
+    assertNull(session.get().watcherPid());
+  }
+
+  @Test
+  void startedRecordsTheWatcherPidWhenTheEventCarriesOne() {
+    tracker.onEvent(
+        Event.of(
+            "backend",
+            "auth",
+            Event.WellKnownTypes.AGENT_SESSION_STARTED,
+            "claude-code",
+            "host",
+            Map.of("pid", 1234, Event.WellKnownData.WATCHER_PID, 5678L)));
+
+    assertEquals(5678, sessionStore.latestForProject("backend").orElseThrow().watcherPid());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WatcherRearmerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WatcherRearmerTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SessionStore;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.LongPredicate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WatcherRearmerTest {
+
+  private static final LongPredicate DEAD = pid -> false;
+  private static final LongPredicate ALIVE = pid -> true;
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private SpecStore specStore;
+  private SessionStore sessionStore;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("rearm.db"));
+    new SchemaManager(db).migrate();
+    specStore = new SpecStore(db);
+    sessionStore = new SessionStore(db);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  private void createInProgressSpec(String id) {
+    specStore.create(
+        new SpecStore.SpecRow(
+            id,
+            "test-project",
+            "Test spec",
+            SpecStatus.IN_PROGRESS,
+            null,
+            "claude-code",
+            null,
+            null,
+            "feat/test",
+            0,
+            null,
+            "",
+            "",
+            null,
+            List.of(),
+            List.of()));
+  }
+
+  private String runningSession(String specId, Integer watcherPid) {
+    return sessionStore.create(
+        "test-project", specId, "claude-code", "feat/test", "task", 1, watcherPid);
+  }
+
+  private WatcherRearmer rearmer(
+      MissedStopReconciler.UnitProbe unitProbe,
+      LongPredicate watcherAlive,
+      WatcherRearmer.WatcherRelauncher relauncher) {
+    return new WatcherRearmer(specStore, sessionStore, unitProbe, watcherAlive, relauncher);
+  }
+
+  @Test
+  void rearmsADeadWatcherOverAStillActiveUnitAndRecordsTheNewPid() {
+    createInProgressSpec("auth");
+    var sessionId = runningSession("auth", 5678);
+    var relaunches = new AtomicInteger();
+
+    var rearmed =
+        rearmer(
+                project -> true,
+                DEAD,
+                project -> {
+                  relaunches.incrementAndGet();
+                  return OptionalLong.of(9012);
+                })
+            .rearm();
+
+    assertEquals(1, rearmed);
+    assertEquals(1, relaunches.get());
+    assertEquals(9012, sessionStore.findById(sessionId).orElseThrow().watcherPid());
+  }
+
+  @Test
+  void aLiveWatcherIsLeftAloneWithoutProbingTheUnit() {
+    createInProgressSpec("auth");
+    runningSession("auth", 5678);
+    var probed = new AtomicInteger();
+
+    var rearmed =
+        rearmer(
+                project -> {
+                  probed.incrementAndGet();
+                  return true;
+                },
+                ALIVE,
+                project -> OptionalLong.of(9012))
+            .rearm();
+
+    assertEquals(0, rearmed);
+    assertEquals(0, probed.get());
+  }
+
+  @Test
+  void aSessionWithoutARecordedWatcherPidIsSkippedNotDoubled() {
+    createInProgressSpec("auth");
+    var sessionId = runningSession("auth", null);
+
+    var rearmed = rearmer(project -> true, DEAD, project -> OptionalLong.of(9012)).rearm();
+
+    assertEquals(0, rearmed);
+    assertTrue(sessionStore.findById(sessionId).orElseThrow().watcherPid() == null);
+  }
+
+  @Test
+  void anInactiveUnitIsTheSweepsJobNotARearm() {
+    createInProgressSpec("auth");
+    runningSession("auth", 5678);
+    var relaunches = new AtomicInteger();
+
+    var rearmed =
+        rearmer(
+                project -> false,
+                DEAD,
+                project -> {
+                  relaunches.incrementAndGet();
+                  return OptionalLong.of(9012);
+                })
+            .rearm();
+
+    assertEquals(0, rearmed);
+    assertEquals(0, relaunches.get());
+  }
+
+  @Test
+  void terminalSessionsAndSpecsWithoutSessionsAreIgnored() {
+    createInProgressSpec("finished");
+    var completed = runningSession("finished", 5678);
+    sessionStore.complete(completed, "stopped", 0);
+    createInProgressSpec("bare");
+
+    var rearmed = rearmer(project -> true, DEAD, project -> OptionalLong.of(9012)).rearm();
+
+    assertEquals(0, rearmed);
+  }
+
+  @Test
+  void aProjectWithoutGuardrailsHasNothingToRearm() {
+    createInProgressSpec("auth");
+    var sessionId = runningSession("auth", 5678);
+
+    var rearmed = rearmer(project -> true, DEAD, project -> OptionalLong.empty()).rearm();
+
+    assertEquals(0, rearmed);
+    assertEquals(5678, sessionStore.findById(sessionId).orElseThrow().watcherPid());
+  }
+
+  @Test
+  void aFailingRelaunchIsLoggedAndDoesNotShadowOtherSpecs() {
+    createInProgressSpec("broken");
+    runningSession("broken", 1111);
+    createInProgressSpec("auth");
+    runningSession("auth", 2222);
+    var attempts = new AtomicInteger();
+
+    var rearmed =
+        rearmer(
+                project -> true,
+                DEAD,
+                project -> {
+                  if (attempts.incrementAndGet() == 1) {
+                    throw new IllegalStateException("relaunch failed");
+                  }
+                  return OptionalLong.of(9012);
+                })
+            .rearm();
+
+    assertEquals(1, rearmed);
+    assertEquals(2, attempts.get());
+  }
+
+  @Test
+  void aStoreErrorIsSwallowedSoStartupIsNeverBlocked() {
+    createInProgressSpec("auth");
+    runningSession("auth", 5678);
+    var rearmer = rearmer(project -> true, DEAD, project -> OptionalLong.of(9012));
+    db.close();
+    db = null;
+
+    assertEquals(0, assertDoesNotThrow(rearmer::rearm));
+  }
+
+  @Test
+  void livingProcessSeesThisJvmAliveAndANonexistentPidDead() {
+    var alive = WatcherRearmer.livingProcess();
+
+    assertTrue(alive.test(ProcessHandle.current().pid()));
+    assertFalse(alive.test(999_999_999L));
+  }
+}


### PR DESCRIPTION
## Incident

A daemon restart mid-run kills the guardrail watcher (it lives in the daemon's cgroup). When the agent later finishes, nothing observes it: no authoritative stop, no review, spec stranded `in_progress` until a human notices and restarts the daemon a second time.

## Part 1 — the missed-stop replay becomes periodic

- `MissedStopReconciler.sweep()` is the single routine driven from both the daemon start hook (as before) and a recurring 60s sweep on the reconciler's own scheduler. The shared predicate lives in `MissedStops.assess`.
- Anchored on the spec's **latest session**, never superseded ones:
  - **terminal session** → replay the stop with its recorded exit code;
  - **running session**, past a 2-minute launch grace, whose systemd unit is inactive/absent (via the `ShellExec` systemctl seam; a vanished transient unit reads as inactive) → synthesize a stop with **no exit code**. The unit is garbage-collected on exit so the real code is unrecoverable; this mirrors the replay decision for a terminal session that recorded none, and is documented in the sweep's javadoc.
- **Dedupe:** any `source`-carrying stop recorded since the session started skips the session forever. Watcher-observed crashes are never re-replayed (no duplicate `agent_failed`), fix iterations that re-enter `in_progress` are never re-triggered, and a raw turn-end hook stop never blocks the replay (that stop is exactly what the incident had). Synthesized stops carry `source=reconcile`, so `agent review` and the event log show the stop was reconstructed, not observed.
- **Resilience:** DB-first (zero systemctl calls when nothing is running), per-spec and per-pass error isolation (a throwing pass logs loudly and never cancels the timer), passes never overlap, every replay logs spec, session, and why.

## Part 2 — daemon start re-arms guardrails for still-active sessions

- Dispatch records the watcher's host pid on the session (`watcher_pid`, append-only migration; the pid rides the `agent_session_started` event through `SessionTracker`).
- At daemon start, `WatcherRearmer` relaunches the watcher for each running session of an `in_progress` spec whose unit is still active and whose recorded watcher pid is dead. The relaunched `sail agent watch` recomputes its wall-clock deadline from the session's original `started_at` — an agent 3h into a 4h budget gets 1h, not a fresh 4h.
- Found while scoping this: the watcher seeded its stall clock from session start, so re-arming onto an hours-old session would have tripped `max_idle` instantly and killed a healthy agent. The stall clock now starts at watch launch (idleness the watcher never observed is not idleness); the wall-clock deadline stays anchored to `started_at`.
- Sessions with no recorded watcher pid (CLI dispatches — their watchers are not tied to the daemon's lifetime — and pre-upgrade rows) are skipped with an explicit log line: re-arming unverifiable coverage could stack a second watcher whose guardrail actions (snapshot/kill) would fire twice.

## Race coverage (all deterministic, no sleeps)

- Live-watcher race: watcher stop + reconciler replay delivered back-to-back and mid-pipeline (same-thread executor) → exactly one review.
- Launch race: session claimed seconds ago, unit not yet visible → grace skip, unit never probed.
- Already-replayed: recorded authoritative stop → no-op forever after.
- Exit unknown: synthesized event carries `source=reconcile` and no exit code.
- Sweep resilience: throwing pass survives on schedule, overlap guard, zero-running-sessions fast path.

`StuckSpecReconciler` is untouched — the sweep acts in minutes, the stranding alarm in hours, thresholds independent.

Full `mvn clean verify` green: 2024 tests, jacoco gates met (new api classes at 100% line/method).