### PR TITLE
Stamp the dispatch branch on the spec so review scopes correctly

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -245,17 +245,21 @@ public final class SpecStore implements ConflictResolver {
   }
 
   /**
-   * Status transition that also persists the spec's resolved target repos in the same transaction.
-   * Dispatch resolves repo overrides at launch time; recording them here keeps later store reads
-   * (the review pipeline builds its prompt from the stored repos) aligned with the checkouts the
-   * agent actually worked in.
+   * Status transition that also persists the spec's resolved target repos and its dispatch branch
+   * in the same transaction. Dispatch resolves repo overrides and computes the branch name at
+   * launch time; recording them here keeps later store reads (the review pipeline builds its prompt
+   * from the stored repos and branch) aligned with the checkouts the agent actually worked in —
+   * without this the review prompt fell back to "branch main" and reviewed the wrong scope. A blank
+   * {@code branch} (auto-branching disabled) leaves any previously stored value untouched.
    */
-  public void updateReposAndStatus(String id, List<String> repos, SpecStatus status) {
+  public void updateReposAndStatus(
+      String id, List<String> repos, SpecStatus status, String branch) {
     db.transaction(
         () -> {
           db.execute(
-              "UPDATE specs SET status = ?, updated_at = ? WHERE id = ?",
+              "UPDATE specs SET status = ?, branch = COALESCE(?, branch), updated_at = ? WHERE id = ?",
               status.wire(),
+              Strings.isBlank(branch) ? null : branch,
               DateTimeUtils.now().toString(),
               id);
           db.execute("DELETE FROM spec_repos WHERE spec_id = ?", id);

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
@@ -237,12 +237,23 @@ class SpecStoreTest {
   @Test
   void updateReposAndStatusReplacesReposWithTheStatusTransition() {
     store.create(spec("a", "Test", "pending"));
-    store.updateReposAndStatus("a", List.of("api", "web"), SpecStatus.IN_PROGRESS);
+    store.updateReposAndStatus("a", List.of("api", "web"), SpecStatus.IN_PROGRESS, "agent/a");
 
     var found = store.findById("a").orElseThrow();
     assertEquals(SpecStatus.IN_PROGRESS, found.status());
     assertEquals(List.of("api", "web"), found.repos());
+    assertEquals("agent/a", found.branch());
     assertEquals(2, store.history("a").size());
+  }
+
+  @Test
+  void updateReposAndStatusWithBlankBranchKeepsTheStoredOne() {
+    store.create(spec("a", "Test", "pending"));
+    store.updateReposAndStatus("a", List.of("api"), SpecStatus.IN_PROGRESS, "agent/a");
+    store.updateReposAndStatus("a", List.of("api"), SpecStatus.IN_PROGRESS, null);
+    store.updateReposAndStatus("a", List.of("api"), SpecStatus.IN_PROGRESS, "");
+
+    assertEquals("agent/a", store.findById("a").orElseThrow().branch());
   }
 
   @Test

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -553,14 +553,14 @@ public final class SailApiOperations implements ApiOperations {
 
     var targetRepos = DispatchRepos.resolve(loaded.config(), nextSpec, request.repos());
     var taskSpec = DispatchRepos.withTargetRepos(nextSpec, targetRepos);
-    specStore.updateReposAndStatus(nextSpec.id(), taskSpec.repos(), SpecStatus.IN_PROGRESS);
+    var branch = branchName(loaded.config(), nextSpec);
+    specStore.updateReposAndStatus(nextSpec.id(), taskSpec.repos(), SpecStatus.IN_PROGRESS, branch);
     if (reviewStore != null) {
       reviewStore.supersedeForSpec(nextSpec.id());
     }
     var specBody = specStore.getContent(nextSpec.id()).map(SpecStore.SpecContent::body).orElse("");
     var task = AgentTaskPrompt.build(taskSpec, specBody.isBlank() ? nextSpec.title() : specBody);
     var agentType = taskSpec.agent() != null ? taskSpec.agent() : loaded.config().agent().type();
-    var branch = branchName(loaded.config(), nextSpec);
     publishDispatched(project, nextSpec.id(), agentType, branch, request.mode());
     var snapshot = createSnapshotIfNeeded(project, loaded.config());
     if (!snapshot.isEmpty()) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
@@ -439,7 +439,11 @@ public final class DispatchCommand implements Runnable {
       }
       var targetRepos = DispatchRepos.resolve(config, resolution.spec(), repoOverrides);
       var taskSpec = DispatchRepos.withTargetRepos(resolution.spec(), targetRepos);
-      store.updateReposAndStatus(taskSpec.id(), taskSpec.repos(), SpecStatus.IN_PROGRESS);
+      store.updateReposAndStatus(
+          taskSpec.id(),
+          taskSpec.repos(),
+          SpecStatus.IN_PROGRESS,
+          BranchPolicy.branchName(config, taskSpec));
       new ReviewStore(db).supersedeForSpec(taskSpec.id());
       var body = store.getContent(taskSpec.id()).map(SpecStore.SpecContent::body).orElse("");
       return new Prepared(resolution, taskSpec, targetRepos, body);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
@@ -1176,6 +1176,25 @@ class SailApiOperationsTest {
   }
 
   @Test
+  void dispatchStampsTheComputedBranchOnTheSpec() throws Exception {
+    var stores = new SpecStore[1];
+    var operations =
+        operationsWithStore(
+            branchYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sail/agent.pid", new ShellExec.Result(1, "", "missing")),
+            store -> {
+              stores[0] = store;
+              seedAuthBillingSetup(store);
+            });
+
+    dispatch(operations, "acme", request("auth", "background", true));
+
+    assertEquals("sail/auth", stores[0].findById("auth").orElseThrow().branch());
+  }
+
+  @Test
   void dispatchCreatesBranchWhenConfigured() throws Exception {
     var operations =
         operations(


### PR DESCRIPTION
`~/.sail/review-prompt.txt` on a dispatched box says "Review the changes on branch **main**" while the agent's work sits on `agent/<spec-id>` — the reviewer is told the wrong scope on every dispatched review, and plausibly explains review loops re-litigating unrelated recent work.

Root cause: dispatch computes the branch via `BranchPolicy.branchName` and creates it in git, but neither lane ever persisted it to the spec row. `ReviewPipelineController` reads `spec.branch` → null → `.orElse("main")`.

Fix at the existing single seam: `SpecStore.updateReposAndStatus` (the dispatch claim step, already documented as what the review pipeline reads) now also stamps the computed branch in the same transaction, called from both the CLI and API dispatch lanes. A blank branch (auto-branching disabled) leaves any stored value untouched via `COALESCE`. Restart and the board get a truthful `spec.branch` for free; the `main` fallback stays for pre-existing specs.

Tests: store-level stamping + blank-keeps-stored, and an API-lane dispatch test asserting the persisted spec carries the computed branch.