### PR TITLE
Longer, configurable passkey session lifetime (default 30 days)

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/auth/PasskeyService.java
+++ b/sail-core/src/main/java/ai/singlr/sail/auth/PasskeyService.java
@@ -31,25 +31,30 @@ public final class PasskeyService implements PasskeyCeremonies {
   static final String REGISTER = "register";
   static final String ASSERT = "assert";
   private static final Duration CHALLENGE_TTL = Duration.ofMinutes(5);
-  private static final Duration SESSION_TTL = Duration.ofHours(12);
 
   private final RelyingParty relyingParty;
   private final FdeStore fdes;
   private final WebauthnCredentialStore credentials;
   private final AuthSessionStore sessions;
   private final PendingChallengeStore challenges;
+  private final Duration sessionTtl;
 
   public PasskeyService(
       RelyingParty relyingParty,
       FdeStore fdes,
       WebauthnCredentialStore credentials,
       AuthSessionStore sessions,
-      PendingChallengeStore challenges) {
+      PendingChallengeStore challenges,
+      Duration sessionTtl) {
     this.relyingParty = Objects.requireNonNull(relyingParty, "relyingParty");
     this.fdes = Objects.requireNonNull(fdes, "fdes");
     this.credentials = Objects.requireNonNull(credentials, "credentials");
     this.sessions = Objects.requireNonNull(sessions, "sessions");
     this.challenges = Objects.requireNonNull(challenges, "challenges");
+    this.sessionTtl = Objects.requireNonNull(sessionTtl, "sessionTtl");
+    if (sessionTtl.isZero() || sessionTtl.isNegative()) {
+      throw new IllegalArgumentException("sessionTtl must be positive, got " + sessionTtl);
+    }
   }
 
   @Override
@@ -134,7 +139,7 @@ public final class PasskeyService implements PasskeyCeremonies {
       throw loginFailed();
     }
     credentials.recordUse(credentialId, newSignCount);
-    var session = sessions.create(credential.fdeId(), SESSION_TTL);
+    var session = sessions.create(credential.fdeId(), sessionTtl);
     return new LoginResult(session.token(), handleOf(credential.fdeId()), session.expiresAt());
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/config/HostYaml.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/HostYaml.java
@@ -136,7 +136,7 @@ public record HostYaml(
     map.put("incus_version", incusVersion);
     map.put("server_ip", serverIp);
     map.put("initialized_at", initializedAt);
-    if (webauthn != null && webauthn.isConfigured()) {
+    if (webauthn != null && !webauthn.equals(WebauthnConfig.disabled())) {
       map.put("webauthn", webauthn.toMap());
     }
     if (sync != null && sync.role() != null) {

--- a/sail-core/src/main/java/ai/singlr/sail/config/WebauthnConfig.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/WebauthnConfig.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.config;
 
 import ai.singlr.sail.common.Strings;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,17 +18,44 @@ import java.util.Objects;
  * and the set of allowed {@code origins} a {@code clientDataJSON} may carry. These come from the
  * TLS-terminating reverse proxy's public {@code https://} origin — sail terminates no TLS itself —
  * so the operator declares them here. A config with no {@code rpId} or no origins is {@link
- * #isConfigured() unconfigured}: passkey login stays disabled until it is set.
+ * #isConfigured() unconfigured}: passkey login stays disabled until it is set. {@code
+ * sessionTtlHours} is the lifetime of a session minted by a passkey login, defaulting to 30 days
+ * when unset and bounded to 1 hour–90 days.
  */
-public record WebauthnConfig(String rpId, String rpName, List<String> origins) {
+public record WebauthnConfig(
+    String rpId, String rpName, List<String> origins, Integer sessionTtlHours) {
+
+  public static final int MIN_SESSION_TTL_HOURS = 1;
+  public static final int MAX_SESSION_TTL_HOURS = 90 * 24;
+  public static final int DEFAULT_SESSION_TTL_HOURS = 30 * 24;
 
   public WebauthnConfig {
     origins = origins == null ? List.of() : List.copyOf(origins);
+    if (sessionTtlHours != null
+        && (sessionTtlHours < MIN_SESSION_TTL_HOURS || sessionTtlHours > MAX_SESSION_TTL_HOURS)) {
+      throw new IllegalArgumentException(
+          "Invalid session TTL: "
+              + sessionTtlHours
+              + " hours. Expected "
+              + MIN_SESSION_TTL_HOURS
+              + " to "
+              + MAX_SESSION_TTL_HOURS
+              + " (1 hour to 90 days).");
+    }
+  }
+
+  public WebauthnConfig(String rpId, String rpName, List<String> origins) {
+    this(rpId, rpName, origins, null);
   }
 
   /** An empty, disabled configuration. */
   public static WebauthnConfig disabled() {
     return new WebauthnConfig(null, null, List.of());
+  }
+
+  /** The lifetime of a session minted by a passkey login; 30 days unless configured. */
+  public Duration sessionTtl() {
+    return Duration.ofHours(Objects.requireNonNullElse(sessionTtlHours, DEFAULT_SESSION_TTL_HOURS));
   }
 
   /** True when an {@code rpId} and at least one origin are present, so login can be served. */
@@ -51,7 +79,10 @@ public record WebauthnConfig(String rpId, String rpName, List<String> origins) {
           case null -> List.<String>of();
           case Object single -> List.of(single.toString());
         };
-    return new WebauthnConfig((String) map.get("rp_id"), (String) map.get("rp_name"), origins);
+    var raw = map.get("session_ttl_hours");
+    var sessionTtlHours = raw == null ? null : Integer.valueOf(raw.toString().strip());
+    return new WebauthnConfig(
+        (String) map.get("rp_id"), (String) map.get("rp_name"), origins, sessionTtlHours);
   }
 
   public Map<String, Object> toMap() {
@@ -59,6 +90,9 @@ public record WebauthnConfig(String rpId, String rpName, List<String> origins) {
     map.put("rp_id", rpId);
     map.put("rp_name", rpName);
     map.put("origins", origins);
+    if (sessionTtlHours != null) {
+      map.put("session_ttl_hours", sessionTtlHours);
+    }
     return map;
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncPrincipal.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncPrincipal.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+/**
+ * The authenticated FDE behind one sync session: the handle the SSH-key gateway resolved and
+ * whether that FDE's role may push. The handle is what binds single-writer aggregates (runs) to
+ * their executing node — a session may only commit runs stamped with its own handle. A {@code null}
+ * handle (unauthenticated or machine session) can never own a run, so it fails closed.
+ */
+public record SyncPrincipal(String handle, boolean canWrite) {
+
+  public static SyncPrincipal readOnly() {
+    return new SyncPrincipal(null, false);
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
@@ -129,12 +129,19 @@ public final class SyncRpcServer {
 
   /**
    * Whether this session may commit the run: both the incoming snapshot's {@code node} and the run
-   * main already holds (either absent for a create or a completed delete) must be the principal's
-   * own handle. Checking both sides refuses a forged foreign stamp and the clobbering of another
-   * node's run with a re-stamped one; a missing or blank stamp fails closed.
+   * main already holds must be the principal's own handle. Checking both sides refuses a forged
+   * foreign stamp and the clobbering of another node's run with a re-stamped one; a missing or
+   * blank stamp fails closed. A null current snapshot alongside a non-null revision is a tombstone,
+   * not a fresh ID — resurrecting it is refused outright, since the deleted run's owner is no
+   * longer readable and fetch hands every session the tombstone's revision to replay against.
    */
   private boolean ownsRunCommit(SyncWire.Commit commit, MainReplica main) {
-    return ownedByPrincipal(commit.snapshot()) && ownedByPrincipal(main.current(commit.entityId()));
+    var incoming = commit.snapshot();
+    var current = main.current(commit.entityId());
+    if (incoming != null && current == null && main.currentRev(commit.entityId()) != null) {
+      return false;
+    }
+    return ownedByPrincipal(incoming) && ownedByPrincipal(current);
   }
 
   private boolean ownedByPrincipal(Map<String, Object> run) {

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
@@ -16,27 +16,32 @@ import java.util.Objects;
  * Main's side of one sync session: a stateless request loop over the SSH channel's stdio. It routes
  * each {@link SyncWire.Fetch}/{@link SyncWire.Commit} to the authoritative {@link MainReplica} for
  * its entity type (specs, files), serves the node's roster pull, and returns at {@link
- * SyncWire.Bye} or end of stream. The {@code writable} gate is the push half of Door-2
+ * SyncWire.Bye} or end of stream. The {@link SyncPrincipal} carries the push half of Door-2
  * authorization: a {@code viewer} opens a session and pulls every type, but its commits are refused
- * so only {@code member}+ work propagates.
+ * so only {@code member}+ work propagates. The principal's handle additionally binds run commits to
+ * execution provenance — a session may create, update, or delete only runs stamped with its own
+ * node, so no member can forge run metadata another box would treat as its own execution.
  */
 public final class SyncRpcServer {
 
+  private static final String RUN_ENTITY = "run";
+
   private final Map<String, MainReplica> replicas;
-  private final boolean writable;
+  private final SyncPrincipal principal;
   private final FdeRoster fdeRoster;
 
   public SyncRpcServer(MainReplica main, boolean writable) {
-    this(Map.of("spec", main), writable, FdeRoster.EMPTY);
+    this(Map.of("spec", main), new SyncPrincipal(null, writable), FdeRoster.EMPTY);
   }
 
   public SyncRpcServer(MainReplica main, boolean writable, FdeRoster fdeRoster) {
-    this(Map.of("spec", main), writable, fdeRoster);
+    this(Map.of("spec", main), new SyncPrincipal(null, writable), fdeRoster);
   }
 
-  public SyncRpcServer(Map<String, MainReplica> replicas, boolean writable, FdeRoster fdeRoster) {
+  public SyncRpcServer(
+      Map<String, MainReplica> replicas, SyncPrincipal principal, FdeRoster fdeRoster) {
     this.replicas = Map.copyOf(replicas);
-    this.writable = writable;
+    this.principal = Objects.requireNonNull(principal, "principal");
     this.fdeRoster = Objects.requireNonNull(fdeRoster, "fdeRoster");
   }
 
@@ -99,7 +104,7 @@ public final class SyncRpcServer {
   }
 
   private SyncWire.Response onCommit(SyncWire.Commit commit) {
-    if (!writable) {
+    if (!principal.canWrite()) {
       return new SyncWire.Failed(
           "Your role is read-only: it can pull the shared board but not push changes.");
     }
@@ -107,10 +112,36 @@ public final class SyncRpcServer {
     if (main == null) {
       return new SyncWire.Failed("Unknown entity type: " + commit.entityType());
     }
+    if (RUN_ENTITY.equals(commit.entityType()) && !ownsRunCommit(commit, main)) {
+      return new SyncWire.Failed(
+          "A sync session may push only runs executed on its own node; run "
+              + commit.entityId()
+              + " is not "
+              + principal.handle()
+              + "'s.");
+    }
     return switch (main.commit(commit.entityId(), commit.snapshot(), commit.expectedRev())) {
       case CommitOutcome.Accepted accepted -> new SyncWire.Committed(accepted.rev(), main.maxSeq());
       case CommitOutcome.Rejected rejected ->
           new SyncWire.Rejected(rejected.currentRev(), rejected.currentSnapshot());
     };
+  }
+
+  /**
+   * Whether this session may commit the run: both the incoming snapshot's {@code node} and the run
+   * main already holds (either absent for a create or a completed delete) must be the principal's
+   * own handle. Checking both sides refuses a forged foreign stamp and the clobbering of another
+   * node's run with a re-stamped one; a missing or blank stamp fails closed.
+   */
+  private boolean ownsRunCommit(SyncWire.Commit commit, MainReplica main) {
+    return ownedByPrincipal(commit.snapshot()) && ownedByPrincipal(main.current(commit.entityId()));
+  }
+
+  private boolean ownedByPrincipal(Map<String, Object> run) {
+    if (run == null) {
+      return true;
+    }
+    var owner = Objects.toString(run.get("node"), "");
+    return !owner.isBlank() && owner.equals(principal.handle());
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/auth/PasskeyServiceTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/auth/PasskeyServiceTest.java
@@ -20,6 +20,8 @@ import ai.singlr.sail.webauthn.RelyingParty;
 import ai.singlr.sail.webauthn.TestAuthenticator;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Set;
@@ -49,14 +51,18 @@ class PasskeyServiceTest {
     credentials = new WebauthnCredentialStore(db);
     sessions = new AuthSessionStore(db);
     fdes.add("uday", null, null);
-    service =
-        new PasskeyService(
-            new RelyingParty(RP_ID, "Sail", Set.of(ORIGIN)),
-            fdes,
-            credentials,
-            sessions,
-            new PendingChallengeStore(db));
+    service = serviceWithTtl(Duration.ofDays(30));
     authenticator = new TestAuthenticator(RP_ID);
+  }
+
+  private PasskeyService serviceWithTtl(Duration sessionTtl) {
+    return new PasskeyService(
+        new RelyingParty(RP_ID, "Sail", Set.of(ORIGIN)),
+        fdes,
+        credentials,
+        sessions,
+        new PendingChallengeStore(db),
+        sessionTtl);
   }
 
   @AfterEach
@@ -95,6 +101,35 @@ class PasskeyServiceTest {
     assertEquals("uday", result.fdeHandle());
     assertTrue(result.sessionToken().startsWith("sess_"));
     assertTrue(sessions.validate(result.sessionToken()).isPresent());
+    var remaining = Duration.between(Instant.now(), Instant.parse(result.expiresAt()));
+    assertTrue(
+        remaining.toHours() >= 29 * 24 && remaining.toHours() <= 30 * 24, remaining::toString);
+  }
+
+  @Test
+  void mintedSessionLastsConfiguredTtl() {
+    enroll("uday");
+    service = serviceWithTtl(Duration.ofHours(2));
+
+    var login = service.startLogin();
+    var assertion = authenticator.assertResponse(challengeOf(login), ORIGIN);
+    var result =
+        service.finishLogin(
+            login.challengeId(),
+            assertion.credentialId(),
+            assertion.clientDataJson(),
+            assertion.authenticatorData(),
+            assertion.signature(),
+            null);
+
+    var remaining = Duration.between(Instant.now(), Instant.parse(result.expiresAt()));
+    assertTrue(remaining.toMinutes() >= 118 && remaining.toMinutes() <= 120, remaining::toString);
+  }
+
+  @Test
+  void rejectsNonPositiveSessionTtl() {
+    assertThrows(IllegalArgumentException.class, () -> serviceWithTtl(Duration.ZERO));
+    assertThrows(IllegalArgumentException.class, () -> serviceWithTtl(Duration.ofHours(-1)));
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/config/HostYamlTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/HostYamlTest.java
@@ -157,6 +157,27 @@ class HostYamlTest {
   }
 
   @Test
+  void partialWebauthnBlockSurvivesRoundTrip() throws Exception {
+    var host =
+        new HostYaml(
+            "dir",
+            "devpool",
+            null,
+            "incusbr0",
+            "singlr-base",
+            "ubuntu/24.04",
+            "6.21",
+            null,
+            "2026-02-18T01:00:00Z",
+            new WebauthnConfig(null, null, null, 48));
+
+    var reparsed = HostYaml.fromMap(YamlUtil.parseMap(YamlUtil.dumpToString(host.toMap())));
+
+    assertEquals(48, reparsed.webauthn().sessionTtlHours());
+    assertFalse(reparsed.webauthn().isConfigured());
+  }
+
+  @Test
   void syncBlockSurvivesRoundTripAndIsOmittedWhenUnset() throws Exception {
     var pointed =
         new HostYaml(

--- a/sail-core/src/test/java/ai/singlr/sail/config/WebauthnConfigTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/WebauthnConfigTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -79,5 +80,48 @@ class WebauthnConfigTest {
   void toMapRoundTrips() {
     var config = new WebauthnConfig("a.dev", "Sail", List.of("https://a.dev"));
     assertEquals(config, WebauthnConfig.fromMap(config.toMap()));
+  }
+
+  @Test
+  void sessionTtlDefaultsToThirtyDays() {
+    assertEquals(Duration.ofDays(30), WebauthnConfig.disabled().sessionTtl());
+    assertEquals(Duration.ofDays(30), new WebauthnConfig("a.dev", "Sail", List.of()).sessionTtl());
+  }
+
+  @Test
+  void configuredSessionTtlOverridesDefault() {
+    var config = new WebauthnConfig("a.dev", "Sail", List.of("https://a.dev"), 12);
+    assertEquals(Duration.ofHours(12), config.sessionTtl());
+  }
+
+  @Test
+  void outOfRangeSessionTtlIsRejected() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new WebauthnConfig("a.dev", "Sail", List.of(), 0));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new WebauthnConfig("a.dev", "Sail", List.of(), 90 * 24 + 1));
+    assertEquals(Duration.ofHours(1), new WebauthnConfig(null, null, null, 1).sessionTtl());
+    assertEquals(Duration.ofDays(90), new WebauthnConfig(null, null, null, 90 * 24).sessionTtl());
+  }
+
+  @Test
+  void fromMapReadsSessionTtlHours() {
+    assertEquals(720, WebauthnConfig.fromMap(Map.of("session_ttl_hours", 720)).sessionTtlHours());
+    assertEquals(720, WebauthnConfig.fromMap(Map.of("session_ttl_hours", "720")).sessionTtlHours());
+    assertNull(WebauthnConfig.fromMap(Map.of("rp_id", "a.dev")).sessionTtlHours());
+    assertThrows(
+        NumberFormatException.class,
+        () -> WebauthnConfig.fromMap(Map.of("session_ttl_hours", "soon")));
+  }
+
+  @Test
+  void toMapRoundTripsSessionTtlAndOmitsItWhenUnset() {
+    var config = new WebauthnConfig("a.dev", "Sail", List.of("https://a.dev"), 48);
+    assertEquals(config, WebauthnConfig.fromMap(config.toMap()));
+    assertFalse(
+        new WebauthnConfig("a.dev", "Sail", List.of("https://a.dev"))
+            .toMap()
+            .containsKey("session_ttl_hours"));
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
@@ -86,11 +86,22 @@ class SyncRpcServerTest {
 
   private static SyncWire.Response serveRun(
       String handle, Map<String, Object> mainCurrent, SyncWire.Commit commit) throws Exception {
+    return serveRun(handle, mainCurrent, mainCurrent == null ? null : "1-x", commit);
+  }
+
+  private static SyncWire.Response serveRun(
+      String handle, Map<String, Object> mainCurrent, String mainRev, SyncWire.Commit commit)
+      throws Exception {
     var main =
         new FakeMain() {
           @Override
           public Map<String, Object> current(String entityId) {
             return mainCurrent;
+          }
+
+          @Override
+          public String currentRev(String entityId) {
+            return mainRev;
           }
         };
     var out = new StringWriter();
@@ -127,6 +138,18 @@ class SyncRpcServerTest {
   void deletingOnesOwnRunIsAccepted() throws Exception {
     var commit = new SyncWire.Commit("run", "r1", null, "1-x");
     assertInstanceOf(SyncWire.Committed.class, serveRun("ada", Map.of("node", "ada"), commit));
+  }
+
+  @Test
+  void recreatingATombstonedRunIdIsRefusedEvenWithOnesOwnStamp() throws Exception {
+    var commit = new SyncWire.Commit("run", "r1", Map.of("node", "ada"), "2-x");
+    assertInstanceOf(SyncWire.Failed.class, serveRun("ada", null, "2-x", commit));
+  }
+
+  @Test
+  void replayingADeleteOverATombstoneStaysAllowed() throws Exception {
+    var commit = new SyncWire.Commit("run", "r1", null, "2-x");
+    assertInstanceOf(SyncWire.Committed.class, serveRun("ada", null, "2-x", commit));
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
@@ -84,6 +84,63 @@ class SyncRpcServerTest {
         SyncWire.Failed.class, serve(false, new SyncWire.Commit("spec", "a", Map.of(), null)));
   }
 
+  private static SyncWire.Response serveRun(
+      String handle, Map<String, Object> mainCurrent, SyncWire.Commit commit) throws Exception {
+    var main =
+        new FakeMain() {
+          @Override
+          public Map<String, Object> current(String entityId) {
+            return mainCurrent;
+          }
+        };
+    var out = new StringWriter();
+    new SyncRpcServer(Map.of("run", main), new SyncPrincipal(handle, true), FdeRoster.EMPTY)
+        .serve(new StringReader(SyncWire.encode(commit) + "\n"), out);
+    return SyncWire.decodeResponse(out.toString().strip());
+  }
+
+  @Test
+  void aSessionCommitsItsOwnRun() throws Exception {
+    var commit = new SyncWire.Commit("run", "r1", Map.of("node", "ada"), null);
+    assertInstanceOf(SyncWire.Committed.class, serveRun("ada", null, commit));
+  }
+
+  @Test
+  void aRunStampedWithAnotherNodeIsRefused() throws Exception {
+    var commit = new SyncWire.Commit("run", "r1", Map.of("node", "grace"), null);
+    assertInstanceOf(SyncWire.Failed.class, serveRun("ada", null, commit));
+  }
+
+  @Test
+  void overwritingAnotherNodesRunWithOnesOwnStampIsRefused() throws Exception {
+    var commit = new SyncWire.Commit("run", "r1", Map.of("node", "ada"), "1-x");
+    assertInstanceOf(SyncWire.Failed.class, serveRun("ada", Map.of("node", "grace"), commit));
+  }
+
+  @Test
+  void deletingAnotherNodesRunIsRefused() throws Exception {
+    var commit = new SyncWire.Commit("run", "r1", null, "1-x");
+    assertInstanceOf(SyncWire.Failed.class, serveRun("ada", Map.of("node", "grace"), commit));
+  }
+
+  @Test
+  void deletingOnesOwnRunIsAccepted() throws Exception {
+    var commit = new SyncWire.Commit("run", "r1", null, "1-x");
+    assertInstanceOf(SyncWire.Committed.class, serveRun("ada", Map.of("node", "ada"), commit));
+  }
+
+  @Test
+  void aRunWithoutANodeStampFailsClosed() throws Exception {
+    var commit = new SyncWire.Commit("run", "r1", Map.of("status", "running"), null);
+    assertInstanceOf(SyncWire.Failed.class, serveRun("ada", null, commit));
+  }
+
+  @Test
+  void aPrincipalWithoutAHandleCanNeverCommitARun() throws Exception {
+    var commit = new SyncWire.Commit("run", "r1", Map.of("node", "ada"), null);
+    assertInstanceOf(SyncWire.Failed.class, serveRun(null, null, commit));
+  }
+
   @Test
   void fetchFdesReturnsTheInjectedRoster() throws Exception {
     var roster = List.<Map<String, Object>>of(Map.of("handle", "ada", "role", "admin"));

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncTransportTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncTransportTest.java
@@ -120,7 +120,9 @@ class SyncTransportTest {
     var clientIn = new BufferedReader(new PipedReader(toClient));
     var server =
         new SyncRpcServer(
-            Map.of("spec", main.replica, "file", mainFileReplica), true, FdeRoster.EMPTY);
+            Map.of("spec", main.replica, "file", mainFileReplica),
+            new SyncPrincipal("A", true),
+            FdeRoster.EMPTY);
     var serverThread =
         Thread.ofVirtual()
             .start(

--- a/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
@@ -286,11 +286,7 @@ final class GlobalSpecOperations {
     if (!Objects.equals(existing.assignee(), targetAssignee)) {
       SpecPolicy.reassign(actor, existing.id(), existing.assignee(), targetAssignee).enforce();
     }
-    try {
-      specStore.restore(specId, request.rev());
-    } catch (IllegalArgumentException e) {
-      throw new ApiException(ErrorCode.INVALID_REQUEST, e.getMessage());
-    }
+    specStore.restore(specId, request.rev());
     var row = specStore.findById(specId).orElseThrow();
     publishBoardUpdated(row.project(), specId, Event.SAIL_AGENT);
     return new GlobalSpecRestoredResponse(GlobalSpecView.from(row), request.rev());

--- a/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.api;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.HostInfo;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.store.ReviewStore;
@@ -268,12 +269,22 @@ final class GlobalSpecOperations {
     return GlobalSpecHistoryResponse.from(specId, specStore.history(specId));
   }
 
+  /**
+   * A historical snapshot carries the assignee, so a restore that changes it is a reassignment in
+   * disguise and must clear {@link SpecPolicy#reassign} on top of the plain mutation gate —
+   * otherwise an assignee could route around the admin-only reassign rule by restoring a revision
+   * owned by someone else.
+   */
   GlobalSpecRestoredResponse restore(String specId, SpecRestoreRequest request, Actor actor) {
     requireStore();
     var existing = findOrThrow(specId);
     SpecPolicy.mutate(actor, existing.id(), existing.assignee(), existing.createdBy()).enforce();
     if (request.rev() == null || request.rev().isBlank()) {
       throw new ApiException(ErrorCode.INVALID_REQUEST, "rev is required.");
+    }
+    var targetAssignee = revisionAssignee(specId, request.rev());
+    if (!Objects.equals(existing.assignee(), targetAssignee)) {
+      SpecPolicy.reassign(actor, existing.id(), existing.assignee(), targetAssignee).enforce();
     }
     try {
       specStore.restore(specId, request.rev());
@@ -283,6 +294,19 @@ final class GlobalSpecOperations {
     var row = specStore.findById(specId).orElseThrow();
     publishBoardUpdated(row.project(), specId, Event.SAIL_AGENT);
     return new GlobalSpecRestoredResponse(GlobalSpecView.from(row), request.rev());
+  }
+
+  private String revisionAssignee(String specId, String rev) {
+    var entry =
+        specStore.history(specId).stream()
+            .filter(candidate -> rev.equals(candidate.rev()))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.INVALID_REQUEST,
+                        "No revision '" + rev + "' recorded for spec '" + specId + "'."));
+    return Objects.toString(YamlUtil.parseMap(entry.snapshot()).get("assignee"), null);
   }
 
   private void publishStatusChanged(

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -28,14 +28,16 @@ import java.util.function.Supplier;
  * another restart.
  *
  * <p>Each pass walks the {@code in_progress} specs and applies {@link MissedStops#assess} to the
- * latest session — database-only checks first, so a pass with nothing to reconcile issues no
- * systemctl calls. A terminal session replays the stop with its recorded exit code. A running
- * session past the launch grace period whose systemd unit is inactive or absent gets a synthesized
- * stop with <em>no exit code</em>: the transient unit is garbage-collected on exit, so the real
- * code is unrecoverable, and the replay path makes the same choice for a terminal session that
- * never recorded one — the pipeline treats the absent code as not-a-failure and lets review judge
- * the work. Every replayed stop carries {@code source=reconcile} so the event log shows it was
- * reconstructed, not observed.
+ * latest session <em>this node executed</em> — a synced foreign run is its executing node's to
+ * reconcile, and probing the local unit for it would synthesize an authoritative stop for an agent
+ * that is still alive elsewhere. Database-only checks come first, so a pass with nothing to
+ * reconcile issues no systemctl calls. A terminal session replays the stop with its recorded exit
+ * code. A running session past the launch grace period whose systemd unit is inactive or absent
+ * gets a synthesized stop with <em>no exit code</em>: the transient unit is garbage-collected on
+ * exit, so the real code is unrecoverable, and the replay path makes the same choice for a terminal
+ * session that never recorded one — the pipeline treats the absent code as not-a-failure and lets
+ * review judge the work. Every replayed stop carries {@code source=reconcile} so the event log
+ * shows it was reconstructed, not observed.
  *
  * <p>Best-effort by design: a failing spec is logged and skipped, a failing pass is logged and
  * retried on the next tick, and passes never overlap. Run after the bus subscribers are wired.
@@ -66,6 +68,7 @@ public final class MissedStopReconciler implements AutoCloseable {
   private final EventStore eventStore;
   private final EventBus bus;
   private final UnitProbe unitProbe;
+  private final Supplier<String> localHandle;
   private final Supplier<Instant> clock;
   private final PeriodicPass pass;
 
@@ -75,12 +78,14 @@ public final class MissedStopReconciler implements AutoCloseable {
       EventStore eventStore,
       EventBus bus,
       UnitProbe unitProbe,
+      Supplier<String> localHandle,
       Supplier<Instant> clock) {
     this.specStore = specStore;
     this.sessionStore = sessionStore;
     this.eventStore = eventStore;
     this.bus = bus;
     this.unitProbe = unitProbe;
+    this.localHandle = localHandle;
     this.clock = clock;
     this.pass = new PeriodicPass("reconcile", this::sweep);
   }
@@ -142,7 +147,11 @@ public final class MissedStopReconciler implements AutoCloseable {
   }
 
   private boolean reconcile(SpecStore.SpecRow spec) throws Exception {
-    var latest = sessionStore.listForSpec(spec.id()).stream().findFirst();
+    var node = localHandle.get();
+    var latest =
+        sessionStore.listForSpec(spec.id()).stream()
+            .filter(run -> SailApiOperations.ownsRun(run.node(), node))
+            .findFirst();
     if (latest.isEmpty()) {
       return false;
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -27,17 +27,19 @@ import java.util.function.Supplier;
  * died with a daemon restart or crashed) is reconciled within a sweep interval instead of requiring
  * another restart.
  *
- * <p>Each pass walks the {@code in_progress} specs and applies {@link MissedStops#assess} to the
- * latest session <em>this node executed</em> — a synced foreign run is its executing node's to
- * reconcile, and probing the local unit for it would synthesize an authoritative stop for an agent
- * that is still alive elsewhere. Database-only checks come first, so a pass with nothing to
- * reconcile issues no systemctl calls. A terminal session replays the stop with its recorded exit
- * code. A running session past the launch grace period whose systemd unit is inactive or absent
- * gets a synthesized stop with <em>no exit code</em>: the transient unit is garbage-collected on
- * exit, so the real code is unrecoverable, and the replay path makes the same choice for a terminal
- * session that never recorded one — the pipeline treats the absent code as not-a-failure and lets
- * review judge the work. Every replayed stop carries {@code source=reconcile} so the event log
- * shows it was reconstructed, not observed.
+ * <p>Each pass walks the {@code in_progress} specs and applies {@link MissedStops#assess} to each
+ * spec's newest session, and only when <em>this node executed it</em> — a synced foreign run is its
+ * executing node's to reconcile, and probing the local unit for it would synthesize an
+ * authoritative stop for an agent that is still alive elsewhere. Ownership is checked after
+ * selecting the newest run, never before: filtering first would fall back to a superseded local
+ * session and replay its stop over a newer foreign run that is still executing. Database-only
+ * checks come first, so a pass with nothing to reconcile issues no systemctl calls. A terminal
+ * session replays the stop with its recorded exit code. A running session past the launch grace
+ * period whose systemd unit is inactive or absent gets a synthesized stop with <em>no exit
+ * code</em>: the transient unit is garbage-collected on exit, so the real code is unrecoverable,
+ * and the replay path makes the same choice for a terminal session that never recorded one — the
+ * pipeline treats the absent code as not-a-failure and lets review judge the work. Every replayed
+ * stop carries {@code source=reconcile} so the event log shows it was reconstructed, not observed.
  *
  * <p>Best-effort by design: a failing spec is logged and skipped, a failing pass is logged and
  * retried on the next tick, and passes never overlap. Run after the bus subscribers are wired.
@@ -150,8 +152,8 @@ public final class MissedStopReconciler implements AutoCloseable {
     var node = localHandle.get();
     var latest =
         sessionStore.listForSpec(spec.id()).stream()
-            .filter(run -> SailApiOperations.ownsRun(run.node(), node))
-            .findFirst();
+            .findFirst()
+            .filter(run -> SailApiOperations.ownsRun(run.node(), node));
     if (latest.isEmpty()) {
       return false;
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewOperations.java
@@ -163,8 +163,17 @@ final class ReviewOperations {
     requireStore();
     var review = findReviewOrThrow(reviewId);
     ReviewPolicy.decide(actor, reviewId, review.specId(), specAssignee(review.specId())).enforce();
-    reviewStore.resolveFinding(findingId, Finding.Resolution.DISMISSED);
-    return new FindingDismissResponse(findingId, true);
+    var finding =
+        reviewStore.findingsForReview(reviewId).stream()
+            .filter(candidate -> candidate.id().equals(findingId))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.NOT_FOUND,
+                        "Finding '" + findingId + "' is not part of review '" + reviewId + "'."));
+    reviewStore.resolveFinding(finding.id(), Finding.Resolution.DISMISSED);
+    return new FindingDismissResponse(finding.id(), true);
   }
 
   /** The current assignee of the review's spec, or null when the spec is absent — fail closed. */

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.api;
 
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Ids;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.BranchPolicy;
 import ai.singlr.sail.config.SailYaml;
@@ -767,19 +768,24 @@ public final class SailApiOperations implements ApiOperations {
   }
 
   /**
-   * Tails a local run's own log file — the run-scoped {@code ~/.sail/runs/<runId>/agent.log} the
-   * run row records — so a log address names exactly one execution, never whatever the shared
-   * per-container file currently holds. The provenance guard already established the run is local.
+   * Tails a local run's own log file — the run-scoped {@code ~/.sail/runs/<runId>/agent.log} — so a
+   * log address names exactly one execution, never whatever the shared per-container file currently
+   * holds. The path is derived from the run's canonical UUID and role rather than the persisted
+   * {@code log_path}: run rows replicate over sync, so a stored path is untrusted input that could
+   * point anywhere the container's dev user can read. The provenance guard already established the
+   * run is local.
    */
   private RunLogResponse runLogValue(RunStore.RunRow run, int tail) {
     requireProjectExists(run.project());
-    var logPath = run.logPath();
-    if (Strings.isBlank(logPath)) {
+    if (Strings.isBlank(run.logPath())) {
       return new RunLogResponse(run.id(), List.of(), "This run has no log file.");
     }
+    var logPath =
+        AgentUnit.fromRole(Objects.requireNonNullElse(run.role(), "build"))
+            .runLogPath(Ids.requireUuid(run.id()));
     var cmd =
         ContainerExec.asDevUser(
-            run.project(), List.of("tail", "-n", String.valueOf(tail), logPath));
+            run.project(), List.of("tail", "-n", String.valueOf(tail), "--", logPath));
     var result = exec(cmd);
     if (!result.ok()) {
       if (result.stderr().contains("No such file")) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/WatcherRearmer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/WatcherRearmer.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * Keeps every running agent guarded: for each {@code in_progress} spec whose latest session is
@@ -20,7 +21,9 @@ import java.util.function.Predicate;
  * mid-run (crash, OOM kill) leaves the agent unguarded for at most one pass interval. The
  * relaunched {@code sail agent watch} recomputes its wall-clock deadline from the session's
  * original {@code started_at}, so an agent three hours into a four-hour budget gets the remaining
- * hour, not a fresh four.
+ * hour, not a fresh four. Only sessions this node executed are considered — a synced foreign run is
+ * its executing node's to guard, and arming a local watcher against it would eventually enforce a
+ * foreign deadline on this box's container.
  *
  * <p>Coverage is probed, not bookkept — and probed at the process level: a recorded watcher pid
  * that is still alive (free, in-process check) or any {@code sail agent watch} process for the
@@ -50,6 +53,7 @@ public final class WatcherRearmer implements AutoCloseable {
   private final MissedStopReconciler.UnitProbe agentUnitProbe;
   private final Predicate<String> watcherRunning;
   private final LongPredicate watcherAlive;
+  private final Supplier<String> localHandle;
   private final WatcherRelauncher relauncher;
   private final PeriodicPass pass;
 
@@ -59,12 +63,14 @@ public final class WatcherRearmer implements AutoCloseable {
       MissedStopReconciler.UnitProbe agentUnitProbe,
       Predicate<String> watcherRunning,
       LongPredicate watcherAlive,
+      Supplier<String> localHandle,
       WatcherRelauncher relauncher) {
     this.specStore = specStore;
     this.sessionStore = sessionStore;
     this.agentUnitProbe = agentUnitProbe;
     this.watcherRunning = watcherRunning;
     this.watcherAlive = watcherAlive;
+    this.localHandle = localHandle;
     this.relauncher = relauncher;
     this.pass = new PeriodicPass("rearm", this::rearm);
   }
@@ -111,7 +117,11 @@ public final class WatcherRearmer implements AutoCloseable {
   }
 
   private boolean rearm(SpecStore.SpecRow spec) throws Exception {
-    var latest = sessionStore.listForSpec(spec.id()).stream().findFirst();
+    var node = localHandle.get();
+    var latest =
+        sessionStore.listForSpec(spec.id()).stream()
+            .filter(run -> SailApiOperations.ownsRun(run.node(), node))
+            .findFirst();
     if (latest.isEmpty() || !"running".equals(latest.get().status())) {
       return false;
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostConfigSetCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostConfigSetCommand.java
@@ -48,12 +48,13 @@ public final class HostConfigSetCommand implements Runnable {
           "webauthn-rp-id",
           "webauthn-rp-name",
           "webauthn-origin",
+          "webauthn-session-ttl-hours",
           "sync-role",
           "sync-main",
           "sync-handle",
           "slack-token");
   private static final Set<String> WEBAUTHN_KEYS =
-      Set.of("webauthn-rp-id", "webauthn-rp-name", "webauthn-origin");
+      Set.of("webauthn-rp-id", "webauthn-rp-name", "webauthn-origin", "webauthn-session-ttl-hours");
   private static final Pattern RP_ID = Pattern.compile("[a-z0-9]([a-z0-9.-]*[a-z0-9])?");
   private static final Pattern ORIGIN = Pattern.compile("https?://\\S+[^/]");
   private static final Pattern SSH_TARGET = Pattern.compile("([a-z_][a-z0-9_-]*@)?[a-zA-Z0-9.-]+");
@@ -410,6 +411,7 @@ public final class HostConfigSetCommand implements Runnable {
                   + " send the origin without one, and the match is exact).");
         }
       }
+      case "webauthn-session-ttl-hours" -> parseSessionTtlHours(value);
       case "sync-role" -> {
         if (!SyncConfig.ROLE_MAIN.equals(value) && !SyncConfig.ROLE_NODE.equals(value)) {
           throw new IllegalArgumentException(
@@ -434,17 +436,59 @@ public final class HostConfigSetCommand implements Runnable {
     return switch (key) {
       case "server-ip" -> withServerIp(current, value);
       case "webauthn-rp-id" ->
-          withWebauthn(current, new WebauthnConfig(value, webauthn.rpName(), webauthn.origins()));
+          withWebauthn(
+              current,
+              new WebauthnConfig(
+                  value, webauthn.rpName(), webauthn.origins(), webauthn.sessionTtlHours()));
       case "webauthn-rp-name" ->
-          withWebauthn(current, new WebauthnConfig(webauthn.rpId(), value, webauthn.origins()));
+          withWebauthn(
+              current,
+              new WebauthnConfig(
+                  webauthn.rpId(), value, webauthn.origins(), webauthn.sessionTtlHours()));
       case "webauthn-origin" ->
           withWebauthn(
-              current, new WebauthnConfig(webauthn.rpId(), webauthn.rpName(), List.of(value)));
+              current,
+              new WebauthnConfig(
+                  webauthn.rpId(), webauthn.rpName(), List.of(value), webauthn.sessionTtlHours()));
+      case "webauthn-session-ttl-hours" ->
+          withWebauthn(
+              current,
+              new WebauthnConfig(
+                  webauthn.rpId(),
+                  webauthn.rpName(),
+                  webauthn.origins(),
+                  parseSessionTtlHours(value)));
       case "sync-role" -> withSync(current, new SyncConfig(value, sync.main(), sync.handle()));
       case "sync-main" -> withSync(current, new SyncConfig(sync.role(), value, sync.handle()));
       case "sync-handle" -> withSync(current, new SyncConfig(sync.role(), sync.main(), value));
       default -> throw new IllegalArgumentException("Unhandled key: " + key);
     };
+  }
+
+  /**
+   * Parses and range-checks the session TTL, so both {@link #validate} and {@link #applyChange}
+   * reject an out-of-range value with the same actionable message.
+   */
+  static int parseSessionTtlHours(String value) {
+    int hours;
+    try {
+      hours = Integer.parseInt(value.strip());
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "Invalid session TTL: '" + value + "'. Expected a whole number of hours, e.g. 720.");
+    }
+    if (hours < WebauthnConfig.MIN_SESSION_TTL_HOURS
+        || hours > WebauthnConfig.MAX_SESSION_TTL_HOURS) {
+      throw new IllegalArgumentException(
+          "Invalid session TTL: "
+              + hours
+              + " hours. Expected "
+              + WebauthnConfig.MIN_SESSION_TTL_HOURS
+              + " to "
+              + WebauthnConfig.MAX_SESSION_TTL_HOURS
+              + " (1 hour to 90 days).");
+    }
+    return hours;
   }
 
   private static HostYaml withServerIp(HostYaml current, String serverIp) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -301,7 +301,8 @@ public final class ServerStartCommand implements Runnable {
     return new WebauthnConfig(
         rpId != null ? rpId : base.rpId(),
         rpName != null ? rpName : base.rpName(),
-        origins != null && !origins.isEmpty() ? origins : base.origins());
+        origins != null && !origins.isEmpty() ? origins : base.origins(),
+        base.sessionTtlHours());
   }
 
   private static PasskeyService buildPasskeyService(Sqlite db, WebauthnConfig webauthn) {
@@ -313,7 +314,8 @@ public final class ServerStartCommand implements Runnable {
         new FdeStore(db),
         new WebauthnCredentialStore(db),
         new AuthSessionStore(db),
-        new PendingChallengeStore(db));
+        new PendingChallengeStore(db),
+        webauthn.sessionTtl());
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -234,7 +234,13 @@ public final class ServerStartCommand implements Runnable {
     var unitProbe = MissedStopReconciler.systemdUnitProbe(reconcileShell);
     var missedStops =
         new MissedStopReconciler(
-            specStore, runStore, eventStore, bus, unitProbe, DateTimeUtils::now);
+            specStore,
+            runStore,
+            eventStore,
+            bus,
+            unitProbe,
+            NodeIdentity::handle,
+            DateTimeUtils::now);
     var watcherSpawner = new WatcherSpawner(reconcileShell, null);
     var rearmer =
         new WatcherRearmer(
@@ -243,6 +249,7 @@ public final class ServerStartCommand implements Runnable {
             unitProbe,
             watcherSpawner::watcherProcessRunning,
             WatcherRearmer.livingProcess(),
+            NodeIdentity::handle,
             operations::relaunchWatcher);
     shutdown
         .register(server)

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
@@ -26,6 +26,7 @@ import ai.singlr.sail.sync.ProjectReplica;
 import ai.singlr.sail.sync.RunReplica;
 import ai.singlr.sail.sync.SpecReplica;
 import ai.singlr.sail.sync.SyncDatabase;
+import ai.singlr.sail.sync.SyncPrincipal;
 import ai.singlr.sail.sync.SyncRpcServer;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -43,10 +44,12 @@ import picocli.CommandLine.Command;
  * Main's side of a sync session, reached only through the SSH-key gateway: a node's {@code sail
  * sync} opens {@code ssh sail@main sail _sync}, the gateway authorizes the calling FDE and re-execs
  * this with {@code SAIL_TOKEN} set, and the {@link SyncRpcServer} then exchanges {@link
- * ai.singlr.sail.sync.SyncWire} over the channel's stdio. The token resolves to the FDE's role:
- * only {@code member}+ may push (write), so a read-only FDE can pull but its commits are refused.
- * The serving database is opened through {@link SyncDatabase}, so main's schema is converged before
- * any revision is served or committed. Not meant to be run by hand.
+ * ai.singlr.sail.sync.SyncWire} over the channel's stdio. The token resolves to a {@link
+ * SyncPrincipal} — the FDE's handle plus its role's write capability: only {@code member}+ may push
+ * (write), a read-only FDE can pull but its commits are refused, and the handle binds run commits
+ * to the pushing node so no FDE can forge another node's execution provenance. The serving database
+ * is opened through {@link SyncDatabase}, so main's schema is converged before any revision is
+ * served or committed. Not meant to be run by hand.
  */
 @Command(
     name = "_sync",
@@ -85,7 +88,7 @@ public final class SyncServerCommand implements Callable<Integer> {
             "project",
                 new ProjectReplica(mainId, new ProjectStore(db), changeLog, conflicts, syncState),
             "run", new RunReplica(mainId, new RunStore(db), changeLog, conflicts, syncState));
-    new SyncRpcServer(replicas, canWrite(db, token), () -> roster(db)).serve(in, out);
+    new SyncRpcServer(replicas, principal(db, token), () -> roster(db)).serve(in, out);
     return 0;
   }
 
@@ -104,14 +107,18 @@ public final class SyncServerCommand implements Callable<Integer> {
     return map;
   }
 
-  private static boolean canWrite(Sqlite db, String token) {
+  private static SyncPrincipal principal(Sqlite db, String token) {
     if (Strings.isBlank(token)) {
-      return false;
+      return SyncPrincipal.readOnly();
     }
     return new AuthSessionStore(db)
         .validate(token)
         .flatMap(session -> new FdeStore(db).byId(session.fdeId()))
-        .map(fde -> Role.fromAttribute(fde.role()).allows(Capability.WRITE))
-        .orElse(false);
+        .map(SyncServerCommand::principalOf)
+        .orElse(SyncPrincipal.readOnly());
+  }
+
+  private static SyncPrincipal principalOf(FdeStore.Fde fde) {
+    return new SyncPrincipal(fde.handle(), Role.fromAttribute(fde.role()).allows(Capability.WRITE));
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
@@ -592,6 +592,47 @@ class GlobalSpecOperationsTest {
   }
 
   @Test
+  void restoreThatChangesTheAssigneeIsAdminOnly() {
+    ops.create(createReq(Map.of("assignee", "alice")).withCreatedBy("uday"));
+    ops.update(
+        "auth", SpecUpdateRequest.fromMap(Map.of("assignee", "bob")).withUpdatedBy("ops"), ADMIN);
+    var aliceRev = ops.history("auth").revisions().getFirst().rev();
+    var bob = new Actor("bob", Role.MEMBER, Actor.Lane.API);
+
+    var ex =
+        assertThrows(
+            ApiException.class, () -> ops.restore("auth", new SpecRestoreRequest(aliceRev), bob));
+
+    assertEquals(ErrorCode.FORBIDDEN_ADMIN_ONLY, ex.failure().errorCode());
+    assertEquals("bob", ops.get("auth").spec().assignee());
+  }
+
+  @Test
+  void anAdminMayRestoreARevisionThatChangesTheAssignee() {
+    ops.create(createReq(Map.of("assignee", "alice")).withCreatedBy("uday"));
+    ops.update(
+        "auth", SpecUpdateRequest.fromMap(Map.of("assignee", "bob")).withUpdatedBy("ops"), ADMIN);
+    var aliceRev = ops.history("auth").revisions().getFirst().rev();
+
+    ops.restore("auth", new SpecRestoreRequest(aliceRev), ADMIN);
+
+    assertEquals("alice", ops.get("auth").spec().assignee());
+  }
+
+  @Test
+  void anAssigneeMayRestoreARevisionThatKeepsTheAssignee() {
+    ops.create(createReq(Map.of("assignee", "bob")).withCreatedBy("uday"));
+    ops.setContent("auth", new SpecContentRequest("good", ""), ADMIN);
+    var goodRev = ops.history("auth").revisions().getLast().rev();
+    ops.setContent("auth", new SpecContentRequest("clobbered", ""), ADMIN);
+    var bob = new Actor("bob", Role.MEMBER, Actor.Lane.API);
+
+    ops.restore("auth", new SpecRestoreRequest(goodRev), bob);
+
+    assertEquals("good", ops.content("auth").body());
+  }
+
+  @Test
   void restoreRejectsAnUnknownRev() {
     ops.create(createReq(Map.of()));
     var ex =

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -137,6 +137,19 @@ class MissedStopReconcilerTest {
         "/home/dev/.sail/runs/r/agent.log");
   }
 
+  private void adoptedForeignRunningSession(String specId, Instant startedAt) {
+    sessionStore.applyRevision(
+        DateTimeUtils.newId().toString(),
+        Map.of(
+            "project", "test-project",
+            "spec_id", specId,
+            "node", "node-b",
+            "agent", "claude-code",
+            "status", "running",
+            "started_at", startedAt.toString()),
+        "1-foreign");
+  }
+
   private void recordStopEvent(String specId, String timestamp, Map<String, Object> data) {
     eventStore.insert(
         new EventStore.EventRow(
@@ -290,6 +303,20 @@ class MissedStopReconcilerTest {
     var replayed = reconciler(new CountingProbe(true), () -> "node-b", Instant::now).sweep();
 
     assertEquals(0, replayed);
+  }
+
+  @Test
+  void aSupersededLocalRunNeverReplaysOverANewerForeignRun() {
+    createInProgressSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    adoptedForeignRunningSession("auth", Instant.now().plus(Duration.ofHours(1)));
+    var probe = new CountingProbe(true);
+
+    var replayed = reconciler(probe, Instant::now).sweep();
+
+    assertEquals(0, replayed);
+    assertEquals(0, probe.calls.get());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -86,7 +86,13 @@ class MissedStopReconcilerTest {
 
   private MissedStopReconciler reconciler(
       MissedStopReconciler.UnitProbe probe, Supplier<Instant> clock) {
-    return new MissedStopReconciler(specStore, sessionStore, eventStore, bus, probe, clock);
+    return reconciler(probe, () -> "node-a", clock);
+  }
+
+  private MissedStopReconciler reconciler(
+      MissedStopReconciler.UnitProbe probe, Supplier<String> localHandle, Supplier<Instant> clock) {
+    return new MissedStopReconciler(
+        specStore, sessionStore, eventStore, bus, probe, localHandle, clock);
   }
 
   private void createInProgressSpec(String id) {
@@ -261,6 +267,29 @@ class MissedStopReconcilerTest {
 
     assertEquals(1, replayed);
     assertEquals(0, probe.calls.get());
+  }
+
+  @Test
+  void aForeignNodesRunIsNeverProbedOrReplayedHere() {
+    createInProgressSpec("auth");
+    runningSession("auth");
+    var probe = new CountingProbe(false);
+
+    var replayed = reconciler(probe, () -> "node-b", PAST_GRACE).sweep();
+
+    assertEquals(0, replayed);
+    assertEquals(0, probe.calls.get());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void aForeignTerminalRunIsNotReplayedHereEither() {
+    createInProgressSpec("auth");
+    finishedSession("auth", "stopped", 0);
+
+    var replayed = reconciler(new CountingProbe(true), () -> "node-b", Instant::now).sweep();
+
+    assertEquals(0, replayed);
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewOperationsTest.java
@@ -157,6 +157,23 @@ class ReviewOperationsTest {
     assertThrows(ApiException.class, () -> ops.dismissFinding("nope", "f1", UDAY_ADMIN));
   }
 
+  @Test
+  void dismissFindingRefusesAFindingFromAnotherReview() {
+    var victimReview = seedReviewWithFinding();
+    var victimFinding = reviewStore.findingsForReview(victimReview).getFirst().id();
+    var otherReview = reviewStore.createReview("auth", 2);
+    reviewStore.createStage(otherReview, "security", "agent");
+
+    var ex =
+        assertThrows(
+            ApiException.class, () -> ops.dismissFinding(otherReview, victimFinding, UDAY_ADMIN));
+
+    assertEquals(ErrorCode.NOT_FOUND, ex.failure().errorCode());
+    assertEquals(
+        Finding.Resolution.OPEN,
+        reviewStore.findingsForReview(victimReview).getFirst().resolution());
+  }
+
   private String seedPassedReviewWithOpenFindings() {
     var reviewId = reviewStore.createReview("auth", 1);
     var stageId = reviewStore.createStage(reviewId, "security", "agent");

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
@@ -607,7 +607,10 @@ class SailApiOperationsTest {
     assertError(ErrorCode.AGENT_STATUS_FAILED, error);
   }
 
-  private static final String RUN_LOG = "/home/dev/.sail/runs/r1/agent.log";
+  private static final String R1 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  private static final String R2 = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+  private static final String RUN_LOG = "/home/dev/.sail/runs/" + R1 + "/agent.log";
+  private static final String R2_LOG = "/home/dev/.sail/runs/" + R2 + "/agent.log";
 
   private SailApiOperations opsWithRun(FakeShell shell) throws Exception {
     return operationsWithStores(
@@ -617,7 +620,7 @@ class SailApiOperationsTest {
         s -> {},
         runs ->
             runs.create(
-                "r1",
+                R1,
                 "acme",
                 "auth",
                 "node-a",
@@ -638,7 +641,7 @@ class SailApiOperationsTest {
         specs -> seedSpec(specs, "auth", "Add auth", "pending", List.of(), "Do auth"),
         runs ->
             runs.create(
-                "r1",
+                R1,
                 "acme",
                 "auth",
                 "node-a",
@@ -655,10 +658,12 @@ class SailApiOperationsTest {
   void runLogAllowsTheRunSpecAssignee() throws Exception {
     var operations =
         opsWithLocalRunAndSpec(
-            shell().on("incus list ^acme$", RUNNING_JSON).on("tail -n 2 " + RUN_LOG, "one\ntwo\n"));
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("tail -n 2 -- " + RUN_LOG, "one\ntwo\n"));
 
     var assignee = new Actor(LOCAL_HANDLE, Role.MEMBER, Actor.Lane.API);
-    var result = operations.runLog("r1", 2, "node-a", assignee);
+    var result = operations.runLog(R1, 2, "node-a", assignee);
 
     assertEquals(List.of("one", "two"), get(result, "lines"));
   }
@@ -668,7 +673,7 @@ class SailApiOperationsTest {
     var operations = opsWithLocalRunAndSpec(shell().on("incus list ^acme$", RUNNING_JSON));
 
     var other = new Actor("raj", Role.MEMBER, Actor.Lane.API);
-    assertError(ErrorCode.FORBIDDEN_NOT_ASSIGNEE, operations.runLog("r1", 200, "node-a", other));
+    assertError(ErrorCode.FORBIDDEN_NOT_ASSIGNEE, operations.runLog(R1, 200, "node-a", other));
   }
 
   @Test
@@ -676,19 +681,49 @@ class SailApiOperationsTest {
     var operations = opsWithLocalRunAndSpec(shell().on("incus list ^acme$", RUNNING_JSON));
 
     var other = new Actor("raj", Role.MEMBER, Actor.Lane.API);
-    assertError(ErrorCode.FORBIDDEN_NOT_ASSIGNEE, operations.stopRun("r1", "node-a", other));
+    assertError(ErrorCode.FORBIDDEN_NOT_ASSIGNEE, operations.stopRun(R1, "node-a", other));
   }
 
   @Test
   void runLogTailsTheRunScopedLogForALocalRun() throws Exception {
     var operations =
         opsWithRun(
-            shell().on("incus list ^acme$", RUNNING_JSON).on("tail -n 2 " + RUN_LOG, "one\ntwo\n"));
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("tail -n 2 -- " + RUN_LOG, "one\ntwo\n"));
 
-    var result = operations.runLog("r1", 2, "node-a", ADMIN);
+    var result = operations.runLog(R1, 2, "node-a", ADMIN);
 
     assertEquals(List.of("one", "two"), get(result, "lines"));
-    assertEquals("r1", get(result, "run_id"));
+    assertEquals(R1, get(result, "run_id"));
+  }
+
+  @Test
+  void runLogIgnoresAForgedPersistedLogPath() throws Exception {
+    var shell =
+        shell().on("incus list ^acme$", RUNNING_JSON).on("tail -n 2 -- " + RUN_LOG, "safe\n");
+    var operations =
+        operationsWithStores(
+            baseYaml(),
+            shell,
+            null,
+            s -> {},
+            runs ->
+                runs.create(
+                    R1,
+                    "acme",
+                    "auth",
+                    "node-a",
+                    "build",
+                    "claude-code",
+                    null,
+                    null,
+                    null,
+                    null,
+                    "/home/dev/.ssh/id_ed25519"));
+
+    assertEquals(List.of("safe"), get(operations.runLog(R1, 2, "node-a", ADMIN), "lines"));
+    assertTrue(shell.invocations().stream().noneMatch(cmd -> cmd.contains("id_ed25519")));
   }
 
   @Test
@@ -697,10 +732,10 @@ class SailApiOperationsTest {
         opsWithRun(
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
-                .on("tail -n 200 " + RUN_LOG, new ShellExec.Result(1, "", "No such file")));
+                .on("tail -n 200 -- " + RUN_LOG, new ShellExec.Result(1, "", "No such file")));
 
     assertEquals(
-        "No log found for this run.", get(operations.runLog("r1", 200, "node-a", ADMIN), "error"));
+        "No log found for this run.", get(operations.runLog(R1, 200, "node-a", ADMIN), "error"));
   }
 
   @Test
@@ -709,16 +744,16 @@ class SailApiOperationsTest {
         opsWithRun(
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
-                .throwOn("tail -n 200 " + RUN_LOG, new IOException("no shell")));
+                .throwOn("tail -n 200 -- " + RUN_LOG, new IOException("no shell")));
 
-    assertError(ErrorCode.COMMAND_FAILED, operations.runLog("r1", 200, "node-a", ADMIN));
+    assertError(ErrorCode.COMMAND_FAILED, operations.runLog(R1, 200, "node-a", ADMIN));
   }
 
   @Test
   void runLogRefusesAForeignRunWithStructuredProvenance() throws Exception {
     var operations = opsWithRun(shell().on("incus list ^acme$", RUNNING_JSON));
 
-    var result = operations.runLog("r1", 200, "sumesh", ADMIN);
+    var result = operations.runLog(R1, 200, "sumesh", ADMIN);
 
     assertError(ErrorCode.RUN_ON_OTHER_NODE, result);
     var fields =
@@ -739,7 +774,7 @@ class SailApiOperationsTest {
             s -> {},
             runs ->
                 runs.create(
-                    "r2",
+                    R2,
                     "acme",
                     "auth",
                     "",
@@ -751,7 +786,7 @@ class SailApiOperationsTest {
                     null,
                     RUN_LOG));
 
-    assertError(ErrorCode.RUN_ON_OTHER_NODE, operations.runLog("r2", 200, "node-a", ADMIN));
+    assertError(ErrorCode.RUN_ON_OTHER_NODE, operations.runLog(R2, 200, "node-a", ADMIN));
   }
 
   @Test
@@ -759,12 +794,12 @@ class SailApiOperationsTest {
     var operations =
         operationsWithStores(
             baseYaml(),
-            shell().on("incus list ^acme$", RUNNING_JSON).on("tail -n 2 " + RUN_LOG, "hi\n"),
+            shell().on("incus list ^acme$", RUNNING_JSON).on("tail -n 2 -- " + R2_LOG, "hi\n"),
             null,
             s -> {},
             runs ->
                 runs.create(
-                    "r2",
+                    R2,
                     "acme",
                     "auth",
                     "",
@@ -776,14 +811,14 @@ class SailApiOperationsTest {
                     null,
                     RUN_LOG));
 
-    assertEquals(List.of("hi"), get(operations.runLog("r2", 2, "", ADMIN), "lines"));
+    assertEquals(List.of("hi"), get(operations.runLog(R2, 2, "", ADMIN), "lines"));
   }
 
   @Test
   void aStampedRunIsForeignToABoxThatHasNoHandle() throws Exception {
     var operations = opsWithRun(shell().on("incus list ^acme$", RUNNING_JSON));
 
-    assertError(ErrorCode.RUN_ON_OTHER_NODE, operations.runLog("r1", 200, "", ADMIN));
+    assertError(ErrorCode.RUN_ON_OTHER_NODE, operations.runLog(R1, 200, "", ADMIN));
   }
 
   @Test
@@ -798,7 +833,7 @@ class SailApiOperationsTest {
     var operations = opsWithRun(shell());
 
     assertEquals(1, ((List<?>) get(operations.runs("acme", null), "runs")).size());
-    assertEquals("node-a", get(operations.run("r1"), "node"));
+    assertEquals("node-a", get(operations.run(R1), "node"));
     assertError(ErrorCode.RUN_NOT_FOUND, operations.run("nope"));
   }
 
@@ -806,7 +841,7 @@ class SailApiOperationsTest {
   void stopRunRefusesAForeignRun() throws Exception {
     var operations = opsWithRun(shell().on("incus list ^acme$", RUNNING_JSON));
 
-    assertError(ErrorCode.RUN_ON_OTHER_NODE, operations.stopRun("r1", "sumesh", ADMIN));
+    assertError(ErrorCode.RUN_ON_OTHER_NODE, operations.stopRun(R1, "sumesh", ADMIN));
   }
 
   @Test
@@ -817,7 +852,7 @@ class SailApiOperationsTest {
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sail/agent.pid", new ShellExec.Result(1, "", "missing")));
 
-    assertEquals(false, get(operations.stopRun("r1", "node-a", ADMIN), "stopped"));
+    assertEquals(false, get(operations.stopRun(R1, "node-a", ADMIN), "stopped"));
   }
 
   @Test
@@ -830,7 +865,7 @@ class SailApiOperationsTest {
             s -> {},
             runs -> {
               runs.create(
-                  "r1",
+                  R1,
                   "acme",
                   "auth",
                   "node-a",
@@ -841,10 +876,10 @@ class SailApiOperationsTest {
                   123,
                   null,
                   RUN_LOG);
-              runs.complete("r1", "completed", 0);
+              runs.complete(R1, "completed", 0);
             });
 
-    var result = operations.stopRun("r1", "node-a", ADMIN);
+    var result = operations.stopRun(R1, "node-a", ADMIN);
 
     assertEquals(false, get(result, "stopped"));
     assertEquals("run_not_running", get(result, "reason"));
@@ -860,9 +895,9 @@ class SailApiOperationsTest {
                 .on("kill -0 999", new ShellExec.Result(0, "", ""))
                 .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"other\"}"));
 
-    var result = operations.stopRun("r1", "node-a", ADMIN);
+    var result = operations.stopRun(R1, "node-a", ADMIN);
 
-    assertEquals(false, get(result, "stopped"), "r1's pid is 123; the live agent is 999");
+    assertEquals(false, get(result, "stopped"), "the run's pid is 123; the live agent is 999");
     assertEquals("run_not_active", get(result, "reason"));
   }
 
@@ -1316,7 +1351,7 @@ class SailApiOperationsTest {
                 .on("kill -9 123", "")
                 .on("rm -f /home/dev/.sail/agent.pid", ""));
 
-    var result = operations.stopRun("r1", "node-a", ADMIN);
+    var result = operations.stopRun(R1, "node-a", ADMIN);
 
     assertEquals(true, get(result, "stopped"));
     assertEquals(123, get(result, "pid"));
@@ -1333,7 +1368,7 @@ class SailApiOperationsTest {
                 .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"work\"}")
                 .throwOn("kill 123", new IOException("permission denied")));
 
-    assertError(ErrorCode.AGENT_STOP_FAILED, operations.stopRun("r1", "node-a", ADMIN));
+    assertError(ErrorCode.AGENT_STOP_FAILED, operations.stopRun(R1, "node-a", ADMIN));
   }
 
   @Test
@@ -1387,9 +1422,9 @@ class SailApiOperationsTest {
         opsWithRun(
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
-                .on("tail -n 200 " + RUN_LOG, new ShellExec.Result(1, "", "permission denied")));
+                .on("tail -n 200 -- " + RUN_LOG, new ShellExec.Result(1, "", "permission denied")));
 
-    assertError(ErrorCode.AGENT_LOG_FAILED, operations.runLog("r1", 200, "node-a", ADMIN));
+    assertError(ErrorCode.AGENT_LOG_FAILED, operations.runLog(R1, 200, "node-a", ADMIN));
   }
 
   @Test
@@ -1678,9 +1713,9 @@ class SailApiOperationsTest {
     var operations = operations(baseYaml(), shell());
 
     assertError(ErrorCode.INTERNAL, operations.runs("acme", null));
-    assertError(ErrorCode.INTERNAL, operations.run("r1"));
-    assertError(ErrorCode.INTERNAL, operations.runLog("r1", 200, "node-a", ADMIN));
-    assertError(ErrorCode.INTERNAL, operations.stopRun("r1", "node-a", ADMIN));
+    assertError(ErrorCode.INTERNAL, operations.run(R1));
+    assertError(ErrorCode.INTERNAL, operations.runLog(R1, 200, "node-a", ADMIN));
+    assertError(ErrorCode.INTERNAL, operations.stopRun(R1, "node-a", ADMIN));
   }
 
   @Test
@@ -1693,7 +1728,7 @@ class SailApiOperationsTest {
             s -> {},
             runs ->
                 runs.create(
-                    "r1",
+                    R1,
                     "acme",
                     "auth",
                     "node-a",
@@ -1706,7 +1741,7 @@ class SailApiOperationsTest {
                     null));
 
     assertEquals(
-        "This run has no log file.", get(operations.runLog("r1", 200, "node-a", ADMIN), "error"));
+        "This run has no log file.", get(operations.runLog(R1, 200, "node-a", ADMIN), "error"));
   }
 
   @Test
@@ -1719,7 +1754,7 @@ class SailApiOperationsTest {
             s -> {},
             runs ->
                 runs.create(
-                    "r1",
+                    R1,
                     "acme",
                     "auth",
                     "node-a",
@@ -1729,7 +1764,7 @@ class SailApiOperationsTest {
                     "do it",
                     123,
                     null,
-                    "/home/dev/.sail/runs/r1/agent.log"));
+                    RUN_LOG));
 
     var result = operations.runs("acme", null);
 
@@ -1751,7 +1786,7 @@ class SailApiOperationsTest {
             store -> seedSpec(store, "auth", "Add auth", "pending", List.of(), ""),
             runs ->
                 runs.create(
-                    "r1",
+                    R1,
                     "acme",
                     "auth",
                     "node-a",
@@ -1761,11 +1796,11 @@ class SailApiOperationsTest {
                     null,
                     null,
                     null,
-                    "/home/dev/.sail/runs/r1/agent.log"));
+                    RUN_LOG));
 
     var latest = (Map<String, Object>) get(operations.globalSpec("auth"), "latest_run");
 
-    assertEquals("r1", latest.get("id"));
+    assertEquals(R1, latest.get("id"));
     assertEquals("node-a", latest.get("node"));
     assertEquals("running", latest.get("status"));
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WatcherRearmerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WatcherRearmerTest.java
@@ -101,7 +101,35 @@ class WatcherRearmerTest {
       LongPredicate watcherAlive,
       WatcherRearmer.WatcherRelauncher relauncher) {
     return new WatcherRearmer(
-        specStore, sessionStore, agentUnitProbe, watcherUnitActive, watcherAlive, relauncher);
+        specStore,
+        sessionStore,
+        agentUnitProbe,
+        watcherUnitActive,
+        watcherAlive,
+        () -> "node-a",
+        relauncher);
+  }
+
+  @Test
+  void aForeignNodesRunIsNeverRearmedHere() {
+    createInProgressSpec("auth");
+    runningSession("auth", 5678);
+    var relaunches = new AtomicInteger();
+    var rearmer =
+        new WatcherRearmer(
+            specStore,
+            sessionStore,
+            project -> true,
+            NO_UNIT,
+            DEAD,
+            () -> "node-b",
+            project -> {
+              relaunches.incrementAndGet();
+              return Optional.of(LAUNCHED);
+            });
+
+    assertEquals(0, rearmer.rearm());
+    assertEquals(0, relaunches.get());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WebauthnAuthHandlerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WebauthnAuthHandlerTest.java
@@ -32,6 +32,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -375,7 +376,8 @@ class WebauthnAuthHandlerTest {
             new FdeStore(db),
             new WebauthnCredentialStore(db),
             new AuthSessionStore(db),
-            new PendingChallengeStore(db));
+            new PendingChallengeStore(db),
+            Duration.ofDays(30));
     startWith(service);
     var authenticator = new TestAuthenticator(RP_ID);
 
@@ -429,7 +431,8 @@ class WebauthnAuthHandlerTest {
             new FdeStore(db),
             new WebauthnCredentialStore(db),
             new AuthSessionStore(db),
-            new PendingChallengeStore(db));
+            new PendingChallengeStore(db),
+            Duration.ofDays(30));
     startWith(
         service,
         new EnrollmentService(new EnrollmentTicketStore(db), new FdeStore(db)),

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/HostConfigSetCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/HostConfigSetCommandTest.java
@@ -172,6 +172,38 @@ class HostConfigSetCommandTest {
   }
 
   @Test
+  void sessionTtlIsSetAndPreservedByOtherWebauthnKeys() {
+    var withTtl = HostConfigSetCommand.applyChange(BASE, "webauthn-session-ttl-hours", "48");
+    assertEquals(48, withTtl.webauthn().sessionTtlHours());
+
+    var withRpId = HostConfigSetCommand.applyChange(withTtl, "webauthn-rp-id", "localhost");
+    var withName = HostConfigSetCommand.applyChange(withRpId, "webauthn-rp-name", "Sail");
+    var withOrigin =
+        HostConfigSetCommand.applyChange(withName, "webauthn-origin", "http://localhost:7070");
+
+    assertEquals(48, withOrigin.webauthn().sessionTtlHours());
+    assertEquals("localhost", withOrigin.webauthn().rpId());
+  }
+
+  @Test
+  void sessionTtlValidationBoundsAndParseErrors() {
+    HostConfigSetCommand.validate("webauthn-session-ttl-hours", "1");
+    HostConfigSetCommand.validate("webauthn-session-ttl-hours", "720");
+    HostConfigSetCommand.validate("webauthn-session-ttl-hours", "2160");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> HostConfigSetCommand.validate("webauthn-session-ttl-hours", "0"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> HostConfigSetCommand.validate("webauthn-session-ttl-hours", "2161"));
+    var thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> HostConfigSetCommand.validate("webauthn-session-ttl-hours", "a-fortnight"));
+    assertTrue(thrown.getMessage().contains("whole number of hours"));
+  }
+
+  @Test
   void serverIpChangePreservesTheWebauthnBlock() {
     var withWebauthn = HostConfigSetCommand.applyChange(BASE, "webauthn-rp-id", "localhost");
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SyncServerCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SyncServerCommandTest.java
@@ -9,15 +9,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.store.AuthSessionStore;
 import ai.singlr.sail.store.ChangeLog;
 import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.SyncConflicts;
 import ai.singlr.sail.store.SyncState;
+import ai.singlr.sail.sync.LocalReplica;
+import ai.singlr.sail.sync.RunReplica;
 import ai.singlr.sail.sync.SpecReplica;
 import ai.singlr.sail.sync.SyncDatabase;
 import ai.singlr.sail.sync.SyncEngine;
@@ -105,6 +109,11 @@ class SyncServerCommandTest {
   }
 
   private SyncEngine.Report syncWithToken(String token) throws Exception {
+    return syncWithToken(token, "spec", nodeReplica);
+  }
+
+  private SyncEngine.Report syncWithToken(String token, String entityType, LocalReplica replica)
+      throws Exception {
     var toServer = new PipedWriter();
     var serverIn = new BufferedReader(new PipedReader(toServer));
     var toClient = new PipedWriter();
@@ -122,7 +131,7 @@ class SyncServerCommandTest {
                 });
 
     try (var session = new SyncSession(clientIn, toServer)) {
-      return new SyncEngine().reconcile(nodeReplica, session.replica("spec"));
+      return new SyncEngine().reconcile(replica, session.replica(entityType));
     } finally {
       serverThread.join();
     }
@@ -156,6 +165,42 @@ class SyncServerCommandTest {
     nodeSpecs.create(spec("auth", "Auth"));
     assertThrows(SyncTransportException.class, () -> syncWithToken(null));
     assertTrue(mainSpecs.findById("auth").isEmpty());
+  }
+
+  private RunReplica nodeRunReplica() {
+    return new RunReplica(
+        "node",
+        new RunStore(nodeDb),
+        new ChangeLog(nodeDb),
+        new SyncConflicts(nodeDb),
+        new SyncState(nodeDb));
+  }
+
+  private String createNodeRun(String node) {
+    var id = DateTimeUtils.newId().toString();
+    new RunStore(nodeDb)
+        .create(
+            id, "proj", "auth", node, "build", "claude-code", "feat/x", "task", 1, null, "/log");
+    return id;
+  }
+
+  @Test
+  void aMemberMayPushARunStampedWithItsOwnHandle() throws Exception {
+    var runId = createNodeRun("uday");
+
+    var report = syncWithToken(tokenFor("member"), "run", nodeRunReplica());
+
+    assertEquals(1, report.pushed());
+    assertEquals("uday", new RunStore(mainDb).findById(runId).orElseThrow().node());
+  }
+
+  @Test
+  void aMemberCannotForgeARunStampedWithAnotherNode() throws Exception {
+    var runId = createNodeRun("grace");
+    var token = tokenFor("member");
+
+    assertThrows(SyncTransportException.class, () -> syncWithToken(token, "run", nodeRunReplica()));
+    assertTrue(new RunStore(mainDb).findById(runId).isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Summary

A passkey login session expired after a hardcoded `SESSION_TTL = 12h` in `PasskeyService`, forcing a mid-day Touch-ID re-login for desktop clients that stay open all day. This makes the minted session lifetime configurable, with the default raised to 30 days.

- **Default raised to 30 days.** `PasskeyService` now takes the session TTL as a constructor argument; `WebauthnConfig.sessionTtl()` supplies it, defaulting to 30 days when unset.
- **Configurable via the webauthn host config.** New `webauthn.session_ttl_hours` key in `host.yaml`, settable with `sail host config set webauthn-session-ttl-hours <n>`. Values are validated to 1–2160 hours (1 hour–90 days); anything outside that range or non-numeric is rejected with a clear error, both at `config set` time and when a hand-edited value is loaded at server start.
- **Expiry/prune untouched.** `AuthSessionStore.validate` still rejects and prunes expired sessions; only the minted lifetime changes.
- **Fix en route:** `HostYaml.toMap` only persisted the webauthn block when fully configured, so a TTL (or rp-name) set before rp-id/origin was silently dropped on write. It now persists any non-disabled block.

## Verification

Drove the real surfaces end-to-end (isolated `user.home`/`SAIL_DATA_DIR`):

- `sail host config set webauthn-session-ttl-hours 48` writes `session_ttl_hours: 48`; `0`, `2161`, and `a-fortnight` are rejected with actionable messages; the TTL survives subsequent rp-id/origin sets.
- Full WebAuthn ceremony over HTTP against a live `sail server start`: with `session_ttl_hours: 48`, `/v1/auth/login/finish` returned `expires_at` ≈ now+48h; with the key removed, ≈ now+720h (30 days).
- With a hand-edited `session_ttl_hours: 0`, the server refuses to start: `Invalid session TTL: 0 hours. Expected 1 to 2160 (1 hour to 90 days).`
- `mvn verify` green, including jacoco coverage gates and spotless.

Spec: sail-passkey-session-ttl