### PR TITLE
Wire the run store into the server's API operations

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiOperations.java
@@ -114,7 +114,7 @@ public final class SailApiOperations implements ApiOperations {
     this(shell, file, eventBus, auditSubscriber, specStore, null);
   }
 
-  /** Construct with the project catalog included; used by {@code sail server start}. */
+  /** Construct with the project catalog included but no sync or run aggregate. */
   public SailApiOperations(
       ShellExec shell,
       String file,
@@ -130,15 +130,17 @@ public final class SailApiOperations implements ApiOperations {
         auditSubscriber,
         specStore,
         reviewStore,
+        null,
         projectStore,
         SyncScheduler.disabled());
   }
 
   /**
    * As {@link #SailApiOperations(ShellExec, String, EventBus, EventSubscriber, SpecStore,
-   * ReviewStore, ProjectStore)} with the node's sync-on-write scheduler; used by {@code sail server
-   * start} so spec mutations propagate to main and stale reads freshen without a manual {@code sail
-   * sync}.
+   * ReviewStore, ProjectStore)} with the node's sync-on-write scheduler and the run aggregate; used
+   * by {@code sail server start} so spec mutations propagate to main, stale reads freshen without a
+   * manual {@code sail sync}, and dispatches record their runs — without the run store every {@code
+   * /v1/runs} route refuses and API-lane dispatches silently record no run at all.
    */
   public SailApiOperations(
       ShellExec shell,
@@ -147,6 +149,7 @@ public final class SailApiOperations implements ApiOperations {
       EventSubscriber auditSubscriber,
       SpecStore specStore,
       ReviewStore reviewStore,
+      RunStore runStore,
       ProjectStore projectStore,
       SyncScheduler syncScheduler) {
     this(
@@ -157,7 +160,7 @@ public final class SailApiOperations implements ApiOperations {
         auditSubscriber instanceof AuditPersister ap ? ap : null,
         specStore,
         reviewStore,
-        null,
+        runStore,
         projectStore,
         ConnectEnvironment::detect,
         syncScheduler);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -169,6 +169,7 @@ public final class ServerStartCommand implements Runnable {
     var bus = new EventBus();
     var persister = new SpecStoreAuditPersister(eventStore);
     var reviewStore = new ReviewStore(db);
+    var runStore = new RunStore(db);
     var syncScheduler = NodeSync.scheduler(false);
     shutdown.register(syncScheduler);
     var operations =
@@ -179,6 +180,7 @@ public final class ServerStartCommand implements Runnable {
             persister,
             specStore,
             reviewStore,
+            runStore,
             new ProjectStore(db),
             syncScheduler);
     var orphaned = reviewStore.failOrphanedRunning();
@@ -196,7 +198,6 @@ public final class ServerStartCommand implements Runnable {
             bus,
             ServerStartCommand::loadProjectYaml,
             new ShellExecutor(false));
-    var runStore = new RunStore(db);
     bus.subscribe(new RunTracker(runStore, syncScheduler, NodeIdentity::handle));
     bus.subscribe(SlackReactor.withDefaults(new SlackThreadStore(db), specStore));
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailApiOperationsTest.java
@@ -1006,6 +1006,29 @@ class SailApiOperationsTest {
   }
 
   @Test
+  void serverStartConstructorWiresTheRunLane() throws Exception {
+    var yaml = tempDir.resolve("sail-" + System.nanoTime() + ".yaml");
+    Files.writeString(yaml, baseYaml());
+    var db = Sqlite.open(tempDir.resolve("specs-" + System.nanoTime() + ".db"));
+    new SchemaManager(db).migrate();
+    var operations =
+        new SailApiOperations(
+            shell().on("incus list ^acme$", RUNNING_JSON),
+            yaml.toString(),
+            new EventBus(),
+            null,
+            new SpecStore(db),
+            new ReviewStore(db),
+            new RunStore(db),
+            new ProjectStore(db),
+            SyncScheduler.disabled());
+
+    var result = operations.runs("acme", null);
+
+    assertTrue(result.isSuccess());
+  }
+
+  @Test
   void dispatchOnAnUnconfiguredRepoIsACallerErrorNamingTheRepo() throws Exception {
     var operations =
         operationsWithStore(


### PR DESCRIPTION
Field report from Mast: `GET /v1/runs?project=light-grid` → `500 internal: Run store not available. Start the server with 'sail server start'.` — on a server that was started exactly that way. Worse, `sail agent logs` tailed a days-old run's log after a fresh dispatch.

One root cause, three symptoms: `ServerStartCommand` built `SailApiOperations` via the constructor that hardcodes `null` for `RunStore` (the store was constructed later, only for `RunTracker`). So on every real server since Brick 2 shipped:
1. every `/v1/runs*` route refused (`requireRunStore`),
2. API-lane dispatch hit `recordRun`'s silent `if (runStore == null) return;` and recorded **no run row**,
3. run-addressed log tails (Mast and `sail agent logs`, which resolve `latestForProjectOnNode`) pointed at the newest *recorded* row — a stale run — while the new agent wrote to an unaddressed `~/.sail/runs/<id>/agent.log`.

Brick-2 tests missed it because they inject the store through package-private constructors; the production constructor was never exercised. Fix: construct the `RunStore` up front, pass it through the public constructor — whose signature now **requires** it, so the wiring can't silently regress — and share the instance with `RunTracker`. The regression test builds operations through the exact constructor `sail server start` uses and asserts the run lane answers.

Runs dispatched while the bug was live remain unrecorded (their record moment has passed); their logs are still on disk under `~/.sail/runs/`.