### PR TITLE
Watcher runs as a systemd unit, immune to Ctrl-C, SSH hangup, and daemon restarts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -359,6 +359,17 @@ On a trip it snapshots or kills the agent and fires notifications. Rollback uses
 snapshots, which are instant on `zfs` and full copies on `dir`, and the pre-dispatch
 snapshot is the restore point.
 
+The watcher runs detached, as the systemd transient unit `sail-watch-<project>` — the same
+mechanism that runs the agent — so it survives Ctrl-C on the dispatch stream, the SSH
+session ending, and daemon restarts. The unit name is deterministic and one agent runs per
+project, so coverage is probed rather than bookkept: spawning against an active unit adopts
+it, the periodic re-armer relaunches a unit for any running agent nothing covers (resuming
+the original deadline, never granting a fresh budget), and the missed-stop sweep replays the
+stop of any agent that still manages to finish unobserved. Where no systemd scope is
+available (busless test environments) the spawn falls back to a plain detached process,
+loudly marked degraded. Every lane — CLI dispatch and API dispatch — spawns through the one
+`WatcherSpawner`, so their survival properties cannot diverge.
+
 **Multi-agent review loop:** review is agent-agnostic across claude-code and codex. When the
 coder's dispatch stops cleanly, the spec moves to `review` and a secondary reviewer runs at
 spec completion (falling back to self-review when only one agent is installed; a per-spec

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -362,13 +362,19 @@ snapshot is the restore point.
 The watcher runs detached, as the systemd transient unit `sail-watch-<project>` — the same
 mechanism that runs the agent — so it survives Ctrl-C on the dispatch stream, the SSH
 session ending, and daemon restarts. The unit name is deterministic and one agent runs per
-project, so coverage is probed rather than bookkept: spawning against an active unit adopts
-it, the periodic re-armer relaunches a unit for any running agent nothing covers (resuming
-the original deadline, never granting a fresh budget), and the missed-stop sweep replays the
-stop of any agent that still manages to finish unobserved. Where no systemd scope is
-available (busless test environments) the spawn falls back to a plain detached process,
-loudly marked degraded. Every lane — CLI dispatch and API dispatch — spawns through the one
-`WatcherSpawner`, so their survival properties cannot diverge.
+project, so coverage is probed rather than bookkept, and the two spawn intents differ
+deliberately: dispatch stops and replaces any unit left over from the previous session (an
+adopted stale watcher would enforce the old session's nearly-spent deadline against the new
+agent), while the periodic re-armer — whose coverage probe is process-level, seeing units in
+any user's systemd scope and plain fallback processes alike — relaunches unit-or-nothing for
+any running agent nothing covers, resuming the original deadline rather than granting a
+fresh budget. The missed-stop sweep still replays the stop of any agent that manages to
+finish unobserved. Units launch with `Type=exec` so exec-phase failures fail the spawn
+loudly, and the `SAIL_*` environment is forwarded explicitly since transient units start
+from systemd's clean environment. Where no systemd scope is available (busless test
+environments) the spawn falls back to a plain detached process, loudly marked degraded.
+Every lane — CLI dispatch and API dispatch — spawns through the one `WatcherSpawner`, so
+their survival properties cannot diverge.
 
 **Multi-agent review loop:** review is agent-agnostic across claude-code and codex. When the
 coder's dispatch stops cleanly, the spec moves to `review` and a secondary reviewer runs at

--- a/sail-core/src/main/java/ai/singlr/sail/store/SessionStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SessionStore.java
@@ -134,13 +134,6 @@ public final class SessionStore {
   }
 
   /** Records the pid of the guardrail watcher currently covering this session. */
