### PR TITLE
Log the swallowed cause behind every generic API 500

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiLog.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiLog.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+/**
+ * The API layer's one logging seam for unexpected failures. Every catch-all that converts an
+ * unanticipated exception into a generic {@code internal} refusal must pass through here first, so
+ * the full stack trace lands on stderr (the server's journal) before the wire response is reduced
+ * to "sail API operation failed." — the client-facing envelope stays generic, but the operator can
+ * actually diagnose the 500. Expected refusals ({@link ApiException}) carry their own structured
+ * story and never travel this path.
+ */
+final class ApiLog {
+
+  private ApiLog() {}
+
+  static void unexpected(String context, Exception e) {
+    System.err.println("  [api] Unexpected error handling " + context + ":");
+    e.printStackTrace();
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -121,6 +121,7 @@ public final class ApiRouter implements HttpHandler {
           ApiResponse.error(
               new Result.Failure<>(ErrorCode.INVALID_REQUEST, e.getMessage(), null, null, e)));
     } catch (Exception e) {
+      ApiLog.unexpected(exchange.getRequestMethod() + " " + exchange.getRequestURI().getPath(), e);
       write(
           exchange,
           ApiResponse.error(

--- a/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
@@ -43,6 +43,7 @@ final class LocalApiRouter implements LocalApiHandler {
     } catch (IllegalArgumentException bad) {
       return problem(400, bad.getMessage());
     } catch (RuntimeException unexpected) {
+      ApiLog.unexpected(request.method() + " " + request.path(), unexpected);
       return problem(500, unexpected.getMessage());
     }
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -1271,6 +1271,7 @@ public final class SailApiOperations implements ApiOperations {
     } catch (ApiException e) {
       return e.failure().asFailure();
     } catch (Exception e) {
+      ApiLog.unexpected("an API operation", e);
       return Result.failure(ErrorCode.INTERNAL, "sail API operation failed.", e);
     }
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiLogTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiLogTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The diagnosability contract: an unexpected exception reaching the API's catch-alls leaves its
+ * full stack trace on stderr before the wire response is reduced to a generic internal error.
+ */
+class ApiLogTest {
+
+  @Test
+  void writesContextAndFullStackTraceToStderr() {
+    var original = System.err;
+    var captured = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+    try {
+      ApiLog.unexpected("GET /v1/boom", new IllegalStateException("kaput"));
+    } finally {
+      System.setErr(original);
+    }
+
+    var log = captured.toString(StandardCharsets.UTF_8);
+    assertTrue(log.contains("Unexpected error handling GET /v1/boom"));
+    assertTrue(log.contains("java.lang.IllegalStateException: kaput"));
+    assertTrue(log.contains("at ai.singlr.sail.api.ApiLogTest"));
+  }
+}


### PR DESCRIPTION
Any unexpected exception in the API layer was reduced to a generic `internal` error (`sail API operation failed.` / `sail API request failed. Check sail API logs.`) with the cause attached to the `Result.Failure` but never logged — and there was no logger anywhere in the API layer, so the journal held no stack trace. Reported via Mast when diagnosing a 500; same family as the silent Callable errors.

`ApiLog.unexpected(context, e)` is the one logging seam: `SailApiOperations.safe()`, `ApiRouter`'s catch-all (with method + path context), and `LocalApiRouter` print the full stack trace to stderr — the server's journal — before the wire response stays generic. Expected refusals (`ApiException`) never travel this path, so 403s don't spam traces.

Test asserts the contract: context line, exception class + message, and stack frames all land on stderr.