### PR TITLE
Sync the review pipeline's status transitions to main immediately

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -55,6 +55,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
   private final Function<String, String> reviewerResolver;
   private final ReviewAgentRunner agentRunner;
   private final EventBus eventBus;
+  private final Runnable syncTrigger;
   private final ConcurrentHashMap<String, CompletableFuture<Void>> inFlight =
       new ConcurrentHashMap<>();
   private final ExecutorService pipelineExecutor;
@@ -70,7 +71,8 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       Function<String, ReviewPipelineConfig> configResolver,
       Function<String, String> reviewerResolver,
       ReviewAgentRunner agentRunner,
-      EventBus eventBus) {
+      EventBus eventBus,
+      Runnable syncTrigger) {
     this(
         specStore,
         reviewStore,
@@ -78,6 +80,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
         reviewerResolver,
         agentRunner,
         eventBus,
+        syncTrigger,
         Executors.newVirtualThreadPerTaskExecutor());
   }
 
@@ -86,6 +89,12 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
    * event-bus drain is never blocked; tests pass a same-thread executor so a pipeline runs to
    * completion synchronously within {@link #onEvent} — no latch, no completion race, deterministic
    * coverage.
+   *
+   * <p>{@code syncTrigger} is fired after every spec status transition the pipeline makes, so the
+   * loop's own state changes (review, awaiting_merge, fix-iteration in_progress) propagate to main
+   * immediately through the same sync-on-write seam manual edits use — main is the notification
+   * authority and must see the loop advance without waiting for a periodic sync. On main and
+   * standalone boxes it is a no-op.
    */
   ReviewPipelineController(
       SpecStore specStore,
@@ -94,6 +103,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       Function<String, String> reviewerResolver,
       ReviewAgentRunner agentRunner,
       EventBus eventBus,
+      Runnable syncTrigger,
       ExecutorService pipelineExecutor) {
     this.specStore = specStore;
     this.reviewStore = reviewStore;
@@ -101,7 +111,14 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     this.reviewerResolver = reviewerResolver;
     this.agentRunner = agentRunner;
     this.eventBus = eventBus;
+    this.syncTrigger = Objects.requireNonNull(syncTrigger, "syncTrigger");
     this.pipelineExecutor = pipelineExecutor;
+  }
+
+  /** Sets a spec's status and immediately signals sync so the transition reaches main. */
+  private void advanceSpec(String specId, SpecStatus status) {
+    specStore.updateStatus(specId, status);
+    syncTrigger.run();
   }
 
   /**
@@ -194,7 +211,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       return;
     }
 
-    specStore.updateStatus(specId, SpecStatus.REVIEW);
+    advanceSpec(specId, SpecStatus.REVIEW);
 
     var config = configResolver.apply(event.project());
     if (config == null || config.stages().isEmpty()) return;
@@ -268,7 +285,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       }
 
       reviewStore.updateReviewStatus(reviewId, "passed");
-      specStore.updateStatus(specId, SpecStatus.AWAITING_MERGE);
+      advanceSpec(specId, SpecStatus.AWAITING_MERGE);
       publishEvent(project, specId, "review_completed", null);
 
     } catch (Exception e) {
@@ -394,7 +411,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
    * maxIterations} is reached.
    */
   private void reReview(ReviewPipelineConfig config, String project, String specId, int iteration) {
-    specStore.updateStatus(specId, SpecStatus.REVIEW);
+    advanceSpec(specId, SpecStatus.REVIEW);
     var reviewId = createReviewWithStages(config, specId, iteration);
     executePipeline(reviewId, config, project, specId);
   }
@@ -404,7 +421,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     if (spec.isEmpty()) return;
 
     var fixTask = FixTaskBuilder.build(spec.get().title(), findings);
-    specStore.updateStatus(specId, SpecStatus.IN_PROGRESS);
+    advanceSpec(specId, SpecStatus.IN_PROGRESS);
     publishEvent(project, specId, "review_iteration_started", null);
 
     try {
@@ -418,7 +435,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
 
   private void escalate(String project, String specId, String reviewId) {
     reviewStore.updateReviewStatus(reviewId, "escalated");
-    specStore.updateStatus(specId, SpecStatus.REVIEW);
+    advanceSpec(specId, SpecStatus.REVIEW);
     publishEvent(project, specId, "review_escalated", null);
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewWiring.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewWiring.java
@@ -35,14 +35,16 @@ public final class ReviewWiring {
       ReviewStore reviewStore,
       EventBus eventBus,
       Function<String, SailYaml> projectLoader,
-      ShellExec shell) {
+      ShellExec shell,
+      Runnable syncTrigger) {
     return new ReviewPipelineController(
         specStore,
         reviewStore,
         configResolver(projectLoader),
         reviewerResolver(projectLoader),
         new ContainerReviewAgentRunner(shell),
-        eventBus);
+        eventBus,
+        syncTrigger);
   }
 
   /** Resolves a project's review pipeline: its configured one, or the mandatory default. */

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -198,7 +198,8 @@ public final class ServerStartCommand implements Runnable {
             reviewStore,
             bus,
             ServerStartCommand::loadProjectYaml,
-            new ShellExecutor(false));
+            new ShellExecutor(false),
+            syncScheduler::afterWrite);
     bus.subscribe(new RunTracker(runStore, syncScheduler, NodeIdentity::handle));
     bus.subscribe(SlackReactor.withDefaults(new SlackThreadStore(db), specStore));
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiCoverageEdgesTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiCoverageEdgesTest.java
@@ -143,7 +143,8 @@ class ApiCoverageEdgesTest {
         var db = Sqlite.open(tmp.resolve("control.db"))) {
       new SchemaManager(db).migrate();
       var controller =
-          ReviewWiring.controller(new SpecStore(db), new ReviewStore(db), bus, p -> null, null);
+          ReviewWiring.controller(
+              new SpecStore(db), new ReviewStore(db), bus, p -> null, null, () -> {});
       try (var server =
           new SailApiServer(
               "127.0.0.1",

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -218,6 +218,7 @@ class MissedStopReconcilerTest {
             p -> "codex",
             (p, a, pr) -> "[]",
             bus,
+            () -> {},
             new DirectExecutorService());
     bus.subscribe(BusTesting.latching(controller, latch));
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopIT.java
@@ -152,6 +152,7 @@ class ReviewAgentLoopIT extends AbstractIncusIT {
               p -> "codex",
               new ContainerReviewAgentRunner(shell),
               null,
+              () -> {},
               new DirectExecutorService());
 
       controller.onEvent(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopTest.java
@@ -114,6 +114,7 @@ class ReviewAgentLoopTest {
             p -> "codex",
             new ContainerReviewAgentRunner(agentShell),
             bus,
+            () -> {},
             new DirectExecutorService());
     bus.subscribe(BusTesting.latching(controller, latch));
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewLoopIntegrationTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewLoopIntegrationTest.java
@@ -124,6 +124,7 @@ class ReviewLoopIntegrationTest {
             p -> "codex",
             runner,
             bus,
+            () -> {},
             new DirectExecutorService());
     bus.subscribe(BusTesting.latching(controller, latch));
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -189,7 +189,35 @@ class ReviewPipelineControllerTest {
       ReviewAgentRunner runner,
       EventBus bus) {
     return new ReviewPipelineController(
-        specStore, reviewStore, config, reviewer, runner, bus, new DirectExecutorService());
+        specStore,
+        reviewStore,
+        config,
+        reviewer,
+        runner,
+        bus,
+        () -> {},
+        new DirectExecutorService());
+  }
+
+  @Test
+  void advancingASpecTriggersSyncSoTheTransitionReachesMain() {
+    createSpec("auth", "in_progress");
+    var syncs = new java.util.concurrent.atomic.AtomicInteger();
+    var ctrl =
+        new ReviewPipelineController(
+            specStore,
+            reviewStore,
+            p -> singleAgentStage("no_critical"),
+            p -> "codex",
+            (p, a, pr) -> "[]",
+            null,
+            syncs::incrementAndGet,
+            new DirectExecutorService());
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
+    assertTrue(syncs.get() > 0, "a spec status transition must trigger sync-on-write to main");
   }
 
   @Test
@@ -837,7 +865,8 @@ class ReviewPipelineControllerTest {
             p -> singleAgentStage("no_critical"),
             p -> "codex",
             gated,
-            null);
+            null,
+            () -> {});
 
     ctrl.onEvent(agentStoppedEvent("auth"));
     assertTrue(started.await(5, TimeUnit.SECONDS), "pipeline should reach the agent runner");
@@ -897,6 +926,7 @@ class ReviewPipelineControllerTest {
             p -> "codex",
             (p, a, pr) -> "[]",
             null,
+            () -> {},
             new DirectExecutorService());
     errDb.close();
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewWiringTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewWiringTest.java
@@ -83,7 +83,7 @@ class ReviewWiringTest {
 
   @Test
   void controllerFactoryAssemblesAReviewPipelineController() {
-    try (var controller = ReviewWiring.controller(null, null, null, p -> null, null)) {
+    try (var controller = ReviewWiring.controller(null, null, null, p -> null, null, () -> {})) {
       assertNotNull(controller);
       assertEquals("review-pipeline", controller.name());
     }


### PR DESCRIPTION
Part of making main the single notification authority (state-derived): main can only narrate the loop from *synced state*, so every loop transition must reach main promptly.

Found while auditing sync-on-write completeness: manual spec mutations (create/update/approve) and dispatch all trigger `syncScheduler.afterWrite()` through the operations seam, but `ReviewPipelineController` called `specStore.updateStatus(...)` directly with no sync trigger. So the loop's own transitions — `review`, `awaiting_merge`, fix-iteration `in_progress`, escalation — only propagated on the next periodic sync, not immediately. That's the same DRY smell that bit the CLI/API lanes: a second code path writing status its own way.

Fix: one `advanceSpec(specId, status)` helper does the write and signals sync; the controller takes a `Runnable syncTrigger` (`ServerStartCommand` passes `syncScheduler::afterWrite`, a no-op on main/standalone). TDD: a counting trigger asserts a transition signals sync.