### PR TITLE
Spec mutations via the API publish bus events

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
@@ -5,11 +5,14 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.HostInfo;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.SpecStore;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -22,14 +25,20 @@ final class GlobalSpecOperations {
 
   private final SpecStore specStore;
   private final ReviewStore reviewStore;
+  private final EventBus eventBus;
 
   GlobalSpecOperations(SpecStore specStore) {
-    this(specStore, null);
+    this(specStore, null, null);
   }
 
   GlobalSpecOperations(SpecStore specStore, ReviewStore reviewStore) {
+    this(specStore, reviewStore, null);
+  }
+
+  GlobalSpecOperations(SpecStore specStore, ReviewStore reviewStore, EventBus eventBus) {
     this.specStore = specStore;
     this.reviewStore = reviewStore;
+    this.eventBus = eventBus;
   }
 
   GlobalSpecsListResponse list(SpecStore.SpecFilter filter) {
@@ -94,6 +103,7 @@ final class GlobalSpecOperations {
           Objects.requireNonNullElse(request.plan(), ""));
     }
     var created = specStore.findById(request.id()).orElseThrow();
+    publishBoardUpdated(created.project(), created.id(), principal(request.createdBy()));
     return new GlobalSpecCreatedResponse(GlobalSpecView.from(created));
   }
 
@@ -128,6 +138,16 @@ final class GlobalSpecOperations {
       reviewStore.resolveSourceFindings(specId);
     }
     var result = specStore.findById(specId).orElseThrow();
+    if (result.status() != existing.status()) {
+      publishStatusChanged(
+          result.project(),
+          specId,
+          existing.status(),
+          result.status(),
+          principal(request.updatedBy()));
+    } else {
+      publishBoardUpdated(result.project(), specId, principal(request.updatedBy()));
+    }
     return new GlobalSpecUpdatedResponse(GlobalSpecView.from(result));
   }
 
