### PR TITLE
Surface operations-layer validation errors as 400, not generic 500

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -1265,11 +1265,22 @@ public final class SailApiOperations implements ApiOperations {
         });
   }
 
+  /**
+   * Maps an operation's outcome onto the wire contract the routers already speak: an {@link
+   * ApiException} is a structured refusal, an {@link IllegalArgumentException} is a caller error —
+   * a validation precondition like "repo not configured in sail.yaml" — surfaced as {@code
+   * invalid_request} (400) with its message, the same convention {@code ApiRouter} and {@code
+   * LocalApiRouter} apply to exceptions escaping their own routing. Only a truly unexpected
+   * exception becomes a generic {@code internal} 500, and its stack trace goes to the journal
+   * first.
+   */
   private static <T> Result<T> safe(Supplier<T> supplier) {
     try {
       return Result.success(supplier.get());
     } catch (ApiException e) {
       return e.failure().asFailure();
+    } catch (IllegalArgumentException e) {
+      return Result.failure(ErrorCode.INVALID_REQUEST, e.getMessage(), e);
     } catch (Exception e) {
       ApiLog.unexpected("an API operation", e);
       return Result.failure(ErrorCode.INTERNAL, "sail API operation failed.", e);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
@@ -1006,6 +1006,24 @@ class SailApiOperationsTest {
   }
 
   @Test
+  void dispatchOnAnUnconfiguredRepoIsACallerErrorNamingTheRepo() throws Exception {
+    var operations =
+        operationsWithStore(
+            baseYaml(),
+            shell().on("incus list ^acme$", RUNNING_JSON),
+            SailApiOperationsTest::seedAuthBillingSetup);
+
+    var error =
+        dispatch(
+            operations,
+            "acme",
+            new DispatchRequest("auth", "background", true, List.of("scim-sql")));
+
+    assertError(ErrorCode.INVALID_REQUEST, error);
+    assertTrue(fullError(error).contains("scim-sql"));
+  }
+
+  @Test
   void dispatchMapsLaunchFailure() throws Exception {
     var runs = new java.util.concurrent.atomic.AtomicReference<RunStore>();
     var operations =


### PR DESCRIPTION
Dispatching from Mast a spec targeting a repo missing from `sail.yaml` returned `500 internal: sail API operation failed.` with no reason on the wire (the journal had the stack trace — thanks to #139 — showing `DispatchRepos.requireConfigured`'s clear message being swallowed).

`ApiRouter` and `LocalApiRouter` already speak the convention `IllegalArgumentException` → 400 `invalid_request` + message, but `SailApiOperations.safe()` sits inside that boundary and caught `Exception` first, so operations-layer validation errors never reached the routers' mapping. `safe()` now applies the identical convention: IAE → `invalid_request` carrying its message (no stack spam — it's a caller error), and only truly unexpected exceptions stay generic-and-journaled.

Regression test reproduces the Mast case: dispatch with an unconfigured repo override → `invalid_request` naming the repo.