### PR TITLE
Serialize the SQLite connection; make dropped stops loud and self-healing

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/MissedStops.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MissedStops.java
@@ -18,13 +18,18 @@ import java.util.Set;
  * may hide an agent that died without any stop signal at all (watcher killed by a daemon restart,
  * hook never fired), which only a systemd liveness probe can confirm.
  *
- * <p>A session already covered by an <em>authoritative</em> stop — one carrying a {@code source},
- * i.e. from the watcher or an earlier reconciler pass — is always skipped: either the pipeline
- * consumed it (a failure verdict deliberately leaves the spec {@code in_progress}, and a fix
- * iteration legitimately re-enters {@code in_progress} mid-review), or it is still in flight.
- * Replaying over it would duplicate failure events or spawn a competing review. A raw turn-end hook
- * stop carries no {@code source} and never blocks a replay — losing exactly the authoritative
- * signal is the failure being repaired.
+ * <p>A session covered by an <em>authoritative</em> stop — one carrying a {@code source}, i.e. from
+ * the watcher or an earlier reconciler pass — is skipped only when the pipeline demonstrably ACTED
+ * on it: a failure verdict deliberately leaves the spec {@code in_progress}, and a fix iteration
+ * legitimately re-enters {@code in_progress} mid-review, and replaying over either would duplicate
+ * failure events or spawn a competing review. But "observed" is not "consumed": in the field, a
+ * raced SQLite statement killed the review kickoff after the watcher's stop was recorded, stranding
+ * the spec with a perfectly delivered stop nobody acted on. The caller therefore passes {@link
+ * StopCoverage}: when an authoritative stop exists but no acted-on evidence has appeared since the
+ * session started (no {@code agent_failed}, no review stage activity) and the stop is older than
+ * the grace window, the stop is replayed — the rescue converges, because the replayed stop's
+ * consumption produces exactly the evidence that stops the next sweep from replaying again. A raw
+ * turn-end hook stop carries no {@code source} and never blocks a replay.
  */
 public final class MissedStops {
 
@@ -51,17 +56,41 @@ public final class MissedStops {
   private MissedStops() {}
 
   /**
+   * How the latest session's authoritative stop was handled. {@code observedAt} is the timestamp of
+   * the newest {@code source}-carrying stop recorded since the session started, or null when none
+   * exists. {@code actedOn} is true when the pipeline left evidence of consuming it since the
+   * session started: an {@code agent_failed} verdict or any review stage activity.
+   */
+  public record StopCoverage(Instant observedAt, boolean actedOn) {
+    public static StopCoverage none() {
+      return new StopCoverage(null, false);
+    }
+  }
+
+  /**
    * Assesses the latest session of an {@code in_progress} spec. Callers must pass the spec's most
-   * recent session — superseded sessions from restarts are never replayed — and whether an
-   * authoritative ({@code source}-carrying) stop has been recorded since the session started.
+   * recent session — superseded sessions from restarts are never replayed — and the {@link
+   * StopCoverage} of authoritative stops recorded since the session started.
    *
-   * <p>{@code grace} shields the dispatch launch window: dispatch claims the spec seconds before
-   * the systemd unit exists, so a young running session is never probed, let alone declared dead.
+   * <p>{@code grace} shields two windows: the dispatch launch window (dispatch claims the spec
+   * seconds before the systemd unit exists, so a young running session is never probed) and the
+   * consumption window (a just-observed stop may still be in flight through the review pipeline, so
+   * a rescue replay waits until the stop is older than {@code grace}).
    */
   public static Outcome assess(
-      RunStore.RunRow session, boolean authoritativeStopObserved, Instant now, Duration grace) {
-    if (authoritativeStopObserved) {
-      return new Outcome.Skip("an authoritative stop is already recorded");
+      RunStore.RunRow session, StopCoverage coverage, Instant now, Duration grace) {
+    if (coverage.observedAt() != null) {
+      if (coverage.actedOn()) {
+        return new Outcome.Skip("an authoritative stop was recorded and acted on");
+      }
+      if (!TERMINAL.contains(session.status())) {
+        return new Outcome.Skip("stop observed but session status is " + session.status());
+      }
+      if (Duration.between(coverage.observedAt(), now).compareTo(grace) < 0) {
+        return new Outcome.Skip("an authoritative stop is still in flight");
+      }
+      return new Outcome.ReplayStop(
+          session.exitCode(), "authoritative stop was recorded but never acted on");
     }
     if (TERMINAL.contains(session.status())) {
       return new Outcome.ReplayStop(session.exitCode(), "finished session never advanced its spec");

--- a/sail-core/src/main/java/ai/singlr/sail/store/Sqlite.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/Sqlite.java
@@ -16,12 +16,21 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 /**
  * Thin Panama FFI wrapper over the system {@code libsqlite3.so.0}. Opens a database with WAL mode,
- * foreign keys enabled, and a 5-second busy timeout. Thread-safe via SQLite's serialized mode
- * (default).
+ * foreign keys enabled, and a 5-second busy timeout.
+ *
+ * <p>Thread-safe at the LOGICAL level, not just the C level: a connection-wide reentrant lock
+ * serializes every statement and every whole transaction scope. SQLite's serialized mode ({@code
+ * FULLMUTEX}) only protects individual C calls — it happily interleaves two threads' {@code BEGIN}s
+ * on one connection, so a server whose event-bus subscribers and request threads share this object
+ * would sporadically die with {@code cannot start a transaction within a transaction} (surfacing as
+ * a scrambled {@code sqlite3_errmsg} like "another row available"), which is exactly how the review
+ * pipeline silently lost agent stops in the field. The lock is reentrant so statements inside a
+ * {@link #transaction} body nest without deadlock.
  *
  * <p>Not a JDBC driver. Exposes exactly the surface Sail needs: execute, query, and transactions.
  */
@@ -40,6 +49,7 @@ public final class Sqlite implements AutoCloseable {
   private final Arena arena;
   private final MemorySegment db;
   private final SqliteLib lib;
+  private final ReentrantLock lock = new ReentrantLock();
   private volatile boolean closed;
 
   private Sqlite(Arena arena, MemorySegment db, SqliteLib lib) {
@@ -89,6 +99,7 @@ public final class Sqlite implements AutoCloseable {
 
   public void execute(String sql, Object... params) {
     requireOpen();
+    lock.lock();
     try (var stmtArena = Arena.ofConfined()) {
       var stmt = prepare(stmtArena, sql);
       try {
@@ -104,11 +115,14 @@ public final class Sqlite implements AutoCloseable {
       throw e;
     } catch (Throwable t) {
       throw new SqliteException("Execute failed: " + sql, t);
+    } finally {
+      lock.unlock();
     }
   }
 
   public <T> List<T> query(String sql, RowMapper<T> mapper, Object... params) {
     requireOpen();
+    lock.lock();
     try (var stmtArena = Arena.ofConfined()) {
       var stmt = prepare(stmtArena, sql);
       try {
@@ -129,6 +143,8 @@ public final class Sqlite implements AutoCloseable {
       throw e;
     } catch (Throwable t) {
       throw new SqliteException("Query failed: " + sql, t);
+    } finally {
+      lock.unlock();
     }
   }
 
@@ -161,27 +177,40 @@ public final class Sqlite implements AutoCloseable {
   }
 
   private <T> T transaction(String begin, Supplier<T> work) {
-    execute(begin);
+    lock.lock();
     try {
-      var result = work.get();
-      execute("COMMIT");
-      return result;
-    } catch (Exception e) {
+      execute(begin);
       try {
-        execute("ROLLBACK");
-      } catch (Exception rollbackEx) {
-        e.addSuppressed(rollbackEx);
+        var result = work.get();
+        execute("COMMIT");
+        return result;
+      } catch (Exception e) {
+        try {
+          execute("ROLLBACK");
+        } catch (Exception rollbackEx) {
+          e.addSuppressed(rollbackEx);
+        }
+        throw e;
       }
-      throw e;
+    } finally {
+      lock.unlock();
     }
   }
 
+  /**
+   * The rows changed by the most recent statement on this connection. Only meaningful for the
+   * caller's own last statement when invoked inside a {@link #transaction} scope, which holds the
+   * connection lock across both calls; outside one, another thread's write may intervene.
+   */
   public int changes() {
     requireOpen();
+    lock.lock();
     try {
       return (int) lib.changes.invokeExact(db);
     } catch (Throwable t) {
       throw new SqliteException("Failed to get changes", t);
+    } finally {
+      lock.unlock();
     }
   }
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/MissedStopsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/MissedStopsTest.java
@@ -38,7 +38,16 @@ class MissedStopsTest {
   }
 
   private static MissedStops.Outcome assess(RunStore.RunRow session, boolean observed) {
-    return MissedStops.assess(session, observed, NOW, GRACE);
+    var coverage =
+        observed
+            ? new MissedStops.StopCoverage(NOW.minus(GRACE).minusSeconds(1), true)
+            : MissedStops.StopCoverage.none();
+    return MissedStops.assess(session, coverage, NOW, GRACE);
+  }
+
+  private static MissedStops.Outcome assessDropped(
+      RunStore.RunRow session, java.time.Instant observedAt) {
+    return MissedStops.assess(session, new MissedStops.StopCoverage(observedAt, false), NOW, GRACE);
   }
 
   @Test
@@ -73,6 +82,44 @@ class MissedStopsTest {
   @Test
   void anAuthoritativeStopAlreadyRecordedSkipsARunningSession() {
     var outcome = assess(session("running", null, "2026-07-06T11:00:00Z"), true);
+
+    assertInstanceOf(MissedStops.Outcome.Skip.class, outcome);
+  }
+
+  @Test
+  void anObservedButUnactedStopOlderThanGraceIsReplayedWithItsExitCode() {
+    var outcome =
+        assessDropped(
+            session("stopped", 0, "2026-07-06T11:00:00Z"), NOW.minus(GRACE).minusSeconds(1));
+
+    var replay = assertInstanceOf(MissedStops.Outcome.ReplayStop.class, outcome);
+    assertEquals(0, replay.exitCode());
+    assertEquals("authoritative stop was recorded but never acted on", replay.why());
+  }
+
+  @Test
+  void anObservedButUnactedFailureStopReplaysTheFailureExitCode() {
+    var outcome =
+        assessDropped(
+            session("stopped", 137, "2026-07-06T11:00:00Z"), NOW.minus(GRACE).minusSeconds(1));
+
+    var replay = assertInstanceOf(MissedStops.Outcome.ReplayStop.class, outcome);
+    assertEquals(137, replay.exitCode());
+  }
+
+  @Test
+  void anObservedButUnactedStopStillInsideGraceStaysInFlight() {
+    var outcome =
+        assessDropped(session("stopped", 0, "2026-07-06T11:00:00Z"), NOW.minusSeconds(30));
+
+    assertInstanceOf(MissedStops.Outcome.Skip.class, outcome);
+  }
+
+  @Test
+  void anObservedUnactedStopOnANonTerminalSessionIsNeverReplayed() {
+    var outcome =
+        assessDropped(
+            session("running", null, "2026-07-06T11:00:00Z"), NOW.minus(GRACE).minusSeconds(1));
 
     assertInstanceOf(MissedStops.Outcome.Skip.class, outcome);
   }

--- a/sail-core/src/test/java/ai/singlr/sail/store/SqliteTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SqliteTest.java
@@ -220,4 +220,44 @@ class SqliteTest {
     assertTrue(result.isPresent());
     assertEquals("persistent", result.get());
   }
+
+  @Test
+  void concurrentTransactionsOnOneConnectionNeverInterleave() throws Exception {
+    db.execute("CREATE TABLE counter (id INTEGER PRIMARY KEY, n INTEGER NOT NULL)");
+    db.execute("INSERT INTO counter VALUES (1, 0)");
+    var threads = 8;
+    var iterations = 25;
+    var start = new java.util.concurrent.CountDownLatch(1);
+
+    try (var executor = java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor()) {
+      var futures = new java.util.ArrayList<java.util.concurrent.Future<?>>();
+      for (var t = 0; t < threads; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  start.await();
+                  for (var i = 0; i < iterations; i++) {
+                    db.immediateTransaction(
+                        () -> {
+                          var n =
+                              db.queryOne(
+                                      "SELECT n FROM counter WHERE id = 1", row -> row.integer(0))
+                                  .orElseThrow();
+                          db.execute("UPDATE counter SET n = ? WHERE id = 1", n + 1);
+                          return null;
+                        });
+                    db.query("SELECT n FROM counter", row -> row.integer(0));
+                  }
+                  return null;
+                }));
+      }
+      start.countDown();
+      for (var future : futures) {
+        future.get(2, java.util.concurrent.TimeUnit.MINUTES);
+      }
+    }
+
+    var total = db.queryOne("SELECT n FROM counter WHERE id = 1", row -> row.integer(0));
+    assertEquals((long) threads * iterations, (long) total.orElseThrow());
+  }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -16,6 +16,7 @@ import ai.singlr.sail.store.SpecStore;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.function.Supplier;
 
 /**
@@ -158,8 +159,8 @@ public final class MissedStopReconciler implements AutoCloseable {
       return false;
     }
     var session = latest.get();
-    var observed = authoritativeStopObserved(spec.id(), session.startedAt());
-    var outcome = MissedStops.assess(session, observed, clock.get(), LAUNCH_GRACE);
+    var coverage = stopCoverage(spec.id(), session.startedAt());
+    var outcome = MissedStops.assess(session, coverage, clock.get(), LAUNCH_GRACE);
     return switch (outcome) {
       case MissedStops.Outcome.ReplayStop replay -> {
         publishStop(spec, session, replay.exitCode(), replay.why());
@@ -177,15 +178,42 @@ public final class MissedStopReconciler implements AutoCloseable {
   }
 
   /**
-   * Whether an authoritative ({@code source}-carrying) stop for this spec has been recorded since
-   * the session started. Such a stop means the watcher (or an earlier pass) already covered this
-   * session; replaying over it would duplicate its outcome. Unreadable rows count as covering — the
-   * sweep must prefer doing nothing over acting on data it cannot interpret.
+   * The {@link MissedStops.StopCoverage} of this session: when an authoritative ({@code
+   * source}-carrying) stop was recorded since the session started, and whether the pipeline left
+   * evidence of acting on it — an {@code agent_failed} verdict or review stage activity since the
+   * same instant. Observed-but-unacted is the field failure this rescues: a raced statement killed
+   * the review kickoff after the watcher's stop landed, and the old observed-means-covered check
+   * made every later sweep skip the stranded spec. Unreadable stop rows count as covering and
+   * in-flight (timestamp {@code MAX}) — the sweep prefers doing nothing over acting on data it
+   * cannot interpret.
    */
-  private boolean authoritativeStopObserved(String specId, String startedAt) {
+  private MissedStops.StopCoverage stopCoverage(String specId, String startedAt) {
     var since = MissedStops.parseOr(startedAt, Instant.MIN);
-    return eventStore.forSpecAndType(specId, Event.WellKnownTypes.AGENT_SESSION_STOPPED).stream()
-        .anyMatch(row -> carriesSource(row) && !timestampOf(row).isBefore(since));
+    var observedAt =
+        eventStore.forSpecAndType(specId, Event.WellKnownTypes.AGENT_SESSION_STOPPED).stream()
+            .filter(row -> carriesSource(row) && !timestampOf(row).isBefore(since))
+            .map(MissedStopReconciler::timestampOf)
+            .max(Instant::compareTo)
+            .orElse(null);
+    if (observedAt == null) {
+      return MissedStops.StopCoverage.none();
+    }
+    return new MissedStops.StopCoverage(observedAt, actedOnSince(specId, since));
+  }
+
+  private static final List<String> ACTED_ON_EVIDENCE =
+      List.of(
+          Event.WellKnownTypes.AGENT_FAILED,
+          "review_stage_started",
+          "review_stage_failed",
+          "review_escalated");
+
+  private boolean actedOnSince(String specId, Instant since) {
+    return ACTED_ON_EVIDENCE.stream()
+        .anyMatch(
+            type ->
+                eventStore.forSpecAndType(specId, type).stream()
+                    .anyMatch(row -> !timestampOf(row).isBefore(since)));
   }
 
   private static boolean carriesSource(EventStore.EventRow row) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -155,6 +156,26 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
               + event.spec()
               + ": "
               + e.getMessage());
+      publishPipelineError(event, e);
+    }
+  }
+
+  /**
+   * A failure in this handler used to be one journal line and a silently stranded spec — the review
+   * never started and nothing downstream noticed (the field incident: a raced SQLite statement
+   * killed the kickoff twice in one week). Publish it loudly so Slack shows the failure, and rely
+   * on {@link MissedStopReconciler}'s rescue replay to retry the kickoff on the next sweep.
+   * Publishing must never mask the original failure.
+   */
+  private void publishPipelineError(Event event, Exception failure) {
+    try {
+      publishEvent(
+          event.project(),
+          event.spec(),
+          "review_pipeline_error",
+          Objects.toString(failure.getMessage(), failure.getClass().getSimpleName()));
+    } catch (RuntimeException e) {
+      System.err.println("review-pipeline: could not publish pipeline error: " + e.getMessage());
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SlackMessage.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SlackMessage.java
@@ -39,6 +39,11 @@ final class SlackMessage {
       case "review_stage_failed" ->
           "Review stage failed: " + detailOr(event, "review") + findingsSuffix(event) + ".";
       case "review_completed" -> "Review passed. Awaiting merge.";
+      case "review_pipeline_error" ->
+          "Review pipeline hit an internal error ("
+              + detailOr(event, "unknown error")
+              + ") — the reconciler retries on its next sweep; if this recurs, check the server"
+              + " journal.";
       case "review_errored" -> "Review errored: " + detailOr(event, "unknown error");
       case "review_iteration_started" -> "Fix iteration started.";
       case "review_escalated" ->

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SlackReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SlackReactor.java
@@ -46,6 +46,7 @@ public final class SlackReactor implements EventSubscriber {
           "review_stage_failed",
           "review_completed",
           "review_errored",
+          "review_pipeline_error",
           "review_iteration_started",
           "review_escalated");
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -150,6 +150,12 @@ class MissedStopReconcilerTest {
         "1-foreign");
   }
 
+  private void recordEvent(String specId, String type, String timestamp) {
+    eventStore.insert(
+        new EventStore.EventRow(
+            0, timestamp, type, "test-project", specId, "claude-code", HostInfo.hostname(), "{}"));
+  }
+
   private void recordStopEvent(String specId, String timestamp, Map<String, Object> data) {
     eventStore.insert(
         new EventStore.EventRow(
@@ -394,6 +400,74 @@ class MissedStopReconcilerTest {
     var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
 
     assertEquals(0, replayed);
+  }
+
+  @Test
+  void aDroppedAuthoritativeStopIsRescuedOnceItsGraceExpires() {
+    createInProgressSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    recordStopEvent(
+        "auth",
+        Instant.now().plusSeconds(1).toString(),
+        Map.of(
+            Event.WellKnownData.EXIT_CODE,
+            0,
+            Event.WellKnownData.SOURCE,
+            Event.WellKnownData.SOURCE_WATCHER));
+
+    var replayed = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+
+    assertEquals(1, replayed);
+  }
+
+  @Test
+  void aDroppedStopAlreadyActedOnIsNeverRescued() {
+    createInProgressSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    recordStopEvent(
+        "auth",
+        Instant.now().plusSeconds(1).toString(),
+        Map.of(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_WATCHER));
+    recordEvent("auth", "review_stage_started", Instant.now().plusSeconds(2).toString());
+
+    var replayed = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+
+    assertEquals(0, replayed);
+  }
+
+  @Test
+  void aDroppedFailureStopWithItsVerdictPublishedIsNeverRescued() {
+    createInProgressSpec("auth");
+    finishedSession("auth", "stopped", 137);
+    recordStopEvent(
+        "auth",
+        Instant.now().plusSeconds(1).toString(),
+        Map.of(
+            Event.WellKnownData.EXIT_CODE,
+            137,
+            Event.WellKnownData.SOURCE,
+            Event.WellKnownData.SOURCE_WATCHER));
+    recordEvent("auth", Event.WellKnownTypes.AGENT_FAILED, Instant.now().plusSeconds(2).toString());
+
+    var replayed = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+
+    assertEquals(0, replayed);
+  }
+
+  @Test
+  void evidenceFromBeforeTheSessionNeverCountsAsActedOn() {
+    createInProgressSpec("auth");
+    recordEvent(
+        "auth", "review_stage_started", Instant.now().minus(Duration.ofHours(2)).toString());
+    finishedSession("auth", "stopped", 0);
+    recordStopEvent(
+        "auth",
+        Instant.now().plusSeconds(1).toString(),
+        Map.of(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_WATCHER));
+
+    var replayed = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+
+    assertEquals(1, replayed);
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -770,6 +770,44 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
+  void aHandlerFailurePublishesALoudPipelineErrorEvent() throws Exception {
+    createSpec("auth", "in_progress");
+    try (var bus = new EventBus()) {
+      var events = new java.util.concurrent.CopyOnWriteArrayList<Event>();
+      var latch = new CountDownLatch(1);
+      bus.subscribe(
+          BusTesting.latching(
+              new EventSubscriber() {
+                @Override
+                public String name() {
+                  return "capture";
+                }
+
+                @Override
+                public java.util.function.Predicate<Event> filter() {
+                  return e -> "review_pipeline_error".equals(e.type());
+                }
+
+                @Override
+                public void onEvent(Event event) {
+                  events.add(event);
+                }
+              },
+              latch));
+      var ctrl =
+          controller(p -> singleAgentStage("no_critical"), p -> "codex", (p, a, pr) -> "[]", bus);
+      db.close();
+
+      ctrl.onEvent(agentStoppedEvent("auth"));
+      BusTesting.awaitDelivery(latch);
+
+      assertEquals(1, events.size());
+      assertEquals("auth", events.getFirst().spec());
+      assertTrue(events.getFirst().data().get("detail").toString().contains("closed"));
+    }
+  }
+
+  @Test
   void aRunningReviewIsNotRestartedByADuplicateEvent() {
     createSpec("auth", "in_progress");
     var reviewId = reviewStore.createReview("auth", 1);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SlackMessageTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SlackMessageTest.java
@@ -268,6 +268,18 @@ class SlackMessageTest {
   }
 
   @Test
+  void reviewPipelineErrorIsLoudAndCarriesTheCause() {
+    var text =
+        SlackMessage.forEvent(
+            event("review_pipeline_error", Map.of("detail", "another row available")), null);
+
+    assertEquals(
+        "Review pipeline hit an internal error (another row available) — the reconciler retries"
+            + " on its next sweep; if this recurs, check the server journal.",
+        text);
+  }
+
+  @Test
   void fixIterationStarted() {
     var text = SlackMessage.forEvent(event("review_iteration_started"), null);
 


### PR DESCRIPTION
Field incident (twice in one week, `sail-dispatch-restart-api` and `mast-redispatch`): agent stops cleanly, watcher publishes the authoritative stop, Slack announces it — and then silence. The spec strands `in_progress`, no review ever starts. Journal: `review-pipeline: failed to process agent_session_stopped … another row available (sqlite error 1)`.

**Root cause**: the server shares one SQLite connection across 14 stores, all HTTP request threads, and every event-bus subscriber (each with its own drain thread). `SQLITE_OPEN_FULLMUTEX` serializes individual C calls but not logical scopes — on a stop event, `RunTracker`'s transaction and the review controller's work interleave, one thread's `BEGIN` lands inside another's open transaction → `SQLITE_ERROR(1)`, with `sqlite3_errmsg` scrambled by the concurrent statement (hence "another row available"). The controller's catch reduced it to one journal line; the reconciler then skipped the spec forever because an authoritative stop had been *observed* — nobody checked it was *consumed*.

**Three layers, one story:**
1. **`Sqlite`** — a connection-wide `ReentrantLock` held for every statement and across whole transaction scopes (reentrant, so nested statements in a transaction body are fine). The class javadoc now states the real thread-safety story instead of claiming serialized mode was enough. New test hammers one connection with 8 threads × read-modify-write transactions; it fails without the lock, passes with it.
2. **`ReviewPipelineController`** — a handler failure also publishes `review_pipeline_error` (Slack: *"Review pipeline hit an internal error (…) — the reconciler retries on its next sweep"*). Behavior test closes the DB under the controller and asserts the event reaches the bus with the cause.
3. **`MissedStops`/`MissedStopReconciler`** — *observed is not consumed*. Coverage now carries the stop timestamp plus acted-on evidence (`agent_failed` or review-stage activity since the session started). A dropped stop is replayed once its grace (2m) expires; the replay's consumption produces exactly the evidence that stops the next sweep — it converges, and deliberate in_progress states (failure verdicts awaiting human action, fix iterations) are untouched because they always leave evidence. Test matrix covers rescue, acted-on skip, failure-verdict skip, pre-session evidence ignored, in-flight grace.

With all three: the race is gone; if anything like it ever recurs, Slack says so within seconds and the loop heals itself within one reconciler sweep.