### PR TITLE
Thin-client passkey DX: one-command enroll and login over an auto-tunnel

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -431,8 +431,9 @@ and `Authorizer`:
 1. **Terminal: SSH key to FDE.** Each registered key is pinned in the `sail` user's
    `authorized_keys` to `command="…/sail _gateway --fde <handle>",restrict`, with no shell
    and no forwarding. Command classification is default-deny: only `spec`, `agent`, and
-   `events` reach the loopback API, `fde` is admin-gated at the gateway (with one
-   self-service carve-out: any active FDE may `fde passkey list|rm` its own pinned handle),
+   `events` reach the loopback API, `fde` is admin-gated at the gateway (with two
+   self-service carve-outs: any active FDE may `fde passkey list|rm` and `fde enroll` its
+   own pinned handle, which is what lets `sail enroll` self-mint an enrollment ticket),
    `_sync` is admitted, and everything else is refused. A short-lived session is minted per invocation. `sail fde
    add <handle> --key "<pubkey>"` is the whole enrollment, and removing the key revokes SSH
    and API access in one step.
@@ -499,8 +500,10 @@ support Mast and direct-API clients:
 3. **Two remote-config models.** `ClientConfig` (SSH-forward through `host` and `user`) and
    `ServerConnectionConfig` (HTTP API through `server` and `token`) both read
    `~/.sail/config.yaml` with different keys. SSH-forwarding papers over this today, but a
-   direct-API client (Mast, or a future direct-mode CLI) needs them reconciled. A passkey
-   `sail login` session has no CLI consumer on a forwarding client yet.
+   direct-API client (Mast, or a future direct-mode CLI) needs them reconciled. `sail login`
+   and `sail enroll` now run their passkey ceremonies from a forwarding client over a
+   supervised SSH tunnel at the canonical origin `http://localhost:7070`, but the stored
+   session token still has no forwarded-command consumer.
 4. **Sync identity is the box hostname.** Replicas key off the hostname rather than a stable
    per-box id, so renames or collisions could confuse sync identity. A stable id is the
    robust fix. The risk is low for a known small fleet and worth doing before larger ones.

