### PR TITLE
Tolerate a missing timeout command in the stop gate's PR check

### DIFF
--- a/sail-harness/src/main/java/ai/singlr/sail/engine/SailStopGate.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/SailStopGate.java
@@ -121,7 +121,9 @@ public final class SailStopGate {
           "${default#origin/}"|main|master) continue ;;
         esac
         command -v gh >/dev/null 2>&1 || continue
-        pr_err="$( (cd "$repo_dir" && timeout 5 gh pr view "$branch" --json state >/dev/null) 2>&1 || true)"
+        GH_TIMEOUT=""
+        command -v timeout >/dev/null 2>&1 && GH_TIMEOUT="timeout 5"
+        pr_err="$( (cd "$repo_dir" && $GH_TIMEOUT gh pr view "$branch" --json state >/dev/null) 2>&1 || true)"
         case "$pr_err" in
           *"no pull requests found"*) note "open a pull request for $branch in $repo" ;;
         esac


### PR DESCRIPTION
The v0.13.158 release build failed on its macOS lane: `SailStopGateTest.aMissingPullRequestBlocksWhenGhKnowsTheBranch` expected a block and got none. macOS has no coreutils `timeout`, so `timeout 5 gh pr view …` failed with command-not-found before `gh` ever ran, the "no pull requests found" note never fired, and the gate allowed the stop. PR CI (Ubuntu-only) can't see this; only the release workflow builds on macOS.

Fix in the script, not the test: use `timeout 5` when the command exists, fall back to a bare `gh` invocation otherwise — still bounded by the hook-level 15s timeout, and production containers (Ubuntu 24.04) keep the exact current behavior. Follow-up worth considering separately: a macOS test job in PR CI so release-only failures can't happen.