### PR TITLE
Extend the stop readiness gate to Codex's hook lane

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/engine/AgentCli.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/AgentCli.java
@@ -116,6 +116,14 @@ public enum AgentCli {
    * during a long-running dispatch. This must be scoped to the background dispatch path only: the
    * review/foreground paths parse the agent's final {@code json} block and would break under
    * streaming output. Codex already streams a readable transcript, so the flag is a no-op for it.
+   *
+   * <p>Full-permission Codex sessions additionally pass {@code --dangerously-bypass-hook-trust}:
+   * Codex silently skips untrusted hooks even in headless {@code exec}, and sail cannot pre-seed
+   * trust hashes for the hooks file it owns and rewrites, so without the flag the sail hooks layer
+   * would never fire (see {@code CodexHookConfig}). It is tied to {@code fullPermissions} because
+   * hooks run outside the Codex sandbox — in a sandboxed session auto-trusting hooks would grant an
+   * escape hatch, while an unsandboxed session gains nothing it did not already have. Every sail
+   * dispatch path runs with full permissions, and interactive engineer sessions never get the flag.
    */
   public String headlessCommand(
       String taskFile,
@@ -141,7 +149,10 @@ public enum AgentCli {
             + task;
       }
       case CODEX -> {
-        var perm = fullPermissions ? " --dangerously-bypass-approvals-and-sandbox" : "";
+        var perm =
+            fullPermissions
+                ? " --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust"
+                : "";
         yield binaryName + " exec" + perm + codexModelOptions(model, reasoningEffort) + " " + task;
       }
     };

--- a/sail-core/src/test/java/ai/singlr/sail/engine/AgentCliTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/AgentCliTest.java
@@ -160,6 +160,10 @@ class AgentCliTest {
 
     assertTrue(cmd.contains("codex exec"));
     assertTrue(cmd.contains("--dangerously-bypass-approvals-and-sandbox"));
+    assertTrue(
+        cmd.contains("--dangerously-bypass-hook-trust"),
+        "Codex silently skips untrusted hooks in headless exec, so without this flag the"
+            + " sail-owned hooks layer (and its stop gate) would never fire");
     assertTrue(cmd.contains("\"$(cat " + TASK + ")\""));
     assertFalse(cmd.contains("--print"));
   }
@@ -170,6 +174,9 @@ class AgentCliTest {
 
     assertTrue(cmd.contains("codex exec"));
     assertFalse(cmd.contains("--full-auto"));
+    assertFalse(
+        cmd.contains("--dangerously-bypass-hook-trust"),
+        "hooks run outside the Codex sandbox, so a sandboxed session must not auto-trust them");
   }
 
   @Test

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/CodexHookConfig.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/CodexHookConfig.java
@@ -15,19 +15,38 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * Writes a sail-owned Codex CLI hooks file at {@link #SETTINGS_PATH} inside the container. Codex
- * does not (yet) expose a {@code --settings <path>} flag the way Claude Code does — its discovery
- * is fixed to {@code ~/.codex/hooks.json} (plus {@code config.toml} and project-scoped variants).
- * To keep engineer interactive {@code codex} sessions from polluting the spec event bus, the
- * in-container {@link SailEventHelper} script self-gates on the {@code SAIL_SPEC_ID} env var: when
- * the engineer runs {@code codex} themselves the hook still fires but the script exits 0 silently
- * because sail did not set that variable.
+ * does not expose a {@code --settings <path>} flag the way Claude Code does — its discovery is
+ * fixed to {@code ~/.codex/hooks.json} (plus {@code config.toml} and project-scoped variants) — so
+ * session scoping runs through Codex's hook trust model instead:
+ *
+ * <p>Codex records trust per hook against a content hash ({@code [hooks.state]} in the engineer's
+ * {@code config.toml}) and <em>silently skips</em> new or changed hooks until they are trusted,
+ * including in headless {@code codex exec} (verified against codex-cli 0.144.0). Sail cannot
+ * pre-seed those hashes — the format is internal and {@code config.toml} belongs to the engineer —
+ * so sail-dispatched sessions pass {@code --dangerously-bypass-hook-trust} instead (see {@link
+ * AgentCli#headlessCommand}). Engineer-run interactive {@code codex} sessions never get that flag,
+ * so this layer stays inert for them unless they trust it via {@code /hooks} — and even then the
+ * {@link SailEventHelper} script self-gates on {@code SAIL_SPEC_ID} and {@link SailStopGate} on
+ * {@code SAIL_RUN_ID}, so nothing leaks into the spec event bus and no interactive stop is gated.
  *
  * <p>Hooks wired:
  *
  * <ul>
  *   <li>{@code SessionStart} → {@code agent_session_started}
- *   <li>{@code Stop} → {@code agent_session_stopped}
+ *   <li>{@code PreToolUse} → {@code agent_tool_started}
+ *   <li>{@code PostToolUse} → {@code agent_tool_finished}
+ *   <li>{@code Stop} → {@link SailStopGate}, which publishes {@code agent_session_stopped} when it
+ *       allows the stop or {@code agent_stop_nudged} when it blocks a premature one. It must be the
+ *       only {@code Stop} hook: matching hooks run concurrently, so a bare publisher beside the
+ *       gate would announce a stop that the gate then cancels. Codex's {@code Stop} payload carries
+ *       the same {@code stop_hook_active} loop guard and honors the same {@code {"decision":
+ *       "block", "reason": ...}} contract as Claude Code, so the one gate script serves both CLIs
+ *       unmodified.
  * </ul>
+ *
+ * <p>The tool hooks are the dispatch watcher's liveness signal, exactly as in {@link
+ * ClaudeCodeHookConfig}: {@code AgentWatchCommand} resets its stall timer on the heartbeats, so a
+ * working Codex agent pushes the {@code max_idle} deadline out on every tool call.
  *
  * <p>Codex has no analogue of Claude Code's {@code SessionEnd}, so we do not emit {@code
  * agent_session_completed} for Codex agents. {@link ai.singlr.sail.api.SpecLifecycleReactor}
@@ -57,10 +76,15 @@ public final class CodexHookConfig {
    */
   public static String render() {
     var sessionStart = hookCommand(SailEventHelper.SCRIPT_PATH, "agent_session_started");
-    var stop = hookCommand(SailEventHelper.SCRIPT_PATH, "agent_session_stopped");
+    var toolStarted =
+        hookCommand(SailEventHelper.SCRIPT_PATH, ClaudeCodeHookConfig.PROGRESS_HOOK_MARKER);
+    var toolFinished = hookCommand(SailEventHelper.SCRIPT_PATH, "agent_tool_finished");
+    var stop = stopGateCommand();
 
     var hooks = new LinkedHashMap<String, Object>();
     hooks.put("SessionStart", List.of(matcherGroup(sessionStart)));
+    hooks.put("PreToolUse", List.of(matcherGroup(toolStarted)));
+    hooks.put("PostToolUse", List.of(matcherGroup(toolFinished)));
     hooks.put("Stop", List.of(matcherGroup(stop)));
 
     var root = new LinkedHashMap<String, Object>();
@@ -105,6 +129,14 @@ public final class CodexHookConfig {
     hook.put("type", "command");
     hook.put("command", script + " " + eventType);
     hook.put("timeout", 10);
+    return hook;
+  }
+
+  private static Map<String, Object> stopGateCommand() {
+    var hook = new LinkedHashMap<String, Object>();
+    hook.put("type", "command");
+    hook.put("command", SailStopGate.SCRIPT_PATH);
+    hook.put("timeout", SailStopGate.HOOK_TIMEOUT_SECONDS);
     return hook;
   }
 }

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
@@ -393,7 +393,9 @@ class AgentSessionTest {
 
     var joined = String.join(" ", cmd);
     assertTrue(
-        joined.contains("codex exec --dangerously-bypass-approvals-and-sandbox --model gpt-5.5"));
+        joined.contains(
+            "codex exec --dangerously-bypass-approvals-and-sandbox"
+                + " --dangerously-bypass-hook-trust --model gpt-5.5"));
     assertTrue(joined.contains("model_reasoning_effort='\"high\"'"));
     assertFalse(joined.contains("exec codex exec"));
   }

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/CodexHookConfigTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/CodexHookConfigTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.YamlUtil;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -27,12 +28,46 @@ class CodexHookConfigTest {
   }
 
   @Test
-  void renderIncludesSessionStartAndStopOnly() {
+  void renderIncludesLifecycleAndToolHooksButNoSessionEnd() {
     var json = CodexHookConfig.render();
 
     assertTrue(json.contains("SessionStart"));
+    assertTrue(json.contains("PreToolUse"));
+    assertTrue(json.contains("PostToolUse"));
     assertTrue(json.contains("Stop"));
     assertFalse(json.contains("SessionEnd"), "Codex has no SessionEnd analogue");
+  }
+
+  @Test
+  void renderWiresToolHooksSoTheStallWatcherSeesProgress() {
+    var json = CodexHookConfig.render();
+    assertTrue(
+        json.contains(SailEventHelper.SCRIPT_PATH + " agent_tool_started"),
+        "PreToolUse must emit agent_tool_started (the event AgentWatchCommand resets the stall"
+            + " on), or the watcher counts a busy Codex agent as idle and kills it at max_idle");
+    assertTrue(
+        json.contains(SailEventHelper.SCRIPT_PATH + " agent_tool_finished"),
+        "PostToolUse must emit agent_tool_finished");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void renderWiresTheStopGateAsTheOnlyStopHook() {
+    var json = CodexHookConfig.render();
+    var hooks = (Map<String, Object>) YamlUtil.parseMap(json).get("hooks");
+    var stopGroups = (List<Map<String, Object>>) hooks.get("Stop");
+    assertEquals(1, stopGroups.size());
+    var stopHooks = (List<Map<String, Object>>) stopGroups.get(0).get("hooks");
+    assertEquals(
+        1,
+        stopHooks.size(),
+        "gating and publishing must live in ONE combined script: matching hooks run concurrently,"
+            + " so a bare publisher beside the gate would announce a cancelled stop");
+    assertEquals(SailStopGate.SCRIPT_PATH, stopHooks.get(0).get("command"));
+    assertEquals(SailStopGate.HOOK_TIMEOUT_SECONDS, stopHooks.get(0).get("timeout"));
+    assertFalse(
+        json.contains(SailEventHelper.SCRIPT_PATH + " agent_session_stopped"),
+        "the bare Stop publisher is replaced by the gate, which publishes the event itself");
   }
 
   @Test
@@ -71,10 +106,11 @@ class CodexHookConfigTest {
   }
 
   @Test
-  void renderOmitsMatcherSinceCodexSessionEventsHaveNoTools() {
+  void renderOmitsMatchersSoToolHooksMatchEveryTool() {
     assertFalse(
         CodexHookConfig.render().contains("\"matcher\""),
-        "SessionStart / Stop in Codex don't take a tool matcher");
+        "no matcher means match-all: the heartbeats must fire for every tool, and SessionStart /"
+            + " Stop take no matcher at all");
   }
 
   @Test

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/SailStopGateTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/SailStopGateTest.java
@@ -33,6 +33,15 @@ class SailStopGateTest {
 
   private static final String STOP_INPUT =
       "{\"session_id\":\"s\",\"hook_event_name\":\"Stop\",\"stop_hook_active\":false}";
+
+  private static final String CODEX_STOP_INPUT =
+      """
+      {"session_id":"019f5813-4a30-7c73-ae8d-77a...","turn_id":"019f5813-4ab1-7292-8f37-97f...",\
+      "transcript_path":"/home/dev/.codex/sessions/2026/07/12/rollout.jsonl",\
+      "cwd":"/home/dev/workspace","hook_event_name":"Stop","model":"gpt-5.6-sol",\
+      "permission_mode":"bypassPermissions","stop_hook_active":false,\
+      "last_assistant_message":"done"}""";
+
   private static final String RUN_ID = "run-1";
 
   @TempDir Path home;
@@ -128,6 +137,30 @@ class SailStopGateTest {
     assertEquals(2, events.size(), events.toString());
     assertTrue(events.get(0).startsWith("agent_stop_nudged "), events.get(0));
     assertEquals("agent_session_stopped", events.get(1));
+  }
+
+  @Test
+  void theVerbatimCodexStopPayloadBlocksADirtyRepo() throws Exception {
+    var repo = repo("sail");
+    Files.writeString(repo.resolve("wip.txt"), "uncommitted");
+
+    var result = runGate(CODEX_STOP_INPUT, RUN_ID);
+
+    assertEquals(0, result.exitCode(), result.stderr());
+    var reason = blockReason(result);
+    assertTrue(reason.contains("commit your work in sail"), reason);
+  }
+
+  @Test
+  void theVerbatimCodexRetryPayloadHonorsStopHookActive() throws Exception {
+    var repo = repo("sail");
+    Files.writeString(repo.resolve("wip.txt"), "uncommitted");
+    var retry = CODEX_STOP_INPUT.replace("\"stop_hook_active\":false", "\"stop_hook_active\":true");
+
+    var result = runGate(retry, RUN_ID);
+
+    assertEquals("", result.stdout(), "Codex re-stops with stop_hook_active=true after a block");
+    assertEquals(List.of("agent_session_stopped"), events());
   }
 
   @Test

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
@@ -22,12 +22,12 @@ import java.util.concurrent.TimeoutException;
  *   <li><b>Helper files in the container.</b> {@code sail-event.sh}, {@code sail-stop-gate}, {@code
  *       claude-settings.json}, and {@code codex hooks.json} are probed with a single {@code test
  *       -f} chain; if any is missing — or the {@code spec} script still references a stale socket
- *       path after the socket moved off {@code /run}, or {@code claude-settings.json} predates the
- *       tool-progress hooks or the stop gate, or {@code sail-event.sh} predates the reason argument
- *       — the installers re-run and rewrite them. The content checks matter because the files are
- *       install-once: without them, a container provisioned before the hooks existed would keep a
- *       settings file the stall watcher gets no progress from, and its agents die at {@code
- *       max_idle}.
+ *       path after the socket moved off {@code /run}, or {@code claude-settings.json} or the codex
+ *       {@code hooks.json} predates the tool-progress hooks or the stop gate, or {@code
+ *       sail-event.sh} predates the reason argument — the installers re-run and rewrite them. The
+ *       content checks matter because the files are install-once: without them, a container
+ *       provisioned before the hooks existed would keep a settings file the stall watcher gets no
+ *       progress from, and its agents die at {@code max_idle}.
  * </ol>
  *
  * Designed for the dispatch hot path: ensureEventSocket is one idempotent shell call, the
@@ -104,6 +104,14 @@ public final class ContainerSailSetup {
                         + " && grep -qsF includeCoAuthoredBy "
                         + ClaudeCodeHookConfig.SETTINGS_PATH
                         + " && test -f "
+                        + CodexHookConfig.SETTINGS_PATH
+                        + " && grep -qsF "
+                        + ClaudeCodeHookConfig.PROGRESS_HOOK_MARKER
+                        + " "
+                        + CodexHookConfig.SETTINGS_PATH
+                        + " && grep -qsF "
+                        + SailStopGate.SCRIPT_PATH
+                        + " "
                         + CodexHookConfig.SETTINGS_PATH
                         + " && grep -qsF "
                         + SpecCliHelper.PATH_MARKER

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -940,7 +940,9 @@ class SailOperationsTest {
             .on("mkdir -p /home/dev/workspace/specs", "")
             .on("printf '%s'", "")
             .on("mkdir -p /home/dev/.sail", "")
-            .on("codex exec --dangerously-bypass-approvals-and-sandbox --model gpt-5.5", "");
+            .on(
+                "codex exec --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust --model gpt-5.5",
+                "");
     var operations =
         operationsWithStore(
             baseYaml(),
@@ -970,7 +972,7 @@ class SailOperationsTest {
             .anyMatch(
                 command ->
                     command.contains(
-                            "codex exec --dangerously-bypass-approvals-and-sandbox --model gpt-5.5")
+                            "codex exec --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust --model gpt-5.5")
                         && command.contains("model_reasoning_effort='\"high\"'")));
     assertFalse(
         shell.invocations().stream().anyMatch(command -> command.contains("claude --print")));

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerSailSetupTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerSailSetupTest.java
@@ -94,6 +94,33 @@ class ContainerSailSetupTest {
   }
 
   @Test
+  void aCodexHooksFileMissingTheStopGateForcesAReinstall() throws Exception {
+    var shell =
+        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+            .onOk("config device get " + CONTAINER, "/run/sail\n")
+            .onFail(
+                "grep -qsF " + SailStopGate.SCRIPT_PATH + " " + CodexHookConfig.SETTINGS_PATH, "");
+
+    var result = ContainerSailSetup.ensureInstalled(shell, CONTAINER);
+
+    assertEquals(
+        ContainerSailSetup.Result.BACKFILLED,
+        result,
+        "a codex hooks.json still wiring the bare Stop publisher is stale and must be rewritten,"
+            + " or premature Codex turn-ends keep stranding dispatched work uncommitted");
+    assertTrue(
+        shell.invocations().stream()
+            .anyMatch(
+                c ->
+                    c.contains(
+                        "grep -qsF "
+                            + SailStopGate.SCRIPT_PATH
+                            + " "
+                            + CodexHookConfig.SETTINGS_PATH)),
+        "the probe must verify the codex hooks file wires the stop gate, not just exists");
+  }
+
+  @Test
   void anEventHelperMissingTheReasonArgForcesAReinstall() throws Exception {
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
@@ -165,6 +192,17 @@ class ContainerSailSetupTest {
         probe.contains(
             "grep -qsF " + SailStopGate.SCRIPT_PATH + " " + ClaudeCodeHookConfig.SETTINGS_PATH),
         "the probe must detect a settings file that still wires the bare Stop publisher");
+    assertTrue(
+        probe.contains(
+            "grep -qsF " + SailStopGate.SCRIPT_PATH + " " + CodexHookConfig.SETTINGS_PATH),
+        "the probe must detect a codex hooks file that still wires the bare Stop publisher");
+    assertTrue(
+        probe.contains(
+            "grep -qsF "
+                + ClaudeCodeHookConfig.PROGRESS_HOOK_MARKER
+                + " "
+                + CodexHookConfig.SETTINGS_PATH),
+        "the probe must detect a codex hooks file predating the tool-progress heartbeats");
     assertTrue(
         probe.contains(
             "grep -qsF " + SailEventHelper.REASON_MARKER + " " + SailEventHelper.SCRIPT_PATH),

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/StopGateIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/StopGateIT.java
@@ -27,10 +27,14 @@ import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 
 /**
- * Exercises the installed stop gate end-to-end in a real container against a live sail-api socket:
- * a dispatched-looking session with a dirty worktree is blocked exactly once (block JSON on
- * stdout), the second stop passes, and the event log shows {@code agent_stop_nudged} followed by
- * {@code agent_session_stopped} — never a stop that did not happen.
+ * Exercises the installed stop gate end-to-end in a real container against a live sail-api socket,
+ * on both hook lanes: a dispatched-looking session with a dirty worktree is blocked exactly once
+ * (block JSON on stdout), the second stop passes, and the event log shows {@code agent_stop_nudged}
+ * followed by {@code agent_session_stopped} — never a stop that did not happen. The Claude lane
+ * retries with the marker-file loop guard; the Codex lane feeds the payload shape captured from a
+ * live headless {@code codex exec} run (codex-cli 0.144.0), where the retry carries {@code
+ * stop_hook_active: true}. One gate script serves both, and the sail-owned codex {@code hooks.json}
+ * must wire it.
  */
 class StopGateIT extends AbstractIncusIT {
 
@@ -73,6 +77,19 @@ class StopGateIT extends AbstractIncusIT {
         Files.createDirectories(SailPaths.apiSocketHostDir());
         ContainerSailSetup.ensureInstalled(shell, CONTAINER);
         new IncusDeviceManager(shell).ensureEventSocket(CONTAINER, socketDir, CONTAINER_DIR);
+
+        var codexHooks =
+            exec(
+                CONTAINER,
+                List.of(
+                    "su",
+                    "-",
+                    "dev",
+                    "-c",
+                    "grep -F " + SailStopGate.SCRIPT_PATH + " " + CodexHookConfig.SETTINGS_PATH));
+        assertTrue(
+            codexHooks.ok(),
+            "the installed codex hooks.json must wire the stop gate: " + codexHooks.stderr());
 
         var prepare =
             exec(
@@ -123,6 +140,37 @@ class StopGateIT extends AbstractIncusIT {
         var reason = Objects.toString(received.get(0).data().get("reason"), "");
         assertTrue(reason.contains("proj"), "the nudge event must carry the reason: " + reason);
         assertEquals("run-1", received.get(0).data().get(Event.WellKnownData.RUN_ID));
+
+        var codexFirst = codexStopAttempt(false);
+        assertTrue(codexFirst.ok(), "the first codex stop must exit 0: " + codexFirst.stderr());
+        assertTrue(
+            codexFirst.stdout().contains("\"decision\": \"block\""),
+            "a dirty worktree must block the first codex stop: " + codexFirst.stdout());
+        assertTrue(
+            codexFirst.stdout().contains("proj"),
+            "the codex block reason must name the dirty repo: " + codexFirst.stdout());
+
+        var codexSecond = codexStopAttempt(true);
+        assertTrue(codexSecond.ok(), "the codex retry must exit 0: " + codexSecond.stderr());
+        assertTrue(
+            codexSecond.stdout().isBlank(),
+            "the retry carries stop_hook_active=true and must pass: " + codexSecond.stdout());
+
+        awaitEvents(received, 4);
+        assertEquals(
+            List.of(
+                Event.WellKnownTypes.AGENT_STOP_NUDGED,
+                Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+                Event.WellKnownTypes.AGENT_STOP_NUDGED,
+                Event.WellKnownTypes.AGENT_SESSION_STOPPED),
+            received.stream().map(Event::type).toList(),
+            "the codex lane must show the same nudged-then-stopped sequence");
+        assertEquals("codex", received.get(2).agent(), "the nudge must be attributed to codex");
+        assertEquals("run-2", received.get(2).data().get(Event.WellKnownData.RUN_ID));
+        var codexReason = Objects.toString(received.get(2).data().get("reason"), "");
+        assertTrue(
+            codexReason.contains("proj"),
+            "the codex nudge must carry the same reason text: " + codexReason);
       }
     } finally {
       deleteContainerQuietly(CONTAINER);
@@ -142,6 +190,29 @@ class StopGateIT extends AbstractIncusIT {
             "printf '{}' | SAIL_SPEC_ID="
                 + SPEC_ID
                 + " SAIL_RUN_ID=run-1 SAIL_AGENT=claude-code "
+                + SailStopGate.SCRIPT_PATH));
+  }
+
+  private ShellExec.Result codexStopAttempt(boolean stopHookActive) throws Exception {
+    var payload =
+        "{\"session_id\":\"s\",\"turn_id\":\"t\",\"transcript_path\":null,"
+            + "\"cwd\":\"/home/dev/workspace\",\"hook_event_name\":\"Stop\","
+            + "\"model\":\"gpt-5.6-sol\",\"permission_mode\":\"bypassPermissions\","
+            + "\"stop_hook_active\":"
+            + stopHookActive
+            + ",\"last_assistant_message\":\"done\"}";
+    return exec(
+        CONTAINER,
+        List.of(
+            "su",
+            "-",
+            "dev",
+            "-c",
+            "printf '%s' '"
+                + payload
+                + "' | SAIL_SPEC_ID="
+                + SPEC_ID
+                + " SAIL_RUN_ID=run-2 SAIL_AGENT=codex "
                 + SailStopGate.SCRIPT_PATH));
   }
 


### PR DESCRIPTION
Closes the Codex half of the stop-readiness guardrail: a sail-dispatched Codex session that tries to end its turn with dirty/unpushed/PR-less work is now blocked exactly once with the same reason text a Claude session gets, via the same `sail-stop-gate` script — zero forks of it (the diff contains no change under `SailStopGate`).

## Verify FIRST — the trust story, pinned

Verified against the live Codex docs and real headless runs of **codex-cli 0.144.0**:

1. **Trust model.** Codex records hook trust per hook against a content hash (`[hooks.state]` in the engineer's `config.toml`) and **silently skips** new or changed hooks until trusted — including in headless `codex exec`. Reproduced live: an untrusted Stop hook produced no execution and no warning in a headless run. Sail rewrites `~/.codex/hooks.json`, which invalidates any recorded hash, and the hash format is internal to Codex while `config.toml` belongs to the engineer — so pre-seeding trust was rejected. A managed layer (`requirements.toml`, `allow_managed_hooks_only`) was also rejected: it is enterprise policy machinery that would constrain the engineer's own sessions. The mechanism that provably executes unattended is `--dangerously-bypass-hook-trust` ("intended only for automation that already vets hook sources" — exactly sail's case: sail wrote the hooks). Full-permission headless sessions now pass it; it is tied to `fullPermissions` because hooks run **outside** the Codex sandbox, so auto-trusting them in a sandboxed session would be a sandbox escape, while an unsandboxed session gains nothing it didn't have. Every sail dispatch path runs full-permission.
2. **Loading layer.** The user layer `~/.codex/hooks.json` (which sail already owns in the container) fires in headless exec under the bypass flag; the reported repo-layer quirks are moot since sail does not use `.codex/` in repos.
3. **Stop payload.** Captured live: `{"session_id":…,"turn_id":…,"transcript_path":…,"cwd":…,"hook_event_name":"Stop","model":…,"permission_mode":…,"stop_hook_active":false,"last_assistant_message":…}` — `stop_hook_active` exists under exactly that name, flips to `true` on the post-block retry, and the block contract is the same `{"decision": "block", "reason": …}` on stdout. The gate's loop guard matches reality unchanged.

## End-to-end acceptance (run live, codex-cli 0.144.0)

Headless `codex exec --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust` with this branch's rendered `hooks.json`, the real gate script (byte-identical to the deployed one), a dirty workspace repo, and `SAIL_RUN_ID` set:

```
hook: Stop
hook: Stop Blocked
codex
I am intentionally blocked.
hook: Stop
hook: Stop Completed
```

Event log: `agent_session_started` → `agent_stop_nudged` ("Not ready to stop: commit your work in proj (the worktree is dirty); push main in proj…") → `agent_session_stopped`. Exactly one block, same reason text as the Claude lane. `PreToolUse`/`PostToolUse` heartbeats verified firing in a separate live run with tool use.

## Scoping

Engineer-run interactive `codex` sessions are never gated: they never receive the bypass flag, so the sail hooks layer (untrusted after every sail rewrite) stays skipped for them — and even a trusted layer self-gates, since `sail-event.sh` exits silently without `SAIL_SPEC_ID` and the gate passes ungated without `SAIL_RUN_ID`.

## Changes

- `CodexHookConfig`: Stop → the shared gate (only Stop hook, 15s timeout), plus `PreToolUse`/`PostToolUse` heartbeats so the watcher's stall timer works identically for Codex agents. No `SessionEnd` exists in Codex's event set, so `agent_session_completed` stays Claude-only — documented gap, not approximated; `SpecLifecycleReactor` already advances the spec on `stopped`.
- `AgentCli`: full-permission Codex headless commands add `--dangerously-bypass-hook-trust`.
- `ContainerSailSetup`: probe greps the codex `hooks.json` for the gate path and heartbeats, so containers provisioned with the bare Stop publisher refresh on next dispatch.
- Tests: `CodexHookConfigTest` mirrors the Claude gate-wiring assertions; `SailStopGateTest` feeds the verbatim captured Codex payloads; `ContainerSailSetupTest` covers the new markers; `StopGateIT` gains a codex lane (real payload shape, `SAIL_AGENT=codex`, retry via `stop_hook_active=true`) sharing the container with the Claude lane. The IT simulates the hook invocation rather than running an authenticated `codex` binary — CI has no OpenAI credentials — with the real-binary flow verified live above.