### PR TITLE
Expose re-dispatch (restart) on the dispatch API

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -139,9 +139,14 @@ record SpecResponse(
   }
 }
 
-record DispatchRequest(String specId, String mode, boolean dryRun, List<String> repos) {
+record DispatchRequest(
+    String specId, String mode, boolean dryRun, List<String> repos, boolean restart) {
   DispatchRequest(String specId, String mode, boolean dryRun) {
     this(specId, mode, dryRun, List.of());
+  }
+
+  DispatchRequest(String specId, String mode, boolean dryRun, List<String> repos) {
+    this(specId, mode, dryRun, repos, false);
   }
 
   DispatchRequest {
@@ -157,7 +162,8 @@ record DispatchResponse(
     DispatchedSpecView spec,
     AgentStatusView agent,
     String snapshot,
-    boolean branchCreated)
+    boolean branchCreated,
+    boolean restarted)
     implements Mappable {
   @Override
   public Map<String, Object> toMap() {
@@ -169,6 +175,7 @@ record DispatchResponse(
     m.put("agent", agent);
     m.put("snapshot", snapshot);
     m.put("branch_created", branchCreated);
+    m.put("restarted", restarted);
     return m;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -53,7 +53,7 @@ public final class DispatchOperations {
 
   private static final Duration SNAPSHOT_INTERVAL = Duration.ofHours(24);
 
-  /** One dispatch invocation, lane-agnostic. {@code restart} is CLI-only until the API grows it. */
+  /** One dispatch invocation, lane-agnostic. */
   public record Request(
       String specId, String mode, boolean dryRun, List<String> repos, boolean restart) {}
 
@@ -64,8 +64,10 @@ public final class DispatchOperations {
   public record NoSpecs() implements Outcome {}
 
   /**
-   * A completed dispatch. {@code session}, {@code exitCode} (foreground only), {@code runId} and
-   * {@code watcher} are absent on a dry run, which stops after the claim/branch phase.
+   * A completed dispatch. {@code restarted} reports whether this dispatch was a re-dispatch that
+   * reset a non-pending spec, so callers can message it as an iteration. {@code session}, {@code
+   * exitCode} (foreground only), {@code runId} and {@code watcher} are absent on a dry run, which
+   * stops after the claim/branch phase.
    */
   public record Dispatched(
       Spec taskSpec,
@@ -75,6 +77,7 @@ public final class DispatchOperations {
       String runId,
       String snapshotLabel,
       boolean branchCreated,
+      boolean restarted,
       AgentSession.SessionInfo session,
       Integer exitCode,
       Optional<WatcherSpawner.Spawned> watcher)
@@ -273,6 +276,7 @@ public final class DispatchOperations {
           null,
           snapshot,
           branchCreated,
+          resolution.restarted(),
           null,
           null,
           Optional.empty());
@@ -313,6 +317,7 @@ public final class DispatchOperations {
           runId,
           snapshot,
           branchCreated,
+          resolution.restarted(),
           status,
           background ? null : launch.exitCode(),
           launch.watcher());
@@ -363,10 +368,12 @@ public final class DispatchOperations {
 
   /**
    * Picks the spec to dispatch. Without {@code specId}, the next ready spec assigned to this box's
-   * FDE (or none). With {@code specId}, the spec must exist, pass {@link DispatchPolicy} (checked
-   * before any mutation, so a refused caller can never reset a status), and be pending with its
-   * dependencies met — unless {@code restart} is set, in which case a non-pending status is reset
-   * to pending in the store and reported so the caller publishes {@code spec_restarted}.
+   * FDE (or none) — unless {@code restart} is set, which {@link RestartResolution} refuses because
+   * a restart must name its target. With {@code specId}, the spec must exist and pass {@link
+   * DispatchPolicy} (checked before any mutation, so a refused caller can never reset a status);
+   * {@link RestartResolution} then decides how its status is treated: pending dispatches normally
+   * with its dependencies met, and a non-pending status is either refused or — on {@code restart} —
+   * reset to pending in the store and reported so the caller publishes {@code spec_restarted}.
    */
   static SpecResolution resolveSpec(
       List<Spec> specs,
@@ -375,7 +382,12 @@ public final class DispatchOperations {
       Actor actor,
       String localHandle,
       SpecStore store) {
-    if (Strings.isBlank(specId)) {
+    var spec = Strings.isBlank(specId) ? null : SpecDirectory.findById(specs, specId);
+    if (spec == null) {
+      if (RestartResolution.decide(specId, null, restart)
+          instanceof RestartResolution.Refused refused) {
+        throw refusal(refused);
+      }
       var next = SpecDirectory.nextReadyAssignedTo(specs, localHandle);
       if (next == null) {
         return SpecResolution.none();
@@ -383,33 +395,23 @@ public final class DispatchOperations {
       requireAllowed(actor, next, localHandle);
       return SpecResolution.of(next);
     }
-    var spec = SpecDirectory.findById(specs, specId);
-    if (spec == null) {
-      throw new ApiException(ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found.");
-    }
     requireAllowed(actor, spec, localHandle);
-    if (spec.status() == SpecStatus.PENDING) {
-      if (!SpecDirectory.isReady(specs, spec)) {
-        throw new ApiException(
-            ErrorCode.SPEC_NOT_READY,
-            "Spec '" + specId + "' is not ready for dispatch.",
-            "Resolve dependencies or choose a ready spec.");
+    return switch (RestartResolution.decide(specId, spec, restart)) {
+      case RestartResolution.Refused refused -> throw refusal(refused);
+      case RestartResolution.NotRestarted ignored -> {
+        if (!SpecDirectory.isReady(specs, spec)) {
+          throw new ApiException(
+              ErrorCode.SPEC_NOT_READY,
+              "Spec '" + specId + "' is not ready for dispatch.",
+              "Resolve dependencies or choose a ready spec.");
+        }
+        yield SpecResolution.of(spec);
       }
-      return SpecResolution.of(spec);
-    }
-    if (!restart) {
-      throw new ApiException(
-          ErrorCode.SPEC_NOT_READY,
-          "Spec '"
-              + specId
-              + "' is not pending (current status: "
-              + spec.status().wire()
-              + "). A spec is dispatched only when pending.",
-          "To dispatch it again, pass --restart (this resets status to pending and records the"
-              + " restart as a lifecycle event).");
-    }
-    store.updateStatus(specId, SpecStatus.PENDING);
-    return SpecResolution.restarted(spec, spec.status().wire());
+      case RestartResolution.Restarted restarted -> {
+        store.updateStatus(specId, SpecStatus.PENDING);
+        yield SpecResolution.restarted(spec, restarted.previousStatus());
+      }
+    };
   }
 
   private static void requireAllowed(Actor actor, Spec spec, String localHandle) {
@@ -474,7 +476,8 @@ public final class DispatchOperations {
       var result =
           exec(
               ContainerExec.asDevUser(
-                  project, branchCheckoutArgs(repoDir, branch, branchExists, restarted)));
+                  project,
+                  RestartResolution.branchCheckoutArgs(repoDir, branch, branchExists, restarted)));
       if (!result.ok()) {
         throw new ApiException(
             ErrorCode.BRANCH_CREATE_FAILED,
@@ -493,25 +496,6 @@ public final class DispatchOperations {
       listener.branchUnavailable(branch);
     }
     return created;
-  }
-
-  /**
-   * The git checkout command for a dispatch's work branch. A fresh branch is created with {@code
-   * checkout -b}; on a restart an already-present branch is reused with a <em>forced</em> {@code
-   * checkout -f} so re-dispatch lands on the prior branch even when the previous run left a dirty
-   * working tree, rather than resuming onto it and aborting.
-   */
-  static List<String> branchCheckoutArgs(
-      String repoDir, String branchName, boolean branchExists, boolean restart) {
-    if (branchExists && !restart) {
-      throw new ApiException(
-          ErrorCode.BRANCH_CREATE_FAILED,
-          "Branch '" + branchName + "' already exists.",
-          "Pass --restart to re-dispatch onto it, or delete it first.");
-    }
-    return branchExists
-        ? List.of("git", "-C", repoDir, "checkout", "-f", branchName)
-        : List.of("git", "-C", repoDir, "checkout", "-b", branchName);
   }
 
   /**
@@ -747,6 +731,10 @@ public final class DispatchOperations {
   }
 
   private static ApiException refusal(DispatchDecision.Refused refused) {
+    return new ApiException(refused.code(), refused.message(), refused.fix());
+  }
+
+  private static ApiException refusal(RestartResolution.Refused refused) {
     return new ApiException(refused.code(), refused.message(), refused.fix());
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/JsonBody.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/JsonBody.java
@@ -25,7 +25,8 @@ public final class JsonBody {
         optionalString(map, "spec_id"),
         optionalString(map, "mode"),
         Boolean.TRUE.equals(map.get("dry_run")),
-        optionalStringList(map, "repo", "repos"));
+        optionalStringList(map, "repo", "repos"),
+        Boolean.TRUE.equals(map.get("restart")));
   }
 
   public static Map<String, Object> readMap(HttpExchange exchange) throws IOException {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RestartResolution.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RestartResolution.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.Spec;
+import ai.singlr.sail.config.SpecStatus;
+import java.util.List;
+
+/**
+ * The single domain home for dispatch restart resolution, shared by both lanes (the in-process
+ * {@code sail spec dispatch --restart} CLI and the HTTP API's {@code restart} field). Pure and
+ * I/O-free — it never touches stores, git, or shells — so the full decision matrix is exhaustively
+ * table-testable, exactly like {@link DispatchPolicy}.
+ *
+ * <p>{@link #decide} answers one question: given the requested spec (or its absence) and the {@code
+ * restart} flag, how must dispatch treat the spec's lifecycle status? Either a {@link Refused} with
+ * the structured code both lanes surface verbatim, a {@link NotRestarted} (dispatch proceeds as a
+ * normal pending dispatch), or a {@link Restarted} instructing the executor to reset the spec to
+ * pending, publish {@code spec_restarted} with the status it held before the reset, and land on the
+ * prior branch. Refusal texts are lane-neutral: they name the {@code restart} option and the spec
+ * id, never a CLI flag spelling, because API callers see them too.
+ *
+ * <p>{@link #branchCheckoutArgs} is the branch half of the same decision: a restart force-checks
+ * out the prior branch when it exists ({@code checkout -f}, so a dirty tree left by the previous
+ * run cannot abort the re-dispatch) and creates it fresh otherwise, while a non-restart dispatch
+ * fails loud on a collision, pointing the caller at the restart option.
+ */
+public sealed interface RestartResolution
+    permits RestartResolution.Refused, RestartResolution.NotRestarted, RestartResolution.Restarted {
+
+  record Refused(ErrorCode code, String message, String fix) implements RestartResolution {}
+
+  record NotRestarted() implements RestartResolution {}
+
+  record Restarted(String previousStatus) implements RestartResolution {}
+
+  static RestartResolution decide(String specId, Spec spec, boolean restart) {
+    if (Strings.isBlank(specId)) {
+      if (!restart) {
+        return new NotRestarted();
+      }
+      return new Refused(
+          ErrorCode.INVALID_REQUEST,
+          "The restart option requires an explicit spec id to identify which spec to restart.",
+          "Set the spec id of the non-pending spec to re-dispatch.");
+    }
+    if (spec == null) {
+      return new Refused(ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found.", null);
+    }
+    if (spec.status() == SpecStatus.PENDING) {
+      return new NotRestarted();
+    }
+    if (!restart) {
+      return new Refused(
+          ErrorCode.SPEC_NOT_READY,
+          "Spec '"
+              + specId
+              + "' is not pending (current status: "
+              + spec.status().wire()
+              + "). A spec is dispatched only when pending.",
+          "To dispatch it again, set the restart option (this resets status to pending and records"
+              + " the restart as a lifecycle event).");
+    }
+    return new Restarted(spec.status().wire());
+  }
+
+  static List<String> branchCheckoutArgs(
+      String repoDir, String branchName, boolean branchExists, boolean restart) {
+    if (branchExists && !restart) {
+      throw new ApiException(
+          ErrorCode.BRANCH_CREATE_FAILED,
+          "Branch '" + branchName + "' already exists.",
+          "Set the restart option to re-dispatch onto it, or delete it first.");
+    }
+    return branchExists
+        ? List.of("git", "-C", repoDir, "checkout", "-f", branchName)
+        : List.of("git", "-C", repoDir, "checkout", "-b", branchName);
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -570,12 +570,16 @@ public final class SailOperations implements Operations {
         dispatchOps.dispatch(
             project,
             new DispatchOperations.Request(
-                request.specId(), request.mode(), request.dryRun(), request.repos(), false),
+                request.specId(),
+                request.mode(),
+                request.dryRun(),
+                request.repos(),
+                request.restart()),
             actor,
             localHandle);
     return switch (outcome) {
       case DispatchOperations.NoSpecs ignored ->
-          new DispatchResponse(project, false, "no_pending_specs", null, null, "", false);
+          new DispatchResponse(project, false, "no_pending_specs", null, null, "", false, false);
       case DispatchOperations.Dispatched dispatched ->
           new DispatchResponse(
               project,
@@ -584,7 +588,8 @@ public final class SailOperations implements Operations {
               dispatchedSpecView(dispatched.taskSpec(), dispatched.branch()),
               agentStatusView(dispatched.agentType(), request.mode(), dispatched.session()),
               dispatched.snapshotLabel(),
-              dispatched.branchCreated());
+              dispatched.branchCreated(),
+              dispatched.restarted());
     };
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
@@ -117,11 +117,6 @@ public final class DispatchCommand implements Runnable {
 
   private void execute(SyncScheduler sync) throws Exception {
     sync.freshenRead();
-    if (restart && specId == null) {
-      throw new IllegalArgumentException(
-          "--restart requires --spec to identify which spec to restart.");
-    }
-
     if (!json) {
       Banner.printBranding(System.out, Ansi.AUTO);
     }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -97,6 +97,31 @@ class ApiRouterTest {
   }
 
   @Test
+  void dispatchParsesRestartFlag() throws Exception {
+    try (var server = server()) {
+      var response =
+          post(
+              server,
+              "/v1/projects/acme/dispatch",
+              "token",
+              "{\"spec_id\": \"auth\", \"restart\": true}");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"restarted\": true"));
+    }
+  }
+
+  @Test
+  void dispatchDefaultsRestartToFalse() throws Exception {
+    try (var server = server()) {
+      var response = post(server, "/v1/projects/acme/dispatch", "token", "{\"spec_id\": \"auth\"}");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"restarted\": false"));
+    }
+  }
+
+  @Test
   void dispatchParsesSingleRepoTarget() throws Exception {
     try (var server = server()) {
       var response =
@@ -1137,7 +1162,8 @@ class ApiRouterTest {
                   request.specId(), "Spec", "in_progress", request.repos(), null, null, null, null),
               null,
               "",
-              false));
+              false,
+              request.restart()));
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/DispatchLaneParityTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/DispatchLaneParityTest.java
@@ -122,7 +122,7 @@ class DispatchLaneParityTest {
   }
 
   @Test
-  void bothLanesProduceTheSameSpecRowRunRowAndEventSequence() throws Exception {
+  void bothLanesProduceTheSameSpecRowRunRowsAndEventSequence() throws Exception {
     var cli = lane("cli");
     var cliOps =
         new DispatchOperations(
@@ -144,10 +144,20 @@ class DispatchLaneParityTest {
             ADMIN,
             HANDLE);
     assertInstanceOf(DispatchOperations.Dispatched.class, cliOutcome);
+    cli.specStore().updateStatus("auth", SpecStatus.REVIEW);
+    var cliRestart =
+        cliOps.dispatch(
+            "acme",
+            new DispatchOperations.Request("auth", "background", false, null, true),
+            ADMIN,
+            HANDLE);
+    assertTrue(
+        assertInstanceOf(DispatchOperations.Dispatched.class, cliRestart).restarted(),
+        "the CLI lane reports the re-dispatch as a restart");
 
     var api = lane("api");
     try (var bus = new EventBus()) {
-      var delivered = new CountDownLatch(1);
+      var delivered = new CountDownLatch(2);
       bus.subscribe(
           new EventSubscriber() {
             @Override
@@ -186,14 +196,29 @@ class DispatchLaneParityTest {
       var result =
           apiOps.dispatch(
               "acme", new DispatchRequest("auth", "background", false, null), ADMIN, HANDLE);
-
       assertTrue(result.isSuccess(), () -> String.valueOf(result.fullError()));
-      assertTrue(delivered.await(10, TimeUnit.SECONDS), "spec_dispatched must reach the bus");
+
+      api.specStore().updateStatus("auth", SpecStatus.REVIEW);
+      var restartResult =
+          apiOps.dispatch(
+              "acme", new DispatchRequest("auth", "background", false, null, true), ADMIN, HANDLE);
+      assertTrue(restartResult.isSuccess(), () -> String.valueOf(restartResult.fullError()));
+      assertTrue(
+          restartResult.orThrow().restarted(), "the API lane reports the re-dispatch as a restart");
+      assertTrue(
+          delivered.await(10, TimeUnit.SECONDS), "both spec_dispatched events must reach the bus");
     }
 
     assertEquals(specRow(cli), specRow(api), "one claim, one branch stamp, on either lane");
-    assertEquals(runRow(cli), runRow(api), "one run recorder, on either lane");
+    assertEquals(runRows(cli), runRows(api), "one run recorder, on either lane");
     assertEquals(eventShapes(cli), eventShapes(api), "one event sequence, on either lane");
+    assertTrue(
+        eventShapes(cli).stream()
+            .anyMatch(
+                shape ->
+                    Event.WellKnownTypes.SPEC_RESTARTED.equals(shape.get("type"))
+                        && Map.of("note", "restarted from review").equals(shape.get("data"))),
+        "the restart round records its lifecycle event with the note payload");
   }
 
   private static Map<String, Object> specRow(Lane lane) {
@@ -205,10 +230,13 @@ class DispatchLaneParityTest {
     return shape;
   }
 
-  private static Map<String, Object> runRow(Lane lane) {
+  private static List<Map<String, Object>> runRows(Lane lane) {
     var runs = lane.runStore().listForProject("acme");
-    assertEquals(1, runs.size(), "each lane records exactly one run");
-    var run = runs.getFirst();
+    assertEquals(2, runs.size(), "each lane records one run per dispatch");
+    return runs.stream().map(DispatchLaneParityTest::runShape).toList();
+  }
+
+  private static Map<String, Object> runShape(RunStore.RunRow run) {
     var shape = new LinkedHashMap<String, Object>();
     shape.put("project", run.project());
     shape.put("spec", run.specId());

--- a/sail-infra/src/test/java/ai/singlr/sail/api/DispatchOperationsResolveSpecTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/DispatchOperationsResolveSpecTest.java
@@ -201,7 +201,22 @@ class DispatchOperationsResolveSpecTest {
     assertEquals(ErrorCode.SPEC_NOT_READY, ex.failure().errorCode());
     assertTrue(ex.getMessage().contains("oauth-flow"));
     assertTrue(ex.getMessage().contains("in_progress"));
-    assertTrue(ex.failure().action().contains("--restart"));
+    assertTrue(ex.failure().action().contains("restart"));
+  }
+
+  @Test
+  void restartWithoutASpecIdIsRefusedBeforeAutoSelection() {
+    var store = store();
+    store.create(row("oauth-flow", "in_progress"));
+
+    var ex = assertThrows(ApiException.class, () -> resolve(null, true, specsOf(store), store));
+
+    assertEquals(ErrorCode.INVALID_REQUEST, ex.failure().errorCode());
+    assertTrue(ex.getMessage().contains("spec id"));
+    assertEquals(
+        SpecStatus.IN_PROGRESS,
+        store.findById("oauth-flow").orElseThrow().status(),
+        "a refused restart must never reset any spec's status");
   }
 
   @Test
@@ -255,38 +270,5 @@ class DispatchOperationsResolveSpecTest {
         SpecStatus.IN_PROGRESS,
         store.findById("theirs").orElseThrow().status(),
         "a refused caller must never reset a spec's status");
-  }
-
-  @Test
-  void branchCheckoutCreatesAFreshBranchWhenItDoesNotExist() {
-    var args = DispatchOperations.branchCheckoutArgs("/w/mast", "agent/x", false, false);
-    assertEquals(List.of("git", "-C", "/w/mast", "checkout", "-b", "agent/x"), args);
-  }
-
-  @Test
-  void branchCheckoutForceReusesAnExistingBranchOnRestart() {
-    var args = DispatchOperations.branchCheckoutArgs("/w/mast", "agent/x", true, true);
-    assertEquals(
-        List.of("git", "-C", "/w/mast", "checkout", "-f", "agent/x"),
-        args,
-        "a restart must land on the existing branch even over a dirty tree from the prior run "
-            + "(untracked scaffold that would otherwise abort a plain checkout)");
-  }
-
-  @Test
-  void branchCheckoutStillCreatesWhenRestartingWithNoPriorBranch() {
-    var args = DispatchOperations.branchCheckoutArgs("/w/mast", "agent/x", false, true);
-    assertEquals(List.of("git", "-C", "/w/mast", "checkout", "-b", "agent/x"), args);
-  }
-
-  @Test
-  void branchCheckoutFailsLoudOnACollisionForAFreshDispatch() {
-    var ex =
-        assertThrows(
-            ApiException.class,
-            () -> DispatchOperations.branchCheckoutArgs("/w/mast", "agent/x", true, false));
-    assertEquals(ErrorCode.BRANCH_CREATE_FAILED, ex.failure().errorCode());
-    assertTrue(ex.failure().action().contains("--restart"), "must point the operator at --restart");
-    assertTrue(ex.getMessage().contains("agent/x"));
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RestartResolutionTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RestartResolutionTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.Spec;
+import ai.singlr.sail.config.SpecStatus;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * The pure restart decision behind both dispatch lanes: the full matrix of {status} x {restart
+ * on/off} x {spec id present/absent} x {branch recorded/blank}, with no store, git, or shell in
+ * sight. Refusal texts must be lane-neutral — they name the {@code restart} option, never a CLI
+ * flag spelling — because API callers see them verbatim.
+ */
+class RestartResolutionTest {
+
+  private static Spec spec(SpecStatus status, String branch) {
+    return new Spec("oauth-flow", "OAuth flow", status, "me", List.of(), branch);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void autoSelectLaneWithoutRestartHasNothingToDecide(boolean blankAsNull) {
+    var decision = RestartResolution.decide(blankAsNull ? null : "  ", null, false);
+
+    assertInstanceOf(RestartResolution.NotRestarted.class, decision);
+  }
+
+  @Test
+  void restartWithoutASpecIdIsRefusedAsACallerError() {
+    var decision = RestartResolution.decide(null, null, true);
+
+    var refused = assertInstanceOf(RestartResolution.Refused.class, decision);
+    assertEquals(ErrorCode.INVALID_REQUEST, refused.code());
+    assertTrue(refused.message().contains("restart"));
+    assertTrue(refused.message().contains("spec id"));
+    assertTrue(refused.fix().contains("spec id"));
+    assertLaneNeutral(refused);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void unknownSpecIsRefusedNotFoundRegardlessOfRestart(boolean restart) {
+    var decision = RestartResolution.decide("nope", null, restart);
+
+    var refused = assertInstanceOf(RestartResolution.Refused.class, decision);
+    assertEquals(ErrorCode.SPEC_NOT_FOUND, refused.code());
+    assertTrue(refused.message().contains("nope"));
+    assertNull(refused.fix());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void pendingSpecHasNothingToRestart(boolean restart) {
+    assertInstanceOf(
+        RestartResolution.NotRestarted.class,
+        RestartResolution.decide("oauth-flow", spec(SpecStatus.PENDING, "agent/x"), restart));
+    assertInstanceOf(
+        RestartResolution.NotRestarted.class,
+        RestartResolution.decide("oauth-flow", spec(SpecStatus.PENDING, null), restart));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = SpecStatus.class,
+      names = {"PENDING"},
+      mode = EnumSource.Mode.EXCLUDE)
+  void everyNonPendingStatusWithoutRestartIsRefusedSpecNotReady(SpecStatus status) {
+    var decision = RestartResolution.decide("oauth-flow", spec(status, "agent/x"), false);
+
+    var refused = assertInstanceOf(RestartResolution.Refused.class, decision);
+    assertEquals(ErrorCode.SPEC_NOT_READY, refused.code());
+    assertTrue(refused.message().contains("oauth-flow"));
+    assertTrue(refused.message().contains(status.wire()));
+    assertTrue(refused.fix().contains("restart"));
+    assertLaneNeutral(refused);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = SpecStatus.class,
+      names = {"PENDING"},
+      mode = EnumSource.Mode.EXCLUDE)
+  void everyNonPendingStatusWithRestartResolvesToARestart(SpecStatus status) {
+    var withPriorBranch = RestartResolution.decide("oauth-flow", spec(status, "agent/x"), true);
+    var withoutPriorBranch = RestartResolution.decide("oauth-flow", spec(status, null), true);
+
+    assertEquals(new RestartResolution.Restarted(status.wire()), withPriorBranch);
+    assertEquals(new RestartResolution.Restarted(status.wire()), withoutPriorBranch);
+  }
+
+  @Test
+  void branchCheckoutCreatesAFreshBranchWhenItDoesNotExist() {
+    var args = RestartResolution.branchCheckoutArgs("/w/mast", "agent/x", false, false);
+
+    assertEquals(List.of("git", "-C", "/w/mast", "checkout", "-b", "agent/x"), args);
+  }
+
+  @Test
+  void branchCheckoutForceReusesAnExistingBranchOnRestart() {
+    var args = RestartResolution.branchCheckoutArgs("/w/mast", "agent/x", true, true);
+
+    assertEquals(
+        List.of("git", "-C", "/w/mast", "checkout", "-f", "agent/x"),
+        args,
+        "a restart must land on the existing branch even over a dirty tree from the prior run "
+            + "(untracked scaffold that would otherwise abort a plain checkout)");
+  }
+
+  @Test
+  void branchCheckoutStillCreatesWhenRestartingWithNoPriorBranch() {
+    var args = RestartResolution.branchCheckoutArgs("/w/mast", "agent/x", false, true);
+
+    assertEquals(List.of("git", "-C", "/w/mast", "checkout", "-b", "agent/x"), args);
+  }
+
+  @Test
+  void branchCheckoutFailsLoudOnACollisionForAFreshDispatch() {
+    var ex =
+        assertThrows(
+            ApiException.class,
+            () -> RestartResolution.branchCheckoutArgs("/w/mast", "agent/x", true, false));
+
+    assertEquals(ErrorCode.BRANCH_CREATE_FAILED, ex.failure().errorCode());
+    assertTrue(ex.getMessage().contains("agent/x"));
+    assertTrue(
+        ex.failure().action().contains("restart"), "must point the caller at the restart option");
+    assertFalse(ex.failure().action().contains("--restart"), "collision fix must be lane-neutral");
+  }
+
+  private static void assertLaneNeutral(RestartResolution.Refused refused) {
+    assertFalse(refused.message().contains("--"), "refusal must not name a CLI flag spelling");
+    assertFalse(refused.fix().contains("--"), "fix must not name a CLI flag spelling");
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -1031,6 +1031,125 @@ class SailOperationsTest {
   }
 
   @Test
+  void dispatchRestartWithoutASpecIdIsACallerError() throws Exception {
+    var operations =
+        operationsWithStore(baseYaml(), idleShell(), SailOperationsTest::seedAuthBillingSetup);
+
+    var error =
+        dispatch(operations, "acme", new DispatchRequest(null, "background", false, null, true));
+
+    assertError(ErrorCode.INVALID_REQUEST, error);
+    assertTrue(fullError(error).contains("spec id"), fullError(error));
+  }
+
+  @Test
+  void dispatchWithoutRestartOnANonPendingSpecKeepsTheStructuredRefusal() throws Exception {
+    var stores = new SpecStore[1];
+    var operations =
+        operationsWithStore(
+            baseYaml(),
+            idleShell(),
+            store -> {
+              stores[0] = store;
+              seedSpec(store, "auth", "Add auth", "review", List.of(), "Do auth");
+            });
+
+    var error = dispatch(operations, "acme", request("auth"));
+
+    assertError(ErrorCode.SPEC_NOT_READY, error);
+    assertTrue(error.action().contains("restart"), error.action());
+    assertFalse(error.action().contains("--restart"), "API callers must see a lane-neutral fix");
+    assertEquals(SpecStatus.REVIEW, stores[0].findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void serverStartConstructorRestartsADoneSpecOntoItsPriorBranch() throws Exception {
+    var yaml = tempDir.resolve("sail-" + System.nanoTime() + ".yaml");
+    Files.writeString(yaml, branchYaml());
+    var db = Sqlite.open(tempDir.resolve("specs-" + System.nanoTime() + ".db"));
+    new SchemaManager(db).migrate();
+    var store = new SpecStore(db);
+    seedSpec(
+        store, "auth", "Add auth", "done", List.of(), "Do auth", null, null, null, "sail/auth");
+    var fdeStore = new FdeStore(db);
+    fdeStore.add(LOCAL_HANDLE, null, null, "admin");
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("cat /home/dev/.sail/agent.pid", new ShellExec.Result(1, "", "missing"))
+            .on("mkdir -p /home/dev/workspace/specs", "")
+            .on("printf '%s'", "")
+            .on("mkdir -p /home/dev/.sail", "")
+            .on("test -d /home/dev/workspace/app/.git", "")
+            .on("rev-parse --verify --quiet refs/heads/sail/auth", "")
+            .on("git -C /home/dev/workspace/app checkout -f sail/auth", "")
+            .on("systemd-run --user", "")
+            .on("claude", "");
+    var operations =
+        new SailOperations(
+            shell,
+            yaml.toString(),
+            null,
+            null,
+            store,
+            new ReviewStore(db),
+            new RunStore(db),
+            new ProjectStore(db),
+            SyncScheduler.disabled(),
+            fdeStore);
+
+    var result =
+        dispatch(operations, "acme", new DispatchRequest("auth", "background", false, null, true));
+
+    assertEquals(true, get(result, "dispatched"));
+    assertEquals(true, get(result, "restarted"));
+    assertTrue(get(result, "spec").toString().contains("sail/auth"));
+    assertEquals(SpecStatus.IN_PROGRESS, store.findById("auth").orElseThrow().status());
+    assertTrue(
+        shell.invocations().stream().anyMatch(command -> command.contains("checkout -f sail/auth")),
+        "a restart force-checks out the prior branch instead of failing on the collision");
+    assertFalse(
+        shell.invocations().stream().anyMatch(command -> command.contains("checkout -b")),
+        "a restart never creates a fresh branch when the prior one exists");
+  }
+
+  @Test
+  void dispatchDryRunWithRestartClaimsTheSpecLikeAnyDispatchDryRun() throws Exception {
+    var stores = new SpecStore[1];
+    var operations =
+        operationsWithStore(
+            branchYaml(),
+            idleShell()
+                .on("test -d /home/dev/workspace/app/.git", "")
+                .on("rev-parse --verify --quiet refs/heads/sail/auth", "")
+                .on("git -C /home/dev/workspace/app checkout -f sail/auth", ""),
+            store -> {
+              stores[0] = store;
+              seedSpec(
+                  store,
+                  "auth",
+                  "Add auth",
+                  "review",
+                  List.of(),
+                  "Do auth",
+                  null,
+                  null,
+                  null,
+                  "sail/auth");
+            });
+
+    var result =
+        dispatch(operations, "acme", new DispatchRequest("auth", "background", true, null, true));
+
+    assertEquals(true, get(result, "dispatched"));
+    assertEquals(true, get(result, "restarted"));
+    assertEquals(
+        SpecStatus.IN_PROGRESS,
+        stores[0].findById("auth").orElseThrow().status(),
+        "a dry run claims the spec — dispatch's existing dry-run semantics, unchanged by restart");
+  }
+
+  @Test
   void dispatchOnAnUnconfiguredRepoIsACallerErrorNamingTheRepo() throws Exception {
     var operations =
         operationsWithStore(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -67,7 +67,8 @@ class TestOperations implements Operations {
                 request.specId(), "Spec", "in_progress", request.repos(), null, null, null, null),
             null,
             "",
-            false));
+            false,
+            request.restart()));
   }
 
   @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
@@ -250,38 +250,6 @@ class DispatchCommandTest {
     assertTrue(help.contains("--restart"));
   }
 
-  @Test
-  void restartWithoutSpecIsRejected() throws Exception {
-    var yaml =
-        """
-        name: test-project
-        resources:
-          cpu: 2
-          memory: 4GB
-          disk: 20GB
-        agent:
-          type: claude-code
-          specs_dir: specs
-        """;
-    var yamlPath = tempDir.resolve("sail.yaml");
-    Files.writeString(yamlPath, yaml);
-
-    var cmd = new CommandLine(new Sail());
-
-    var exitCode =
-        cmd.execute(
-            "spec",
-            "dispatch",
-            "--project",
-            "test-project",
-            "--restart",
-            "-f",
-            yamlPath.toString());
-
-    assertNotEquals(0, exitCode);
-    assertTrue(capturedErr.toString().contains("--restart requires --spec"));
-  }
-
   @TempDir Path dbDir;
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandWiringTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandWiringTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.singlr.sail.api.Actor;
 import ai.singlr.sail.api.ApiException;
 import ai.singlr.sail.api.DispatchOperations;
+import ai.singlr.sail.api.ErrorCode;
 import ai.singlr.sail.api.Event;
 import ai.singlr.sail.api.SailOperations;
 import ai.singlr.sail.api.SyncScheduler;
@@ -176,6 +177,47 @@ class DispatchCommandWiringTest {
     var served = server.runs("acme", null);
     assertTrue(
         served.isSuccess(), "/v1/runs answers from the rows a CLI-lane dispatch just recorded");
+  }
+
+  @Test
+  void cliRestartWithoutASpecIsRefusedByTheSharedExecutor() throws Exception {
+    var operations = cliOperations(shell(), new ArrayList<>());
+    new FdeStore(db).add(HANDLE, null, null, "admin");
+    var request = new DispatchOperations.Request(null, "background", false, null, true);
+
+    var ex =
+        assertThrows(
+            ApiException.class,
+            () -> operations.dispatch("acme", request, Actor.cliOperator(HANDLE), HANDLE));
+
+    assertEquals(ErrorCode.INVALID_REQUEST, ex.failure().errorCode());
+    assertTrue(ex.getMessage().contains("spec id"));
+  }
+
+  @Test
+  void cliRestartRedispatchesAReviewSpecOntoItsPriorBranch() throws Exception {
+    var events = new ArrayList<Event>();
+    var operations =
+        cliOperations(
+            shell()
+                .on("git -C /home/dev/workspace/app rev-parse --verify --quiet refs/heads/x", "")
+                .on("git -C /home/dev/workspace/app checkout -f x", ""),
+            events);
+    new FdeStore(db).add(HANDLE, null, null, "admin");
+    var specStore = new SpecStore(db);
+    specStore.updateReposAndStatus("auth", List.of("app"), SpecStatus.REVIEW, "x");
+    var request = new DispatchOperations.Request("auth", "background", false, null, true);
+
+    var outcome = operations.dispatch("acme", request, Actor.cliOperator(HANDLE), HANDLE);
+
+    var dispatched = assertInstanceOf(DispatchOperations.Dispatched.class, outcome);
+    assertTrue(dispatched.restarted());
+    assertEquals("x", dispatched.branch(), "a restart lands on the recorded prior branch");
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    assertEquals(
+        List.of(Event.WellKnownTypes.SPEC_RESTARTED, Event.WellKnownTypes.SPEC_DISPATCHED),
+        events.stream().map(Event::type).toList());
+    assertEquals(Map.of("note", "restarted from review"), events.getFirst().data());
   }
 
   @Test


### PR DESCRIPTION
Implements spec `sail-dispatch-restart-api`. An API client (Mast's `mast-redispatch`) can now re-run a reviewed/finished spec: `POST /v1/projects/{p}/dispatch` with `{specId, restart:true}` resets it to pending, re-dispatches onto the prior branch (force-checkout), and emits `spec_restarted` — identical to `sail spec dispatch --restart`, because both lanes run the same executor.

- **`RestartResolution`** (peer of `DispatchPolicy`): pure, sealed decision over {specId presence, spec existence, status, restart flag} plus the branch plan (`checkout -f` prior vs `checkout -b`); refusal texts are lane-neutral (they name the `restart` option, never the `--restart` flag). Full parameterized matrix test, lane-neutrality asserted.
- **`DispatchOperations.resolveSpec`** consults it in exactly one place; the inline restart logic and the CLI-side `IllegalArgumentException` guard are deleted — restart without a spec id now refuses as 400 `invalid_request` identically on both lanes (#141 contract).
- **Wire models**: `DispatchRequest.restart` (compact constructor keeps old shape), `DispatchResponse.restarted`, `JsonBody` parses the flag, `SailOperations.dispatchValue` passes it through instead of hardcoding `false`.
- **Tests**: restart matrix, API route-level success/refusal, production-constructor restart onto the prior branch (#142 lesson), a restart round in `DispatchLaneParityTest`, and dry-run-with-restart pinned to existing dispatch dry-run semantics.

Provenance: the dispatched agent completed this implementation and its targeted tests, then backgrounded its final `mvn clean verify` and ended its turn — the session terminated with the work uncommitted (second occurrence of this trap). Full `mvn clean verify` was re-run green (including the 100% api.* gate) before this PR.