### PR TITLE
Mount the live agent-log SSE endpoint (GET /v1/projects/{p}/agent/stream)

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/AgentLogStreamer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/AgentLogStreamer.java
@@ -5,7 +5,8 @@
 
 package ai.singlr.sail.api;
 
-import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.ContainerExec;
+import ai.singlr.sail.engine.NameValidator;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import java.io.BufferedReader;
@@ -14,12 +15,31 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
  * SSE handler that streams agent log output from a container. Tails the agent log file via {@code
  * incus exec} and sends each line as an SSE {@code data:} event. Supports {@code ?since=N} to
  * replay from a specific line number for client reconnection.
+ *
+ * <p>Mounted by {@link ApiRouter}, which delegates {@code GET /v1/projects/{p}/agent/stream}
+ * straight to this handler so the long-lived connection never runs through the buffered
+ * request/response path. It is not registered as its own {@link
+ * com.sun.net.httpserver.HttpServer#createContext} because the path carries a variable project
+ * segment, which prefix-matching cannot isolate from the rest of {@code /v1/projects/...}.
+ *
+ * <p>Authentication is the {@code Authorization: Bearer} header only — the same gate {@code
+ * /v1/events/stream} uses (accepting {@code sess_} login sessions via {@link SessionAwareAuth}).
+ * There is deliberately no query-parameter token: a browser {@code EventSource} cannot set headers
+ * and is unsupported, but a native client that sets the header (Mast's Rust core, {@code sail agent
+ * stream}) authenticates normally.
+ *
+ * <p>The tail runs as a raw long-lived {@link Process} rather than through {@link
+ * ai.singlr.sail.engine.ShellExec}: {@code tail -f} never terminates, so the streaming loop needs
+ * the live process handle and incremental stdout, not a run-to-completion executor. The command
+ * itself is built through {@link ContainerExec#asDevUser} for parity with every other in-container
+ * invocation.
  */
 public final class AgentLogStreamer implements HttpHandler {
 
@@ -28,12 +48,10 @@ public final class AgentLogStreamer implements HttpHandler {
   private static final long HEARTBEAT_INTERVAL_NANOS = Duration.ofSeconds(15).toNanos();
 
   private final ApiAuth auth;
-  private final ShellExec shell;
   private final LongAdder activeStreams = new LongAdder();
 
-  public AgentLogStreamer(ApiAuth auth, ShellExec shell) {
+  public AgentLogStreamer(ApiAuth auth) {
     this.auth = auth;
-    this.shell = shell;
   }
 
   @Override
@@ -53,6 +71,12 @@ public final class AgentLogStreamer implements HttpHandler {
       var project = extractProject(exchange.getRequestURI().getPath());
       if (project == null) {
         sendError(exchange, 400, "Missing project name");
+        return;
+      }
+      try {
+        NameValidator.requireValidProjectName(project);
+      } catch (IllegalArgumentException e) {
+        sendError(exchange, 400, "Invalid project name");
         return;
       }
 
@@ -120,20 +144,9 @@ public final class AgentLogStreamer implements HttpHandler {
   }
 
   static String[] buildTailCommand(String project, int since) {
-    var tailArgs = since > 0 ? "tail -n +" + since + " -f" : "tail -f";
-    return new String[] {
-      "incus",
-      "exec",
-      project,
-      "--user",
-      "1000",
-      "--group",
-      "1000",
-      "--",
-      "bash",
-      "-c",
-      tailArgs + " " + LOG_PATH
-    };
+    var tail = since > 0 ? "tail -n +" + since + " -f " : "tail -f ";
+    return ContainerExec.asDevUser(project, List.of("bash", "-c", tail + LOG_PATH))
+        .toArray(String[]::new);
   }
 
   static String extractProject(String path) {
@@ -142,6 +155,16 @@ public final class AgentLogStreamer implements HttpHandler {
       return segments[3];
     }
     return null;
+  }
+
+  /** True when {@code path} is exactly {@code /v1/projects/{project}/agent/stream}. */
+  static boolean isStreamPath(String path) {
+    var segments = path.split("/");
+    return segments.length == 6
+        && "v1".equals(segments[1])
+        && "projects".equals(segments[2])
+        && "agent".equals(segments[4])
+        && "stream".equals(segments[5]);
   }
 
   static int parseSince(String query) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/AgentLogStreamer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/AgentLogStreamer.java
@@ -110,25 +110,7 @@ public final class AgentLogStreamer implements HttpHandler {
             new BufferedReader(
                 new InputStreamReader(tailProcess.getInputStream(), StandardCharsets.UTF_8))) {
       writeComment(out, "streaming " + project);
-      var lineNumber = since > 0 ? since : 1;
-      var lastHeartbeat = System.nanoTime();
-
-      while (true) {
-        if (reader.ready()) {
-          var line = reader.readLine();
-          if (line == null) break;
-          writeSseData(out, lineNumber, line);
-          lineNumber++;
-          lastHeartbeat = System.nanoTime();
-        } else {
-          if (System.nanoTime() - lastHeartbeat > HEARTBEAT_INTERVAL_NANOS) {
-            out.write(HEARTBEAT);
-            out.flush();
-            lastHeartbeat = System.nanoTime();
-          }
-          Thread.sleep(100);
-        }
-      }
+      pump(tailProcess, reader, out, since);
     } catch (IOException e) {
       // Client disconnected — expected during streaming
     } catch (InterruptedException e) {
@@ -136,6 +118,39 @@ public final class AgentLogStreamer implements HttpHandler {
     } finally {
       tailProcess.destroyForcibly();
       activeStreams.decrement();
+    }
+  }
+
+  /**
+   * Relays the tail's output as SSE until the client disconnects or the tail process exits. Ending
+   * on process death is the load-bearing part: {@code tail -f} in a container that never existed
+   * (bad project) or whose agent has stopped exits, and without this the loop would heartbeat onto
+   * a dead pipe forever, holding the connection open and never closing the stream. Buffered lines
+   * are drained through the ready() branch before the exit is observed, so no output is lost.
+   */
+  static void pump(Process tailProcess, BufferedReader reader, OutputStream out, int since)
+      throws IOException, InterruptedException {
+    var lineNumber = since > 0 ? since : 1;
+    var lastHeartbeat = System.nanoTime();
+    while (true) {
+      if (reader.ready()) {
+        var line = reader.readLine();
+        if (line == null) {
+          break;
+        }
+        writeSseData(out, lineNumber, line);
+        lineNumber++;
+        lastHeartbeat = System.nanoTime();
+      } else if (!tailProcess.isAlive()) {
+        break;
+      } else {
+        if (System.nanoTime() - lastHeartbeat > HEARTBEAT_INTERVAL_NANOS) {
+          out.write(HEARTBEAT);
+          out.flush();
+          lastHeartbeat = System.nanoTime();
+        }
+        Thread.sleep(100);
+      }
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -63,19 +63,38 @@ public final class ApiRouter implements HttpHandler {
   private final ApiOperations operations;
   private final ApiAuth auth;
   private final RateLimiter rateLimiter;
-
-  public ApiRouter(ApiOperations operations, ApiAuth auth) {
-    this(operations, auth, RateLimiter.perMinute(DEFAULT_PERMITS_PER_MINUTE, DEFAULT_BURST));
-  }
+  private final AgentLogStreamer agentStreamer;
 
   public ApiRouter(ApiOperations operations, ApiAuth auth, RateLimiter rateLimiter) {
+    this(operations, auth, rateLimiter, null);
+  }
+
+  public ApiRouter(ApiOperations operations, ApiAuth auth, AgentLogStreamer agentStreamer) {
+    this(
+        operations,
+        auth,
+        RateLimiter.perMinute(DEFAULT_PERMITS_PER_MINUTE, DEFAULT_BURST),
+        agentStreamer);
+  }
+
+  public ApiRouter(
+      ApiOperations operations,
+      ApiAuth auth,
+      RateLimiter rateLimiter,
+      AgentLogStreamer agentStreamer) {
     this.operations = operations;
     this.auth = auth;
     this.rateLimiter = rateLimiter;
+    this.agentStreamer = agentStreamer;
   }
 
   @Override
   public void handle(HttpExchange exchange) throws IOException {
+    if (agentStreamer != null
+        && AgentLogStreamer.isStreamPath(exchange.getRequestURI().getPath())) {
+      agentStreamer.handle(exchange);
+      return;
+    }
     try {
       var response = route(exchange);
       write(exchange, response);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiServer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiServer.java
@@ -189,7 +189,7 @@ public final class SailApiServer implements AutoCloseable {
             : null;
     server = HttpServer.create(new InetSocketAddress(host, port), 32);
     executor = Executors.newVirtualThreadPerTaskExecutor();
-    server.createContext("/", new ApiRouter(operations, auth));
+    server.createContext("/", new ApiRouter(operations, auth, new AgentLogStreamer(auth)));
     if (passkeyHandler != null) {
       server.createContext("/v1/auth", passkeyHandler);
       var pages = new WebauthnPageHandler();

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AgentLogStreamerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AgentLogStreamerTest.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -75,5 +76,22 @@ class AgentLogStreamerTest {
     var joined = String.join(" ", cmd);
     assertTrue(joined.contains("--user 1000"));
     assertTrue(joined.contains("--group 1000"));
+  }
+
+  @Test
+  void isStreamPathMatchesCanonicalPath() {
+    assertTrue(AgentLogStreamer.isStreamPath("/v1/projects/backend/agent/stream"));
+  }
+
+  @Test
+  void isStreamPathRejectsOtherAgentSubResources() {
+    assertFalse(AgentLogStreamer.isStreamPath("/v1/projects/backend/agent/log"));
+    assertFalse(AgentLogStreamer.isStreamPath("/v1/projects/backend/agent"));
+  }
+
+  @Test
+  void isStreamPathRejectsWrongPrefix() {
+    assertFalse(AgentLogStreamer.isStreamPath("/v1/other/backend/agent/stream"));
+    assertFalse(AgentLogStreamer.isStreamPath("/v1/events/stream"));
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AgentLogStreamerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AgentLogStreamerTest.java
@@ -8,8 +8,14 @@ package ai.singlr.sail.api;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 class AgentLogStreamerTest {
@@ -93,5 +99,42 @@ class AgentLogStreamerTest {
   void isStreamPathRejectsWrongPrefix() {
     assertFalse(AgentLogStreamer.isStreamPath("/v1/other/backend/agent/stream"));
     assertFalse(AgentLogStreamer.isStreamPath("/v1/events/stream"));
+  }
+
+  @Test
+  void pumpTerminatesWhenTheTailProcessExitsInsteadOfHeartbeatingForever() {
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(5),
+        () -> {
+          var process = new ProcessBuilder("sh", "-c", "printf 'first\\nsecond\\n'").start();
+          var reader =
+              new BufferedReader(
+                  new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
+          var out = new ByteArrayOutputStream();
+
+          AgentLogStreamer.pump(process, reader, out, 0);
+
+          var body = out.toString(StandardCharsets.UTF_8);
+          assertTrue(body.contains("first"), body);
+          assertTrue(body.contains("second"), body);
+          assertFalse(process.isAlive());
+        });
+  }
+
+  @Test
+  void pumpStopsPromptlyWhenAnAlreadyDeadProcessHasNoOutput() {
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(5),
+        () -> {
+          var process = new ProcessBuilder("sh", "-c", "true").start();
+          process.waitFor();
+          var reader =
+              new BufferedReader(
+                  new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
+
+          AgentLogStreamer.pump(process, reader, new ByteArrayOutputStream(), 0);
+
+          assertFalse(process.isAlive());
+        });
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AgentLogStreamerWiringTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AgentLogStreamerWiringTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Proves {@code GET /v1/projects/{p}/agent/stream} is mounted: the real {@link SailApiServer}
+ * wiring routes it to {@link AgentLogStreamer} rather than returning 404, and it rejects an
+ * unauthenticated caller exactly as {@code /v1/events/stream} does. The tail itself is not
+ * exercised here (no live container), so the authenticated request lands on the handler and fails
+ * to spawn the container tail — the point is that it reaches the handler at all.
+ */
+class AgentLogStreamerWiringTest {
+
+  private static HttpRequest streamRequest(int port, String token) {
+    var builder =
+        HttpRequest.newBuilder(
+                URI.create("http://127.0.0.1:" + port + "/v1/projects/backend/agent/stream"))
+            .header("Accept", "text/event-stream")
+            .timeout(Duration.ofSeconds(15))
+            .GET();
+    if (token != null) {
+      builder.header("Authorization", "Bearer " + token);
+    }
+    return builder.build();
+  }
+
+  private static SailApiServer server(Path tmp) throws Exception {
+    return new SailApiServer(
+        "127.0.0.1",
+        0,
+        new SailApiOperations(),
+        new FixedTokenTestAuth("tok"),
+        new EventBus(),
+        new AuditPersister(tmp.resolve("events.jsonl"), 8),
+        tmp.resolve("api.sock"));
+  }
+
+  @Test
+  void authenticatedStreamRequestReachesHandlerNot404(@TempDir Path tmp) throws Exception {
+    try (var server = server(tmp)) {
+      server.start();
+      var response =
+          HttpClient.newHttpClient()
+              .send(streamRequest(server.port(), "tok"), HttpResponse.BodyHandlers.ofString());
+      assertNotEquals(404, response.statusCode(), "stream route must be mounted");
+      assertNotEquals(401, response.statusCode(), "authenticated caller must pass the auth gate");
+      assertNotEquals(403, response.statusCode(), "authenticated caller must pass the auth gate");
+    }
+  }
+
+  @Test
+  void unauthenticatedStreamRequestIsRejected(@TempDir Path tmp) throws Exception {
+    try (var server = server(tmp)) {
+      server.start();
+      var response =
+          HttpClient.newHttpClient()
+              .send(streamRequest(server.port(), null), HttpResponse.BodyHandlers.ofString());
+      assertEquals(401, response.statusCode());
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AgentLogStreamerWiringTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AgentLogStreamerWiringTest.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -52,25 +53,44 @@ class AgentLogStreamerWiringTest {
 
   @Test
   void authenticatedStreamRequestReachesHandlerNot404(@TempDir Path tmp) throws Exception {
-    try (var server = server(tmp)) {
-      server.start();
-      var response =
-          HttpClient.newHttpClient()
-              .send(streamRequest(server.port(), "tok"), HttpResponse.BodyHandlers.ofString());
-      assertNotEquals(404, response.statusCode(), "stream route must be mounted");
-      assertNotEquals(401, response.statusCode(), "authenticated caller must pass the auth gate");
-      assertNotEquals(403, response.statusCode(), "authenticated caller must pass the auth gate");
-    }
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(20),
+        () -> {
+          try (var server = server(tmp)) {
+            server.start();
+            var status = statusFromHeaders(server.port(), "tok");
+            assertNotEquals(404, status, "stream route must be mounted");
+            assertNotEquals(401, status, "authenticated caller must pass the auth gate");
+            assertNotEquals(403, status, "authenticated caller must pass the auth gate");
+          }
+        });
   }
 
   @Test
   void unauthenticatedStreamRequestIsRejected(@TempDir Path tmp) throws Exception {
-    try (var server = server(tmp)) {
-      server.start();
-      var response =
-          HttpClient.newHttpClient()
-              .send(streamRequest(server.port(), null), HttpResponse.BodyHandlers.ofString());
-      assertEquals(401, response.statusCode());
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(20),
+        () -> {
+          try (var server = server(tmp)) {
+            server.start();
+            assertEquals(401, statusFromHeaders(server.port(), null));
+          }
+        });
+  }
+
+  /**
+   * Reads only the response status from the headers and closes the body without draining it. The
+   * endpoint is an SSE stream over {@code tail -f}, which never reaches EOF against a live
+   * container, so consuming the body ({@code BodyHandlers.ofString()}) would block forever — the
+   * bug that hung this test for 34 minutes in the incus lane. The wiring assertion is a status
+   * check, and the status is in the headers.
+   */
+  private static int statusFromHeaders(int port, String token) throws Exception {
+    var response =
+        HttpClient.newHttpClient()
+            .send(streamRequest(port, token), HttpResponse.BodyHandlers.ofInputStream());
+    try (var body = response.body()) {
+      return response.statusCode();
     }
   }
 }


### PR DESCRIPTION
## What

Wires the already-built, already-tested `AgentLogStreamer` into the HTTP server. Before this, the handler existed but was never registered, so `GET /v1/projects/{p}/agent/stream` returned 404 — and `sail agent stream` / Mast's monitor 404'd with it. Now a running agent's stdout is reachable over HTTP as SSE.

## How

- **Mount via `ApiRouter` delegation.** The path carries a variable project segment, which `HttpServer.createContext` prefix-matching can't isolate from the rest of `/v1/projects/...`. So `ApiRouter.handle` detects `/v1/projects/{p}/agent/stream` and hands the exchange straight to `AgentLogStreamer`, before the buffered `route()`/`write()` path — no injected Content-Length, no response buffering. The stream is written unbuffered with `sendResponseHeaders(200, 0)`.
- **Auth + capability.** Same `auth.require` gate as `/v1/events/stream` (`Authorization: Bearer`, incl. `sess_` login sessions via `SessionAwareAuth`). An unauthenticated request is rejected with 401, exactly as the events stream. There is deliberately **no query-param token** — a browser `EventSource` can't set headers and is unsupported, but a native client that sets the header (Mast's Rust core, `sail agent stream`) authenticates normally.
- **`?since=N` + 15s heartbeats** are end-to-end (already in the handler): a dropped connection resumes at the given line.
- **Reconciled container exec.** `buildTailCommand` now builds through `ContainerExec.asDevUser` for parity with every other in-container invocation (and it validates the project name). The raw long-lived `Process` is kept because `tail -f` never terminates — the streaming loop needs the live handle and incremental stdout, not a run-to-completion executor. Dropped the unused `ShellExec` field.
- Removed the now-orphaned two-arg `ApiRouter` constructor.

## Tests

- Existing `AgentLogStreamerTest` still passes; extended with `isStreamPath` cases.
- New `AgentLogStreamerWiringTest` starts the real `SailApiServer` and proves the route is mounted (authenticated request reaches the handler, not 404) and that an unauthenticated request is rejected with 401 — matching `/v1/events/stream`.
- Full `mvn verify` green, including the 100% api-package coverage gate.