--- a/sail-core/src/main/java/ai/singlr/sail/ssh/SshGateway.java
+++ b/sail-core/src/main/java/ai/singlr/sail/ssh/SshGateway.java
@@ -9,6 +9,7 @@ import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.store.AuthSessionStore;
 import ai.singlr.sail.store.FdeStore;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -25,8 +26,10 @@ import java.util.Set;
  *   <li>{@link #API_COMMANDS} run for every active FDE — they talk to the loopback API, where the
  *       FDE's role decides what each request may do.
  *   <li>{@link #ADMIN_COMMANDS} are database-direct, so no downstream check exists; the gateway
- *       itself requires the {@code admin} role — except {@code fde passkey list|rm} on the caller's
- *       own pinned handle, which any active FDE may run.
+ *       itself requires the {@code admin} role — except {@code fde passkey list|rm} and {@code fde
+ *       enroll} on the caller's own pinned handle, which any active FDE may run. A bare {@code fde
+ *       enroll} is pinned to the caller's handle first, so a thin client can self-enroll without
+ *       knowing it.
  *   <li>Everything else ({@code project}, {@code host}, {@code server}, {@code migrate}, …) runs
  *       with host privileges the {@code sail} user must never have, and is refused.
  * </ul>
@@ -77,6 +80,7 @@ public final class SshGateway {
     if (tokens.isEmpty()) {
       return new Rejected("No 'sail' subcommand supplied.");
     }
+    tokens = withSelfEnrollHandle(tokens, fdeHandle);
     var subcommand = tokens.getFirst();
     if (!API_COMMANDS.contains(subcommand)
         && !ADMIN_COMMANDS.contains(subcommand)
@@ -93,13 +97,9 @@ public final class SshGateway {
     }
     if (ADMIN_COMMANDS.contains(subcommand)
         && !"admin".equals(fde.get().role())
-        && !isOwnPasskeyCommand(tokens, fdeHandle)) {
-      return new Rejected(
-          isPasskeyCommand(tokens)
-              ? "Managing another FDE's passkeys requires the admin role. You may manage your"
-                  + " own: sail fde passkey list "
-                  + fdeHandle
-              : "'" + subcommand + "' requires the admin role.");
+        && !isOwnPasskeyCommand(tokens, fdeHandle)
+        && !isOwnEnrollCommand(tokens, fdeHandle)) {
+      return new Rejected(adminRequiredReason(tokens, fdeHandle, subcommand));
     }
     var session = sessions.create(fde.get().id(), SESSION_TTL);
     return new Authorized(List.copyOf(tokens), session.token());
@@ -121,5 +121,47 @@ public final class SshGateway {
 
   private static boolean isPasskeyCommand(List<String> tokens) {
     return tokens.size() >= 2 && tokens.get(0).equals("fde") && tokens.get(1).equals("passkey");
+  }
+
+  /**
+   * Pins a bare {@code fde enroll} (no target handle) to the caller. A thin client cannot know its
+   * own handle — the handle bound to the calling key on the {@code authorized_keys} line is the
+   * identity the gateway trusts — so self-enrollment sends {@code fde enroll} and the gateway fills
+   * in the caller before authorization runs.
+   */
+  private static List<String> withSelfEnrollHandle(List<String> tokens, String fdeHandle) {
+    if (isEnrollCommand(tokens) && (tokens.size() == 2 || tokens.get(2).startsWith("-"))) {
+      var pinned = new ArrayList<>(tokens);
+      pinned.add(2, fdeHandle);
+      return List.copyOf(pinned);
+    }
+    return tokens;
+  }
+
+  /**
+   * The second self-service carve-out: an FDE may mint an enrollment ticket for itself ({@code fde
+   * enroll <own-handle>}), compared against the pinned handle exactly like {@link
+   * #isOwnPasskeyCommand}. Minting for anyone else stays admin-only.
+   */
+  private static boolean isOwnEnrollCommand(List<String> tokens, String fdeHandle) {
+    return isEnrollCommand(tokens) && tokens.size() >= 3 && tokens.get(2).equals(fdeHandle);
+  }
+
+  private static boolean isEnrollCommand(List<String> tokens) {
+    return tokens.size() >= 2 && tokens.get(0).equals("fde") && tokens.get(1).equals("enroll");
+  }
+
+  private static String adminRequiredReason(
+      List<String> tokens, String fdeHandle, String subcommand) {
+    if (isPasskeyCommand(tokens)) {
+      return "Managing another FDE's passkeys requires the admin role. You may manage your"
+          + " own: sail fde passkey list "
+          + fdeHandle;
+    }
+    if (isEnrollCommand(tokens)) {
+      return "Minting an enrollment ticket for another FDE requires the admin role."
+          + " Enroll yourself with: sail enroll";
+    }
+    return "'" + subcommand + "' requires the admin role.";
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/ssh/SshGatewayTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/ssh/SshGatewayTest.java
@@ -107,11 +107,44 @@ class SshGatewayTest {
             "sail fde passkey list",
             "sail fde passkey add uday",
             "sail fde passkey rm --credential abc123 uday",
-            "sail fde enroll uday",
             "sail fde rm uday")) {
       var rejected = assertInstanceOf(SshGateway.Rejected.class, authorize(command, "uday"));
       assertTrue(rejected.reason().contains("admin role"));
     }
+  }
+
+  @Test
+  void memberMintsItsOwnEnrollmentTicket() {
+    var authorized =
+        assertInstanceOf(SshGateway.Authorized.class, authorize("sail fde enroll uday", "uday"));
+    assertEquals(List.of("fde", "enroll", "uday"), authorized.args());
+    assertTrue(sessions.validate(authorized.sessionToken()).isPresent());
+  }
+
+  @Test
+  void bareEnrollIsPinnedToTheCallersHandle() {
+    var bare = assertInstanceOf(SshGateway.Authorized.class, authorize("sail fde enroll", "uday"));
+    assertEquals(List.of("fde", "enroll", "uday"), bare.args());
+    var withFlag =
+        assertInstanceOf(SshGateway.Authorized.class, authorize("sail fde enroll --json", "uday"));
+    assertEquals(List.of("fde", "enroll", "uday", "--json"), withFlag.args());
+  }
+
+  @Test
+  void memberCannotMintAnEnrollmentTicketForAnotherFde() {
+    fdes.add("ada", null, null, "member");
+    var rejected =
+        assertInstanceOf(SshGateway.Rejected.class, authorize("sail fde enroll ada", "uday"));
+    assertTrue(rejected.reason().contains("admin role"));
+    assertTrue(rejected.reason().contains("sail enroll"));
+  }
+
+  @Test
+  void adminMintsEnrollmentTicketsForAnyFde() {
+    fdes.add("ada", null, null, "admin");
+    var authorized =
+        assertInstanceOf(SshGateway.Authorized.class, authorize("sail fde enroll uday", "ada"));
+    assertEquals(List.of("fde", "enroll", "uday"), authorized.args());
   }
 
   @Test

--- a/sail-infra/src/main/java/ai/singlr/sail/Sail.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/Sail.java
@@ -8,6 +8,7 @@ package ai.singlr.sail;
 import ai.singlr.sail.commands.AgentCommand;
 import ai.singlr.sail.commands.ClientInitCommand;
 import ai.singlr.sail.commands.ConflictsCommand;
+import ai.singlr.sail.commands.EnrollCommand;
 import ai.singlr.sail.commands.EventsCommand;
 import ai.singlr.sail.commands.FdeCommand;
 import ai.singlr.sail.commands.GatewayCommand;
@@ -40,6 +41,7 @@ import picocli.CommandLine.Help.Ansi;
       ServerCommand.class,
       FdeCommand.class,
       LoginCommand.class,
+      EnrollCommand.class,
       SpecCommand.class,
       AgentCommand.class,
       EventsCommand.class,

--- a/sail-infra/src/main/java/ai/singlr/sail/api/WebauthnAuthHandler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/WebauthnAuthHandler.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -31,6 +32,10 @@ import java.util.Objects;
  * fields, delegates to {@link PasskeyCeremonies}, and maps {@link PasskeyException} to an HTTP
  * status. When no relying party is configured ({@code ceremonies} is null) every route returns
  * {@link ErrorCode#PASSKEY_NOT_CONFIGURED} so the feature stays cleanly disabled.
+ *
+ * <p>{@code /login/start} additionally advertises the allowed WebAuthn {@code origins} — they are
+ * public by nature (they are the URLs a browser signs in at), and a tunneled CLI preflights them to
+ * fail with configuration guidance instead of a doomed browser ceremony.
  */
 public final class WebauthnAuthHandler implements HttpHandler {
 
@@ -41,17 +46,19 @@ public final class WebauthnAuthHandler implements HttpHandler {
   private final PasskeyCeremonies ceremonies;
   private final EnrollmentTickets enrollment;
   private final ApiAuth auth;
+  private final List<String> origins;
   private final String enrollOrigin;
 
   public WebauthnAuthHandler(
       PasskeyCeremonies ceremonies,
       EnrollmentTickets enrollment,
       ApiAuth auth,
-      String enrollOrigin) {
+      List<String> origins) {
     this.ceremonies = ceremonies;
     this.enrollment = enrollment;
     this.auth = Objects.requireNonNull(auth, "auth");
-    this.enrollOrigin = enrollOrigin;
+    this.origins = origins == null ? List.of() : List.copyOf(origins);
+    this.enrollOrigin = this.origins.isEmpty() ? null : this.origins.getFirst();
   }
 
   @Override
@@ -168,7 +175,11 @@ public final class WebauthnAuthHandler implements HttpHandler {
 
   private ApiResponse loginStart(HttpExchange exchange) throws IOException {
     JsonBody.readMap(exchange);
-    return ApiResponse.ok(ceremonyBody(ceremonies.startLogin()));
+    var body = ceremonyBody(ceremonies.startLogin());
+    if (!origins.isEmpty()) {
+      body.put("origins", origins);
+    }
+    return ApiResponse.ok(body);
   }
 
   private ApiResponse loginFinish(HttpExchange exchange) throws IOException {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/Browser.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/Browser.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Opens the engineer's default browser — {@code open} on macOS, {@code xdg-open} elsewhere. A
+ * ceremony never depends on this succeeding: the caller prints the URL first, so when no opener is
+ * available the engineer pastes it by hand.
+ */
+final class Browser {
+
+  private Browser() {}
+
+  static void open(String url) {
+    var os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+    var command = os.contains("mac") ? List.of("open", url) : List.of("xdg-open", url);
+    try {
+      new ProcessBuilder(command).start();
+    } catch (IOException ignored) {
+      System.out.println("  (Could not open a browser automatically — open the URL above.)");
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/EnrollCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/EnrollCommand.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.ClientConfig;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.RuntimeMode;
+import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.ShellExecutor;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Spec;
+
+/**
+ * Self-enrolls a passkey from a thin client with no admin round-trip. The command mints an
+ * enrollment ticket for the caller's own handle by sending {@code fde enroll --json} down the
+ * existing SSH gateway lane — the gateway pins the caller's identity from their key, so a member
+ * may mint for themself while minting for others stays admin-only — then opens a supervised {@link
+ * SshTunnel} and drives the box's {@code /enroll} page at the canonical origin {@link
+ * SshTunnel#ORIGIN}, where the browser prompts for a credential label and creates the passkey. A
+ * loopback callback signals completion so the tunnel is torn down the moment the ceremony ends.
+ */
+@Command(
+    name = "enroll",
+    description = "Enroll a passkey for yourself over an SSH tunnel to your Sail box.",
+    mixinStandardHelpOptions = true)
+public final class EnrollCommand implements Runnable {
+
+  @Option(
+      names = "--timeout",
+      description = "Seconds to wait for the browser enrollment to complete.",
+      defaultValue = "300")
+  private int timeoutSeconds;
+
+  @Spec private CommandSpec spec;
+
+  private final ShellExec shell;
+
+  public EnrollCommand() {
+    this(new ShellExecutor(false, Duration.ofSeconds(30)));
+  }
+
+  EnrollCommand(ShellExec shell) {
+    this.shell = shell;
+  }
+
+  record Ticket(String ticket, String fde) {}
+
+  @Override
+  public void run() {
+    CliCommand.run(
+        spec,
+        () -> {
+          var client = requireThinClient();
+          var ticket = mintTicket(client);
+          System.out.println("  Opening an SSH tunnel to " + client.host() + "…");
+          try (var tunnel = SshTunnel.open(client.host())) {
+            OriginPreflight.requireCanonicalOrigin(client.host());
+            browserCeremony(ticket, tunnel);
+          }
+        });
+  }
+
+  private void browserCeremony(Ticket ticket, SshTunnel tunnel) throws Exception {
+    var state = LoopbackCallbackServer.newState();
+    try (var callback = LoopbackCallbackServer.forEnrollment(state)) {
+      callback.start();
+      var url = enrollUrl(ticket.ticket(), callback.redirectUri(), state);
+      System.out.println("  Opening your browser to enroll a passkey for " + ticket.fde() + ":");
+      System.out.println(Ansi.AUTO.string("    @|cyan " + url + "|@"));
+      Browser.open(url);
+      System.out.println("  Waiting for the browser enrollment to complete…");
+      callback.awaitToken(Duration.ofSeconds(timeoutSeconds), tunnel::ensureAlive);
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|green ✓|@ Passkey enrolled for " + ticket.fde() + ". Sign in with: sail login"));
+    }
+  }
+
+  private Ticket mintTicket(ClientConfig client) throws Exception {
+    System.out.println("  Minting an enrollment ticket via " + client.gatewayTarget() + "…");
+    var result = shell.exec(mintCommand(client));
+    if (!result.ok()) {
+      throw new IllegalStateException(mintFailure(client.gatewayTarget(), result));
+    }
+    return parseTicket(result.stdout());
+  }
+
+  static List<String> mintCommand(ClientConfig client) {
+    return List.of(
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "PasswordAuthentication=no",
+        "-o",
+        "KbdInteractiveAuthentication=no",
+        "--",
+        client.gatewayTarget(),
+        "sail",
+        "fde",
+        "enroll",
+        "--json");
+  }
+
+  static Ticket parseTicket(String stdout) {
+    Map<String, Object> body;
+    try {
+      body = YamlUtil.parseMap(stdout);
+    } catch (Exception e) {
+      throw new IllegalStateException(unexpectedTicket(stdout), e);
+    }
+    var ticket = Objects.toString(body.get("ticket"), "");
+    var fde = Objects.toString(body.get("fde"), "");
+    if (Strings.isBlank(ticket) || Strings.isBlank(fde)) {
+      throw new IllegalStateException(unexpectedTicket(stdout));
+    }
+    return new Ticket(ticket, fde);
+  }
+
+  static String enrollUrl(String ticket, String redirectUri, String state) {
+    return SshTunnel.ORIGIN
+        + "/enroll?ticket="
+        + URLEncoder.encode(ticket, StandardCharsets.UTF_8)
+        + "&redirect_uri="
+        + URLEncoder.encode(redirectUri, StandardCharsets.UTF_8)
+        + "&state="
+        + state;
+  }
+
+  static String mintFailure(String gatewayTarget, ShellExec.Result result) {
+    var stderr = result.stderr().strip();
+    return "Could not mint an enrollment ticket via "
+        + gatewayTarget
+        + " (ssh exit "
+        + result.exitCode()
+        + ")."
+        + (stderr.isEmpty() ? "" : "\n  ssh said: " + stderr)
+        + "\n  Not registered yet? An admin runs: sail fde add <handle> --key \"<your pubkey>\"";
+  }
+
+  private static String unexpectedTicket(String stdout) {
+    return "The box returned an unexpected enrollment ticket response:\n"
+        + stdout.strip()
+        + "\n  The box may be running an older sail — upgrade it with: sail host update";
+  }
+
+  private static ClientConfig requireThinClient() throws Exception {
+    if (!(RuntimeMode.detect() instanceof RuntimeMode.Client client)) {
+      throw new IllegalStateException(
+          "'sail enroll' is the thin-client flow, and this box is not configured as one."
+              + "\n  On the box itself, mint a ticket with: sail fde enroll <handle>"
+              + "\n  On your laptop, point the CLI at the box first: sail init <host>");
+    }
+    if (!client.config().gatewayEnabled()) {
+      throw new IllegalStateException(
+          "Self-enrollment needs the FDE gateway — it is how the box knows who you are."
+              + "\n  Set 'user: sail' in "
+              + SailPaths.clientConfigPath());
+    }
+    return client.config();
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/FdeCommand.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.commands;
 
 import ai.singlr.sail.auth.EnrollmentService;
+import ai.singlr.sail.auth.EnrollmentTickets;
 import ai.singlr.sail.auth.Passkeys;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.YamlUtil;
@@ -22,7 +23,9 @@ import ai.singlr.sail.store.SqliteException;
 import ai.singlr.sail.store.WebauthnCredentialStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import picocli.CommandLine.Command;
@@ -311,6 +314,9 @@ public final class FdeCommand implements Runnable {
     @Parameters(index = "0", description = "FDE handle to enroll (must already exist).")
     private String handle;
 
+    @Option(names = "--json", description = "Print the ticket as JSON.")
+    private boolean json;
+
     @Spec private CommandSpec spec;
 
     @Override
@@ -322,6 +328,10 @@ public final class FdeCommand implements Runnable {
               var ticket =
                   new EnrollmentService(new EnrollmentTicketStore(db), new FdeStore(db))
                       .issue(handle);
+              if (json) {
+                System.out.println(YamlUtil.dumpJson(ticketJson(ticket, enrollOrigin())));
+                return;
+              }
               System.out.println(
                   Ansi.AUTO.string(
                       "  @|green ✓|@ Enrollment ticket for "
@@ -345,6 +355,17 @@ public final class FdeCommand implements Runnable {
               }
             }
           });
+    }
+
+    static Map<String, Object> ticketJson(EnrollmentTickets.Ticket ticket, String origin) {
+      var map = new LinkedHashMap<String, Object>();
+      map.put("ticket", ticket.ticket());
+      map.put("fde", ticket.fdeHandle());
+      map.put("expires_at", ticket.expiresAt());
+      if (origin != null) {
+        map.put("enroll_url", origin + "/enroll?ticket=" + ticket.ticket());
+      }
+      return map;
     }
 
     private static String enrollOrigin() throws Exception {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/LoginCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/LoginCommand.java
@@ -8,16 +8,13 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.api.ServerConnectionConfig;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.RuntimeMode;
 import ai.singlr.sail.engine.SailPaths;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.security.SecureRandom;
 import java.time.Duration;
-import java.util.HexFormat;
-import java.util.List;
-import java.util.Locale;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -30,6 +27,11 @@ import picocli.CommandLine.Spec;
  * loopback {@code /callback} as the redirect target and a one-time {@code state} nonce; the page
  * redirects the minted session token back to that loopback, which this command captures and writes
  * to the client config so subsequent {@code sail} calls authenticate as the FDE.
+ *
+ * <p>On a thin client (a box with a client config and no host config) there is no local origin to
+ * sign in at, so the command opens a supervised {@link SshTunnel} to the configured host and runs
+ * the ceremony at the canonical tunnel origin {@link SshTunnel#ORIGIN}, which the box must
+ * allowlist. {@code --origin} (a reverse-proxy URL) or {@code --no-tunnel} keeps the direct path.
  */
 @Command(
     name = "login",
@@ -40,9 +42,14 @@ public final class LoginCommand implements Runnable {
   @Option(
       names = "--origin",
       description =
-          "Control-plane origin, e.g. https://sail.example.dev. Defaults to the configured"
-              + " webauthn origin from host.yaml.")
+          "Control-plane origin, e.g. https://sail.example.dev. Defaults to an SSH tunnel to the"
+              + " configured client host, or to the webauthn origin from host.yaml on a box.")
   private String origin;
+
+  @Option(
+      names = "--no-tunnel",
+      description = "Do not open an SSH tunnel; sign in at the configured origin directly.")
+  private boolean noTunnel;
 
   @Option(
       names = "--timeout",
@@ -57,32 +64,50 @@ public final class LoginCommand implements Runnable {
     CliCommand.run(
         spec,
         () -> {
+          if (origin == null
+              && !noTunnel
+              && RuntimeMode.detect() instanceof RuntimeMode.Client client) {
+            tunneledCeremony(client.config().host());
+            return;
+          }
           var resolvedOrigin = origin != null ? origin : configuredOrigin();
           if (resolvedOrigin == null) {
             throw new IllegalArgumentException(
                 "No control-plane origin. Pass --origin or configure the webauthn block in"
                     + " host.yaml.");
           }
-          var state = randomState();
-          try (var callback = new LoopbackCallbackServer(state)) {
-            callback.start();
-            var url =
-                resolvedOrigin
-                    + "/login?redirect_uri="
-                    + URLEncoder.encode(callback.redirectUri(), StandardCharsets.UTF_8)
-                    + "&state="
-                    + state;
-            System.out.println("  Opening your browser to sign in:");
-            System.out.println(Ansi.AUTO.string("    @|cyan " + url + "|@"));
-            openBrowser(url);
-            System.out.println("  Waiting for sign-in to complete…");
-            var token = callback.awaitToken(Duration.ofSeconds(timeoutSeconds));
-            var configPath = SailPaths.clientConfigPath();
-            ServerConnectionConfig.saveSessionToken(token, configPath);
-            System.out.println(
-                Ansi.AUTO.string("  @|green ✓|@ Signed in. Session saved to " + configPath));
-          }
+          ceremony(resolvedOrigin, () -> {});
         });
+  }
+
+  private void tunneledCeremony(String host) throws Exception {
+    System.out.println("  Opening an SSH tunnel to " + host + "…");
+    try (var tunnel = SshTunnel.open(host)) {
+      OriginPreflight.requireCanonicalOrigin(host);
+      ceremony(SshTunnel.ORIGIN, tunnel::ensureAlive);
+    }
+  }
+
+  private void ceremony(String resolvedOrigin, Runnable liveness) throws Exception {
+    var state = LoopbackCallbackServer.newState();
+    try (var callback = new LoopbackCallbackServer(state)) {
+      callback.start();
+      var url =
+          resolvedOrigin
+              + "/login?redirect_uri="
+              + URLEncoder.encode(callback.redirectUri(), StandardCharsets.UTF_8)
+              + "&state="
+              + state;
+      System.out.println("  Opening your browser to sign in:");
+      System.out.println(Ansi.AUTO.string("    @|cyan " + url + "|@"));
+      Browser.open(url);
+      System.out.println("  Waiting for sign-in to complete…");
+      var token = callback.awaitToken(Duration.ofSeconds(timeoutSeconds), liveness);
+      var configPath = SailPaths.clientConfigPath();
+      ServerConnectionConfig.saveSessionToken(token, configPath);
+      System.out.println(
+          Ansi.AUTO.string("  @|green ✓|@ Signed in. Session saved to " + configPath));
+    }
   }
 
   private static String configuredOrigin() throws IOException {
@@ -92,21 +117,5 @@ public final class LoginCommand implements Runnable {
     }
     var webauthn = HostYaml.fromMap(YamlUtil.parseFile(path)).webauthn();
     return webauthn.isConfigured() ? webauthn.origins().getFirst() : null;
-  }
-
-  private static void openBrowser(String url) {
-    var os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
-    var command = os.contains("mac") ? List.of("open", url) : List.of("xdg-open", url);
-    try {
-      new ProcessBuilder(command).start();
-    } catch (IOException ignored) {
-      System.out.println("  (Could not open a browser automatically — open the URL above.)");
-    }
-  }
-
-  private static String randomState() {
-    var bytes = new byte[16];
-    new SecureRandom().nextBytes(bytes);
-    return HexFormat.of().formatHex(bytes);
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/LoopbackCallbackServer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/LoopbackCallbackServer.java
@@ -12,29 +12,42 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
 import java.time.Duration;
+import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * A short-lived loopback HTTP listener that receives the session token from a browser passkey
- * login. {@code sail login} opens the browser at the control-plane {@code /login} page passing this
+ * A short-lived loopback HTTP listener that receives the outcome of a browser passkey ceremony.
+ * {@code sail login} opens the browser at the control-plane {@code /login} page passing this
  * listener's {@code /callback} as the redirect target and an opaque {@code state} nonce; the page
  * redirects back with the minted token. The token is accepted only when the returned {@code state}
- * matches the one issued, so a stale or forged callback cannot inject a token. Binds {@code
+ * matches the one issued, so a stale or forged callback cannot inject a token. {@code sail enroll}
+ * uses the {@link #forEnrollment(String) enrollment mode}, where the {@code /enroll} page redirects
+ * back with the state alone (enrollment mints no token) purely as a completion signal. Binds {@code
  * 127.0.0.1} only — never reachable off the machine.
  */
 public final class LoopbackCallbackServer implements AutoCloseable {
+
+  private static final Duration LIVENESS_INTERVAL = Duration.ofMillis(500);
 
   private static final String DONE_PAGE =
       """
       <!doctype html><meta charset="utf-8"><title>Sail</title>
       <body style="font-family:system-ui,sans-serif;max-width:32rem;margin:4rem auto">
       <h1>Signed in to Sail</h1><p>You can close this tab and return to the terminal.</p></body>
+      """;
+  private static final String ENROLLED_PAGE =
+      """
+      <!doctype html><meta charset="utf-8"><title>Sail</title>
+      <body style="font-family:system-ui,sans-serif;max-width:32rem;margin:4rem auto">
+      <h1>Passkey enrolled</h1><p>You can close this tab and return to the terminal.</p></body>
       """;
   private static final String ERROR_PAGE =
       """
@@ -45,12 +58,36 @@ public final class LoopbackCallbackServer implements AutoCloseable {
 
   private final HttpServer server;
   private final String state;
+  private final boolean requireToken;
+  private final String donePage;
   private final CompletableFuture<String> token = new CompletableFuture<>();
 
   public LoopbackCallbackServer(String state) throws IOException {
+    this(state, true, DONE_PAGE);
+  }
+
+  private LoopbackCallbackServer(String state, boolean requireToken, String donePage)
+      throws IOException {
     this.state = state;
+    this.requireToken = requireToken;
+    this.donePage = donePage;
     server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
     server.createContext("/callback", this::handle);
+  }
+
+  /**
+   * A listener for the {@code /enroll} page, which redirects back with the {@code state} alone —
+   * enrollment mints no token, so the callback is purely a completion signal.
+   */
+  public static LoopbackCallbackServer forEnrollment(String state) throws IOException {
+    return new LoopbackCallbackServer(state, false, ENROLLED_PAGE);
+  }
+
+  /** A fresh unguessable {@code state} nonce binding a browser callback to this CLI invocation. */
+  public static String newState() {
+    var bytes = new byte[16];
+    new SecureRandom().nextBytes(bytes);
+    return HexFormat.of().formatHex(bytes);
   }
 
   public void start() {
@@ -71,14 +108,37 @@ public final class LoopbackCallbackServer implements AutoCloseable {
    */
   public String awaitToken(Duration wait)
       throws InterruptedException, ExecutionException, TimeoutException {
-    return token.get(wait.toMillis(), TimeUnit.MILLISECONDS);
+    return awaitToken(wait, () -> {});
+  }
+
+  /**
+   * Blocks like {@link #awaitToken(Duration)} while running {@code liveness} every poll slice, so a
+   * transport the ceremony depends on (an SSH tunnel) can abort the wait the moment it dies instead
+   * of letting the engineer stare at a doomed timeout.
+   */
+  public String awaitToken(Duration wait, Runnable liveness)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    var deadline = System.nanoTime() + wait.toNanos();
+    while (true) {
+      liveness.run();
+      var remaining = deadline - System.nanoTime();
+      if (remaining <= 0) {
+        throw new TimeoutException("The browser ceremony did not complete in time.");
+      }
+      try {
+        return token.get(Math.min(remaining, LIVENESS_INTERVAL.toNanos()), TimeUnit.NANOSECONDS);
+      } catch (TimeoutException slice) {
+        continue;
+      }
+    }
   }
 
   private void handle(HttpExchange exchange) throws IOException {
     var query = parseQuery(exchange.getRequestURI().getRawQuery());
     var received = query.get("token");
-    var accepted = state.equals(query.get("state")) && Strings.isNotBlank(received);
-    var body = accepted ? DONE_PAGE : ERROR_PAGE;
+    var accepted =
+        state.equals(query.get("state")) && (Strings.isNotBlank(received) || !requireToken);
+    var body = accepted ? donePage : ERROR_PAGE;
     var bytes = body.getBytes(StandardCharsets.UTF_8);
     exchange.getResponseHeaders().set("Content-Type", "text/html; charset=utf-8");
     exchange.sendResponseHeaders(accepted ? 200 : 400, bytes.length);
@@ -87,7 +147,7 @@ public final class LoopbackCallbackServer implements AutoCloseable {
     }
     exchange.close();
     if (accepted) {
-      token.complete(received);
+      token.complete(Objects.toString(received, ""));
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/OriginPreflight.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/OriginPreflight.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.config.YamlUtil;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Preflights a tunneled passkey ceremony. {@code /v1/auth/login/start} advertises the box's allowed
+ * WebAuthn origins; the server later matches the ceremony origin exactly, so when the canonical
+ * tunnel origin {@link SshTunnel#ORIGIN} is not among them the ceremony is doomed before the
+ * browser opens. Failing here names the exact {@code host.yaml} block to add instead of leaving the
+ * engineer with a bare in-browser ceremony error.
+ */
+final class OriginPreflight {
+
+  private OriginPreflight() {}
+
+  static void requireCanonicalOrigin(String box) throws IOException, InterruptedException {
+    check(box, loginStartBody());
+  }
+
+  static void check(String box, Map<String, Object> body) {
+    if (body.get("error") instanceof Map<?, ?> error) {
+      if ("passkey_not_configured".equals(error.get("code"))) {
+        throw new IllegalStateException(
+            originGuidance(box, "Passkey login is not configured on " + box + "."));
+      }
+      throw new IllegalStateException(
+          "The control plane on "
+              + box
+              + " refused the passkey preflight: "
+              + error.get("message"));
+    }
+    if (body.get("origins") instanceof List<?> origins && !origins.contains(SshTunnel.ORIGIN)) {
+      throw new IllegalStateException(
+          originGuidance(
+              box,
+              "The box "
+                  + box
+                  + " does not allowlist the tunnel origin "
+                  + SshTunnel.ORIGIN
+                  + "."));
+    }
+  }
+
+  private static String originGuidance(String box, String lead) {
+    return """
+        %s
+          Tunneled ceremonies run at %s, and the server matches that origin exactly.
+          Add this webauthn block to host.yaml on %s:
+
+              webauthn:
+                rp_id: localhost
+                origins:
+                  - http://localhost:7070
+
+          Then restart the control plane there: sudo sail host service restart"""
+        .formatted(lead, SshTunnel.ORIGIN, box);
+  }
+
+  private static Map<String, Object> loginStartBody() throws IOException, InterruptedException {
+    var request =
+        HttpRequest.newBuilder(
+                URI.create("http://127.0.0.1:" + SshTunnel.PORT + "/v1/auth/login/start"))
+            .timeout(Duration.ofSeconds(5))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString("{}"))
+            .build();
+    try (var client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build()) {
+      return YamlUtil.parseMap(client.send(request, HttpResponse.BodyHandlers.ofString()).body());
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -201,10 +201,12 @@ public final class ServerStartCommand implements Runnable {
     var passkeyService = configured ? buildPasskeyService(db, webauthn) : null;
     var enrollment =
         configured ? new EnrollmentService(new EnrollmentTicketStore(db), new FdeStore(db)) : null;
-    var enrollOrigin = configured ? webauthn.origins().getFirst() : null;
     var passkeyHandler =
         new WebauthnAuthHandler(
-            passkeyService, enrollment, new TokenAuth(tokenStore), enrollOrigin);
+            passkeyService,
+            enrollment,
+            new TokenAuth(tokenStore),
+            configured ? webauthn.origins() : null);
     var auth =
         new SessionAwareAuth(new AuthSessionStore(db), new FdeStore(db), new TokenAuth(tokenStore));
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SshTunnel.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SshTunnel.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.engine.SailPaths;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+/**
+ * A supervised {@code ssh -N -L} tunnel from the canonical control-plane port on this machine to
+ * the same port on the box, so a browser passkey ceremony can run at the origin {@code
+ * http://localhost:7070} the box allowlists. The local end must be the canonical port — the server
+ * matches the ceremony origin exactly, so an ephemeral port can never validate — which is why a
+ * busy port 7070 fails loud instead of falling back.
+ *
+ * <p>{@code BatchMode} keeps ssh from ever prompting (a missing key fails fast), {@code
+ * ExitOnForwardFailure} turns a lost port race into a clean exit, and a health check against the
+ * forwarded {@code /v1/health} proves the control plane is answering before any ceremony starts.
+ * The tunnel rides the engineer's own SSH identity for {@code host} — the {@code sail} gateway
+ * account's keys are {@code restrict}-ed and cannot forward ports.
+ */
+public final class SshTunnel implements AutoCloseable {
+
+  public static final int PORT = 7070;
+  public static final String ORIGIN = "http://localhost:" + PORT;
+
+  private static final int HEALTH_ATTEMPTS = 20;
+  private static final Duration HEALTH_INTERVAL = Duration.ofMillis(500);
+  private static final Pattern PLAIN_HOST = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._@-]{0,252}");
+
+  @FunctionalInterface
+  interface Launcher {
+    Process launch(List<String> command) throws IOException;
+  }
+
+  @FunctionalInterface
+  interface HealthProbe {
+    boolean healthy() throws IOException, InterruptedException;
+  }
+
+  private final String host;
+  private final Process process;
+  private final ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+  private final Thread drainer;
+
+  private SshTunnel(String host, Process process) {
+    this.host = host;
+    this.process = process;
+    this.drainer =
+        Thread.startVirtualThread(
+            () -> {
+              try {
+                process.getErrorStream().transferTo(stderr);
+              } catch (IOException ignored) {
+                return;
+              }
+            });
+  }
+
+  /** Opens the tunnel to {@code host} and blocks until the forwarded control plane is healthy. */
+  public static SshTunnel open(String host) throws IOException, InterruptedException {
+    return open(
+        host,
+        PORT,
+        command -> new ProcessBuilder(command).start(),
+        healthProbe(PORT),
+        HEALTH_ATTEMPTS,
+        HEALTH_INTERVAL);
+  }
+
+  static SshTunnel open(
+      String host,
+      int port,
+      Launcher launcher,
+      HealthProbe probe,
+      int attempts,
+      Duration interval)
+      throws IOException, InterruptedException {
+    requirePlainHost(host);
+    requireFreePort(port);
+    var tunnel = new SshTunnel(host, launcher.launch(command(host, port)));
+    try {
+      tunnel.awaitHealthy(probe, attempts, interval);
+    } catch (Exception e) {
+      tunnel.close();
+      throw e;
+    }
+    return tunnel;
+  }
+
+  static List<String> command(String host, int port) {
+    return List.of(
+        "ssh",
+        "-N",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ExitOnForwardFailure=yes",
+        "-o",
+        "ConnectTimeout=10",
+        "-o",
+        "ServerAliveInterval=15",
+        "-o",
+        "ServerAliveCountMax=2",
+        "-L",
+        "127.0.0.1:" + port + ":127.0.0.1:" + PORT,
+        "--",
+        host);
+  }
+
+  /** Throws with the box name and captured ssh stderr if the tunnel died mid-ceremony. */
+  public void ensureAlive() {
+    if (!process.isAlive()) {
+      throw new IllegalStateException(
+          "The SSH tunnel to " + host + " died mid-ceremony." + sshDiagnostics());
+    }
+  }
+
+  @Override
+  public void close() {
+    process.destroy();
+    try {
+      if (!process.waitFor(2, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+      }
+    } catch (InterruptedException e) {
+      process.destroyForcibly();
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private void awaitHealthy(HealthProbe probe, int attempts, Duration interval)
+      throws InterruptedException {
+    for (var attempt = 0; attempt < attempts; attempt++) {
+      if (!process.isAlive()) {
+        throw new IllegalStateException(
+            "The SSH tunnel to "
+                + host
+                + " exited before it became healthy."
+                + sshDiagnostics()
+                + "\n  Check that 'ssh "
+                + host
+                + "' signs in with your key alone — the tunnel never prompts.");
+      }
+      if (probeQuietly(probe)) {
+        return;
+      }
+      Thread.sleep(interval);
+    }
+    throw new IllegalStateException(
+        "The SSH tunnel to "
+            + host
+            + " is up, but "
+            + ORIGIN
+            + "/v1/health did not answer within "
+            + interval.multipliedBy(attempts).toSeconds()
+            + "s."
+            + "\n  Is the control plane running on "
+            + host
+            + "? Install it there with: sudo sail host service install"
+            + sshDiagnostics());
+  }
+
+  private static boolean probeQuietly(HealthProbe probe) throws InterruptedException {
+    try {
+      return probe.healthy();
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  private String sshDiagnostics() {
+    try {
+      drainer.join(Duration.ofMillis(500));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    var text = stderr.toString(StandardCharsets.UTF_8).strip();
+    return text.isEmpty() ? "" : "\n  ssh said: " + text;
+  }
+
+  private static void requirePlainHost(String host) {
+    if (host == null || !PLAIN_HOST.matcher(host).matches()) {
+      throw new IllegalArgumentException(
+          "Refusing to tunnel to '"
+              + host
+              + "' — the client host must be a plain hostname, IP, or SSH alias."
+              + "\n  Fix 'host:' in "
+              + SailPaths.clientConfigPath());
+    }
+  }
+
+  private static void requireFreePort(int port) {
+    try (var socket = new ServerSocket()) {
+      socket.setReuseAddress(true);
+      socket.bind(new InetSocketAddress("127.0.0.1", port));
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          "Local port "
+              + port
+              + " is already in use. The passkey ceremony must run at the canonical origin"
+              + " http://localhost:"
+              + port
+              + " — the box allowlists that exact origin, so an ephemeral port cannot work."
+              + "\n  Find the holder: lsof -nP -iTCP:"
+              + port
+              + " -sTCP:LISTEN"
+              + "\n  Free the port and rerun.");
+    }
+  }
+
+  private static HealthProbe healthProbe(int port) {
+    var request =
+        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/v1/health"))
+            .timeout(Duration.ofSeconds(2))
+            .GET()
+            .build();
+    return () -> {
+      try (var client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build()) {
+        return client.send(request, HttpResponse.BodyHandlers.discarding()).statusCode() == 200;
+      } catch (UncheckedIOException e) {
+        return false;
+      }
+    };
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SshTunnel.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SshTunnel.java
@@ -84,12 +84,7 @@ public final class SshTunnel implements AutoCloseable {
   }
 
   static SshTunnel open(
-      String host,
-      int port,
-      Launcher launcher,
-      HealthProbe probe,
-      int attempts,
-      Duration interval)
+      String host, int port, Launcher launcher, HealthProbe probe, int attempts, Duration interval)
       throws IOException, InterruptedException {
     requirePlainHost(host);
     requireFreePort(port);

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/RemoteCommandRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/RemoteCommandRunner.java
@@ -31,7 +31,7 @@ import picocli.CommandLine.Help.Ansi;
 public final class RemoteCommandRunner {
 
   private static final Set<String> LOCAL_COMMANDS =
-      Set.of("--version", "-V", "upgrade", "init", "client", "login");
+      Set.of("--version", "-V", "upgrade", "init", "client", "login", "enroll");
   private static final Set<String> INTERACTIVE_COMMANDS = Set.of("shell", "exec");
   private static final Set<String> HOST_ONLY_COMMANDS = Set.of("host");
   private static final Set<String> GATEWAY_COMMANDS =
@@ -51,9 +51,10 @@ public final class RemoteCommandRunner {
    * <p>Routes commands into three categories:
    *
    * <ul>
-   *   <li>Local: {@code --version}, {@code upgrade}, {@code init}, {@code client}, {@code login} —
-   *       run on the client, not forwarded ({@code login} drives the client's browser and a
-   *       loopback callback; {@code client} writes this machine's client config)
+   *   <li>Local: {@code --version}, {@code upgrade}, {@code init}, {@code client}, {@code login},
+   *       {@code enroll} — run on the client, not forwarded ({@code login} and {@code enroll} drive
+   *       the client's browser, a loopback callback, and their own SSH tunnel; {@code client}
+   *       writes this machine's client config)
    *   <li>Host-only: {@code host init}, {@code host config} — error with guidance
    *   <li>Everything else: forwarded to the remote host via SSH, as {@code sail@host} when the FDE
    *       gateway accepts the command and as the plain host otherwise

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WebauthnAuthHandlerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WebauthnAuthHandlerTest.java
@@ -431,7 +431,9 @@ class WebauthnAuthHandlerTest {
             new AuthSessionStore(db),
             new PendingChallengeStore(db));
     startWith(
-        service, new EnrollmentService(new EnrollmentTicketStore(db), new FdeStore(db)), ORIGIN);
+        service,
+        new EnrollmentService(new EnrollmentTicketStore(db), new FdeStore(db)),
+        List.of(ORIGIN));
     var authenticator = new TestAuthenticator(RP_ID);
 
     var mint =

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WebauthnAuthHandlerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WebauthnAuthHandlerTest.java
@@ -33,6 +33,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Path;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -73,11 +74,11 @@ class WebauthnAuthHandlerTest {
     startWith(
         ceremonies,
         ceremonies == null ? null : new FakeEnrollment(),
-        ceremonies == null ? null : ORIGIN);
+        ceremonies == null ? null : List.of(ORIGIN));
   }
 
   private void startWith(
-      PasskeyCeremonies ceremonies, EnrollmentTickets enrollment, String enrollOrigin)
+      PasskeyCeremonies ceremonies, EnrollmentTickets enrollment, List<String> origins)
       throws Exception {
     server =
         new SailApiServer(
@@ -87,8 +88,7 @@ class WebauthnAuthHandlerTest {
             tokenStore,
             new EventBus(),
             null,
-            new WebauthnAuthHandler(
-                ceremonies, enrollment, new TokenAuth(tokenStore), enrollOrigin));
+            new WebauthnAuthHandler(ceremonies, enrollment, new TokenAuth(tokenStore), origins));
     server.start();
   }
 
@@ -200,6 +200,20 @@ class WebauthnAuthHandlerTest {
     var response = post("/v1/auth/login/start", null, "{}");
     assertEquals(200, response.statusCode());
     assertEquals("wac_login", YamlUtil.parseMap(response.body()).get("challenge_id"));
+  }
+
+  @Test
+  void loginStartAdvertisesTheAllowedOrigins() throws Exception {
+    startWith(new FakeCeremonies());
+    var body = YamlUtil.parseMap(post("/v1/auth/login/start", null, "{}").body());
+    assertEquals(List.of(ORIGIN), body.get("origins"));
+  }
+
+  @Test
+  void loginStartOmitsOriginsWhenNoneConfigured() throws Exception {
+    startWith(new FakeCeremonies(), new FakeEnrollment(), null);
+    var body = YamlUtil.parseMap(post("/v1/auth/login/start", null, "{}").body());
+    assertFalse(body.containsKey("origins"));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
@@ -34,6 +34,7 @@ class CommandTaxonomyTest {
             "server",
             "fde",
             "login",
+            "enroll",
             "spec",
             "agent",
             "events",

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/EnrollCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/EnrollCommandTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.ClientConfig;
+import ai.singlr.sail.engine.ShellExec;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class EnrollCommandTest {
+
+  @Test
+  void mintCommandRidesTheGatewayLaneAndNeverPrompts() {
+    var command = EnrollCommand.mintCommand(new ClientConfig("devbox"));
+    assertEquals("ssh", command.getFirst());
+    assertTrue(
+        command.containsAll(
+            List.of(
+                "BatchMode=yes", "PasswordAuthentication=no", "KbdInteractiveAuthentication=no")));
+    assertTrue(command.contains("sail@devbox"));
+    assertEquals(
+        List.of("sail", "fde", "enroll", "--json"),
+        command.subList(command.size() - 4, command.size()));
+    assertEquals("--", command.get(command.indexOf("sail@devbox") - 1));
+  }
+
+  @Test
+  void parseTicketReadsTheGatewayJson() {
+    var ticket =
+        EnrollCommand.parseTicket(
+            """
+            {"ticket": "tkt_abc", "fde": "uday", "expires_at": "2026-07-07T10:15:30Z"}
+            """);
+    assertEquals("tkt_abc", ticket.ticket());
+    assertEquals("uday", ticket.fde());
+  }
+
+  @Test
+  void parseTicketFailsLoudOnUnexpectedOutput() {
+    var error =
+        assertThrows(
+            IllegalStateException.class, () -> EnrollCommand.parseTicket("sail: unknown option"));
+    assertTrue(error.getMessage().contains("sail: unknown option"));
+    assertTrue(error.getMessage().contains("sail host update"));
+  }
+
+  @Test
+  void enrollUrlTargetsTheCanonicalOriginAndEncodesEveryParameter() {
+    var url = EnrollCommand.enrollUrl("tkt/+abc", "http://127.0.0.1:49152/callback", "state-nonce");
+    assertTrue(url.startsWith(SshTunnel.ORIGIN + "/enroll?ticket=tkt%2F%2Babc"));
+    assertTrue(url.contains("redirect_uri=http%3A%2F%2F127.0.0.1%3A49152%2Fcallback"));
+    assertTrue(url.endsWith("&state=state-nonce"));
+  }
+
+  @Test
+  void mintFailureNamesTheGatewayAndSurfacesSshStderr() {
+    var failure =
+        EnrollCommand.mintFailure(
+            "sail@devbox", new ShellExec.Result(255, "", "Permission denied (publickey).\n"));
+    assertTrue(failure.contains("sail@devbox"));
+    assertTrue(failure.contains("ssh exit 255"));
+    assertTrue(failure.contains("Permission denied (publickey)."));
+    assertTrue(failure.contains("sail fde add"));
+  }
+
+  @Test
+  void mintFailureStaysCleanWhenSshWasSilent() {
+    var failure = EnrollCommand.mintFailure("sail@devbox", new ShellExec.Result(1, "", ""));
+    assertTrue(failure.contains("ssh exit 1"));
+    assertTrue(failure.lines().noneMatch(line -> line.contains("ssh said")));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/FdeCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/FdeCommandTest.java
@@ -5,9 +5,13 @@
 
 package ai.singlr.sail.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.singlr.sail.auth.EnrollmentTickets;
 import ai.singlr.sail.auth.Passkeys;
+import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.store.WebauthnCredentialStore;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -54,6 +58,24 @@ class FdeCommandTest {
     var message = FdeCommand.Passkey.noMatchMessage("uday", "zz", List.of());
     assertTrue(message.contains("'uday' has no passkeys"));
     assertTrue(message.contains("sail fde enroll uday"));
+  }
+
+  @Test
+  void enrollTicketJsonCarriesTicketFdeAndExpiry() {
+    var ticket = new EnrollmentTickets.Ticket("tkt_abc", "uday", "2026-07-07T10:15:30Z");
+    var json = YamlUtil.dumpJson(FdeCommand.Enroll.ticketJson(ticket, "https://sail.acme.dev"));
+    var parsed = YamlUtil.parseMap(json);
+    assertEquals("tkt_abc", parsed.get("ticket"));
+    assertEquals("uday", parsed.get("fde"));
+    assertEquals("2026-07-07T10:15:30Z", parsed.get("expires_at"));
+    assertEquals("https://sail.acme.dev/enroll?ticket=tkt_abc", parsed.get("enroll_url"));
+  }
+
+  @Test
+  void enrollTicketJsonOmitsEnrollUrlWithoutAConfiguredOrigin() {
+    var ticket = new EnrollmentTickets.Ticket("tkt_abc", "uday", "2026-07-07T10:15:30Z");
+    var parsed = YamlUtil.parseMap(YamlUtil.dumpJson(FdeCommand.Enroll.ticketJson(ticket, null)));
+    assertFalse(parsed.containsKey("enroll_url"));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/LoopbackCallbackServerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/LoopbackCallbackServerTest.java
@@ -6,6 +6,8 @@
 package ai.singlr.sail.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
@@ -13,6 +15,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,5 +65,52 @@ class LoopbackCallbackServerTest {
   @Test
   void missingTokenIsRejected() throws Exception {
     assertEquals(400, hit("state=state-nonce").statusCode());
+  }
+
+  @Test
+  void enrollmentModeCompletesOnStateAlone() throws Exception {
+    callback.close();
+    callback = LoopbackCallbackServer.forEnrollment("state-nonce");
+    callback.start();
+    var response = hit("state=state-nonce");
+    assertEquals(200, response.statusCode());
+    assertTrue(response.body().contains("Passkey enrolled"));
+    assertEquals("", callback.awaitToken(Duration.ofSeconds(5)));
+  }
+
+  @Test
+  void enrollmentModeStillRejectsAMismatchedState() throws Exception {
+    callback.close();
+    callback = LoopbackCallbackServer.forEnrollment("state-nonce");
+    callback.start();
+    assertEquals(400, hit("state=wrong").statusCode());
+  }
+
+  @Test
+  void awaitTokenTimesOutWhenNoCallbackArrives() {
+    assertThrows(
+        TimeoutException.class, () -> callback.awaitToken(Duration.ofMillis(50), () -> {}));
+  }
+
+  @Test
+  void awaitTokenAbortsTheWaitWhenLivenessFails() {
+    var error =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                callback.awaitToken(
+                    Duration.ofSeconds(30),
+                    () -> {
+                      throw new IllegalStateException("tunnel died");
+                    }));
+    assertEquals("tunnel died", error.getMessage());
+  }
+
+  @Test
+  void newStateIsUnguessableAndFresh() {
+    var first = LoopbackCallbackServer.newState();
+    var second = LoopbackCallbackServer.newState();
+    assertEquals(32, first.length());
+    assertFalse(first.equals(second));
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/OriginPreflightTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/OriginPreflightTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OriginPreflightTest {
+
+  @Test
+  void passesWhenTheCanonicalOriginIsAllowlisted() {
+    assertDoesNotThrow(
+        () ->
+            OriginPreflight.check(
+                "devbox", Map.of("origins", List.of("https://sail.acme.dev", SshTunnel.ORIGIN))));
+  }
+
+  @Test
+  void passesWhenTheServerDoesNotAdvertiseOrigins() {
+    assertDoesNotThrow(() -> OriginPreflight.check("devbox", Map.of("challenge_id", "wac_1")));
+  }
+
+  @Test
+  void failsWithTheExactHostYamlBlockWhenTheCanonicalOriginIsMissing() {
+    var error =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                OriginPreflight.check(
+                    "devbox", Map.of("origins", List.of("https://sail.acme.dev"))));
+    assertTrue(error.getMessage().contains("devbox"));
+    assertTrue(error.getMessage().contains("rp_id: localhost"));
+    assertTrue(error.getMessage().contains("- http://localhost:7070"));
+    assertTrue(error.getMessage().contains("sudo sail host service restart"));
+  }
+
+  @Test
+  void failsWithTheSameGuidanceWhenPasskeysAreNotConfiguredAtAll() {
+    var error =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                OriginPreflight.check(
+                    "devbox",
+                    Map.of(
+                        "error",
+                        Map.of("code", "passkey_not_configured", "message", "not configured"))));
+    assertTrue(error.getMessage().contains("rp_id: localhost"));
+    assertTrue(error.getMessage().contains("- http://localhost:7070"));
+  }
+
+  @Test
+  void surfacesOtherControlPlaneErrorsVerbatim() {
+    var error =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                OriginPreflight.check(
+                    "devbox", Map.of("error", Map.of("code", "internal", "message", "boom"))));
+    assertTrue(error.getMessage().contains("devbox"));
+    assertTrue(error.getMessage().contains("boom"));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SshTunnelTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SshTunnelTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class SshTunnelTest {
+
+  private static final Duration FAST = Duration.ofMillis(1);
+
+  private static int freePort() throws Exception {
+    try (var socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    }
+  }
+
+  @Test
+  void commandNeverPromptsAndFailsOnALostPortRace() {
+    var command = SshTunnel.command("devbox", 7070);
+    assertEquals("ssh", command.getFirst());
+    assertTrue(command.containsAll(List.of("-N", "BatchMode=yes", "ExitOnForwardFailure=yes")));
+    assertTrue(command.contains("127.0.0.1:7070:127.0.0.1:7070"));
+    assertEquals("devbox", command.getLast());
+    assertEquals("--", command.get(command.size() - 2));
+  }
+
+  @Test
+  void openBecomesHealthyThenClosesTheTunnelWithTheCommand() throws Exception {
+    var ssh = new FakeSshProcess("");
+    try (var tunnel = SshTunnel.open("devbox", freePort(), cmd -> ssh, () -> true, 3, FAST)) {
+      assertDoesNotThrow(tunnel::ensureAlive);
+    }
+    assertFalse(ssh.isAlive());
+  }
+
+  @Test
+  void openFailsLoudWhenTheCanonicalPortIsBusy() throws Exception {
+    try (var holder = new ServerSocket()) {
+      holder.setReuseAddress(true);
+      holder.bind(new InetSocketAddress("127.0.0.1", 0));
+      var port = holder.getLocalPort();
+      var launched = new AtomicInteger();
+      var error =
+          assertThrows(
+              IllegalStateException.class,
+              () ->
+                  SshTunnel.open(
+                      "devbox",
+                      port,
+                      cmd -> {
+                        launched.incrementAndGet();
+                        return new FakeSshProcess("");
+                      },
+                      () -> true,
+                      3,
+                      FAST));
+      assertTrue(error.getMessage().contains("already in use"));
+      assertTrue(error.getMessage().contains("lsof -nP -iTCP:" + port));
+      assertEquals(0, launched.get());
+    }
+  }
+
+  @Test
+  void openSurfacesSshStderrWhenSshDiesBeforeBecomingHealthy() throws Exception {
+    var ssh = new FakeSshProcess("Permission denied (publickey).");
+    ssh.kill();
+    var port = freePort();
+    var error =
+        assertThrows(
+            IllegalStateException.class,
+            () -> SshTunnel.open("devbox", port, cmd -> ssh, () -> false, 3, FAST));
+    assertTrue(error.getMessage().contains("devbox"));
+    assertTrue(error.getMessage().contains("Permission denied (publickey)."));
+    assertTrue(error.getMessage().contains("signs in with your key alone"));
+  }
+
+  @Test
+  void openFailsWithGuidanceWhenTheHealthCheckTimesOut() throws Exception {
+    var ssh = new FakeSshProcess("");
+    var port = freePort();
+    var error =
+        assertThrows(
+            IllegalStateException.class,
+            () -> SshTunnel.open("devbox", port, cmd -> ssh, () -> false, 3, FAST));
+    assertTrue(error.getMessage().contains("/v1/health did not answer"));
+    assertTrue(error.getMessage().contains("devbox"));
+    assertTrue(error.getMessage().contains("sail host service install"));
+    assertFalse(ssh.isAlive());
+  }
+
+  @Test
+  void ensureAliveNamesTheBoxAndSurfacesSshStderrWhenTheTunnelDiesMidCeremony() throws Exception {
+    var ssh = new FakeSshProcess("client_loop: send disconnect: Broken pipe");
+    var tunnel = SshTunnel.open("devbox", freePort(), cmd -> ssh, () -> true, 3, FAST);
+    ssh.kill();
+    var error = assertThrows(IllegalStateException.class, tunnel::ensureAlive);
+    assertTrue(error.getMessage().contains("died mid-ceremony"));
+    assertTrue(error.getMessage().contains("devbox"));
+    assertTrue(error.getMessage().contains("Broken pipe"));
+    tunnel.close();
+  }
+
+  @Test
+  void refusesHostsThatCouldSmuggleSshOptions() throws Exception {
+    var port = freePort();
+    for (var host : new String[] {"-oProxyCommand=evil", "", null, "box name", "box;rm"}) {
+      var error =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> SshTunnel.open(host, port, cmd -> new FakeSshProcess(""), () -> true, 3, FAST));
+      assertTrue(error.getMessage().contains("plain hostname"));
+    }
+  }
+
+  private static final class FakeSshProcess extends Process {
+
+    private final InputStream stderr;
+    private volatile boolean alive = true;
+
+    FakeSshProcess(String stderrText) {
+      this.stderr = new ByteArrayInputStream(stderrText.getBytes(StandardCharsets.UTF_8));
+    }
+
+    void kill() {
+      alive = false;
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+      return OutputStream.nullOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+      return stderr;
+    }
+
+    @Override
+    public int waitFor() {
+      return 1;
+    }
+
+    @Override
+    public boolean waitFor(long timeout, TimeUnit unit) {
+      return !alive;
+    }
+
+    @Override
+    public int exitValue() {
+      if (alive) {
+        throw new IllegalThreadStateException();
+      }
+      return 1;
+    }
+
+    @Override
+    public void destroy() {
+      alive = false;
+    }
+
+    @Override
+    public Process destroyForcibly() {
+      alive = false;
+      return this;
+    }
+
+    @Override
+    public boolean isAlive() {
+      return alive;
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/RemoteCommandRunnerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/RemoteCommandRunnerTest.java
@@ -158,6 +158,7 @@ class RemoteCommandRunnerTest {
     assertTrue(RemoteCommandRunner.isLocalCommand("upgrade"));
     assertTrue(RemoteCommandRunner.isLocalCommand("init"));
     assertTrue(RemoteCommandRunner.isLocalCommand("login"));
+    assertTrue(RemoteCommandRunner.isLocalCommand("enroll"));
     assertFalse(RemoteCommandRunner.isLocalCommand("spec"));
     assertFalse(RemoteCommandRunner.isLocalCommand("dispatch"));
   }


### PR DESCRIPTION
Implements spec `thin-client-passkey-dx`. The passkey ceremony must run at the Relying Party origin, and the field-proven thin-client path is an SSH tunnel to the box's loopback with `http://localhost:7070` as the origin — previously assembled by hand. Both halves are now one command, mirroring Mast's proven tunnel convention (canonical port 7070, since the server matches ceremony origins exactly).

## What

- **`sail login`** on a thin client auto-opens a supervised `ssh -N -L 127.0.0.1:7070:127.0.0.1:7070` tunnel using the engineer's own SSH identity (the `sail` gateway account's keys are `restrict`-ed and cannot forward ports), health-checks the forwarded control plane, runs the loopback-callback ceremony at the canonical origin, stores the session token, and tears the tunnel down with the command. A busy port 7070 fails loud — an ephemeral port can never validate against the exact-match origin allowlist. `--no-tunnel` / `--origin` keep the reverse-proxy path unchanged.
- **`sail enroll`** — self-enrollment with no admin round-trip: mints an enrollment ticket over the existing SSH gateway lane, then reuses the tunnel machinery to drive the box's `/enroll` page, where the browser prompts for the credential label.
- **Identity binding is gateway-side by construction**: a bare `fde enroll` has the caller's pinned handle *injected by the gateway* (`withSelfEnrollHandle`) — the client never asserts who it is. Naming another FDE's handle still requires the admin role, the same self-vs-others rule as `fde passkey`.
- **`OriginPreflight`** dooms-early: before the browser opens, `/v1/auth/login/start` is checked for the canonical tunnel origin, and failure prints the exact `host.yaml` webauthn block to add rather than leaving a bare in-browser ceremony error.
- Tunnel hardening: `BatchMode` (never prompts; missing key fails fast with the ssh stderr and the box named), `ExitOnForwardFailure`, keepalives, host-argument validation with `--` guards against option injection, `ensureAlive()` surfaces a mid-ceremony tunnel death with diagnostics.

## Provenance

First attempt died on provider rate limits mid-run; its work was preserved as the WIP commit and this attempt continued from it. The finishing agent completed the implementation but its session ended before commit/push/PR (backgrounded its final verify and terminated waiting on it), so the maintainer completed the protocol: reviewed the full diff (gateway binding, origin preflight, tunnel identity/injection guards), ran `mvn clean verify` green — full suite, all JaCoCo gates including 100% on `api.*` — and committed.

## Verification

- `mvn clean verify` green: full suite, spotless, all coverage gates.
- New tests: `SshTunnelTest` (command shape, health-check lifecycle, busy-port, death diagnostics), `EnrollCommandTest` (gateway mint round-trip, ticket parsing, thin-client guards), `OriginPreflightTest` (unconfigured, refused, missing-origin guidance), `LoopbackCallbackServerTest` additions, gateway carve-out tests for the injected handle.