@@ -153,8 +173,9 @@ final class GlobalSpecOperations {
 
   GlobalSpecDeletedResponse delete(String specId) {
     requireStore();
-    findOrThrow(specId);
+    var existing = findOrThrow(specId);
     specStore.delete(specId);
+    publishBoardUpdated(existing.project(), specId, Event.SAIL_AGENT);
     return new GlobalSpecDeletedResponse(specId);
   }
 
@@ -167,12 +188,13 @@ final class GlobalSpecOperations {
 
   GlobalSpecContentResponse setContent(String specId, SpecContentRequest request) {
     requireStore();
-    findOrThrow(specId);
+    var existing = findOrThrow(specId);
     specStore.setContent(
         specId,
         Objects.requireNonNullElse(request.body(), ""),
         Objects.requireNonNullElse(request.plan(), ""));
     var content = specStore.getContent(specId).orElseThrow();
+    publishBoardUpdated(existing.project(), specId, Event.SAIL_AGENT);
     return new GlobalSpecContentResponse(specId, content.body(), content.plan());
   }
 
@@ -217,7 +239,36 @@ final class GlobalSpecOperations {
       throw new ApiException(ErrorCode.INVALID_REQUEST, e.getMessage());
     }
     var row = specStore.findById(specId).orElseThrow();
+    publishBoardUpdated(row.project(), specId, Event.SAIL_AGENT);
     return new GlobalSpecRestoredResponse(GlobalSpecView.from(row), request.rev());
+  }
+
+  private void publishStatusChanged(
+      String project, String specId, SpecStatus from, SpecStatus to, String principal) {
+    if (eventBus == null) {
+      return;
+    }
+    eventBus.publish(
+        Event.of(
+            project,
+            specId,
+            Event.WellKnownTypes.SPEC_STATUS_CHANGED,
+            principal,
+            HostInfo.hostname(),
+            Map.of("from", from.wire(), "to", to.wire())));
+  }
+
+  private void publishBoardUpdated(String project, String specId, String principal) {
+    if (eventBus == null) {
+      return;
+    }
+    eventBus.publish(
+        Event.of(
+            project, specId, Event.WellKnownTypes.BOARD_UPDATED, principal, HostInfo.hostname()));
+  }
+
+  private static String principal(String actor) {
+    return Strings.isNotBlank(actor) ? actor : Event.SAIL_AGENT;
   }
 
   private SpecStore.SpecRow findOrThrow(String specId) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -194,7 +194,7 @@ public final class SailApiOperations implements ApiOperations {
     this.sessionStore = sessionStore;
     this.projectStore = projectStore;
     this.connectEnvironment = connectEnvironment;
-    this.globalSpecOps = new GlobalSpecOperations(specStore, reviewStore);
+    this.globalSpecOps = new GlobalSpecOperations(specStore, reviewStore, eventBus);
     this.reviewOps = new ReviewOperations(reviewStore, specStore);
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
@@ -17,8 +17,11 @@ import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Predicate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -322,6 +325,118 @@ class GlobalSpecOperationsTest {
   void boardReturnsSummary() {
     ops.create(createReq(Map.of("status", "pending")));
     assertNotNull(ops.board("manatee").board());
+  }
+
+  @Test
+  void updateStatusChangePublishesSpecStatusChangedWithFromTo() throws Exception {
+    ops.create(createReq(Map.of("status", "pending")));
+    var event =
+        captureOne(
+            bus ->
+                bus.update(
+                    "auth",
+                    SpecUpdateRequest.fromMap(Map.of("status", "in_progress"))
+                        .withUpdatedBy("nova")));
+    assertEquals(Event.WellKnownTypes.SPEC_STATUS_CHANGED, event.type());
+    assertEquals("manatee", event.project());
+    assertEquals("auth", event.spec());
+    assertEquals("nova", event.agent());
+    assertEquals("pending", event.data().get("from"));
+    assertEquals("in_progress", event.data().get("to"));
+  }
+
+  @Test
+  void updateNonStatusChangePublishesBoardUpdatedAttributedToActor() throws Exception {
+    ops.create(createReq(Map.of("status", "pending")));
+    var event =
+        captureOne(
+            bus ->
+                bus.update(
+                    "auth",
+                    SpecUpdateRequest.fromMap(Map.of("title", "Renamed")).withUpdatedBy("nova")));
+    assertEquals(Event.WellKnownTypes.BOARD_UPDATED, event.type());
+    assertEquals("auth", event.spec());
+    assertEquals("nova", event.agent());
+  }
+
+  @Test
+  void updateWithoutActorFallsBackToSailAgent() throws Exception {
+    ops.create(createReq(Map.of("status", "pending")));
+    var event =
+        captureOne(
+            bus -> bus.update("auth", SpecUpdateRequest.fromMap(Map.of("title", "Renamed"))));
+    assertEquals(Event.SAIL_AGENT, event.agent());
+  }
+
+  @Test
+  void createPublishesBoardUpdatedAttributedToAuthor() throws Exception {
+    var event = captureOne(bus -> bus.create(createReq(Map.of()).withCreatedBy("uday")));
+    assertEquals(Event.WellKnownTypes.BOARD_UPDATED, event.type());
+    assertEquals("manatee", event.project());
+    assertEquals("auth", event.spec());
+    assertEquals("uday", event.agent());
+  }
+
+  @Test
+  void deletePublishesBoardUpdatedForTheSpecProject() throws Exception {
+    ops.create(createReq(Map.of()));
+    var event = captureOne(bus -> bus.delete("auth"));
+    assertEquals(Event.WellKnownTypes.BOARD_UPDATED, event.type());
+    assertEquals("manatee", event.project());
+    assertEquals("auth", event.spec());
+    assertEquals(Event.SAIL_AGENT, event.agent());
+  }
+
+  @Test
+  void setContentPublishesBoardUpdated() throws Exception {
+    ops.create(createReq(Map.of()));
+    var event =
+        captureOne(
+            bus -> bus.setContent("auth", SpecContentRequest.fromMap(Map.of("body", "Body"))));
+    assertEquals(Event.WellKnownTypes.BOARD_UPDATED, event.type());
+    assertEquals("auth", event.spec());
+  }
+
+  @Test
+  void restorePublishesBoardUpdated() throws Exception {
+    ops.create(createReq(Map.of()));
+    ops.setContent("auth", new SpecContentRequest("good", "good plan"));
+    var goodRev = ops.history("auth").revisions().getLast().rev();
+    ops.setContent("auth", new SpecContentRequest("clobbered", "clobbered"));
+    var event = captureOne(bus -> bus.restore("auth", new SpecRestoreRequest(goodRev)));
+    assertEquals(Event.WellKnownTypes.BOARD_UPDATED, event.type());
+    assertEquals("auth", event.spec());
+  }
+
+  private Event captureOne(java.util.function.Consumer<GlobalSpecOperations> mutation)
+      throws Exception {
+    try (var bus = new EventBus()) {
+      var seen = new ArrayList<Event>();
+      var latch = new CountDownLatch(1);
+      bus.subscribe(BusTesting.latching(capture(seen), latch));
+      mutation.accept(new GlobalSpecOperations(specStore, reviewStore, bus));
+      BusTesting.awaitDelivery(latch);
+      return seen.getFirst();
+    }
+  }
+
+  private static EventSubscriber capture(List<Event> sink) {
+    return new EventSubscriber() {
+      @Override
+      public String name() {
+        return "capture";
+      }
+
+      @Override
+      public Predicate<Event> filter() {
+        return EventSubscriber.all();
+      }
+
+      @Override
+      public void onEvent(Event event) {
+        sink.add(event);
+      }
+    };
   }
 
   @Test


### PR DESCRIPTION
## Why

Live consumers of `GET /v1/events/stream` (the Mast board, `sail watch`) rely on `spec_status_changed` / `board_updated` to reflect changes without polling. The global spec API paths in `GlobalSpecOperations` — create/update/delete/setContent/restore — published nothing, so a human moving a spec (Mast drag → `PUT /v1/specs/{id}`) was invisible to every other connected client.

## What

`GlobalSpecOperations` now publishes onto the existing `EventBus` (already wired for dispatch events) at the point of each mutation, once:

- **`update`** with a status change → `spec_status_changed` carrying `data: {from, to}` and the acting principal (`updated_by`) as `agent`; any other field change → `board_updated`.
- **`create` / `delete` / `setContent` / `restore`** → `board_updated` scoped to the spec's project. Create/update attribute the event to the authenticated principal; the others emit as `sail`.

The event bus is threaded through the `SailApiOperations` → `GlobalSpecOperations` constructor. The sync path is untouched, so `sail sync` still emits exactly one `board_updated` per applied round — no double-publish.

## Tests

Added API-level tests driving each mutation against an in-process `EventBus` + subscriber, asserting the event type, project/spec scope, principal attribution, and `from`/`to` payload. Full suite (2082 tests) green and the `ai.singlr.sail.api.*` 100% coverage gate holds.