### PR TITLE
Scope the stop gate's readiness checks to the spec's repos

### DIFF
--- a/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
@@ -112,7 +112,7 @@ public final class AgentSession {
   public void writeSession(
       String containerName, String task, String branch, String specId, String agentType)
       throws IOException, InterruptedException, TimeoutException {
-    writeSession(containerName, task, branch, specId, agentType, "", AgentUnit.BUILD);
+    writeSession(containerName, task, branch, specId, agentType, "", List.of(), AgentUnit.BUILD);
   }
 
   /**
@@ -128,7 +128,24 @@ public final class AgentSession {
       String agentType,
       String runId)
       throws IOException, InterruptedException, TimeoutException {
-    writeSession(containerName, task, branch, specId, agentType, runId, AgentUnit.BUILD);
+    writeSession(containerName, task, branch, specId, agentType, runId, List.of(), AgentUnit.BUILD);
+  }
+
+  /**
+   * Writes session metadata carrying the run id and the spec's resolved repos, so the stop gate can
+   * scope its readiness checks to exactly the repos this dispatch works in rather than every repo
+   * in the shared container.
+   */
+  public void writeSession(
+      String containerName,
+      String task,
+      String branch,
+      String specId,
+      String agentType,
+      String runId,
+      List<String> repos)
+      throws IOException, InterruptedException, TimeoutException {
+    writeSession(containerName, task, branch, specId, agentType, runId, repos, AgentUnit.BUILD);
   }
 
   /** Writes session metadata for the given role's unit (its own session file and log path). */
@@ -139,6 +156,7 @@ public final class AgentSession {
       String specId,
       String agentType,
       String runId,
+      List<String> repos,
       AgentUnit unit)
       throws IOException, InterruptedException, TimeoutException {
     var map = new LinkedHashMap<String, Object>();
@@ -147,6 +165,7 @@ public final class AgentSession {
     map.put("spec_id", Objects.requireNonNullElse(specId, ""));
     map.put("agent_type", Objects.requireNonNullElse(agentType, ""));
     map.put("run_id", Objects.requireNonNullElse(runId, ""));
+    map.put("repos", Objects.requireNonNullElse(repos, List.<String>of()));
     map.put("started_at", Instant.now().toString());
     map.put("log_path", unit.logPath());
     var json = YamlUtil.dumpJson(map);

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/SailStopGate.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/SailStopGate.java
@@ -21,6 +21,12 @@ import java.util.concurrent.TimeoutException;
  * sessions load no settings file at all, and ad-hoc {@code sail agent start} or engineer sessions
  * carry no run id, so all of them keep the old publish-and-allow behavior.
  *
+ * <p>The dirty/unpushed/PR checks are scoped to the run's spec repos — read from {@code repos} in
+ * {@code ~/.sail/agent-session.json}, which dispatch stamps with the spec's resolved repos. A repo
+ * the spec does not target (left dirty by a previous dispatch in the shared container) never nudges
+ * this run. When the session lists no repos — an older session file or a non-dispatch launch —
+ * every workspace repo is checked, the prior behavior.
+ *
  * <p>The gate blocks at most once per run — the first block drops a marker file under {@code
  * ~/.sail/runs/&lt;runId&gt;/} — so the agent keeps its contractual right to stop-and-report
  * failure: the second stop always wins. It fails open on every unexpected condition (unparseable
@@ -60,6 +66,7 @@ public final class SailStopGate {
       EVENT_HELPER="$SAIL_HOME/.sail/bin/sail-event.sh"
       WORKSPACE="$SAIL_HOME/workspace"
       RUNS_DIR="$SAIL_HOME/.sail/runs"
+      SESSION="$SAIL_HOME/.sail/agent-session.json"
 
       publish() {
         if [ -x "$EVENT_HELPER" ]; then
@@ -93,6 +100,21 @@ public final class SailStopGate {
       MARKER="$RUNS_DIR/$RUN_ID/stop-nudged"
       [ ! -f "$MARKER" ] || allow
 
+      REPOS="$(python3 -c '
+      import json, sys
+      try:
+          repos = json.load(open(sys.argv[1])).get("repos") or []
+      except Exception:
+          sys.exit(0)
+      for r in repos:
+          print(r)
+      ' "$SESSION" 2>/dev/null || true)"
+
+      in_scope() {
+        [ -n "$REPOS" ] || return 0
+        printf '%s\n' "$REPOS" | grep -qxF "$1"
+      }
+
       REASONS=""
       note() {
         if [ -n "$REASONS" ]; then
@@ -105,6 +127,7 @@ public final class SailStopGate {
       for repo_dir in "$WORKSPACE"/*/; do
         [ -e "$repo_dir.git" ] || continue
         repo="$(basename "$repo_dir")"
+        in_scope "$repo" || continue
         dirty="$(git -C "$repo_dir" status --porcelain 2>/dev/null || true)"
         [ -z "$dirty" ] || note "commit your work in $repo (the worktree is dirty)"
         branch="$(git -C "$repo_dir" symbolic-ref --short -q HEAD 2>/dev/null || true)"

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
@@ -797,4 +797,17 @@ class AgentSessionTest {
     assertTrue(cmd.contains("v1-sync-commit-integrity"));
     assertTrue(cmd.contains("claude-code"));
   }
+
+  @Test
+  void writeSessionPersistsTheSpecReposForStopGateScoping() throws Exception {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
+    var session = new AgentSession(shell);
+
+    session.writeSession(
+        "acme", "task", "branch", "spec-1", "claude-code", "run-1", List.of("manatee-nexus"));
+
+    var cmd = shell.invocations().getFirst();
+    assertTrue(cmd.contains("repos"), "session must persist repos for stop-gate scoping");
+    assertTrue(cmd.contains("manatee-nexus"), cmd);
+  }
 }

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/SailStopGateTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/SailStopGateTest.java
@@ -323,6 +323,42 @@ class SailStopGateTest {
     assertThrows(Exception.class, () -> gate.install("../bad"));
   }
 
+  @Test
+  void aDirtyRepoOutsideTheSpecReposIsNotNudged() throws Exception {
+    pushToFreshOrigin(repo("manatee-nexus"), "main");
+    var other = repo("manatee-assessments");
+    Files.writeString(other.resolve("wip.txt"), "leftover from another run");
+    writeSessionRepos(List.of("manatee-nexus"));
+
+    var result = runGate(STOP_INPUT, RUN_ID);
+
+    assertEquals("", result.stdout(), "a repo outside the spec's repos must not block the stop");
+    assertEquals(List.of("agent_session_stopped"), events());
+  }
+
+  @Test
+  void aDirtySpecRepoStillBlocksWhenScoped() throws Exception {
+    var target = repo("manatee-nexus");
+    Files.writeString(target.resolve("wip.txt"), "uncommitted");
+    repo("manatee-assessments");
+    writeSessionRepos(List.of("manatee-nexus"));
+
+    var reason = blockReason(runGate(STOP_INPUT, RUN_ID));
+
+    assertTrue(reason.contains("commit your work in manatee-nexus"), reason);
+    assertFalse(reason.contains("manatee-assessments"), reason);
+  }
+
+  private void writeSessionRepos(List<String> repos) throws IOException {
+    var session = home.resolve(".sail/agent-session.json");
+    Files.createDirectories(session.getParent());
+    var quoted = repos.stream().map(r -> "\"" + r + "\"").toList();
+    Files.writeString(
+        session,
+        "{\"spec_id\": \"s\", \"repos\": [" + String.join(", ", quoted) + "]}",
+        StandardCharsets.UTF_8);
+  }
+
   private String blockReason(GateResult result) {
     var block = YamlUtil.parseMap(result.stdout());
     assertEquals("block", block.get("decision"), result.stdout());

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -523,7 +523,13 @@ public final class DispatchOperations {
       session.resetLog(project, AgentUnit.REVIEW);
       session.writeTaskFile(project, task);
       session.writeSession(
-          project, task, Objects.requireNonNullElse(branch, ""), spec.id(), agentType, runId);
+          project,
+          task,
+          Objects.requireNonNullElse(branch, ""),
+          spec.id(),
+          agentType,
+          runId,
+          targetRepos.stream().map(SailYaml.Repo::path).toList());
       var agentCli = AgentCli.fromYamlName(agentType);
       var workDir = AgentSession.launchWorkDir(config.sshUser(), targetRepos);
       var command =


### PR DESCRIPTION
Reported from the field: a dispatched agent for `nexus-accounts-record` (repo `manatee-nexus`) was nudged to commit `manatee-assessments` and `manatee-client-web` too — repos its spec has nothing to do with, left dirty by earlier dispatches in the same shared container. A safety guardrail telling an agent to commit work that isn't its own is worse than no guardrail.

Fix: dispatch stamps the spec's resolved repos into `~/.sail/agent-session.json`; the gate reads them and scopes its dirty/unpushed/PR checks to exactly those repos. A session that lists no repos — an older file or a non-dispatch launch — keeps the prior check-everything behavior, so nothing regresses for existing containers until they refresh.

TDD: the two new gate tests (`aDirtyRepoOutsideTheSpecReposIsNotNudged`, `aDirtySpecRepoStillBlocksWhenScoped`) fail against the old script and pass with the scoping; a session-write test pins that dispatch persists the repos.