-  public void updateWatcherPid(String id, Integer watcherPid) {
-    db.execute(
-        "UPDATE agent_sessions SET watcher_pid = ? WHERE id = ?",
-        watcherPid != null ? watcherPid.longValue() : null,
-        id);
-  }
-
   private SessionRow mapSession(Sqlite.Row row) {
     return new SessionRow(
         row.text(0),

--- a/sail-core/src/test/java/ai/singlr/sail/store/SessionStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SessionStoreTest.java
@@ -71,22 +71,6 @@ class SessionStoreTest {
   }
 
   @Test
-  void updateWatcherPidReplacesTheRecordedWatcher() {
-    var id = store.create("backend", "auth", "claude-code", null, null, 1234, 5678);
-    store.updateWatcherPid(id, 9012);
-
-    assertEquals(9012, store.findById(id).orElseThrow().watcherPid());
-  }
-
-  @Test
-  void updateWatcherPidClearsWhenNull() {
-    var id = store.create("backend", "auth", "claude-code", null, null, 1234, 5678);
-    store.updateWatcherPid(id, null);
-
-    assertNull(store.findById(id).orElseThrow().watcherPid());
-  }
-
-  @Test
   void completeSession() {
     var id = store.create("backend", "auth", "claude-code", null, null, null);
     store.complete(id, "completed", 0);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -16,10 +16,6 @@ import ai.singlr.sail.store.SpecStore;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 /**
@@ -71,8 +67,7 @@ public final class MissedStopReconciler implements AutoCloseable {
   private final EventBus bus;
   private final UnitProbe unitProbe;
   private final Supplier<Instant> clock;
-  private final ScheduledExecutorService scheduler;
-  private final AtomicBoolean sweeping = new AtomicBoolean();
+  private final PeriodicPass pass;
 
   public MissedStopReconciler(
       SpecStore specStore,
@@ -87,9 +82,7 @@ public final class MissedStopReconciler implements AutoCloseable {
     this.bus = bus;
     this.unitProbe = unitProbe;
     this.clock = clock;
-    this.scheduler =
-        Executors.newSingleThreadScheduledExecutor(
-            Thread.ofVirtual().name("sail-missed-stop-", 0).factory());
+    this.pass = new PeriodicPass("reconcile", this::sweep);
   }
 
   /**
@@ -109,8 +102,7 @@ public final class MissedStopReconciler implements AutoCloseable {
   }
 
   public void start(Duration interval) {
-    scheduler.scheduleAtFixedRate(
-        this::sweepIfIdle, interval.toMillis(), interval.toMillis(), TimeUnit.MILLISECONDS);
+    pass.start(interval);
   }
 
   /**
@@ -118,15 +110,7 @@ public final class MissedStopReconciler implements AutoCloseable {
    * whether the pass ran; never throws, so the schedule survives any failure.
    */
   boolean sweepIfIdle() {
-    if (!sweeping.compareAndSet(false, true)) {
-      return false;
-    }
-    try {
-      sweep();
-    } finally {
-      sweeping.set(false);
-    }
-    return true;
+    return pass.runIfIdle();
   }
 
   /**
@@ -243,6 +227,6 @@ public final class MissedStopReconciler implements AutoCloseable {
 
   @Override
   public void close() {
-    scheduler.close();
+    pass.close();
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/PeriodicPass.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/PeriodicPass.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * One recurring maintenance pass on its own single-threaded scheduler: passes never overlap (a slow
+ * pass makes the next tick a no-op rather than stacking), a throwing pass is logged and never
+ * cancels the schedule, and {@link #close()} stops the timer. Shared by the reconciliation loops so
+ * their scheduling discipline cannot drift apart.
+ */
+final class PeriodicPass implements AutoCloseable {
+
+  private final String name;
+  private final Runnable pass;
+  private final ScheduledExecutorService scheduler;
+  private final AtomicBoolean running = new AtomicBoolean();
+
+  PeriodicPass(String name, Runnable pass) {
+    this.name = name;
+    this.pass = pass;
+    this.scheduler =
+        Executors.newSingleThreadScheduledExecutor(
+            Thread.ofVirtual().name("sail-" + name + "-", 0).factory());
+  }
+
+  void start(Duration interval) {
+    scheduler.scheduleAtFixedRate(
+        this::runIfIdle, interval.toMillis(), interval.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  /** Runs one pass unless another is still in flight. Returns whether the pass ran. */
+  boolean runIfIdle() {
+    if (!running.compareAndSet(false, true)) {
+      return false;
+    }
+    try {
+      pass.run();
+    } catch (RuntimeException e) {
+      System.err.println("  [" + name + "] pass failed: " + e.getMessage());
+    } finally {
+      running.set(false);
+    }
+    return true;
+  }
+
+  @Override
+  public void close() {
+    scheduler.shutdownNow();
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/PeriodicPass.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/PeriodicPass.java
@@ -13,9 +13,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * One recurring maintenance pass on its own single-threaded scheduler: passes never overlap (a slow
- * pass makes the next tick a no-op rather than stacking), a throwing pass is logged and never
- * cancels the schedule, and {@link #close()} stops the timer. Shared by the reconciliation loops so
- * their scheduling discipline cannot drift apart.
+ * pass makes the next tick a no-op rather than stacking), a throwing pass — {@link Throwable}
+ * included, since an escaped {@link Error} would silently cancel every future tick — is logged with
+ * its stack and never cancels the schedule, and {@link #close()} stops the timer after waiting out
+ * any in-flight pass, so shutdown never interrupts a half-applied reconciliation. Shared by the
+ * reconciliation loops so their scheduling discipline cannot drift apart.
  */
 final class PeriodicPass implements AutoCloseable {
 
@@ -44,8 +46,9 @@ final class PeriodicPass implements AutoCloseable {
     }
     try {
       pass.run();
-    } catch (RuntimeException e) {
-      System.err.println("  [" + name + "] pass failed: " + e.getMessage());
+    } catch (Throwable t) {
+      System.err.println("  [" + name + "] pass failed: " + t);
+      t.printStackTrace();
     } finally {
       running.set(false);
     }
@@ -54,6 +57,6 @@ final class PeriodicPass implements AutoCloseable {
 
   @Override
   public void close() {
-    scheduler.shutdownNow();
+    scheduler.close();
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -28,13 +28,13 @@ import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SnapshotManager;
+import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.SessionStore;
 import ai.singlr.sail.store.SpecStore;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -42,7 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.OptionalLong;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.function.Supplier;
 
@@ -52,7 +52,7 @@ public final class SailApiOperations implements ApiOperations {
 
   private final ShellExec shell;
   private final String file;
-  private final WatcherLauncher watcherLauncher;
+  private final WatcherSpawner watcherSpawner;
   private final EventBus eventBus;
   private final AuditPersister auditPersister;
   private final SpecStore specStore;
@@ -68,18 +68,17 @@ public final class SailApiOperations implements ApiOperations {
   }
 
   public SailApiOperations(ShellExec shell, String file) {
-    this(shell, file, SailApiOperations::launchWatcherProcess);
+    this(shell, file, WatcherSpawner::spawnProcess);
   }
 
-  SailApiOperations(ShellExec shell, String file, WatcherLauncher watcherLauncher) {
-    this(shell, file, watcherLauncher, null, null);
+  SailApiOperations(ShellExec shell, String file, WatcherSpawner.ProcessSpawner watcherFallback) {
+    this(shell, file, watcherFallback, null, null);
   }
 
   /** Construct with explicit event-bus wiring; used by {@link SailApiServer}. */
   public SailApiOperations(
       ShellExec shell, String file, EventBus eventBus, AuditPersister auditPersister) {
-    this(
-        shell, file, SailApiOperations::launchWatcherProcess, eventBus, auditPersister, null, null);
+    this(shell, file, WatcherSpawner::spawnProcess, eventBus, auditPersister, null, null);
   }
 
   /** Construct with database-backed stores; used by the control plane server. */
@@ -93,7 +92,7 @@ public final class SailApiOperations implements ApiOperations {
     this(
         shell,
         file,
-        SailApiOperations::launchWatcherProcess,
+        WatcherSpawner::spawnProcess,
         eventBus,
         auditSubscriber instanceof AuditPersister ap ? ap : null,
         specStore,
@@ -122,7 +121,7 @@ public final class SailApiOperations implements ApiOperations {
     this(
         shell,
         file,
-        SailApiOperations::launchWatcherProcess,
+        WatcherSpawner::spawnProcess,
         eventBus,
         auditSubscriber instanceof AuditPersister ap ? ap : null,
         specStore,
@@ -135,27 +134,27 @@ public final class SailApiOperations implements ApiOperations {
   SailApiOperations(
       ShellExec shell,
       String file,
-      WatcherLauncher watcherLauncher,
+      WatcherSpawner.ProcessSpawner watcherFallback,
       EventBus eventBus,
       AuditPersister auditPersister) {
-    this(shell, file, watcherLauncher, eventBus, auditPersister, null, null);
+    this(shell, file, watcherFallback, eventBus, auditPersister, null, null);
   }
 
   SailApiOperations(
       ShellExec shell,
       String file,
-      WatcherLauncher watcherLauncher,
+      WatcherSpawner.ProcessSpawner watcherFallback,
       EventBus eventBus,
       AuditPersister auditPersister,
       SpecStore specStore,
       ReviewStore reviewStore) {
-    this(shell, file, watcherLauncher, eventBus, auditPersister, specStore, reviewStore, null);
+    this(shell, file, watcherFallback, eventBus, auditPersister, specStore, reviewStore, null);
   }
 
   SailApiOperations(
       ShellExec shell,
       String file,
-      WatcherLauncher watcherLauncher,
+      WatcherSpawner.ProcessSpawner watcherFallback,
       EventBus eventBus,
       AuditPersister auditPersister,
       SpecStore specStore,
@@ -164,7 +163,7 @@ public final class SailApiOperations implements ApiOperations {
     this(
         shell,
         file,
-        watcherLauncher,
+        watcherFallback,
         eventBus,
         auditPersister,
         specStore,
@@ -177,7 +176,7 @@ public final class SailApiOperations implements ApiOperations {
   SailApiOperations(
       ShellExec shell,
       String file,
-      WatcherLauncher watcherLauncher,
+      WatcherSpawner.ProcessSpawner watcherFallback,
       EventBus eventBus,
       AuditPersister auditPersister,
       SpecStore specStore,
@@ -187,7 +186,7 @@ public final class SailApiOperations implements ApiOperations {
       Supplier<ConnectEnvironment> connectEnvironment) {
     this.shell = shell;
     this.file = file;
-    this.watcherLauncher = watcherLauncher;
+    this.watcherSpawner = new WatcherSpawner(shell, watcherFallback);
     this.eventBus = eventBus;
     this.auditPersister = auditPersister;
     this.specStore = specStore;
@@ -381,7 +380,7 @@ public final class SailApiOperations implements ApiOperations {
     var branchCreated = createBranchIfNeeded(project, loaded.config(), targetRepos, branch);
 
     if (!request.dryRun()) {
-      var watcherPid =
+      var watcher =
           launchAgent(
               project,
               loaded.config(),
@@ -393,7 +392,7 @@ public final class SailApiOperations implements ApiOperations {
               agentType);
       var status = querySession(agentSession, project);
       if (status != null && status.running()) {
-        publishAgentSessionStarted(project, nextSpec.id(), agentType, status.pid(), watcherPid);
+        publishAgentSessionStarted(project, nextSpec.id(), agentType, status.pid(), watcher);
       }
       return new DispatchResponse(
           project,
@@ -450,7 +449,11 @@ public final class SailApiOperations implements ApiOperations {
   }
 
   private void publishAgentSessionStarted(
-      String project, String specId, String agentType, Integer pid, OptionalLong watcherPid) {
+      String project,
+      String specId,
+      String agentType,
+      Integer pid,
+      Optional<WatcherSpawner.Spawned> watcher) {
     if (eventBus == null) {
       return;
     }
@@ -458,8 +461,8 @@ public final class SailApiOperations implements ApiOperations {
     if (pid != null) {
       data.put("pid", pid);
     }
-    if (watcherPid.isPresent()) {
-      data.put(Event.WellKnownData.WATCHER_PID, watcherPid.getAsLong());
+    if (watcher.orElse(null) instanceof WatcherSpawner.Fallback fallback) {
+      data.put(Event.WellKnownData.WATCHER_PID, fallback.pid());
     }
     eventBus.publish(
         Event.of(
@@ -677,7 +680,7 @@ public final class SailApiOperations implements ApiOperations {
     return created;
   }
 
-  private OptionalLong launchAgent(
+  private Optional<WatcherSpawner.Spawned> launchAgent(
       String project,
       SailYaml config,
       List<SailYaml.Repo> targetRepos,
@@ -721,7 +724,7 @@ public final class SailApiOperations implements ApiOperations {
       if (!result.ok()) {
         throw new ApiException(ErrorCode.AGENT_LAUNCH_FAILED, "Failed to launch agent.");
       }
-      return launchWatcherIfGuardrails(project, config);
+      return launchWatcherIfAgent(project, config);
     } catch (Exception e) {
       throw new ApiException(ErrorCode.AGENT_LAUNCH_FAILED, "Failed to launch agent.", e);
     }
@@ -741,41 +744,38 @@ public final class SailApiOperations implements ApiOperations {
 
   /**
    * Relaunches the guardrail watcher for a project whose original watcher died (e.g. with a daemon
-   * restart mid-run). The relaunched {@code sail agent watch} recomputes its deadlines from the
-   * session's original {@code started_at} inside the container, so a re-armed agent keeps its
-   * remaining budget rather than getting a fresh one. Returns the new watcher pid, or empty when
-   * the project declares no guardrails (no watcher existed to re-arm).
+   * restart mid-run). Unit-or-nothing: the relaunch never falls back to a plain process, so a
+   * doubled watcher is unrepresentable on this path — empty means the project declares no agent
+   * block or no systemd scope accepted the unit. The relaunched {@code sail agent watch} recomputes
+   * its deadlines from the session's original {@code started_at} inside the container, so a
+   * re-armed agent keeps its remaining budget rather than getting a fresh one.
    */
-  public OptionalLong relaunchWatcher(String project) throws IOException {
+  public Optional<WatcherSpawner.Unit> relaunchWatcher(String project) throws IOException {
     var loaded = loadProject(project);
-    return launchWatcherIfGuardrails(project, loaded.config());
-  }
-
-  private OptionalLong launchWatcherIfGuardrails(String project, SailYaml config)
-      throws IOException {
-    if (config.agent() == null || config.agent().guardrails() == null) {
-      return OptionalLong.empty();
+    if (loaded.config().agent() == null) {
+      return Optional.empty();
     }
-    var cmd =
-        List.of(
-            "nohup",
-            SailPaths.binaryPath().toString(),
-            "agent",
-            "watch",
-            project,
-            "-f",
-            SailPaths.resolveSailYaml(project, file).toAbsolutePath().toString());
-    var watchLog = SailPaths.projectDir(project).resolve("watch.log");
-    Files.createDirectories(watchLog.getParent());
-    return OptionalLong.of(watcherLauncher.launch(cmd, watchLog));
+    return watcherSpawner.spawnUnit(
+        project,
+        SailPaths.resolveSailYaml(project, file).toAbsolutePath(),
+        SailPaths.projectDir(project).resolve("watch.log"));
   }
 
-  static long launchWatcherProcess(List<String> command, Path logPath) throws IOException {
-    return new ProcessBuilder(command)
-        .redirectOutput(ProcessBuilder.Redirect.to(logPath.toFile()))
-        .redirectErrorStream(true)
-        .start()
-        .pid();
+  /**
+   * Spawns the detached watcher whenever the project declares an agent block — supervision is on by
+   * default, with {@code Guardrails.defaults()} applying when none are declared, and the watcher is
+   * also the authoritative stop observer the review pipeline depends on.
+   */
+  private Optional<WatcherSpawner.Spawned> launchWatcherIfAgent(String project, SailYaml config)
+      throws IOException {
+    if (config.agent() == null) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        watcherSpawner.spawn(
+            project,
+            SailPaths.resolveSailYaml(project, file).toAbsolutePath(),
+            SailPaths.projectDir(project).resolve("watch.log")));
   }
 
   private static boolean shouldSnapshot(SnapshotManager snapMgr, String project) {
@@ -1019,10 +1019,4 @@ public final class SailApiOperations implements ApiOperations {
   }
 
   private record LoadedProject(SailYaml config, ContainerState state) {}
-
-  /** Spawns the host-side guardrail watcher process and returns its pid. */
-  @FunctionalInterface
-  interface WatcherLauncher {
-    long launch(List<String> command, Path logPath) throws IOException;
-  }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/WatcherRearmer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/WatcherRearmer.java
@@ -5,59 +5,86 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.store.SessionStore;
 import ai.singlr.sail.store.SpecStore;
-import java.util.OptionalLong;
+import java.time.Duration;
+import java.util.Optional;
 import java.util.function.LongPredicate;
+import java.util.function.Predicate;
 
 /**
- * Daemon-start recovery for runs left unwatched: the guardrail watcher lives in the daemon's
- * cgroup, so a restart mid-run kills it while the agent keeps going — no stall detection, no
- * max-duration enforcement until the agent exits. For each {@code in_progress} spec whose latest
- * session is still {@code running}, whose systemd unit is still active, and whose recorded watcher
- * pid is dead, this relaunches the watcher against the existing unit. The relaunched {@code sail
- * agent watch} reads the session's original {@code started_at} from the container and computes the
- * wall-clock deadline from it, so an agent three hours into a four-hour budget gets the remaining
+ * Keeps every running agent guarded: for each {@code in_progress} spec whose latest session is
+ * still {@code running} and whose agent unit is still active, but which no live watcher covers,
+ * this relaunches the watcher — at daemon start and then periodically, so a watcher that dies
+ * mid-run (crash, OOM kill) leaves the agent unguarded for at most one pass interval. The
+ * relaunched {@code sail agent watch} recomputes its wall-clock deadline from the session's
+ * original {@code started_at}, so an agent three hours into a four-hour budget gets the remaining
  * hour, not a fresh four.
  *
- * <p>A session with no recorded watcher pid (a CLI-side dispatch, whose watcher is not tied to the
- * daemon's lifetime, or a pre-upgrade row) cannot be verified as uncovered; re-arming it could
- * stack a second watcher whose guardrail actions would fire twice, so it is skipped with a log line
- * saying so. A session whose unit is already dead is the missed-stop sweep's job, not this one's.
+ * <p>Coverage is probed, not bookkept: the watcher unit name is deterministic per project ({@code
+ * sail-watch-<project>}), so an active unit means covered; a recorded watcher pid that is still
+ * alive means covered by a pre-unit or degraded-fallback watcher. Relaunching is unit-or-nothing
+ * ({@link WatcherSpawner#spawnUnit}), so a doubled watcher — whose guardrail actions would fire
+ * twice — is unrepresentable on this path; where systemd is unavailable the relaunch is empty and
+ * the missed-stop sweep still replays the stop when the agent ends. A session whose agent unit is
+ * already dead is that sweep's job, not this one's.
  */
-public final class WatcherRearmer {
+public final class WatcherRearmer implements AutoCloseable {
+
+  /** Re-arm cadence, matching the missed-stop sweep: unguarded time is bounded by one interval. */
+  public static final Duration DEFAULT_INTERVAL = MissedStopReconciler.DEFAULT_INTERVAL;
 
   private static final SpecStore.SpecFilter IN_PROGRESS =
       new SpecStore.SpecFilter(null, "in_progress", null, null, null);
 
-  /** Relaunches a project's guardrail watcher; empty when the project declares no guardrails. */
+  /** Relaunches a project's watcher as a unit; empty when neither systemd scope accepts it. */
   @FunctionalInterface
   public interface WatcherRelauncher {
-    OptionalLong relaunch(String project) throws Exception;
+    Optional<WatcherSpawner.Unit> relaunch(String project) throws Exception;
   }
 
   private final SpecStore specStore;
   private final SessionStore sessionStore;
-  private final MissedStopReconciler.UnitProbe unitProbe;
+  private final MissedStopReconciler.UnitProbe agentUnitProbe;
+  private final Predicate<String> watcherUnitActive;
   private final LongPredicate watcherAlive;
   private final WatcherRelauncher relauncher;
+  private final PeriodicPass pass;
 
   public WatcherRearmer(
       SpecStore specStore,
       SessionStore sessionStore,
-      MissedStopReconciler.UnitProbe unitProbe,
+      MissedStopReconciler.UnitProbe agentUnitProbe,
+      Predicate<String> watcherUnitActive,
       LongPredicate watcherAlive,
       WatcherRelauncher relauncher) {
     this.specStore = specStore;
     this.sessionStore = sessionStore;
-    this.unitProbe = unitProbe;
+    this.agentUnitProbe = agentUnitProbe;
+    this.watcherUnitActive = watcherUnitActive;
     this.watcherAlive = watcherAlive;
     this.relauncher = relauncher;
+    this.pass = new PeriodicPass("rearm", this::rearm);
   }
 
   /** Liveness of a host process by pid — how recorded watcher pids are checked in production. */
   public static LongPredicate livingProcess() {
     return pid -> ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false);
+  }
+
+  /** Starts the periodic re-arm at the default cadence. */
+  public void start() {
+    start(DEFAULT_INTERVAL);
+  }
+
+  public void start(Duration interval) {
+    pass.start(interval);
+  }
+
+  /** Runs one pass unless another is still in flight. Returns whether the pass ran. */
+  boolean rearmIfIdle() {
+    return pass.runIfIdle();
   }
 
   /**
@@ -88,7 +115,17 @@ public final class WatcherRearmer {
       return false;
     }
     var session = latest.get();
-    if (session.watcherPid() == null) {
+    if (watcherUnitActive.test(spec.project())) {
+      return false;
+    }
+    if (session.watcherPid() != null && watcherAlive.test(session.watcherPid())) {
+      return false;
+    }
+    if (!agentUnitProbe.active(spec.project())) {
+      return false;
+    }
+    var unit = relauncher.relaunch(spec.project());
+    if (unit.isEmpty()) {
       System.err.println(
           "  [rearm] "
               + spec.project()
@@ -96,31 +133,11 @@ public final class WatcherRearmer {
               + spec.id()
               + " (session "
               + session.id()
-              + "): no watcher pid recorded, so coverage cannot be verified; not re-arming"
-              + " (a second watcher would double guardrail actions)");
+              + "): agent is running unwatched but no watcher unit could be launched (no agent"
+              + " block or no systemd scope); the missed-stop sweep still replays its stop when"
+              + " the agent ends");
       return false;
     }
-    if (watcherAlive.test(session.watcherPid())) {
-      return false;
-    }
-    if (!unitProbe.active(spec.project())) {
-      return false;
-    }
-    var pid = relauncher.relaunch(spec.project());
-    if (pid.isEmpty()) {
-      System.err.println(
-          "  [rearm] "
-              + spec.project()
-              + "/"
-              + spec.id()
-              + " (session "
-              + session.id()
-              + "): watcher pid "
-              + session.watcherPid()
-              + " is dead but the project declares no guardrails; nothing to re-arm");
-      return false;
-    }
-    sessionStore.updateWatcherPid(session.id(), (int) pid.getAsLong());
     System.err.println(
         "  [rearm] re-armed watcher for "
             + spec.project()
@@ -128,11 +145,19 @@ public final class WatcherRearmer {
             + spec.id()
             + " (session "
             + session.id()
-            + "): watcher pid "
-            + session.watcherPid()
-            + " died while the agent unit is still active; new watcher pid "
-            + pid.getAsLong()
-            + " resumes the original deadline from the session's started_at");
+            + "): "
+            + (unit.get().adopted()
+                ? "adopted already-active unit " + unit.get().name()
+                : "launched unit "
+                    + unit.get().name()
+                    + " ("
+                    + unit.get().scope()
+                    + " scope), resuming the original deadline from the session's started_at"));
     return true;
+  }
+
+  @Override
+  public void close() {
+    pass.close();
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/WatcherRearmer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/WatcherRearmer.java
@@ -22,13 +22,14 @@ import java.util.function.Predicate;
  * original {@code started_at}, so an agent three hours into a four-hour budget gets the remaining
  * hour, not a fresh four.
  *
- * <p>Coverage is probed, not bookkept: the watcher unit name is deterministic per project ({@code
- * sail-watch-<project>}), so an active unit means covered; a recorded watcher pid that is still
- * alive means covered by a pre-unit or degraded-fallback watcher. Relaunching is unit-or-nothing
- * ({@link WatcherSpawner#spawnUnit}), so a doubled watcher — whose guardrail actions would fire
- * twice — is unrepresentable on this path; where systemd is unavailable the relaunch is empty and
- * the missed-stop sweep still replays the stop when the agent ends. A session whose agent unit is
- * already dead is that sweep's job, not this one's.
+ * <p>Coverage is probed, not bookkept — and probed at the process level: a recorded watcher pid
+ * that is still alive (free, in-process check) or any {@code sail agent watch} process for the
+ * project ({@link WatcherSpawner#watcherProcessRunning}, which sees every systemd scope, every
+ * user's manager, and plain fallback processes alike) means covered. Unit-name probes alone would
+ * be blind to a watcher armed in another user's manager and re-arm a double whose guardrail actions
+ * fire twice. Relaunching is unit-or-nothing ({@link WatcherSpawner#spawnUnit}); where systemd is
+ * unavailable the relaunch is empty and the missed-stop sweep still replays the stop when the agent
+ * ends. A session whose agent unit is already dead is that sweep's job, not this one's.
  */
 public final class WatcherRearmer implements AutoCloseable {
 
@@ -47,7 +48,7 @@ public final class WatcherRearmer implements AutoCloseable {
   private final SpecStore specStore;
   private final SessionStore sessionStore;
   private final MissedStopReconciler.UnitProbe agentUnitProbe;
-  private final Predicate<String> watcherUnitActive;
+  private final Predicate<String> watcherRunning;
   private final LongPredicate watcherAlive;
   private final WatcherRelauncher relauncher;
   private final PeriodicPass pass;
@@ -56,13 +57,13 @@ public final class WatcherRearmer implements AutoCloseable {
       SpecStore specStore,
       SessionStore sessionStore,
       MissedStopReconciler.UnitProbe agentUnitProbe,
-      Predicate<String> watcherUnitActive,
+      Predicate<String> watcherRunning,
       LongPredicate watcherAlive,
       WatcherRelauncher relauncher) {
     this.specStore = specStore;
     this.sessionStore = sessionStore;
     this.agentUnitProbe = agentUnitProbe;
-    this.watcherUnitActive = watcherUnitActive;
+    this.watcherRunning = watcherRunning;
     this.watcherAlive = watcherAlive;
     this.relauncher = relauncher;
     this.pass = new PeriodicPass("rearm", this::rearm);
@@ -115,10 +116,10 @@ public final class WatcherRearmer implements AutoCloseable {
       return false;
     }
     var session = latest.get();
-    if (watcherUnitActive.test(spec.project())) {
+    if (session.watcherPid() != null && watcherAlive.test(session.watcherPid())) {
       return false;
     }
-    if (session.watcherPid() != null && watcherAlive.test(session.watcherPid())) {
+    if (watcherRunning.test(spec.project())) {
       return false;
     }
     if (!agentUnitProbe.active(spec.project())) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLaunchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLaunchCommand.java
@@ -291,7 +291,7 @@ public final class AgentLaunchCommand implements Runnable {
     Banner.printAgentLaunched(name, task, branchName, System.out, Ansi.AUTO);
 
     if (!dryRun) {
-      GuardrailWatcher.launch(name, file, config);
+      GuardrailWatcher.launch(name, file, config, shell);
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
@@ -311,7 +311,7 @@ public final class DispatchCommand implements Runnable {
       }
       Banner.printAgentLaunched(name, task, branchName, System.out, Ansi.AUTO);
       if (!dryRun) {
-        GuardrailWatcher.launch(name, file, config);
+        GuardrailWatcher.launch(name, file, config, shell);
       }
     } else {
       var sshCmd =

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
@@ -327,7 +327,7 @@ public final class RunCommand implements Runnable {
     Banner.printAgentLaunched(name, task, branchName, System.out, Ansi.AUTO);
 
     if (!dryRun) {
-      GuardrailWatcher.launch(name, file, config);
+      GuardrailWatcher.launch(name, file, config, shell);
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -31,6 +31,7 @@ import ai.singlr.sail.engine.GracefulShutdown;
 import ai.singlr.sail.engine.HostInfo;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.store.AuthSessionStore;
 import ai.singlr.sail.store.DataMigration;
 import ai.singlr.sail.store.EnrollmentTicketStore;
@@ -227,7 +228,21 @@ public final class ServerStartCommand implements Runnable {
     var missedStops =
         new MissedStopReconciler(
             specStore, sessionStore, eventStore, bus, unitProbe, DateTimeUtils::now);
-    shutdown.register(server).register(sweeper).register(reconciler).register(missedStops);
+    var watcherSpawner = new WatcherSpawner(new ShellExecutor(false), null);
+    var rearmer =
+        new WatcherRearmer(
+            specStore,
+            sessionStore,
+            unitProbe,
+            watcherSpawner::unitActive,
+            WatcherRearmer.livingProcess(),
+            operations::relaunchWatcher);
+    shutdown
+        .register(server)
+        .register(sweeper)
+        .register(reconciler)
+        .register(missedStops)
+        .register(rearmer);
     try {
       server.start();
       sweeper.start();
@@ -239,14 +254,8 @@ public final class ServerStartCommand implements Runnable {
                 "  @|green ✓|@ Replayed " + replayed + " agent stop(s) missed while offline"));
       }
       missedStops.start();
-      var rearmed =
-          new WatcherRearmer(
-                  specStore,
-                  sessionStore,
-                  unitProbe,
-                  WatcherRearmer.livingProcess(),
-                  operations::relaunchWatcher)
-              .rearm();
+      var rearmed = rearmer.rearm();
+      rearmer.start();
       if (rearmed > 0) {
         System.out.println(
             Ansi.AUTO.string(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -224,17 +224,18 @@ public final class ServerStartCommand implements Runnable {
     var reconciler =
         new StuckSpecReconciler(
             dbPath, StuckSpecReconciler.DEFAULT_THRESHOLD, stranded -> surface(bus, stranded));
-    var unitProbe = MissedStopReconciler.systemdUnitProbe(new ShellExecutor(false));
+    var reconcileShell = new ShellExecutor(false);
+    var unitProbe = MissedStopReconciler.systemdUnitProbe(reconcileShell);
     var missedStops =
         new MissedStopReconciler(
             specStore, sessionStore, eventStore, bus, unitProbe, DateTimeUtils::now);
-    var watcherSpawner = new WatcherSpawner(new ShellExecutor(false), null);
+    var watcherSpawner = new WatcherSpawner(reconcileShell, null);
     var rearmer =
         new WatcherRearmer(
             specStore,
             sessionStore,
             unitProbe,
-            watcherSpawner::unitActive,
+            watcherSpawner::watcherProcessRunning,
             WatcherRearmer.livingProcess(),
             operations::relaunchWatcher);
     shutdown

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/GuardrailWatcher.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/GuardrailWatcher.java
@@ -6,16 +6,16 @@
 package ai.singlr.sail.engine;
 
 import ai.singlr.sail.config.SailYaml;
-import java.nio.file.Files;
-import java.util.List;
+import java.nio.file.Path;
 import picocli.CommandLine.Help.Ansi;
 
 /**
  * Starts the background guardrail watcher ({@code sail agent watch}) for a project. Supervision is
  * on by default: the watcher is spawned for every dispatched agent and applies {@link
  * ai.singlr.sail.config.Guardrails#defaults()} when sail.yaml declares no guardrails of its own.
- * Shared by the CLI dispatch/run/launch commands, which all spawn it the same way; failures are
- * reported but never fatal to the launch.
+ * Shared by the CLI dispatch/run/launch commands, which all spawn it the same way through {@link
+ * WatcherSpawner} — detached from this process, so it survives Ctrl-C on the dispatch stream and
+ * the SSH session ending. Failures are reported but never fatal to the launch.
  */
 public final class GuardrailWatcher {
 
@@ -29,28 +29,11 @@ public final class GuardrailWatcher {
       return;
     }
     try {
-      var sailBinary = SailPaths.binaryPath().toString();
       var sailYamlPath = SailPaths.resolveSailYaml(project, file);
-      var cmd =
-          List.of(
-              "nohup",
-              sailBinary,
-              "agent",
-              "watch",
-              project,
-              "-f",
-              sailYamlPath.toAbsolutePath().toString());
-
       var watchLog = SailPaths.projectDir(project).resolve("watch.log");
-      Files.createDirectories(watchLog.getParent());
-
-      var pb = new ProcessBuilder(cmd);
-      pb.redirectOutput(ProcessBuilder.Redirect.to(watchLog.toFile()));
-      pb.redirectErrorStream(true);
-      pb.start();
-
-      System.out.println(
-          Ansi.AUTO.string("  @|green ✓|@ Guardrail watcher started (log: " + watchLog + ")"));
+      var spawner = new WatcherSpawner(new ShellExecutor(false), WatcherSpawner::spawnProcess);
+      var spawned = spawner.spawn(project, sailYamlPath, watchLog);
+      System.out.println(Ansi.AUTO.string("  @|green ✓|@ " + describe(spawned, watchLog)));
     } catch (Exception e) {
       System.err.println(
           Banner.errorLine(
@@ -60,5 +43,26 @@ public final class GuardrailWatcher {
                   + project,
               Ansi.AUTO));
     }
+  }
+
+  static String describe(WatcherSpawner.Spawned spawned, Path watchLog) {
+    return switch (spawned) {
+      case WatcherSpawner.Unit unit when unit.adopted() ->
+          "Guardrail watcher already active (unit " + unit.name() + ", log: " + watchLog + ")";
+      case WatcherSpawner.Unit unit ->
+          "Guardrail watcher started (unit "
+              + unit.name()
+              + ", "
+              + unit.scope()
+              + " scope, log: "
+              + watchLog
+              + ")";
+      case WatcherSpawner.Fallback fallback ->
+          "Guardrail watcher started (pid "
+              + fallback.pid()
+              + ", detached process — no systemd available, log: "
+              + watchLog
+              + ")";
+    };
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/GuardrailWatcher.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/GuardrailWatcher.java
@@ -22,16 +22,17 @@ public final class GuardrailWatcher {
   private GuardrailWatcher() {}
 
   /**
-   * Spawns a detached watcher for the project's agent (no-op only when there is no agent block).
+   * Spawns a detached watcher for the project's agent (no-op only when there is no agent block),
+   * through the caller's own shell so wiring matches the rest of the command.
    */
-  public static void launch(String project, String file, SailYaml config) {
+  public static void launch(String project, String file, SailYaml config, ShellExec shell) {
     if (config == null || config.agent() == null) {
       return;
     }
     try {
       var sailYamlPath = SailPaths.resolveSailYaml(project, file);
       var watchLog = SailPaths.projectDir(project).resolve("watch.log");
-      var spawner = new WatcherSpawner(new ShellExecutor(false), WatcherSpawner::spawnProcess);
+      var spawner = new WatcherSpawner(shell, WatcherSpawner::spawnProcess);
       var spawned = spawner.spawn(project, sailYamlPath, watchLog);
       System.out.println(Ansi.AUTO.string("  @|green ✓|@ " + describe(spawned, watchLog)));
     } catch (Exception e) {

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/WatcherSpawner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/WatcherSpawner.java
@@ -5,6 +5,8 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.engine.SystemdServiceInstaller.Mode;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -16,20 +18,30 @@ import java.util.Optional;
  * Spawns the guardrail watcher ({@code sail agent watch}) detached from the caller, as a systemd
  * transient unit named {@code sail-watch-<project>} — the same mechanism that keeps the agent
  * itself alive, so the watcher is immune to Ctrl-C on the dispatch stream, SSH hangup, and daemon
- * restarts alike. The unit name is deterministic and one agent runs per project, so liveness is
- * probed ({@link #unitActive}) rather than recorded, and spawning against an already-active unit
- * adopts it instead of stacking a second watcher.
+ * restarts alike. Scope ladder: the caller's user manager first, the system scope second, and —
+ * only when a {@link ProcessSpawner} fallback is supplied — a plain detached process last, loudly
+ * marked degraded because no unit name can address it.
  *
- * <p>Scope ladder: a user-manager unit first, a system-scope unit second, and — only when a {@link
- * ProcessSpawner} fallback is supplied — a plain detached process last, loudly marked degraded
- * because nothing can re-arm or address it. Unit-only callers (the re-armer) pass no fallback, so a
- * doubled watcher is unrepresentable on that path. The unit needs no explicit teardown: the watcher
- * exits on its own after observing the agent unit stop, and {@code --collect} garbage-collects the
+ * <p>Two spawn intents with different collision semantics. {@link #spawn} serves dispatch: a fresh
+ * session must get a fresh watcher whose deadline anchors to it, so any unit still active from the
+ * previous session is stopped and replaced — an adopted stale watcher would enforce the old
+ * session's nearly-spent deadline against a brand-new agent. {@link #spawnUnit} serves the
+ * re-armer: it only runs against a session already verified uncovered, so an active unit means a
+ * concurrent pass won the race and is adopted, never doubled.
+ *
+ * <p>{@code Type=exec} makes exec-phase failures (unopenable log path, missing binary) fail the
+ * rung visibly instead of reporting a unit that died at birth, and the {@code SAIL_*} environment a
+ * shell-configured deployment relies on is forwarded explicitly — a transient unit starts from
+ * systemd's clean environment, not the dispatcher's. The unit needs no teardown of its own: the
+ * watcher exits after observing the agent unit stop, and {@code --collect} garbage-collects the
  * unit whatever its exit status.
  */
 public final class WatcherSpawner {
 
   static final String UNIT_PREFIX = "sail-watch-";
+
+  private static final List<String> FORWARDED_ENV =
+      List.of("SAIL_TOKEN", "SAIL_TOKEN_FILE", "SAIL_SERVER", "SAIL_DATA_DIR");
 
   /** How a watcher ended up running. */
   public sealed interface Spawned permits Unit, Fallback {}
@@ -48,9 +60,6 @@ public final class WatcherSpawner {
   public interface ProcessSpawner {
     long spawn(List<String> command, Path logPath) throws IOException;
   }
-
-  private static final String USER_SCOPE = "user";
-  private static final String SYSTEM_SCOPE = "system";
 
   private final ShellExec shell;
   private final ProcessSpawner fallback;
@@ -86,15 +95,20 @@ public final class WatcherSpawner {
   }
 
   /**
-   * Spawns the project's watcher: adopt an active unit, else launch one, else fall back to a
-   * detached process when a fallback was supplied. Throws only when every rung failed — the
-   * caller's dispatch flow treats that as a launch failure.
+   * Spawns a fresh watcher for a fresh session: any unit still active from a previous session is
+   * stopped first — never adopted, because its wall-clock deadline anchors to the old session and
+   * would be enforced against the new agent. Falls back to a detached process when no systemd scope
+   * accepts and a fallback was supplied; throws when every rung failed or the thread was
+   * interrupted mid-ladder, which the dispatch flow treats as a launch failure.
    */
   public Spawned spawn(String project, Path sailYaml, Path watchLog) throws IOException {
-    var unit = spawnUnit(project, sailYaml, watchLog);
+    stopExisting(project);
+    ensureLogDirectory(watchLog);
+    var unit = launch(project, watchCommand(project, sailYaml), watchLog);
     if (unit.isPresent()) {
       return unit.get();
     }
+    requireNotInterrupted(project);
     if (fallback == null) {
       throw new IOException(
           "No systemd scope accepted unit " + unitName(project) + " and no fallback is allowed.");
@@ -102,7 +116,6 @@ public final class WatcherSpawner {
     var command = new ArrayList<String>();
     command.add("nohup");
     command.addAll(watchCommand(project, sailYaml));
-    ensureLogDirectory(watchLog);
     var pid = fallback.spawn(command, watchLog);
     System.err.println(
         "  [watch] degraded: no systemd scope accepted unit "
@@ -114,37 +127,71 @@ public final class WatcherSpawner {
   }
 
   /**
-   * Unit-or-nothing spawn: adopts the active unit when one covers the project, otherwise tries the
-   * user then system scope. Empty means no systemd scope is available — never a plain process, so
-   * callers that must not risk a doubled watcher use this path.
+   * Unit-or-nothing spawn for the re-armer, which has already verified the session is uncovered: an
+   * active unit means a concurrent pass won the race and is adopted. Never falls back to a plain
+   * process. Empty means no systemd scope is available.
    */
-  public Optional<Unit> spawnUnit(String project, Path sailYaml, Path watchLog) {
+  public Optional<Unit> spawnUnit(String project, Path sailYaml, Path watchLog) throws IOException {
     return spawnUnit(project, watchCommand(project, sailYaml), watchLog);
   }
 
-  Optional<Unit> spawnUnit(String project, List<String> argv, Path watchLog) {
+  Optional<Unit> spawnUnit(String project, List<String> argv, Path watchLog) throws IOException {
     var adopted = activeScope(project);
     if (adopted.isPresent()) {
-      return Optional.of(new Unit(unitName(project), adopted.get(), true));
+      return Optional.of(new Unit(unitName(project), scopeName(adopted.get()), true));
     }
     ensureLogDirectory(watchLog);
-    for (var scope : List.of(USER_SCOPE, SYSTEM_SCOPE)) {
-      if (execOk(systemdRun(project, argv, watchLog, scope))) {
-        return Optional.of(new Unit(unitName(project), scope, false));
-      }
+    var launched = launch(project, argv, watchLog);
+    if (launched.isPresent()) {
+      return launched;
     }
-    return activeScope(project).map(scope -> new Unit(unitName(project), scope, true));
+    return activeScope(project).map(mode -> new Unit(unitName(project), scopeName(mode), true));
   }
 
-  /** Whether a watcher unit for the project is active in either systemd scope. */
+  /** Whether a watcher unit for the project is active in either scope of this systemd view. */
   public boolean unitActive(String project) {
     return activeScope(project).isPresent();
   }
 
-  private Optional<String> activeScope(String project) {
-    for (var scope : List.of(USER_SCOPE, SYSTEM_SCOPE)) {
-      if (execOk(systemctlIsActive(project, scope))) {
-        return Optional.of(scope);
+  /**
+   * Whether any {@code sail agent watch} process for the project is running on this host —
+   * unit-spawned in any user's manager, fallback-spawned, or run by hand. Process visibility is
+   * global where unit visibility is scoped to one systemd view, so this is the coverage probe the
+   * re-armer trusts: a watcher it cannot address is still a watcher it must not double.
+   */
+  public boolean watcherProcessRunning(String project) {
+    return execOk(List.of("pgrep", "-f", "--", "agent watch " + project + " -f "));
+  }
+
+  private Optional<Unit> launch(String project, List<String> argv, Path watchLog) {
+    for (var mode : Mode.values()) {
+      if (execOk(systemdRun(project, argv, watchLog, mode))) {
+        return Optional.of(new Unit(unitName(project), scopeName(mode), false));
+      }
+    }
+    return Optional.empty();
+  }
+
+  private void stopExisting(String project) {
+    for (var mode : Mode.values()) {
+      if (execOk(
+          SystemdServiceInstaller.systemctl(mode, "--quiet", "is-active", unitName(project)))) {
+        execOk(SystemdServiceInstaller.systemctl(mode, "stop", unitName(project)));
+        System.err.println(
+            "  [watch] stopped stale watcher unit "
+                + unitName(project)
+                + " ("
+                + scopeName(mode)
+                + " scope) from a previous session before arming the new one");
+      }
+    }
+  }
+
+  private Optional<Mode> activeScope(String project) {
+    for (var mode : Mode.values()) {
+      if (execOk(
+          SystemdServiceInstaller.systemctl(mode, "--quiet", "is-active", unitName(project)))) {
+        return Optional.of(mode);
       }
     }
     return Optional.empty();
@@ -153,28 +200,29 @@ public final class WatcherSpawner {
   private boolean execOk(List<String> command) {
     try {
       return shell.exec(command).ok();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
     } catch (Exception e) {
       return false;
     }
   }
 
-  private static List<String> systemctlIsActive(String project, String scope) {
-    var command = new ArrayList<String>();
-    command.add("systemctl");
-    if (USER_SCOPE.equals(scope)) {
-      command.add("--user");
+  private static void requireNotInterrupted(String project) throws IOException {
+    if (Thread.currentThread().isInterrupted()) {
+      throw new IOException(
+          "Interrupted while spawning watcher for " + project + "; not falling back.");
     }
-    command.add("--quiet");
-    command.add("is-active");
-    command.add(unitName(project));
-    return command;
   }
 
-  private static List<String> systemdRun(
-      String project, List<String> argv, Path watchLog, String scope) {
+  private static String scopeName(Mode mode) {
+    return mode == Mode.USER ? "user" : "system";
+  }
+
+  private List<String> systemdRun(String project, List<String> argv, Path watchLog, Mode mode) {
     var command = new ArrayList<String>();
     command.add("systemd-run");
-    if (USER_SCOPE.equals(scope)) {
+    if (mode == Mode.USER) {
       command.add("--user");
     }
     command.add("--collect");
@@ -182,18 +230,23 @@ public final class WatcherSpawner {
     command.add("--unit");
     command.add(unitName(project));
     command.add("--property");
+    command.add("Type=exec");
+    command.add("--property");
     command.add("StandardOutput=append:" + watchLog.toAbsolutePath());
     command.add("--property");
     command.add("StandardError=append:" + watchLog.toAbsolutePath());
+    for (var name : FORWARDED_ENV) {
+      var value = System.getenv(name);
+      if (Strings.isNotBlank(value)) {
+        command.add("--setenv");
+        command.add(name + "=" + value);
+      }
+    }
     command.addAll(argv);
     return command;
   }
 
-  private static void ensureLogDirectory(Path watchLog) {
-    try {
-      Files.createDirectories(watchLog.toAbsolutePath().getParent());
-    } catch (IOException e) {
-      System.err.println("  [watch] could not create log directory: " + e.getMessage());
-    }
+  private static void ensureLogDirectory(Path watchLog) throws IOException {
+    Files.createDirectories(watchLog.toAbsolutePath().getParent());
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/WatcherSpawner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/WatcherSpawner.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Spawns the guardrail watcher ({@code sail agent watch}) detached from the caller, as a systemd
+ * transient unit named {@code sail-watch-<project>} — the same mechanism that keeps the agent
+ * itself alive, so the watcher is immune to Ctrl-C on the dispatch stream, SSH hangup, and daemon
+ * restarts alike. The unit name is deterministic and one agent runs per project, so liveness is
+ * probed ({@link #unitActive}) rather than recorded, and spawning against an already-active unit
+ * adopts it instead of stacking a second watcher.
+ *
+ * <p>Scope ladder: a user-manager unit first, a system-scope unit second, and — only when a {@link
+ * ProcessSpawner} fallback is supplied — a plain detached process last, loudly marked degraded
+ * because nothing can re-arm or address it. Unit-only callers (the re-armer) pass no fallback, so a
+ * doubled watcher is unrepresentable on that path. The unit needs no explicit teardown: the watcher
+ * exits on its own after observing the agent unit stop, and {@code --collect} garbage-collects the
+ * unit whatever its exit status.
+ */
+public final class WatcherSpawner {
+
+  static final String UNIT_PREFIX = "sail-watch-";
+
+  /** How a watcher ended up running. */
+  public sealed interface Spawned permits Unit, Fallback {}
+
+  /**
+   * A watcher running as a systemd transient unit; {@code adopted} means an already-active unit was
+   * found covering the project rather than a new one launched.
+   */
+  public record Unit(String name, String scope, boolean adopted) implements Spawned {}
+
+  /** A watcher running as a plain detached process — the degraded, unaddressable path. */
+  public record Fallback(long pid) implements Spawned {}
+
+  /** Spawns the fallback watcher process and returns its pid. A seam for tests. */
+  @FunctionalInterface
+  public interface ProcessSpawner {
+    long spawn(List<String> command, Path logPath) throws IOException;
+  }
+
+  private static final String USER_SCOPE = "user";
+  private static final String SYSTEM_SCOPE = "system";
+
+  private final ShellExec shell;
+  private final ProcessSpawner fallback;
+
+  /** With a {@code null} fallback the spawner is unit-only: no systemd, no watcher. */
+  public WatcherSpawner(ShellExec shell, ProcessSpawner fallback) {
+    this.shell = shell;
+    this.fallback = fallback;
+  }
+
+  public static String unitName(String project) {
+    return UNIT_PREFIX + project;
+  }
+
+  /** The watcher argv, shared by every spawn path. */
+  public static List<String> watchCommand(String project, Path sailYaml) {
+    return List.of(
+        SailPaths.binaryPath().toString(),
+        "agent",
+        "watch",
+        project,
+        "-f",
+        sailYaml.toAbsolutePath().toString());
+  }
+
+  /** Starts a detached process, mirroring the historic fallback spawn. */
+  public static long spawnProcess(List<String> command, Path logPath) throws IOException {
+    return new ProcessBuilder(command)
+        .redirectOutput(ProcessBuilder.Redirect.to(logPath.toFile()))
+        .redirectErrorStream(true)
+        .start()
+        .pid();
+  }
+
+  /**
+   * Spawns the project's watcher: adopt an active unit, else launch one, else fall back to a
+   * detached process when a fallback was supplied. Throws only when every rung failed — the
+   * caller's dispatch flow treats that as a launch failure.
+   */
+  public Spawned spawn(String project, Path sailYaml, Path watchLog) throws IOException {
+    var unit = spawnUnit(project, sailYaml, watchLog);
+    if (unit.isPresent()) {
+      return unit.get();
+    }
+    if (fallback == null) {
+      throw new IOException(
+          "No systemd scope accepted unit " + unitName(project) + " and no fallback is allowed.");
+    }
+    var command = new ArrayList<String>();
+    command.add("nohup");
+    command.addAll(watchCommand(project, sailYaml));
+    ensureLogDirectory(watchLog);
+    var pid = fallback.spawn(command, watchLog);
+    System.err.println(
+        "  [watch] degraded: no systemd scope accepted unit "
+            + unitName(project)
+            + "; watcher runs as plain process "
+            + pid
+            + " (dies with its session, cannot be re-armed)");
+    return new Fallback(pid);
+  }
+
+  /**
+   * Unit-or-nothing spawn: adopts the active unit when one covers the project, otherwise tries the
+   * user then system scope. Empty means no systemd scope is available — never a plain process, so
+   * callers that must not risk a doubled watcher use this path.
+   */
+  public Optional<Unit> spawnUnit(String project, Path sailYaml, Path watchLog) {
+    return spawnUnit(project, watchCommand(project, sailYaml), watchLog);
+  }
+
+  Optional<Unit> spawnUnit(String project, List<String> argv, Path watchLog) {
+    var adopted = activeScope(project);
+    if (adopted.isPresent()) {
+      return Optional.of(new Unit(unitName(project), adopted.get(), true));
+    }
+    ensureLogDirectory(watchLog);
+    for (var scope : List.of(USER_SCOPE, SYSTEM_SCOPE)) {
+      if (execOk(systemdRun(project, argv, watchLog, scope))) {
+        return Optional.of(new Unit(unitName(project), scope, false));
+      }
+    }
+    return activeScope(project).map(scope -> new Unit(unitName(project), scope, true));
+  }
+
+  /** Whether a watcher unit for the project is active in either systemd scope. */
+  public boolean unitActive(String project) {
+    return activeScope(project).isPresent();
+  }
+
+  private Optional<String> activeScope(String project) {
+    for (var scope : List.of(USER_SCOPE, SYSTEM_SCOPE)) {
+      if (execOk(systemctlIsActive(project, scope))) {
+        return Optional.of(scope);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private boolean execOk(List<String> command) {
+    try {
+      return shell.exec(command).ok();
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private static List<String> systemctlIsActive(String project, String scope) {
+    var command = new ArrayList<String>();
+    command.add("systemctl");
+    if (USER_SCOPE.equals(scope)) {
+      command.add("--user");
+    }
+    command.add("--quiet");
+    command.add("is-active");
+    command.add(unitName(project));
+    return command;
+  }
+
+  private static List<String> systemdRun(
+      String project, List<String> argv, Path watchLog, String scope) {
+    var command = new ArrayList<String>();
+    command.add("systemd-run");
+    if (USER_SCOPE.equals(scope)) {
+      command.add("--user");
+    }
+    command.add("--collect");
+    command.add("--quiet");
+    command.add("--unit");
+    command.add(unitName(project));
+    command.add("--property");
+    command.add("StandardOutput=append:" + watchLog.toAbsolutePath());
+    command.add("--property");
+    command.add("StandardError=append:" + watchLog.toAbsolutePath());
+    command.addAll(argv);
+    return command;
+  }
+
+  private static void ensureLogDirectory(Path watchLog) {
+    try {
+      Files.createDirectories(watchLog.toAbsolutePath().getParent());
+    } catch (IOException e) {
+      System.err.println("  [watch] could not create log directory: " + e.getMessage());
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/PeriodicPassTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/PeriodicPassTest.java
@@ -40,20 +40,23 @@ class PeriodicPassTest {
   }
 
   @Test
-  void aThrowingPassIsLoggedAndDoesNotPoisonLaterRuns() {
+  void aThrowingPassEvenAnErrorIsLoggedAndDoesNotPoisonLaterRuns() {
     var runs = new AtomicInteger();
     try (var pass =
         new PeriodicPass(
             "test",
             () -> {
-              if (runs.incrementAndGet() == 1) {
-                throw new IllegalStateException("boom");
+              switch (runs.incrementAndGet()) {
+                case 1 -> throw new IllegalStateException("boom");
+                case 2 -> throw new AssertionError("an Error must not cancel the schedule");
+                default -> {}
               }
             })) {
 
       assertTrue(pass.runIfIdle());
       assertTrue(pass.runIfIdle());
-      assertEquals(2, runs.get());
+      assertTrue(pass.runIfIdle());
+      assertEquals(3, runs.get());
     }
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/PeriodicPassTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/PeriodicPassTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class PeriodicPassTest {
+
+  @Test
+  void aPassInFlightMakesTheNextTickANoOpInsteadOfStacking() throws Exception {
+    var entered = new CountDownLatch(1);
+    var release = new CountDownLatch(1);
+    try (var pass =
+        new PeriodicPass(
+            "test",
+            () -> {
+              entered.countDown();
+              await(release);
+            })) {
+      var first = Thread.ofVirtual().start(pass::runIfIdle);
+      assertTrue(entered.await(5, TimeUnit.SECONDS));
+
+      assertFalse(pass.runIfIdle());
+
+      release.countDown();
+      first.join();
+      assertTrue(pass.runIfIdle());
+    }
+  }
+
+  @Test
+  void aThrowingPassIsLoggedAndDoesNotPoisonLaterRuns() {
+    var runs = new AtomicInteger();
+    try (var pass =
+        new PeriodicPass(
+            "test",
+            () -> {
+              if (runs.incrementAndGet() == 1) {
+                throw new IllegalStateException("boom");
+              }
+            })) {
+
+      assertTrue(pass.runIfIdle());
+      assertTrue(pass.runIfIdle());
+      assertEquals(2, runs.get());
+    }
+  }
+
+  @Test
+  void startSchedulesOnItsOwnSchedulerAndCloseStopsIt() {
+    var pass = new PeriodicPass("test", () -> {});
+    pass.start(Duration.ofHours(1));
+
+    pass.close();
+
+    assertTrue(pass.runIfIdle());
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.engine.ConnectEnvironment;
 import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.store.Finding;
 import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.ReviewStore;
@@ -734,16 +735,6 @@ class SailApiOperationsTest {
   }
 
   @Test
-  void watcherProcessLauncherStartsCommandAndReturnsItsPid() throws Exception {
-    var logPath = tempDir.resolve("watch.log");
-
-    var pid = SailApiOperations.launchWatcherProcess(List.of("sh", "-c", "true"), logPath);
-
-    assertTrue(pid > 0);
-    assertTrue(Files.exists(logPath));
-  }
-
-  @Test
   void dispatchRecordsTheWatcherPidOnTheSessionStartedEvent() throws Exception {
     var yaml = tempDir.resolve("sail-watcher-pid.yaml");
     Files.writeString(yaml, guardrailsYaml());
@@ -798,23 +789,46 @@ class SailApiOperationsTest {
   }
 
   @Test
-  void relaunchWatcherReturnsTheNewWatcherPid() throws Exception {
+  void relaunchWatcherLaunchesAUnitAndNeverFallsBackToAPlainProcess() throws Exception {
+    var operations =
+        operations(
+            guardrailsYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("systemd-run --user", new ShellExec.Result(0, "", "")),
+            (command, logPath) -> {
+              throw new IOException("relaunch must never use the process fallback");
+            });
+
+    var unit = operations.relaunchWatcher("acme").orElseThrow();
+
+    assertEquals(new WatcherSpawner.Unit("sail-watch-acme", "user", false), unit);
+  }
+
+  @Test
+  void relaunchWatcherIsEmptyWhenNoSystemdScopeAccepts() throws Exception {
     var operations =
         operations(
             guardrailsYaml(),
             shell().on("incus list ^acme$", RUNNING_JSON),
             (command, logPath) -> 4242L);
 
-    var pid = operations.relaunchWatcher("acme");
-
-    assertEquals(4242L, pid.orElseThrow());
+    assertTrue(operations.relaunchWatcher("acme").isEmpty());
   }
 
   @Test
-  void relaunchWatcherIsEmptyWhenTheProjectDeclaresNoGuardrails() throws Exception {
+  void relaunchWatcherIsEmptyWhenTheProjectDeclaresNoAgent() throws Exception {
     var operations =
         operations(
-            baseYaml(), shell().on("incus list ^acme$", RUNNING_JSON), (command, logPath) -> 4242L);
+            """
+            name: acme
+            ssh:
+              user: dev
+            """,
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("systemd-run --user", new ShellExec.Result(0, "", "")),
+            (command, logPath) -> 4242L);
 
     assertTrue(operations.relaunchWatcher("acme").isEmpty());
   }
@@ -1482,7 +1496,14 @@ class SailApiOperationsTest {
     seedSpecs.accept(specStore);
     seedSessions.accept(sessionStore);
     return new SailApiOperations(
-        shell, yaml.toString(), null, bus, null, specStore, reviewStore, sessionStore);
+        shell,
+        yaml.toString(),
+        (command, logPath) -> 4242L,
+        bus,
+        null,
+        specStore,
+        reviewStore,
+        sessionStore);
   }
 
   /** Builds operations with a seeded project catalog and a fixed connect environment. */
@@ -1520,7 +1541,7 @@ class SailApiOperationsTest {
       String yamlContent,
       FakeShell shell,
       java.util.function.Consumer<SpecStore> seed,
-      SailApiOperations.WatcherLauncher watcher)
+      WatcherSpawner.ProcessSpawner watcher)
       throws Exception {
     var yaml = tempDir.resolve("sail-" + System.nanoTime() + ".yaml");
     Files.writeString(yaml, yamlContent);
@@ -1528,9 +1549,9 @@ class SailApiOperationsTest {
     new SchemaManager(db).migrate();
     var store = new SpecStore(db);
     seed.accept(store);
-    return watcher == null
-        ? new SailApiOperations(shell, yaml.toString(), null, (EventSubscriber) null, store)
-        : new SailApiOperations(shell, yaml.toString(), watcher, null, null, store, null);
+    WatcherSpawner.ProcessSpawner fallback =
+        watcher != null ? watcher : (command, logPath) -> 4242L;
+    return new SailApiOperations(shell, yaml.toString(), fallback, null, null, store, null);
   }
 
   /**
@@ -1584,7 +1605,7 @@ class SailApiOperationsTest {
   }
 
   private SailApiOperations operations(
-      String yamlContent, FakeShell shell, SailApiOperations.WatcherLauncher watcherLauncher)
+      String yamlContent, FakeShell shell, WatcherSpawner.ProcessSpawner watcherLauncher)
       throws Exception {
     return operationsWithStore(
         yamlContent, shell, SailApiOperationsTest::seedAuthBillingSetup, watcherLauncher);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WatcherRearmerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WatcherRearmerTest.java
@@ -11,15 +11,18 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SessionStore;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
-import java.util.OptionalLong;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongPredicate;
+import java.util.function.Predicate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +32,13 @@ class WatcherRearmerTest {
 
   private static final LongPredicate DEAD = pid -> false;
   private static final LongPredicate ALIVE = pid -> true;
+  private static final Predicate<String> NO_UNIT = project -> false;
+  private static final Predicate<String> UNIT_ACTIVE = project -> true;
+
+  private static final WatcherSpawner.Unit LAUNCHED =
+      new WatcherSpawner.Unit("sail-watch-test-project", "user", false);
+  private static final WatcherSpawner.Unit ADOPTED =
+      new WatcherSpawner.Unit("sail-watch-test-project", "system", true);
 
   @TempDir Path tempDir;
   private Sqlite db;
@@ -75,37 +85,39 @@ class WatcherRearmerTest {
   }
 
   private WatcherRearmer rearmer(
-      MissedStopReconciler.UnitProbe unitProbe,
+      MissedStopReconciler.UnitProbe agentUnitProbe,
+      Predicate<String> watcherUnitActive,
       LongPredicate watcherAlive,
       WatcherRearmer.WatcherRelauncher relauncher) {
-    return new WatcherRearmer(specStore, sessionStore, unitProbe, watcherAlive, relauncher);
+    return new WatcherRearmer(
+        specStore, sessionStore, agentUnitProbe, watcherUnitActive, watcherAlive, relauncher);
   }
 
   @Test
-  void rearmsADeadWatcherOverAStillActiveUnitAndRecordsTheNewPid() {
+  void rearmsAnUncoveredRunningAgentAsAUnit() {
     createInProgressSpec("auth");
-    var sessionId = runningSession("auth", 5678);
+    runningSession("auth", 5678);
     var relaunches = new AtomicInteger();
 
     var rearmed =
         rearmer(
                 project -> true,
+                NO_UNIT,
                 DEAD,
                 project -> {
                   relaunches.incrementAndGet();
-                  return OptionalLong.of(9012);
+                  return Optional.of(LAUNCHED);
                 })
             .rearm();
 
     assertEquals(1, rearmed);
     assertEquals(1, relaunches.get());
-    assertEquals(9012, sessionStore.findById(sessionId).orElseThrow().watcherPid());
   }
 
   @Test
-  void aLiveWatcherIsLeftAloneWithoutProbingTheUnit() {
+  void anActiveWatcherUnitCoversTheProjectWithoutConsultingPidOrAgentUnit() {
     createInProgressSpec("auth");
-    runningSession("auth", 5678);
+    runningSession("auth", null);
     var probed = new AtomicInteger();
 
     var rearmed =
@@ -114,8 +126,9 @@ class WatcherRearmerTest {
                   probed.incrementAndGet();
                   return true;
                 },
-                ALIVE,
-                project -> OptionalLong.of(9012))
+                UNIT_ACTIVE,
+                DEAD,
+                project -> Optional.of(LAUNCHED))
             .rearm();
 
     assertEquals(0, rearmed);
@@ -123,18 +136,38 @@ class WatcherRearmerTest {
   }
 
   @Test
-  void aSessionWithoutARecordedWatcherPidIsSkippedNotDoubled() {
+  void aLiveRecordedWatcherPidCoversTheProject() {
     createInProgressSpec("auth");
-    var sessionId = runningSession("auth", null);
+    runningSession("auth", 5678);
+    var relaunches = new AtomicInteger();
 
-    var rearmed = rearmer(project -> true, DEAD, project -> OptionalLong.of(9012)).rearm();
+    var rearmed =
+        rearmer(
+                project -> true,
+                NO_UNIT,
+                ALIVE,
+                project -> {
+                  relaunches.incrementAndGet();
+                  return Optional.of(LAUNCHED);
+                })
+            .rearm();
 
     assertEquals(0, rearmed);
-    assertTrue(sessionStore.findById(sessionId).orElseThrow().watcherPid() == null);
+    assertEquals(0, relaunches.get());
   }
 
   @Test
-  void anInactiveUnitIsTheSweepsJobNotARearm() {
+  void aSessionWithNoRecordedPidAndNoUnitIsRearmedBecauseDoublingIsUnrepresentable() {
+    createInProgressSpec("auth");
+    runningSession("auth", null);
+
+    var rearmed = rearmer(project -> true, NO_UNIT, DEAD, project -> Optional.of(ADOPTED)).rearm();
+
+    assertEquals(1, rearmed);
+  }
+
+  @Test
+  void anInactiveAgentUnitIsTheSweepsJobNotARearm() {
     createInProgressSpec("auth");
     runningSession("auth", 5678);
     var relaunches = new AtomicInteger();
@@ -142,10 +175,11 @@ class WatcherRearmerTest {
     var rearmed =
         rearmer(
                 project -> false,
+                NO_UNIT,
                 DEAD,
                 project -> {
                   relaunches.incrementAndGet();
-                  return OptionalLong.of(9012);
+                  return Optional.of(LAUNCHED);
                 })
             .rearm();
 
@@ -160,20 +194,19 @@ class WatcherRearmerTest {
     sessionStore.complete(completed, "stopped", 0);
     createInProgressSpec("bare");
 
-    var rearmed = rearmer(project -> true, DEAD, project -> OptionalLong.of(9012)).rearm();
+    var rearmed = rearmer(project -> true, NO_UNIT, DEAD, project -> Optional.of(LAUNCHED)).rearm();
 
     assertEquals(0, rearmed);
   }
 
   @Test
-  void aProjectWithoutGuardrailsHasNothingToRearm() {
+  void anEmptyRelaunchIsLoggedNotCounted() {
     createInProgressSpec("auth");
-    var sessionId = runningSession("auth", 5678);
+    runningSession("auth", 5678);
 
-    var rearmed = rearmer(project -> true, DEAD, project -> OptionalLong.empty()).rearm();
+    var rearmed = rearmer(project -> true, NO_UNIT, DEAD, project -> Optional.empty()).rearm();
 
     assertEquals(0, rearmed);
-    assertEquals(5678, sessionStore.findById(sessionId).orElseThrow().watcherPid());
   }
 
   @Test
@@ -187,12 +220,13 @@ class WatcherRearmerTest {
     var rearmed =
         rearmer(
                 project -> true,
+                NO_UNIT,
                 DEAD,
                 project -> {
                   if (attempts.incrementAndGet() == 1) {
                     throw new IllegalStateException("relaunch failed");
                   }
-                  return OptionalLong.of(9012);
+                  return Optional.of(LAUNCHED);
                 })
             .rearm();
 
@@ -204,11 +238,23 @@ class WatcherRearmerTest {
   void aStoreErrorIsSwallowedSoStartupIsNeverBlocked() {
     createInProgressSpec("auth");
     runningSession("auth", 5678);
-    var rearmer = rearmer(project -> true, DEAD, project -> OptionalLong.of(9012));
+    var rearmer = rearmer(project -> true, NO_UNIT, DEAD, project -> Optional.of(LAUNCHED));
     db.close();
     db = null;
 
     assertEquals(0, assertDoesNotThrow(rearmer::rearm));
+  }
+
+  @Test
+  void periodicRearmSchedulesRunsAndClosesWithoutStackingPasses() {
+    createInProgressSpec("auth");
+    runningSession("auth", 5678);
+    try (var rearmer = rearmer(project -> true, NO_UNIT, DEAD, project -> Optional.of(LAUNCHED))) {
+      rearmer.start();
+      rearmer.start(Duration.ofHours(1));
+
+      assertTrue(rearmer.rearmIfIdle());
+    }
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/GuardrailWatcherTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/GuardrailWatcherTest.java
@@ -45,6 +45,6 @@ class GuardrailWatcherTest {
 
   @Test
   void launchIsANoOpWithoutAnAgentBlock() {
-    assertDoesNotThrow(() -> GuardrailWatcher.launch("acme", "sail.yaml", null));
+    assertDoesNotThrow(() -> GuardrailWatcher.launch("acme", "sail.yaml", null, null));
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/GuardrailWatcherTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/GuardrailWatcherTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class GuardrailWatcherTest {
+
+  private static final Path LOG = Path.of("/tmp/watch.log");
+
+  @Test
+  void describesALaunchedUnitWithItsScope() {
+    var line =
+        GuardrailWatcher.describe(new WatcherSpawner.Unit("sail-watch-acme", "user", false), LOG);
+
+    assertEquals(
+        "Guardrail watcher started (unit sail-watch-acme, user scope, log: /tmp/watch.log)", line);
+  }
+
+  @Test
+  void describesAnAdoptedUnitAsAlreadyActive() {
+    var line =
+        GuardrailWatcher.describe(new WatcherSpawner.Unit("sail-watch-acme", "system", true), LOG);
+
+    assertEquals(
+        "Guardrail watcher already active (unit sail-watch-acme, log: /tmp/watch.log)", line);
+  }
+
+  @Test
+  void describesTheDegradedFallbackByPid() {
+    var line = GuardrailWatcher.describe(new WatcherSpawner.Fallback(4242L), LOG);
+
+    assertEquals(
+        "Guardrail watcher started (pid 4242, detached process — no systemd available, log:"
+            + " /tmp/watch.log)",
+        line);
+  }
+
+  @Test
+  void launchIsANoOpWithoutAnAgentBlock() {
+    assertDoesNotThrow(() -> GuardrailWatcher.launch("acme", "sail.yaml", null));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/WatcherSpawnerIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/WatcherSpawnerIT.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Exercises {@link WatcherSpawner} against the machine's <strong>real</strong> systemd (or its
+ * absence): the scope ladder must land somewhere real, an active unit must be adopted rather than
+ * doubled, and teardown must leave nothing behind. Both branches assert real behavior — a systemd
+ * host proves the unit path (detachment from this JVM included, since each spawning shell has
+ * already exited by the time the unit is probed), and a busless environment proves the degraded
+ * fallback still yields a live, detached process.
+ */
+class WatcherSpawnerIT {
+
+  private static final String PROJECT = "wsit-" + ProcessHandle.current().pid();
+
+  @TempDir Path tempDir;
+
+  private final ShellExecutor shell = new ShellExecutor(false);
+  private final WatcherSpawner spawner = new WatcherSpawner(shell, WatcherSpawner::spawnProcess);
+
+  @AfterEach
+  void tearDown() {
+    stopQuietly(List.of("systemctl", "--user", "stop", WatcherSpawner.unitName(PROJECT)));
+    stopQuietly(List.of("systemctl", "stop", WatcherSpawner.unitName(PROJECT)));
+  }
+
+  private void stopQuietly(List<String> command) {
+    try {
+      shell.exec(command);
+    } catch (Exception ignored) {
+    }
+  }
+
+  @Test
+  void theLadderLandsOnARealScopeAndNeverStacksASecondWatcher() throws Exception {
+    var log = tempDir.resolve("watch.log");
+    var argv = List.of("sleep", "30");
+
+    var spawned = spawner.spawnUnit(PROJECT, argv, log);
+
+    if (spawned.isPresent()) {
+      assertFalse(spawned.get().adopted(), "first spawn must launch, not adopt");
+      assertTrue(spawner.unitActive(PROJECT), "unit must be active right after spawn");
+
+      var second = spawner.spawnUnit(PROJECT, argv, log).orElseThrow();
+      assertTrue(second.adopted(), "second spawn must adopt the active unit");
+      assertEquals(WatcherSpawner.unitName(PROJECT), second.name());
+    } else {
+      var pid = WatcherSpawner.spawnProcess(List.of("sleep", "30"), log);
+      var handle = ProcessHandle.of(pid).orElseThrow();
+      assertTrue(handle.isAlive(), "degraded fallback must yield a live detached process");
+      handle.destroy();
+    }
+  }
+
+  @Test
+  void aStoppedUnitIsCollectedSoTheNameIsReusable() throws Exception {
+    var log = tempDir.resolve("watch.log");
+    var first = spawner.spawnUnit(PROJECT, List.of("sleep", "30"), log);
+    if (first.isEmpty()) {
+      assertFalse(spawner.unitActive(PROJECT));
+      return;
+    }
+    tearDown();
+
+    assertFalse(spawner.unitActive(PROJECT), "stopped unit must not read as active");
+    var respawned = spawner.spawnUnit(PROJECT, List.of("sleep", "30"), log).orElseThrow();
+    assertFalse(respawned.adopted(), "collected name must be reusable for a fresh launch");
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/WatcherSpawnerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/WatcherSpawnerTest.java
@@ -19,8 +19,10 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -67,13 +69,28 @@ class WatcherSpawnerTest {
     assertEquals(new WatcherSpawner.Unit("sail-watch-acme", "user", false), unit);
     assertEquals(
         String.join(
-            " ",
-            "systemd-run --user --collect --quiet --unit sail-watch-acme",
-            "--property StandardOutput=append:" + log().toAbsolutePath(),
-            "--property StandardError=append:" + log().toAbsolutePath(),
-            SailPaths.binaryPath().toString(),
-            "agent watch acme -f " + yaml().toAbsolutePath()),
+                " ",
+                "systemd-run --user --collect --quiet --unit sail-watch-acme",
+                "--property Type=exec",
+                "--property StandardOutput=append:" + log().toAbsolutePath(),
+                "--property StandardError=append:" + log().toAbsolutePath(),
+                forwardedEnvArgs(),
+                SailPaths.binaryPath().toString(),
+                "agent watch acme -f " + yaml().toAbsolutePath())
+            .replace("  ", " "),
         shell.invocationsMatching("systemd-run").getFirst());
+  }
+
+  private static String forwardedEnvArgs() {
+    var parts = new ArrayList<String>();
+    for (var name : List.of("SAIL_TOKEN", "SAIL_TOKEN_FILE", "SAIL_SERVER", "SAIL_DATA_DIR")) {
+      var value = System.getenv(name);
+      if (value != null && !value.isBlank()) {
+        parts.add("--setenv");
+        parts.add(name + "=" + value);
+      }
+    }
+    return String.join(" ", parts);
   }
 
   @Test
@@ -119,18 +136,53 @@ class WatcherSpawnerTest {
   }
 
   @Test
-  void spawnAdoptsAnAlreadyActiveUnitInsteadOfStackingASecondWatcher() throws Exception {
-    var shell = new FakeShell().on("--quiet is-active sail-watch-acme", ok());
+  void spawnStopsAStaleUnitAndLaunchesFreshInsteadOfAdoptingItsOldDeadline() throws Exception {
+    var shell =
+        new FakeShell()
+            .onSequence("systemctl --user --quiet is-active", ok(), fail())
+            .on("systemctl --user stop sail-watch-acme", ok())
+            .on("systemd-run --user", ok());
     var spawner = new WatcherSpawner(shell, WatcherSpawnerTest::failingFallback);
 
     var spawned = spawner.spawn("acme", yaml(), log());
 
-    assertEquals(new WatcherSpawner.Unit("sail-watch-acme", "user", true), spawned);
+    assertEquals(new WatcherSpawner.Unit("sail-watch-acme", "user", false), spawned);
+    assertEquals(1, shell.invocationsMatching("stop sail-watch-acme").size());
+    assertEquals(1, shell.invocationsMatching("systemd-run").size());
+  }
+
+  @Test
+  void spawnUnitAdoptsAnAlreadyActiveUnitInsteadOfStackingASecondWatcher() throws Exception {
+    var shell = new FakeShell().on("--quiet is-active sail-watch-acme", ok());
+    var spawner = new WatcherSpawner(shell, WatcherSpawnerTest::failingFallback);
+
+    var spawned = spawner.spawnUnit("acme", yaml(), log());
+
+    assertEquals(new WatcherSpawner.Unit("sail-watch-acme", "user", true), spawned.orElseThrow());
     assertTrue(shell.invocationsMatching("systemd-run").isEmpty());
   }
 
   @Test
-  void spawnAdoptsTheUnitALostRaceJustLaunched() {
+  void anInterruptMidLadderAbortsInsteadOfCascadingToTheFallback() {
+    var shell = new FakeShell().interruptOn("systemd-run");
+    var spawner = new WatcherSpawner(shell, (command, logPath) -> 4242L);
+
+    var error = assertThrows(IOException.class, () -> spawner.spawn("acme", yaml(), log()));
+
+    assertTrue(error.getMessage().contains("Interrupted"));
+    assertTrue(Thread.interrupted(), "interrupt flag must be restored");
+  }
+
+  @Test
+  void watcherProcessRunningProbesByProcessPattern() {
+    var shell = new FakeShell().on("pgrep -f -- agent watch acme -f ", ok());
+
+    assertTrue(new WatcherSpawner(shell, null).watcherProcessRunning("acme"));
+    assertFalse(new WatcherSpawner(new FakeShell(), null).watcherProcessRunning("acme"));
+  }
+
+  @Test
+  void spawnAdoptsTheUnitALostRaceJustLaunched() throws Exception {
     var shell =
         new FakeShell()
             .onSequence("systemctl --user --quiet is-active", fail(), ok())
@@ -144,7 +196,7 @@ class WatcherSpawnerTest {
   }
 
   @Test
-  void spawnUnitIsEmptyWhenNoSystemdScopeExists() {
+  void spawnUnitIsEmptyWhenNoSystemdScopeExists() throws Exception {
     var spawner = new WatcherSpawner(new FakeShell(), null);
 
     assertTrue(spawner.spawnUnit("acme", yaml(), log()).isEmpty());
@@ -195,6 +247,7 @@ class WatcherSpawnerTest {
     private final Map<String, ShellExec.Result> scripts = new LinkedHashMap<>();
     private final Map<String, Deque<ShellExec.Result>> sequences = new LinkedHashMap<>();
     private final Map<String, IOException> failures = new LinkedHashMap<>();
+    private final Set<String> interrupts = new LinkedHashSet<>();
     private final List<String> invocations = new ArrayList<>();
 
     FakeShell on(String pattern, ShellExec.Result result) {
@@ -212,14 +265,24 @@ class WatcherSpawnerTest {
       return this;
     }
 
+    FakeShell interruptOn(String pattern) {
+      interrupts.add(pattern);
+      return this;
+    }
+
     List<String> invocationsMatching(String pattern) {
       return invocations.stream().filter(line -> line.contains(pattern)).toList();
     }
 
     @Override
-    public Result exec(List<String> command) throws IOException {
+    public Result exec(List<String> command) throws IOException, InterruptedException {
       var joined = String.join(" ", command);
       invocations.add(joined);
+      for (var pattern : interrupts) {
+        if (joined.contains(pattern)) {
+          throw new InterruptedException("interrupted");
+        }
+      }
       for (var entry : failures.entrySet()) {
         if (joined.contains(entry.getKey())) {
           throw entry.getValue();
@@ -240,7 +303,8 @@ class WatcherSpawnerTest {
     }
 
     @Override
-    public Result exec(List<String> command, Path workDir, Duration timeout) throws IOException {
+    public Result exec(List<String> command, Path workDir, Duration timeout)
+        throws IOException, InterruptedException {
       return exec(command);
     }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/WatcherSpawnerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/WatcherSpawnerTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WatcherSpawnerTest {
+
+  @TempDir Path tempDir;
+
+  private Path yaml() {
+    return tempDir.resolve("sail.yaml");
+  }
+
+  private Path log() {
+    return tempDir.resolve("acme").resolve("watch.log");
+  }
+
+  @Test
+  void watchCommandNamesTheBinaryProjectAndDescriptor() {
+    var command = WatcherSpawner.watchCommand("acme", yaml());
+
+    assertEquals(
+        List.of(
+            SailPaths.binaryPath().toString(),
+            "agent",
+            "watch",
+            "acme",
+            "-f",
+            yaml().toAbsolutePath().toString()),
+        command);
+  }
+
+  @Test
+  void unitNameIsDeterministicPerProject() {
+    assertEquals("sail-watch-acme", WatcherSpawner.unitName("acme"));
+  }
+
+  @Test
+  void spawnLaunchesAUserScopeUnitFirst() throws Exception {
+    var shell = new FakeShell().on("systemd-run --user", ok());
+    var spawner = new WatcherSpawner(shell, WatcherSpawnerTest::failingFallback);
+
+    var spawned = spawner.spawn("acme", yaml(), log());
+
+    var unit = assertInstanceOf(WatcherSpawner.Unit.class, spawned);
+    assertEquals(new WatcherSpawner.Unit("sail-watch-acme", "user", false), unit);
+    assertEquals(
+        String.join(
+            " ",
+            "systemd-run --user --collect --quiet --unit sail-watch-acme",
+            "--property StandardOutput=append:" + log().toAbsolutePath(),
+            "--property StandardError=append:" + log().toAbsolutePath(),
+            SailPaths.binaryPath().toString(),
+            "agent watch acme -f " + yaml().toAbsolutePath()),
+        shell.invocationsMatching("systemd-run").getFirst());
+  }
+
+  @Test
+  void spawnFallsToSystemScopeWhenTheUserManagerRefuses() throws Exception {
+    var shell = new FakeShell().on("systemd-run --user", fail()).on("systemd-run --collect", ok());
+    var spawner = new WatcherSpawner(shell, WatcherSpawnerTest::failingFallback);
+
+    var spawned = spawner.spawn("acme", yaml(), log());
+
+    assertEquals(new WatcherSpawner.Unit("sail-watch-acme", "system", false), spawned);
+  }
+
+  @Test
+  void spawnFallsBackToADetachedProcessWhenNoScopeAccepts() throws Exception {
+    var launched = new LinkedHashMap<String, Object>();
+    var spawner =
+        new WatcherSpawner(
+            new FakeShell(),
+            (command, logPath) -> {
+              launched.put("command", command);
+              launched.put("log", logPath);
+              return 4242L;
+            });
+
+    var spawned = spawner.spawn("acme", yaml(), log());
+
+    assertEquals(new WatcherSpawner.Fallback(4242L), spawned);
+    var command = new ArrayList<>(List.of("nohup"));
+    command.addAll(WatcherSpawner.watchCommand("acme", yaml()));
+    assertEquals(command, launched.get("command"));
+    assertEquals(log(), launched.get("log"));
+    assertTrue(Files.isDirectory(log().getParent()));
+  }
+
+  @Test
+  void spawnWithoutAFallbackFailsLoudWhenNoScopeAccepts() {
+    var spawner = new WatcherSpawner(new FakeShell(), null);
+
+    var error = assertThrows(IOException.class, () -> spawner.spawn("acme", yaml(), log()));
+
+    assertTrue(error.getMessage().contains("sail-watch-acme"));
+    assertTrue(error.getMessage().contains("no fallback"));
+  }
+
+  @Test
+  void spawnAdoptsAnAlreadyActiveUnitInsteadOfStackingASecondWatcher() throws Exception {
+    var shell = new FakeShell().on("--quiet is-active sail-watch-acme", ok());
+    var spawner = new WatcherSpawner(shell, WatcherSpawnerTest::failingFallback);
+
+    var spawned = spawner.spawn("acme", yaml(), log());
+
+    assertEquals(new WatcherSpawner.Unit("sail-watch-acme", "user", true), spawned);
+    assertTrue(shell.invocationsMatching("systemd-run").isEmpty());
+  }
+
+  @Test
+  void spawnAdoptsTheUnitALostRaceJustLaunched() {
+    var shell =
+        new FakeShell()
+            .onSequence("systemctl --user --quiet is-active", fail(), ok())
+            .on("systemctl --quiet is-active", fail())
+            .on("systemd-run", fail());
+    var spawner = new WatcherSpawner(shell, null);
+
+    var unit = spawner.spawnUnit("acme", yaml(), log());
+
+    assertEquals(new WatcherSpawner.Unit("sail-watch-acme", "user", true), unit.orElseThrow());
+  }
+
+  @Test
+  void spawnUnitIsEmptyWhenNoSystemdScopeExists() {
+    var spawner = new WatcherSpawner(new FakeShell(), null);
+
+    assertTrue(spawner.spawnUnit("acme", yaml(), log()).isEmpty());
+  }
+
+  @Test
+  void unitActiveProbesUserThenSystemScope() {
+    assertTrue(
+        new WatcherSpawner(new FakeShell().on("systemctl --user --quiet is-active", ok()), null)
+            .unitActive("acme"));
+    assertTrue(
+        new WatcherSpawner(new FakeShell().on("systemctl --quiet is-active", ok()), null)
+            .unitActive("acme"));
+    assertFalse(new WatcherSpawner(new FakeShell(), null).unitActive("acme"));
+  }
+
+  @Test
+  void aThrowingShellCountsAsAnUnavailableScope() throws Exception {
+    var shell = new FakeShell().throwOn("systemd-run", new IOException("no bus"));
+    var spawner = new WatcherSpawner(shell, (command, logPath) -> 7L);
+
+    assertEquals(new WatcherSpawner.Fallback(7L), spawner.spawn("acme", yaml(), log()));
+  }
+
+  @Test
+  void spawnProcessStartsTheCommandAndReturnsItsPid() throws Exception {
+    var logPath = tempDir.resolve("watch.log");
+
+    var pid = WatcherSpawner.spawnProcess(List.of("sh", "-c", "true"), logPath);
+
+    assertTrue(pid > 0);
+    assertTrue(Files.exists(logPath));
+  }
+
+  private static ShellExec.Result ok() {
+    return new ShellExec.Result(0, "", "");
+  }
+
+  private static ShellExec.Result fail() {
+    return new ShellExec.Result(1, "", "refused");
+  }
+
+  private static long failingFallback(List<String> command, Path logPath) throws IOException {
+    throw new IOException("fallback must not be used");
+  }
+
+  private static final class FakeShell implements ShellExec {
+    private final Map<String, ShellExec.Result> scripts = new LinkedHashMap<>();
+    private final Map<String, Deque<ShellExec.Result>> sequences = new LinkedHashMap<>();
+    private final Map<String, IOException> failures = new LinkedHashMap<>();
+    private final List<String> invocations = new ArrayList<>();
+
+    FakeShell on(String pattern, ShellExec.Result result) {
+      scripts.put(pattern, result);
+      return this;
+    }
+
+    FakeShell onSequence(String pattern, ShellExec.Result... results) {
+      sequences.put(pattern, new ArrayDeque<>(List.of(results)));
+      return this;
+    }
+
+    FakeShell throwOn(String pattern, IOException failure) {
+      failures.put(pattern, failure);
+      return this;
+    }
+
+    List<String> invocationsMatching(String pattern) {
+      return invocations.stream().filter(line -> line.contains(pattern)).toList();
+    }
+
+    @Override
+    public Result exec(List<String> command) throws IOException {
+      var joined = String.join(" ", command);
+      invocations.add(joined);
+      for (var entry : failures.entrySet()) {
+        if (joined.contains(entry.getKey())) {
+          throw entry.getValue();
+        }
+      }
+      for (var entry : sequences.entrySet()) {
+        if (joined.contains(entry.getKey())) {
+          var queue = entry.getValue();
+          return queue.size() > 1 ? queue.poll() : queue.peek();
+        }
+      }
+      for (var entry : scripts.entrySet()) {
+        if (joined.contains(entry.getKey())) {
+          return entry.getValue();
+        }
+      }
+      return new Result(1, "", "no script for " + joined);
+    }
+
+    @Override
+    public Result exec(List<String> command, Path workDir, Duration timeout) throws IOException {
+      return exec(command);
+    }
+
+    @Override
+    public boolean isDryRun() {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Implements spec `watcher-detached-lifetime`. The watcher was a bare ProcessBuilder child of whoever dispatched: Ctrl-C on the dispatch stream SIGINTed it, closing the SSH session SIGHUPed it (`nohup` covered only the latter), and the API lane's variant died with the daemon. The agent survived all of yesterday's incidents because it runs in its own systemd unit; its guardian did not. Root cause of all three orphaned-session incidents on 2026-07-06/07.

## Design

**One spawn mechanism for every lane.** `WatcherSpawner` replaces both the CLI lane's ProcessBuilder child and the daemon lane's child process: a systemd transient unit `sail-watch-<project>` (user scope, then system scope), with a plain detached process as a loudly-degraded fallback only where no systemd scope exists. `Type=exec` makes exec-phase failures fail the spawn visibly instead of reporting a unit that died at birth; `SAIL_TOKEN/SAIL_TOKEN_FILE/SAIL_SERVER/SAIL_DATA_DIR` are forwarded explicitly since transient units start from systemd's clean environment. The unit needs no teardown: the watcher exits after observing the agent stop, and `--collect` garbage-collects the unit.

**Two spawn intents, deliberately different collision semantics.**
- *Dispatch* stops-and-replaces any unit left from the previous session: an adopted stale watcher's wall-clock deadline anchors to the OLD session's `started_at` and would guardrail-kill a fresh agent near the old budget's end (and the stale-watcher window is not 15s — a chatty review stream starves the old watcher's liveness probe, making adoption the common case for review-gated re-dispatches).
- *The re-armer* adopts on its lost-race path only, where the session was already verified uncovered.

**Coverage is probed at the process level, not bookkept.** `systemctl --user` sees only the caller's own user manager — a root daemon probing for a dev-user's unit would relaunch a double whose guardrail actions fire twice. The re-armer's probe is now `pgrep` for the watch command (sees every scope, every user's manager, and fallback processes), with the free recorded-pid check first. Relaunching stays unit-or-nothing, so the doubled watcher stays unrepresentable — now across systemd views, not just within one.

**Re-arming is periodic, not start-only.** `PeriodicPass` extracts the scheduling discipline shared with the missed-stop sweep (no overlap; a throwing pass — `Throwable` included, since an escaped `Error` silently cancels a `scheduleAtFixedRate` task — logs with stack and never cancels the schedule; `close()` waits out the in-flight pass rather than interrupting a half-applied reconciliation). A watcher that dies mid-run leaves the agent unguarded for at most one 60s interval.

**Behavior unification (deliberate, ships silently):** API dispatches to projects declaring an agent block without explicit guardrails now get a watcher enforcing `Guardrails.defaults()` (4h wall / 20m stall), matching what the CLI lane always did and what the watcher docs promise. The watcher is also the authoritative stop observer the review pipeline depends on, so an unwatched API dispatch was a stop-observation hole.

## Self-review

An 8-angle adversarial review ran before push; confirmed findings (stale-deadline adoption, cross-scope probe blindness, `Error` cancelling the schedule, `shutdownNow` interrupting mid-sweep, interrupt cascading to a doubled fallback, swallowed log-dir failures, dead `updateWatcherPid`, parallel systemd-scope encoding) are all fixed in the second commit. Known accepted gap: `--dry-run` dispatch still prints nothing about the watcher spawn (pre-existing; the callers skip the launch entirely under dry-run).

## Verification

- `mvn clean verify` green: full suite, all JaCoCo gates including 100% line/method on `ai.singlr.sail.api.*` (new `PeriodicPass`, rewritten `WatcherRearmer`).
- `WatcherSpawnerIT` (incus lane, real systemd): ladder lands on a real scope, unit active after the spawning shell exits, adopt-not-stack on respawn, stop-collect-name-reuse.
- Real-environment probe of the exact mechanism in a project container: unit survives spawner exit; name collision refused by systemd; stop → collected → reusable.

Closes spec `watcher-detached-lifetime` (depends on `periodic-missed-stop-sweep`, shipped in 0.13.147).