### PR TITLE
Bricks 2+3: main narrates the loop from synced state; Slack goes main-only

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
@@ -29,6 +29,7 @@ public final class SyncRpcServer {
   private final Map<String, MainReplica> replicas;
   private final SyncPrincipal principal;
   private final FdeRoster fdeRoster;
+  private final SyncTransitionSink transitionSink;
 
   public SyncRpcServer(MainReplica main, boolean writable) {
     this(Map.of("spec", main), new SyncPrincipal(null, writable), FdeRoster.EMPTY);
@@ -40,9 +41,18 @@ public final class SyncRpcServer {
 
   public SyncRpcServer(
       Map<String, MainReplica> replicas, SyncPrincipal principal, FdeRoster fdeRoster) {
+    this(replicas, principal, fdeRoster, SyncTransitionSink.NONE);
+  }
+
+  public SyncRpcServer(
+      Map<String, MainReplica> replicas,
+      SyncPrincipal principal,
+      FdeRoster fdeRoster,
+      SyncTransitionSink transitionSink) {
     this.replicas = Map.copyOf(replicas);
     this.principal = Objects.requireNonNull(principal, "principal");
     this.fdeRoster = Objects.requireNonNull(fdeRoster, "fdeRoster");
+    this.transitionSink = Objects.requireNonNull(transitionSink, "transitionSink");
   }
 
   public void serve(Reader in, Writer out) throws IOException {
@@ -120,11 +130,33 @@ public final class SyncRpcServer {
               + principal.handle()
               + "'s.");
     }
+    var before = main.current(commit.entityId());
     return switch (main.commit(commit.entityId(), commit.snapshot(), commit.expectedRev())) {
-      case CommitOutcome.Accepted accepted -> new SyncWire.Committed(accepted.rev(), main.maxSeq());
+      case CommitOutcome.Accepted accepted -> {
+        emitTransitions(commit, before, main);
+        yield new SyncWire.Committed(accepted.rev(), main.maxSeq());
+      }
       case CommitOutcome.Rejected rejected ->
           new SyncWire.Rejected(rejected.currentRev(), rejected.currentSnapshot());
     };
+  }
+
+  /**
+   * Hands each real transition of an accepted commit to the sink. Shielded: the commit is already
+   * durable, so a sink failure must degrade to a logged warning — letting it propagate would return
+   * {@link SyncWire.Failed} for a change main actually applied and make the node retry it forever.
+   */
+  private void emitTransitions(
+      SyncWire.Commit commit, Map<String, Object> before, MainReplica main) {
+    try {
+      var after = main.current(commit.entityId());
+      for (var transition :
+          SyncTransitions.detect(commit.entityType(), commit.entityId(), before, after)) {
+        transitionSink.onTransition(transition);
+      }
+    } catch (RuntimeException e) {
+      System.err.println("  [sync] transition notification failed; the sync is unaffected: " + e);
+    }
   }
 
   /**

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncTransition.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncTransition.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * One real state transition observed while committing a node's push on main: an entity's {@code
+ * status} moved from {@code from} to {@code to}. Detected by {@link SyncTransitions} from the
+ * before/after comparable snapshots around a {@link MainReplica#commit}, so a re-applied identical
+ * revision produces none. {@code snapshot} is the committed after-state (for a {@code review_stage}
+ * transition, the stage's map augmented with the review's {@code spec_id}), giving a consumer
+ * everything it needs to narrate the transition without re-reading the store.
+ *
+ * @param entityType {@code spec}, {@code run}, {@code review}, or {@code review_stage}
+ * @param entityId the entity's id ({@code review_stage} carries the stage's id)
+ * @param from the prior status, or {@code null} when the entity is new to main
+ * @param to the committed status
+ * @param snapshot the committed after-state the transition was read from
+ */
+public record SyncTransition(
+    String entityType, String entityId, String from, String to, Map<String, Object> snapshot) {
+
+  public SyncTransition {
+    Objects.requireNonNull(entityType, "entityType");
+    Objects.requireNonNull(entityId, "entityId");
+    Objects.requireNonNull(to, "to");
+    Objects.requireNonNull(snapshot, "snapshot");
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncTransitionSink.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncTransitionSink.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+/**
+ * Receives each {@link SyncTransition} the {@link SyncRpcServer} detects while committing a node's
+ * push. The server invokes the sink after the commit succeeds and shields the session from any sink
+ * failure, so an implementation may do best-effort side work (main publishes lifecycle events to
+ * its local sail-api) without ever affecting the sync itself.
+ */
+@FunctionalInterface
+public interface SyncTransitionSink {
+
+  /** A sink that ignores every transition — the default for callers that do not narrate. */
+  SyncTransitionSink NONE = transition -> {};
+
+  void onTransition(SyncTransition transition);
+}

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncTransitions.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncTransitions.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Pure detection of real state transitions between two comparable snapshots of a synced entity.
+ * Compares only what narration cares about — the {@code status} of a spec, run, or review, and for
+ * the review aggregate each stage's status — so a re-applied identical revision, a timestamp churn,
+ * or a metadata-only edit yields nothing. A deletion (null after-state) also yields nothing: a
+ * tombstone has no lifecycle to narrate. No I/O and no store access; the {@link SyncRpcServer}
+ * feeds it the snapshots it already holds around a commit.
+ */
+public final class SyncTransitions {
+
+  private SyncTransitions() {}
+
+  public static List<SyncTransition> detect(
+      String entityType, String entityId, Map<String, Object> before, Map<String, Object> after) {
+    if (after == null) {
+      return List.of();
+    }
+    return switch (entityType) {
+      case "spec", "run" -> statusChange(entityType, entityId, before, after);
+      case "review" -> reviewChanges(entityId, before, after);
+      default -> List.of();
+    };
+  }
+
+  private static List<SyncTransition> statusChange(
+      String entityType, String entityId, Map<String, Object> before, Map<String, Object> after) {
+    var from = status(before);
+    var to = status(after);
+    if (to == null || Objects.equals(from, to)) {
+      return List.of();
+    }
+    return List.of(new SyncTransition(entityType, entityId, from, to, after));
+  }
+
+  /**
+   * The review is an aggregate: its own status transition plus one per stage whose status moved.
+   * Stages are matched by id between the two snapshots; a stage new to main transitions from {@code
+   * null}, so a debounce-coalesced push (created + started in one commit) still narrates. Each
+   * stage transition's snapshot is the stage map plus the review's {@code spec_id}, the key a
+   * consumer needs to address the spec the stage belongs to.
+   */
+  private static List<SyncTransition> reviewChanges(
+      String reviewId, Map<String, Object> before, Map<String, Object> after) {
+    var transitions = new ArrayList<>(statusChange("review", reviewId, before, after));
+    var previous = new LinkedHashMap<String, Map<String, Object>>();
+    for (var stage : stagesOf(before)) {
+      previous.put(stageKey(stage), stage);
+    }
+    for (var stage : stagesOf(after)) {
+      var from = status(previous.get(stageKey(stage)));
+      var to = status(stage);
+      if (to == null || Objects.equals(from, to)) {
+        continue;
+      }
+      var context = new LinkedHashMap<>(stage);
+      context.put("spec_id", after.get("spec_id"));
+      transitions.add(new SyncTransition("review_stage", stageKey(stage), from, to, context));
+    }
+    return List.copyOf(transitions);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Map<String, Object>> stagesOf(Map<String, Object> aggregate) {
+    if (aggregate == null || !(aggregate.get("stages") instanceof List<?> raw)) {
+      return List.of();
+    }
+    return raw.stream()
+        .filter(entry -> entry instanceof Map)
+        .map(entry -> (Map<String, Object>) entry)
+        .toList();
+  }
+
+  private static String stageKey(Map<String, Object> stage) {
+    var id = stage.get("id");
+    return Objects.toString(id, Objects.toString(stage.get("name"), ""));
+  }
+
+  private static String status(Map<String, Object> snapshot) {
+    return snapshot == null ? null : Objects.toString(snapshot.get("status"), null);
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
@@ -165,6 +165,99 @@ class SyncRpcServerTest {
   }
 
   @Test
+  void anAcceptedCommitHandsItsTransitionsToTheSink() throws Exception {
+    var main =
+        new FakeMain() {
+          private Map<String, Object> committed;
+
+          @Override
+          public Map<String, Object> current(String entityId) {
+            return committed;
+          }
+
+          @Override
+          public CommitOutcome commit(
+              String entityId, Map<String, Object> snapshot, String expectedRev) {
+            committed = snapshot;
+            return new CommitOutcome.Accepted("1-x");
+          }
+        };
+    var seen = new java.util.ArrayList<SyncTransition>();
+    var out = new StringWriter();
+    var commit = new SyncWire.Commit("spec", "auth", Map.of("status", "in_progress"), null);
+
+    new SyncRpcServer(
+            Map.of("spec", main), new SyncPrincipal(null, true), FdeRoster.EMPTY, seen::add)
+        .serve(new StringReader(SyncWire.encode(commit) + "\n"), out);
+
+    assertInstanceOf(SyncWire.Committed.class, SyncWire.decodeResponse(out.toString().strip()));
+    assertEquals(1, seen.size());
+    assertEquals("in_progress", seen.getFirst().to());
+  }
+
+  @Test
+  void aRejectedCommitNeverReachesTheSink() throws Exception {
+    var main =
+        new FakeMain() {
+          @Override
+          public CommitOutcome commit(
+              String entityId, Map<String, Object> snapshot, String expectedRev) {
+            return new CommitOutcome.Rejected("2-y", Map.of("status", "review"));
+          }
+        };
+    var seen = new java.util.ArrayList<SyncTransition>();
+    var out = new StringWriter();
+    var commit = new SyncWire.Commit("spec", "auth", Map.of("status", "in_progress"), "1-x");
+
+    new SyncRpcServer(
+            Map.of("spec", main), new SyncPrincipal(null, true), FdeRoster.EMPTY, seen::add)
+        .serve(new StringReader(SyncWire.encode(commit) + "\n"), out);
+
+    assertInstanceOf(SyncWire.Rejected.class, SyncWire.decodeResponse(out.toString().strip()));
+    assertTrue(seen.isEmpty());
+  }
+
+  @Test
+  void aThrowingSinkNeverFailsTheCommittedReply() throws Exception {
+    var main =
+        new FakeMain() {
+          private Map<String, Object> committed;
+
+          @Override
+          public Map<String, Object> current(String entityId) {
+            return committed;
+          }
+
+          @Override
+          public CommitOutcome commit(
+              String entityId, Map<String, Object> snapshot, String expectedRev) {
+            committed = snapshot;
+            return new CommitOutcome.Accepted("1-x");
+          }
+        };
+    var out = new StringWriter();
+    var commit = new SyncWire.Commit("spec", "auth", Map.of("status", "in_progress"), null);
+    var captured = new ByteArrayOutputStream();
+    var originalErr = System.err;
+    System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+    try {
+      new SyncRpcServer(
+              Map.of("spec", main),
+              new SyncPrincipal(null, true),
+              FdeRoster.EMPTY,
+              transition -> {
+                throw new IllegalStateException("slack is down");
+              })
+          .serve(new StringReader(SyncWire.encode(commit) + "\n"), out);
+    } finally {
+      System.setErr(originalErr);
+    }
+
+    assertInstanceOf(SyncWire.Committed.class, SyncWire.decodeResponse(out.toString().strip()));
+    assertTrue(captured.toString(StandardCharsets.UTF_8).contains("slack is down"));
+  }
+
+  @Test
   void fetchFdesReturnsTheInjectedRoster() throws Exception {
     var roster = List.<Map<String, Object>>of(Map.of("handle", "ada", "role", "admin"));
     var out = new StringWriter();

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncTransitionsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncTransitionsTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Pure transition detection: only a real status move between two snapshots yields anything. */
+class SyncTransitionsTest {
+
+  private static Map<String, Object> spec(String status) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("project", "proj");
+    map.put("status", status);
+    map.put("branch", "feat/auth");
+    return map;
+  }
+
+  @Test
+  void aSpecMovingFromPendingToInProgressEmitsOneDispatchTransition() {
+    var emitted = SyncTransitions.detect("spec", "auth", spec("pending"), spec("in_progress"));
+
+    assertEquals(1, emitted.size());
+    var transition = emitted.getFirst();
+    assertEquals("spec", transition.entityType());
+    assertEquals("auth", transition.entityId());
+    assertEquals("pending", transition.from());
+    assertEquals("in_progress", transition.to());
+    assertEquals("feat/auth", transition.snapshot().get("branch"));
+  }
+
+  @Test
+  void anIdenticalReApplyEmitsNothing() {
+    assertTrue(SyncTransitions.detect("spec", "auth", spec("review"), spec("review")).isEmpty());
+  }
+
+  @Test
+  void aBrandNewEntityTransitionsFromNull() {
+    var emitted = SyncTransitions.detect("spec", "auth", null, spec("in_progress"));
+
+    assertEquals(1, emitted.size());
+    assertNull(emitted.getFirst().from());
+    assertEquals("in_progress", emitted.getFirst().to());
+  }
+
+  @Test
+  void aDeletionEmitsNothing() {
+    assertTrue(SyncTransitions.detect("spec", "auth", spec("pending"), null).isEmpty());
+  }
+
+  @Test
+  void aStatuslessSnapshotEmitsNothing() {
+    assertTrue(SyncTransitions.detect("spec", "auth", spec("pending"), Map.of()).isEmpty());
+  }
+
+  @Test
+  void anUnknownEntityTypeEmitsNothing() {
+    assertTrue(SyncTransitions.detect("file", "f1", null, Map.of("status", "changed")).isEmpty());
+  }
+
+  @Test
+  void aRunCompletingEmitsAnAgentStoppedTransition() {
+    var running = Map.<String, Object>of("project", "proj", "status", "running");
+    var completed =
+        Map.<String, Object>of("project", "proj", "status", "completed", "exit_code", 0);
+
+    var emitted = SyncTransitions.detect("run", "r1", running, completed);
+
+    assertEquals(1, emitted.size());
+    assertEquals("running", emitted.getFirst().from());
+    assertEquals("completed", emitted.getFirst().to());
+    assertEquals(0, emitted.getFirst().snapshot().get("exit_code"));
+  }
+
+  @SafeVarargs
+  private static Map<String, Object> review(String status, Map<String, Object>... stages) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("spec_id", "auth");
+    map.put("iteration", 1);
+    map.put("status", status);
+    map.put("stages", List.of(stages));
+    return map;
+  }
+
+  private static Map<String, Object> stage(String id, String status, Map<String, Object> counts) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("id", id);
+    map.put("name", "quality-gate");
+    map.put("status", status);
+    map.put("finding_counts", counts);
+    return map;
+  }
+
+  @Test
+  void aStageFlippingToFailedCarriesItsCountsAndSpecId() {
+    var before = review("running", stage("s1", "running", Map.of()));
+    var after = review("running", stage("s1", "failed", Map.of("HIGH", 2, "MEDIUM", 2)));
+
+    var emitted = SyncTransitions.detect("review", "rev1", before, after);
+
+    assertEquals(1, emitted.size());
+    var transition = emitted.getFirst();
+    assertEquals("review_stage", transition.entityType());
+    assertEquals("s1", transition.entityId());
+    assertEquals("running", transition.from());
+    assertEquals("failed", transition.to());
+    assertEquals("auth", transition.snapshot().get("spec_id"));
+    assertEquals(Map.of("HIGH", 2, "MEDIUM", 2), transition.snapshot().get("finding_counts"));
+  }
+
+  @Test
+  void aCoalescedNewReviewEmitsTheReviewAndEachStartedStage() {
+    var after = review("running", stage("s1", "running", Map.of()));
+
+    var emitted = SyncTransitions.detect("review", "rev1", null, after);
+
+    assertEquals(2, emitted.size());
+    assertEquals("review", emitted.get(0).entityType());
+    assertNull(emitted.get(0).from());
+    assertEquals("running", emitted.get(0).to());
+    assertEquals("review_stage", emitted.get(1).entityType());
+    assertNull(emitted.get(1).from());
+    assertEquals("running", emitted.get(1).to());
+  }
+
+  @Test
+  void aReviewPassingEmitsOnlyTheReviewTransitionWhenStagesAreUnchanged() {
+    var passedStage = stage("s1", "passed", Map.of());
+    var emitted =
+        SyncTransitions.detect(
+            "review", "rev1", review("running", passedStage), review("passed", passedStage));
+
+    assertEquals(1, emitted.size());
+    assertEquals("review", emitted.getFirst().entityType());
+    assertEquals("passed", emitted.getFirst().to());
+  }
+
+  @Test
+  void aSupersededFlagAloneEmitsNothing() {
+    var before = review("escalated", stage("s1", "failed", Map.of("HIGH", 1)));
+    var after = review("escalated", stage("s1", "failed", Map.of("HIGH", 1)));
+    after.put("superseded_at", "2026-07-13T00:00:00Z");
+
+    assertTrue(SyncTransitions.detect("review", "rev1", before, after).isEmpty());
+  }
+
+  @Test
+  void anIdWithoutAStageIdFallsBackToTheStageName() {
+    var nameless = new LinkedHashMap<String, Object>(Map.of("name", "gate", "status", "running"));
+    var after = review("running", nameless);
+
+    var emitted = SyncTransitions.detect("review", "rev1", review("running"), after);
+
+    assertEquals(1, emitted.size());
+    assertEquals("gate", emitted.getFirst().entityId());
+  }
+
+  @Test
+  void malformedStagesAreIgnored() {
+    var after = new LinkedHashMap<String, Object>();
+    after.put("spec_id", "auth");
+    after.put("status", "running");
+    after.put("stages", List.of("not-a-map"));
+
+    var emitted = SyncTransitions.detect("review", "rev1", null, after);
+
+    assertEquals(1, emitted.size());
+    assertEquals("review", emitted.getFirst().entityType());
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
@@ -111,6 +111,14 @@ public record Event(
      */
     public static final String SOURCE_RECONCILE = "reconcile";
 
+    /**
+     * {@link #SOURCE} value: an event main derived from a node's synced state transition. Carried
+     * on every sync-derived event so main-side narration (Slack) treats it as authoritative while
+     * the execution-side reactors — the review pipeline, webhooks the origin node already sent —
+     * leave it alone; the work it describes lives on another box.
+     */
+    public static final String SOURCE_SYNC = "sync";
+
     /** The agent process's exit code, carried on an authoritative stop. */
     public static final String EXIT_CODE = "exit_code";
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -475,10 +475,14 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
    * Whether this stop is the real termination, not a mid-run turn-end. The in-container agent hook
    * fires {@code Stop} when a turn ends — before the process exits and with no exit code — so the
    * controller waits for the watcher's poll-derived stop (which carries a {@code source}) rather
-   * than reviewing on a turn boundary, or on a crash the hook can't report an exit code for.
+   * than reviewing on a turn boundary, or on a crash the hook can't report an exit code for. A
+   * sync-derived stop is narration, not execution: it describes an agent that ran on another box,
+   * whose own controller drives the review there — kicking a pipeline here would review the wrong
+   * box's checkout.
    */
   private static boolean isAuthoritative(Event event) {
-    return event.data().get(Event.WellKnownData.SOURCE) != null;
+    var source = event.data().get(Event.WellKnownData.SOURCE);
+    return source != null && !Event.WellKnownData.SOURCE_SYNC.equals(source);
   }
 
   private static Integer exitCodeOf(Event event) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SyncTransitionEvents.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SyncTransitionEvents.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.sync.SyncTransition;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Pure mapping from a node's synced state transition to the lifecycle events main narrates from —
+ * the state-derived replacement for the events the node's own bus fired. Each mapped event carries
+ * {@code data.source = "sync"} so consumers can tell narration input from local execution: the
+ * Slack reactor treats a sync-sourced stop as authoritative, while the review pipeline and webhook
+ * reactors skip it (the executing node owns that work). No I/O; the two lookups resolve a review's
+ * spec to its project and a spec's latest review status from main's already-synced stores.
+ *
+ * <p>The message vocabulary is exactly today's: a dispatch roots the thread, a restart posts the
+ * same re-dispatch pair the node used to, review stages carry their finding counts, and a non-zero
+ * exit follows the stop with the same {@code agent_failed} detail.
+ */
+public final class SyncTransitionEvents {
+
+  private static final String IN_PROGRESS = "in_progress";
+  private static final Set<String> TERMINAL_RUN_STATUSES = Set.of("completed", "stopped", "failed");
+  private static final List<String> SEVERITY_ORDER = List.of("critical", "high", "medium", "low");
+
+  private SyncTransitionEvents() {}
+
+  public static List<Event> eventsFor(
+      SyncTransition transition,
+      Function<String, String> projectOfSpec,
+      Function<String, String> latestReviewStatusOfSpec,
+      String host) {
+    return switch (transition.entityType()) {
+      case "spec" -> specEvents(transition, latestReviewStatusOfSpec, host);
+      case "run" -> runEvents(transition, host);
+      case "review" -> reviewEvents(transition, projectOfSpec, host);
+      case "review_stage" -> stageEvents(transition, projectOfSpec, host);
+      default -> List.of();
+    };
+  }
+
+  /**
+   * Only the move into {@code in_progress} narrates from the spec itself: from {@code pending} it
+   * is the dispatch that roots the thread; from {@code review} with a failed (non-escalated) latest
+   * review it is the pipeline's fix iteration; from anywhere else it is a restart, which posts the
+   * same re-dispatch + dispatch pair the node published before Slack went main-only. Every other
+   * spec move is narrated by the run or review transition that caused it.
+   */
+  private static List<Event> specEvents(
+      SyncTransition transition, Function<String, String> latestReviewStatusOfSpec, String host) {
+    var project = text(transition.snapshot(), "project");
+    if (!IN_PROGRESS.equals(transition.to()) || project == null) {
+      return List.of();
+    }
+    var from = transition.from();
+    if (from == null || "pending".equals(from)) {
+      return List.of(dispatched(transition, project, host));
+    }
+    if ("review".equals(from)
+        && "failed".equals(latestReviewStatusOfSpec.apply(transition.entityId()))) {
+      return List.of(
+          event(
+              project,
+              transition.entityId(),
+              "review_iteration_started",
+              Event.SAIL_AGENT,
+              host,
+              Map.of()));
+    }
+    var restarted =
+        event(
+            project,
+            transition.entityId(),
+            Event.WellKnownTypes.SPEC_RESTARTED,
+            Event.SAIL_AGENT,
+            host,
+            Map.of("note", "restarted from " + from));
+    return List.of(restarted, dispatched(transition, project, host));
+  }
+
+  private static Event dispatched(SyncTransition transition, String project, String host) {
+    var data = new LinkedHashMap<String, Object>();
+    var branch = text(transition.snapshot(), "branch");
+    if (branch != null) {
+      data.put("branch", branch);
+    }
+    return event(
+        project,
+        transition.entityId(),
+        Event.WellKnownTypes.SPEC_DISPATCHED,
+        Event.SAIL_AGENT,
+        host,
+        data);
+  }
+
+  /**
+   * A run reaching a terminal status is the agent's authoritative stop; a non-zero exit code also
+   * carries today's {@code agent_failed} follow-up. The run id rides along so run-addressed
+   * consumers can correlate — main's own run tracker ignores it, since the run belongs to the
+   * pushing node.
+   */
+  private static List<Event> runEvents(SyncTransition transition, String host) {
+    var project = text(transition.snapshot(), "project");
+    if (project == null || !isTerminal(transition.to()) || isTerminal(transition.from())) {
+      return List.of();
+    }
+    var specId = text(transition.snapshot(), "spec_id");
+    var agent = Objects.requireNonNullElse(text(transition.snapshot(), "agent"), Event.SAIL_AGENT);
+    var data = new LinkedHashMap<String, Object>();
+    data.put(Event.WellKnownData.RUN_ID, transition.entityId());
+    var exitCode = transition.snapshot().get("exit_code") instanceof Number n ? n.intValue() : null;
+    if (exitCode != null) {
+      data.put(Event.WellKnownData.EXIT_CODE, exitCode);
+    }
+    var stopped =
+        event(project, specId, Event.WellKnownTypes.AGENT_SESSION_STOPPED, agent, host, data);
+    if (exitCode == null || exitCode == 0) {
+      return List.of(stopped);
+    }
+    var failed =
+        event(
+            project,
+            specId,
+            Event.WellKnownTypes.AGENT_FAILED,
+            Event.SAIL_AGENT,
+            host,
+            Map.of("detail", "exit " + exitCode));
+    return List.of(stopped, failed);
+  }
+
+  private static boolean isTerminal(String status) {
+    return status != null && TERMINAL_RUN_STATUSES.contains(status);
+  }
+
+  private static List<Event> reviewEvents(
+      SyncTransition transition, Function<String, String> projectOfSpec, String host) {
+    var located = locate(transition, projectOfSpec);
+    if (located == null) {
+      return List.of();
+    }
+    return switch (transition.to()) {
+      case "passed" -> List.of(located.event("review_completed", Map.of(), host));
+      case "escalated" -> List.of(located.event("review_escalated", Map.of(), host));
+      case "failed" -> reviewErrored(transition, located, host);
+      default -> List.of();
+    };
+  }
+
+  /**
+   * A failed review narrates only when it failed by infrastructure error — a gate failure is
+   * already told by its failing stage.
+   */
+  private static List<Event> reviewErrored(
+      SyncTransition transition, Located located, String host) {
+    var error = text(transition.snapshot(), "error");
+    if (error == null) {
+      return List.of();
+    }
+    return List.of(located.event("review_errored", Map.of("detail", error), host));
+  }
+
+  private static List<Event> stageEvents(
+      SyncTransition transition, Function<String, String> projectOfSpec, String host) {
+    var located = locate(transition, projectOfSpec);
+    if (located == null) {
+      return List.of();
+    }
+    var data = new LinkedHashMap<String, Object>();
+    var name = text(transition.snapshot(), "name");
+    if (name != null) {
+      data.put("detail", name);
+    }
+    return switch (transition.to()) {
+      case "running" -> List.of(located.event("review_stage_started", data, host));
+      case "passed", "failed" -> {
+        var findings = findingsData(transition.snapshot());
+        if (!findings.isEmpty()) {
+          data.put("findings", findings);
+        }
+        var type = "passed".equals(transition.to()) ? "review_stage_passed" : "review_stage_failed";
+        yield List.of(located.event(type, data, host));
+      }
+      default -> List.of();
+    };
+  }
+
+  /** A review-side transition addressed to its spec and project, or null when unresolvable. */
+  private record Located(String project, String specId) {
+    Event event(String type, Map<String, Object> data, String host) {
+      return SyncTransitionEvents.event(project, specId, type, Event.SAIL_AGENT, host, data);
+    }
+  }
+
+  private static Located locate(SyncTransition transition, Function<String, String> projectOfSpec) {
+    var specId = text(transition.snapshot(), "spec_id");
+    if (specId == null) {
+      return null;
+    }
+    var project = projectOfSpec.apply(specId);
+    return project == null ? null : new Located(project, specId);
+  }
+
+  /**
+   * The synced counts keyed by severity name, re-shaped to today's event payload: lowercase keys in
+   * severity order, zero and unknown severities omitted.
+   */
+  private static Map<String, Object> findingsData(Map<String, Object> stage) {
+    if (!(stage.get("finding_counts") instanceof Map<?, ?> counts)) {
+      return Map.of();
+    }
+    var data = new LinkedHashMap<String, Object>();
+    for (var severity : SEVERITY_ORDER) {
+      if (counts.get(severity.toUpperCase(Locale.ROOT)) instanceof Number n && n.intValue() > 0) {
+        data.put(severity, n.intValue());
+      }
+    }
+    return data;
+  }
+
+  private static Event event(
+      String project,
+      String spec,
+      String type,
+      String agent,
+      String host,
+      Map<String, Object> data) {
+    var payload = new LinkedHashMap<>(data);
+    payload.put(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_SYNC);
+    return Event.of(project, spec, type, agent, host, payload);
+  }
+
+  private static String text(Map<String, Object> map, String key) {
+    var value = map.get(key);
+    return value == null ? null : value.toString();
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/WebhookReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/WebhookReactor.java
@@ -70,6 +70,9 @@ public final class WebhookReactor implements EventSubscriber {
 
   @Override
   public void onEvent(Event event) {
+    if (isSyncDerived(event)) {
+      return;
+    }
     var notifications = resolver.resolve(event.project());
     if (notifications == null || notifications.url() == null) {
       return;
@@ -84,5 +87,14 @@ public final class WebhookReactor implements EventSubscriber {
 
   private WebhookSender senderFor(String url) {
     return senders.computeIfAbsent(url, senderFactory);
+  }
+
+  /**
+   * A sync-derived event replays a transition another box already executed — and, with this same
+   * webhook configuration in its synced project descriptor, already notified. Sending it again from
+   * main would double every webhook, so narration input stays Slack-only.
+   */
+  private static boolean isSyncDerived(Event event) {
+    return Event.WellKnownData.SOURCE_SYNC.equals(event.data().get(Event.WellKnownData.SOURCE));
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -24,6 +24,7 @@ import ai.singlr.sail.auth.PasskeyService;
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.HostYaml;
 import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.config.SyncConfig;
 import ai.singlr.sail.config.WebauthnConfig;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.BindPolicy;
@@ -201,7 +202,14 @@ public final class ServerStartCommand implements Runnable {
             new ShellExecutor(false),
             syncScheduler::afterWrite);
     bus.subscribe(new RunTracker(runStore, syncScheduler, NodeIdentity::handle));
-    bus.subscribe(SlackReactor.withDefaults(new SlackThreadStore(db), specStore));
+    if (narratesSlack(HostSync.config())) {
+      bus.subscribe(SlackReactor.withDefaults(new SlackThreadStore(db), specStore));
+    } else {
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|faint Slack narration is main's job — this node's work is announced there once"
+                  + " it syncs.|@"));
+    }
 
     var webauthn = resolveWebauthn();
     var configured = webauthn.isConfigured();
@@ -326,6 +334,15 @@ public final class ServerStartCommand implements Runnable {
         new AuthSessionStore(db),
         new PendingChallengeStore(db),
         webauthn.sessionTtl());
+  }
+
+  /**
+   * Whether this box is the single Slack notification authority. Main and a standalone box narrate
+   * their own state; a node never posts — its transitions sync to main, whose {@code _sync} process
+   * turns them into the lifecycle events main's reactor announces. Exactly one notifier per fleet.
+   */
+  static boolean narratesSlack(SyncConfig sync) {
+    return !HostSync.isNode(sync);
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
@@ -6,7 +6,10 @@
 package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.Capability;
+import ai.singlr.sail.api.Event;
 import ai.singlr.sail.api.Role;
+import ai.singlr.sail.api.SailEventPublisher;
+import ai.singlr.sail.api.SyncTransitionEvents;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.engine.HostInfo;
 import ai.singlr.sail.engine.SailPaths;
@@ -30,6 +33,7 @@ import ai.singlr.sail.sync.SpecReplica;
 import ai.singlr.sail.sync.SyncDatabase;
 import ai.singlr.sail.sync.SyncPrincipal;
 import ai.singlr.sail.sync.SyncRpcServer;
+import ai.singlr.sail.sync.SyncTransitionSink;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -72,12 +76,24 @@ public final class SyncServerCommand implements Callable<Integer> {
     try (mainDb) {
       var in = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
       var out = new OutputStreamWriter(System.out, StandardCharsets.UTF_8);
-      return serve(mainDb, host, System.getenv("SAIL_TOKEN"), in, out);
+      return serve(
+          mainDb, host, System.getenv("SAIL_TOKEN"), in, out, transitionBridge(mainDb.db(), host));
     }
   }
 
   static int serve(
       SyncDatabase converged, String mainId, String token, BufferedReader in, Writer out)
+      throws IOException {
+    return serve(converged, mainId, token, in, out, SyncTransitionSink.NONE);
+  }
+
+  static int serve(
+      SyncDatabase converged,
+      String mainId,
+      String token,
+      BufferedReader in,
+      Writer out,
+      SyncTransitionSink transitionSink)
       throws IOException {
     var db = converged.db();
     var changeLog = new ChangeLog(db);
@@ -92,8 +108,54 @@ public final class SyncServerCommand implements Callable<Integer> {
             "run", new RunReplica(mainId, new RunStore(db), changeLog, conflicts, syncState),
             "review",
                 new ReviewReplica(mainId, new ReviewStore(db), changeLog, conflicts, syncState));
-    new SyncRpcServer(replicas, principal(db, token), () -> roster(db)).serve(in, out);
+    new SyncRpcServer(replicas, principal(db, token), () -> roster(db), transitionSink)
+        .serve(in, out);
     return 0;
+  }
+
+  /**
+   * The bridge from a committed transition to main's running server: maps it to today's lifecycle
+   * events and posts each to the local sail-api, where main's bus (and its Slack reactor) picks it
+   * up. This {@code _sync} subprocess shares main's database but not the server's in-process bus,
+   * so the local-socket publisher {@code notifyBoardUpdated} already uses is the one proven path.
+   * Best-effort by contract: a down sail-api costs the narration, never the sync.
+   */
+  static SyncTransitionSink transitionBridge(Sqlite db, String host) {
+    var specs = new SpecStore(db);
+    var reviews = new ReviewStore(db);
+    var publisher = new SailEventPublisher[1];
+    return transition -> {
+      var events =
+          SyncTransitionEvents.eventsFor(
+              transition,
+              specId -> specs.findById(specId).map(SpecStore.SpecRow::project).orElse(null),
+              specId ->
+                  reviews
+                      .latestReviewForSpec(specId)
+                      .map(ReviewStore.ReviewRow::status)
+                      .orElse(null),
+              host);
+      for (var event : events) {
+        publish(publisher, event);
+      }
+    };
+  }
+
+  private static void publish(SailEventPublisher[] publisher, Event event) {
+    try {
+      if (publisher[0] == null) {
+        publisher[0] = SailEventPublisher.localDefault();
+      }
+      publisher[0].publish(event);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    } catch (Exception e) {
+      System.err.println(
+          "  [sync] could not hand "
+              + event.type()
+              + " to the local sail-api; the sync is unaffected: "
+              + e.getMessage());
+    }
   }
 
   static List<Map<String, Object>> roster(Sqlite db) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -221,6 +221,24 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
+  void aSyncDerivedStopNeverStartsAPipelineTheWorkLivesOnAnotherBox() {
+    createSpec("auth", "in_progress");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr) -> "[]");
+
+    ctrl.onEvent(
+        Event.of(
+            "test-project",
+            "auth",
+            Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+            "claude-code",
+            "host",
+            Map.of(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_SYNC)));
+
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    assertTrue(reviewStore.latestReviewForSpec("auth").isEmpty());
+  }
+
+  @Test
   void skipsAnUnknownSpec() {
     var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr) -> "[]");
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SlackFromSyncNarrationTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SlackFromSyncNarrationTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import ai.singlr.sail.config.Notifications;
+import ai.singlr.sail.config.SlackNotifications;
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.SlackPoster;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SlackThreadStore;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import ai.singlr.sail.sync.SyncTransitions;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The Brick 3 acceptance loop end-to-end on main's side: a node's synced state transitions run
+ * through detection and mapping and land on the Slack reactor, which posts today's exact message
+ * copy — one thread root per dispatch, every later step threaded under it, nothing duplicated. The
+ * node needs no Slack configuration anywhere in this test; everything is derived from replicated
+ * state on main.
+ */
+class SlackFromSyncNarrationTest {
+
+  private static final Notifications SLACK_ONLY =
+      new Notifications(null, null, new SlackNotifications("#sail-activity"));
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private RecordingPoster poster;
+  private SlackReactor reactor;
+  private Function<String, String> latestReviewStatus = specId -> null;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    poster = new RecordingPoster();
+    reactor =
+        new SlackReactor(project -> SLACK_ONLY, new SlackThreadStore(db), id -> specRow(), poster);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  private static SpecStore.SpecRow specRow() {
+    return new SpecStore.SpecRow(
+        "auth",
+        "proj",
+        "Add auth",
+        SpecStatus.fromWire("in_progress"),
+        null,
+        "claude-code",
+        null,
+        null,
+        "feat/auth",
+        0,
+        "uday",
+        "",
+        "",
+        "uday",
+        List.of(),
+        List.of());
+  }
+
+  private void sync(
+      String entityType, String id, Map<String, Object> before, Map<String, Object> after) {
+    for (var transition : SyncTransitions.detect(entityType, id, before, after)) {
+      for (var event :
+          SyncTransitionEvents.eventsFor(
+              transition, specId -> "proj", latestReviewStatus, "main")) {
+        reactor.onEvent(event);
+      }
+    }
+  }
+
+  private static Map<String, Object> spec(String status) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("project", "proj");
+    map.put("title", "Add auth");
+    map.put("status", status);
+    map.put("agent", "claude-code");
+    map.put("branch", "feat/auth");
+    return map;
+  }
+
+  private static Map<String, Object> run(String status, Integer exitCode) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("project", "proj");
+    map.put("spec_id", "auth");
+    map.put("agent", "claude-code");
+    map.put("status", status);
+    map.put("exit_code", exitCode);
+    return map;
+  }
+
+  private static Map<String, Object> review(
+      String reviewStatus, String stageStatus, Map<String, Object> counts) {
+    var stage = new LinkedHashMap<String, Object>();
+    stage.put("id", "s1");
+    stage.put("name", "quality-gate");
+    stage.put("status", stageStatus);
+    stage.put("finding_counts", counts);
+    var map = new LinkedHashMap<String, Object>();
+    map.put("spec_id", "auth");
+    map.put("iteration", 1);
+    map.put("status", reviewStatus);
+    map.put("stages", List.of(stage));
+    return map;
+  }
+
+  @Test
+  void theFullLoopNarratesFromSyncedStateWithTodaysCopy() {
+    sync("spec", "auth", spec("pending"), spec("in_progress"));
+    sync("run", "r1", null, run("running", null));
+    sync("run", "r1", run("running", null), run("completed", 0));
+    sync("spec", "auth", spec("in_progress"), spec("review"));
+    sync("review", "rev1", null, review("running", "running", Map.of()));
+    var counts = Map.<String, Object>of("HIGH", 2, "MEDIUM", 2);
+    sync(
+        "review",
+        "rev1",
+        review("running", "running", Map.of()),
+        review("running", "failed", counts));
+    sync("review", "rev1", review("running", "failed", counts), review("failed", "failed", counts));
+    latestReviewStatus = specId -> "failed";
+    sync("spec", "auth", spec("review"), spec("in_progress"));
+    sync("spec", "auth", spec("in_progress"), spec("review"));
+    sync("review", "rev2", null, review("running", "running", Map.of()));
+    sync(
+        "review",
+        "rev2",
+        review("running", "running", Map.of()),
+        review("running", "passed", Map.of()));
+    sync(
+        "review",
+        "rev2",
+        review("running", "passed", Map.of()),
+        review("passed", "passed", Map.of()));
+    sync("spec", "auth", spec("review"), spec("awaiting_merge"));
+
+    var texts = poster.posts.stream().map(SlackPoster.Post::text).toList();
+    assertEquals(
+        List.of(
+            "Dispatched *auth*: Add auth\nproject `proj` · branch `feat/auth` · agent"
+                + " `claude-code`",
+            "Agent claude-code stopped (exit 0).",
+            "Review started: quality-gate.",
+            "Review stage failed: quality-gate (2 high, 2 medium).",
+            "Fix iteration started.",
+            "Review started: quality-gate.",
+            "Review stage passed: quality-gate (no findings).",
+            "Review passed. Awaiting merge."),
+        texts);
+  }
+
+  @Test
+  void theDispatchRootsTheThreadAndEveryLaterStepRepliesInIt() {
+    sync("spec", "auth", spec("pending"), spec("in_progress"));
+    sync("run", "r1", run("running", null), run("completed", 0));
+
+    assertEquals(2, poster.posts.size());
+    assertNull(poster.posts.get(0).threadTs());
+    assertEquals("1.100", poster.posts.get(1).threadTs());
+  }
+
+  @Test
+  void reApplyingTheSameSyncedStateNeverDuplicatesAPost() {
+    sync("spec", "auth", spec("pending"), spec("in_progress"));
+    sync("spec", "auth", spec("in_progress"), spec("in_progress"));
+    sync("run", "r1", run("running", null), run("completed", 0));
+    sync("run", "r1", run("completed", 0), run("completed", 0));
+
+    assertEquals(2, poster.posts.size());
+  }
+
+  @Test
+  void anEscalationBroadcastsTheThreadReply() {
+    sync("spec", "auth", spec("pending"), spec("in_progress"));
+    sync(
+        "review",
+        "rev1",
+        review("failed", "failed", Map.of("HIGH", 1)),
+        review("escalated", "failed", Map.of("HIGH", 1)));
+
+    var reply = poster.posts.getLast();
+    assertEquals(
+        "Escalated: review iterations exhausted. This spec needs a human decision.", reply.text());
+    assertEquals("1.100", reply.threadTs());
+  }
+
+  private static final class RecordingPoster implements SlackPoster {
+    final List<Post> posts = new ArrayList<>();
+
+    @Override
+    public Result post(Post post) {
+      posts.add(post);
+      return new Result("C123", "1.100");
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SyncTransitionEventsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SyncTransitionEventsTest.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.sync.SyncTransition;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The state-to-event vocabulary: every mapped event matches what the node's own bus used to fire,
+ * plus the {@code source=sync} stamp that keeps execution-side reactors away from it.
+ */
+class SyncTransitionEventsTest {
+
+  private static final Function<String, String> PROJECT_OF_SPEC =
+      specId -> "auth".equals(specId) ? "proj" : null;
+  private static final Function<String, String> NO_REVIEW = specId -> null;
+
+  private static List<Event> map(SyncTransition transition) {
+    return map(transition, NO_REVIEW);
+  }
+
+  private static List<Event> map(
+      SyncTransition transition, Function<String, String> latestReviewStatus) {
+    return SyncTransitionEvents.eventsFor(transition, PROJECT_OF_SPEC, latestReviewStatus, "main");
+  }
+
+  private static Map<String, Object> spec(String status) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("project", "proj");
+    map.put("status", status);
+    map.put("branch", "feat/auth");
+    return map;
+  }
+
+  @Test
+  void aPendingToInProgressSpecBecomesTheDispatchRoot() {
+    var events =
+        map(new SyncTransition("spec", "auth", "pending", "in_progress", spec("in_progress")));
+
+    assertEquals(1, events.size());
+    var event = events.getFirst();
+    assertEquals(Event.WellKnownTypes.SPEC_DISPATCHED, event.type());
+    assertEquals("proj", event.project());
+    assertEquals("auth", event.spec());
+    assertEquals("main", event.host());
+    assertEquals("feat/auth", event.data().get("branch"));
+    assertEquals(Event.WellKnownData.SOURCE_SYNC, event.data().get(Event.WellKnownData.SOURCE));
+  }
+
+  @Test
+  void aSpecNewToMainAlreadyInProgressStillDispatches() {
+    var snapshot = spec("in_progress");
+    snapshot.remove("branch");
+
+    var events = map(new SyncTransition("spec", "auth", null, "in_progress", snapshot));
+
+    assertEquals(Event.WellKnownTypes.SPEC_DISPATCHED, events.getFirst().type());
+    assertNull(events.getFirst().data().get("branch"));
+  }
+
+  @Test
+  void aFixIterationIsReadFromReviewToInProgressOverAFailedReview() {
+    var events =
+        map(
+            new SyncTransition("spec", "auth", "review", "in_progress", spec("in_progress")),
+            specId -> "failed");
+
+    assertEquals(1, events.size());
+    assertEquals("review_iteration_started", events.getFirst().type());
+  }
+
+  @Test
+  void aRestartFromAnEscalatedReviewPostsTheReDispatchPair() {
+    var events =
+        map(
+            new SyncTransition("spec", "auth", "review", "in_progress", spec("in_progress")),
+            specId -> "escalated");
+
+    assertEquals(2, events.size());
+    assertEquals(Event.WellKnownTypes.SPEC_RESTARTED, events.get(0).type());
+    assertEquals("restarted from review", events.get(0).data().get("note"));
+    assertEquals(Event.WellKnownTypes.SPEC_DISPATCHED, events.get(1).type());
+  }
+
+  @Test
+  void aRestartFromAwaitingMergePostsTheReDispatchPair() {
+    var events =
+        map(
+            new SyncTransition(
+                "spec", "auth", "awaiting_merge", "in_progress", spec("in_progress")));
+
+    assertEquals(2, events.size());
+    assertEquals("restarted from awaiting_merge", events.get(0).data().get("note"));
+  }
+
+  @Test
+  void aSpecMoveOutOfInProgressIsSilent() {
+    assertTrue(
+        map(new SyncTransition("spec", "auth", "in_progress", "review", spec("review"))).isEmpty());
+  }
+
+  @Test
+  void aProjectlessSpecSnapshotIsSilent() {
+    var snapshot = new LinkedHashMap<String, Object>(Map.of("status", "in_progress"));
+
+    assertTrue(
+        map(new SyncTransition("spec", "auth", "pending", "in_progress", snapshot)).isEmpty());
+  }
+
+  private static Map<String, Object> run(String status, Integer exitCode) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("project", "proj");
+    map.put("spec_id", "auth");
+    map.put("agent", "claude-code");
+    map.put("status", status);
+    map.put("exit_code", exitCode);
+    return map;
+  }
+
+  @Test
+  void aCleanRunCompletionBecomesTheAuthoritativeStop() {
+    var events = map(new SyncTransition("run", "r1", "running", "completed", run("completed", 0)));
+
+    assertEquals(1, events.size());
+    var stop = events.getFirst();
+    assertEquals(Event.WellKnownTypes.AGENT_SESSION_STOPPED, stop.type());
+    assertEquals("claude-code", stop.agent());
+    assertEquals("r1", stop.data().get(Event.WellKnownData.RUN_ID));
+    assertEquals(0, stop.data().get(Event.WellKnownData.EXIT_CODE));
+    assertEquals(Event.WellKnownData.SOURCE_SYNC, stop.data().get(Event.WellKnownData.SOURCE));
+  }
+
+  @Test
+  void aNonZeroExitFollowsTheStopWithAgentFailed() {
+    var events = map(new SyncTransition("run", "r1", "running", "stopped", run("stopped", 2)));
+
+    assertEquals(2, events.size());
+    assertEquals(Event.WellKnownTypes.AGENT_SESSION_STOPPED, events.get(0).type());
+    assertEquals(Event.WellKnownTypes.AGENT_FAILED, events.get(1).type());
+    assertEquals("exit 2", events.get(1).data().get("detail"));
+  }
+
+  @Test
+  void aStopWithoutAnExitCodeOmitsIt() {
+    var snapshot = run("stopped", null);
+    snapshot.remove("agent");
+
+    var events = map(new SyncTransition("run", "r1", null, "stopped", snapshot));
+
+    assertEquals(1, events.size());
+    assertEquals(Event.SAIL_AGENT, events.getFirst().agent());
+    assertNull(events.getFirst().data().get(Event.WellKnownData.EXIT_CODE));
+  }
+
+  @Test
+  void aRunLaunchIsSilent() {
+    assertTrue(
+        map(new SyncTransition("run", "r1", null, "running", run("running", null))).isEmpty());
+  }
+
+  @Test
+  void aTerminalToTerminalRunMoveIsSilent() {
+    assertTrue(
+        map(new SyncTransition("run", "r1", "stopped", "completed", run("completed", 0)))
+            .isEmpty());
+  }
+
+  @Test
+  void aProjectlessRunSnapshotIsSilent() {
+    var snapshot = new LinkedHashMap<String, Object>(Map.of("status", "completed"));
+
+    assertTrue(map(new SyncTransition("run", "r1", "running", "completed", snapshot)).isEmpty());
+  }
+
+  private static Map<String, Object> review(String status, String error) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("spec_id", "auth");
+    map.put("status", status);
+    map.put("error", error);
+    return map;
+  }
+
+  @Test
+  void aPassedReviewBecomesReviewCompleted() {
+    var events =
+        map(new SyncTransition("review", "rev1", "running", "passed", review("passed", null)));
+
+    assertEquals(1, events.size());
+    assertEquals("review_completed", events.getFirst().type());
+    assertEquals("proj", events.getFirst().project());
+    assertEquals("auth", events.getFirst().spec());
+  }
+
+  @Test
+  void anEscalatedReviewBecomesReviewEscalated() {
+    var events =
+        map(new SyncTransition("review", "rev1", "failed", "escalated", review("escalated", null)));
+
+    assertEquals("review_escalated", events.getFirst().type());
+  }
+
+  @Test
+  void anErroredReviewCarriesItsErrorDetail() {
+    var events =
+        map(
+            new SyncTransition(
+                "review",
+                "rev1",
+                "running",
+                "failed",
+                review("failed", "reviewer quota exceeded")));
+
+    assertEquals("review_errored", events.getFirst().type());
+    assertEquals("reviewer quota exceeded", events.getFirst().data().get("detail"));
+  }
+
+  @Test
+  void aGateFailedReviewIsSilentItsStageAlreadyTold() {
+    assertTrue(
+        map(new SyncTransition("review", "rev1", "running", "failed", review("failed", null)))
+            .isEmpty());
+  }
+
+  @Test
+  void aReviewCreationIsSilent() {
+    assertTrue(
+        map(new SyncTransition("review", "rev1", null, "running", review("running", null)))
+            .isEmpty());
+  }
+
+  @Test
+  void aReviewOfAnUnknownSpecIsSilent() {
+    var snapshot = review("passed", null);
+    snapshot.put("spec_id", "ghost");
+
+    assertTrue(map(new SyncTransition("review", "rev1", "running", "passed", snapshot)).isEmpty());
+  }
+
+  @Test
+  void aSpecIdLessReviewIsSilent() {
+    var snapshot = new LinkedHashMap<String, Object>(Map.of("status", "passed"));
+
+    assertTrue(map(new SyncTransition("review", "rev1", "running", "passed", snapshot)).isEmpty());
+  }
+
+  private static Map<String, Object> stage(String status, Map<String, Object> counts) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("spec_id", "auth");
+    map.put("name", "quality-gate");
+    map.put("status", status);
+    map.put("finding_counts", counts);
+    return map;
+  }
+
+  @Test
+  void aStartedStageCarriesItsNameAsDetail() {
+    var events =
+        map(
+            new SyncTransition(
+                "review_stage", "s1", "pending", "running", stage("running", Map.of())));
+
+    assertEquals("review_stage_started", events.getFirst().type());
+    assertEquals("quality-gate", events.getFirst().data().get("detail"));
+  }
+
+  @Test
+  void aFailedStageCarriesLowercaseCountsInSeverityOrder() {
+    var counts = Map.<String, Object>of("MEDIUM", 2, "HIGH", 2, "LOW", 0);
+
+    var events =
+        map(new SyncTransition("review_stage", "s1", "running", "failed", stage("failed", counts)));
+
+    assertEquals("review_stage_failed", events.getFirst().type());
+    var findings = (Map<?, ?>) events.getFirst().data().get("findings");
+    assertEquals(List.of("high", "medium"), List.copyOf(findings.keySet()));
+    assertEquals(2, findings.get("high"));
+  }
+
+  @Test
+  void aPassedStageWithoutFindingsOmitsTheFindingsKey() {
+    var events =
+        map(
+            new SyncTransition(
+                "review_stage", "s1", "running", "passed", stage("passed", Map.of())));
+
+    assertEquals("review_stage_passed", events.getFirst().type());
+    assertNull(events.getFirst().data().get("findings"));
+  }
+
+  @Test
+  void aNamelessCountlessFailedStageOmitsDetailAndFindings() {
+    var snapshot = stage("failed", Map.of());
+    snapshot.remove("name");
+    snapshot.remove("finding_counts");
+
+    var events = map(new SyncTransition("review_stage", "s1", "running", "failed", snapshot));
+
+    assertEquals("review_stage_failed", events.getFirst().type());
+    assertNull(events.getFirst().data().get("detail"));
+    assertNull(events.getFirst().data().get("findings"));
+  }
+
+  @Test
+  void aStageResetToPendingIsSilent() {
+    assertTrue(
+        map(new SyncTransition(
+                "review_stage", "s1", "running", "pending", stage("pending", Map.of())))
+            .isEmpty());
+  }
+
+  @Test
+  void aStageOfAnUnknownSpecIsSilent() {
+    var snapshot = stage("running", Map.of());
+    snapshot.put("spec_id", "ghost");
+
+    assertTrue(
+        map(new SyncTransition("review_stage", "s1", "pending", "running", snapshot)).isEmpty());
+  }
+
+  @Test
+  void anUnknownEntityTypeIsSilent() {
+    assertTrue(
+        map(new SyncTransition("file", "f1", null, "changed", Map.of("status", "changed")))
+            .isEmpty());
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WebhookReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WebhookReactorTest.java
@@ -80,6 +80,25 @@ class WebhookReactorTest {
   }
 
   @Test
+  void onEventSkipsSyncDerivedEventsTheOriginNodeAlreadyNotified() {
+    var calls = new ArrayList<String>();
+    var notifications = new Notifications("https://example.com/wh", List.of("spec_dispatched"));
+    var reactor = new WebhookReactor(project -> notifications, url -> recorder(calls));
+
+    reactor.onEvent(
+        Event.of(
+                "light",
+                "oauth",
+                "spec_dispatched",
+                "sail",
+                "h",
+                Map.of(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_SYNC))
+            .withId(1L));
+
+    assertTrue(calls.isEmpty());
+  }
+
+  @Test
   void onEventFiresForSubscribedType() {
     var calls = new ArrayList<String>();
     var notifications = new Notifications("https://example.com/wh", List.of("spec_dispatched"));

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ServerStartCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ServerStartCommandTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SyncConfig;
+import org.junit.jupiter.api.Test;
+
+/** Exactly one Slack notifier per fleet: main (or a lone box) narrates, a node never does. */
+class ServerStartCommandTest {
+
+  @Test
+  void mainNarratesSlack() {
+    assertTrue(ServerStartCommand.narratesSlack(new SyncConfig("main", null, "uday")));
+  }
+
+  @Test
+  void aStandaloneBoxNarratesItsOwnWork() {
+    assertTrue(ServerStartCommand.narratesSlack(SyncConfig.unset()));
+  }
+
+  @Test
+  void aNodePointedAtMainNeverPosts() {
+    assertFalse(ServerStartCommand.narratesSlack(new SyncConfig("node", "sail@main", "uday")));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SyncServerCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SyncServerCommandTest.java
@@ -26,6 +26,8 @@ import ai.singlr.sail.sync.SpecReplica;
 import ai.singlr.sail.sync.SyncDatabase;
 import ai.singlr.sail.sync.SyncEngine;
 import ai.singlr.sail.sync.SyncSession;
+import ai.singlr.sail.sync.SyncTransition;
+import ai.singlr.sail.sync.SyncTransitionSink;
 import ai.singlr.sail.sync.SyncTransportException;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -114,6 +116,12 @@ class SyncServerCommandTest {
 
   private SyncEngine.Report syncWithToken(String token, String entityType, LocalReplica replica)
       throws Exception {
+    return syncWithToken(token, entityType, replica, SyncTransitionSink.NONE);
+  }
+
+  private SyncEngine.Report syncWithToken(
+      String token, String entityType, LocalReplica replica, SyncTransitionSink sink)
+      throws Exception {
     var toServer = new PipedWriter();
     var serverIn = new BufferedReader(new PipedReader(toServer));
     var toClient = new PipedWriter();
@@ -124,7 +132,7 @@ class SyncServerCommandTest {
             .start(
                 () -> {
                   try {
-                    SyncServerCommand.serve(mainReplicaDb, "main", token, serverIn, toClient);
+                    SyncServerCommand.serve(mainReplicaDb, "main", token, serverIn, toClient, sink);
                   } catch (IOException e) {
                     throw new UncheckedIOException(e);
                   }
@@ -201,6 +209,32 @@ class SyncServerCommandTest {
 
     assertThrows(SyncTransportException.class, () -> syncWithToken(token, "run", nodeRunReplica()));
     assertTrue(new RunStore(mainDb).findById(runId).isEmpty());
+  }
+
+  @Test
+  void aCommittedPushHandsItsTransitionsToTheSink() throws Exception {
+    nodeSpecs.create(spec("auth", "Auth"));
+    nodeSpecs.updateStatus("auth", SpecStatus.fromWire("in_progress"));
+    var seen = new java.util.ArrayList<SyncTransition>();
+
+    syncWithToken(tokenFor("member"), "spec", nodeReplica, seen::add);
+
+    assertEquals(1, seen.size());
+    assertEquals("spec", seen.getFirst().entityType());
+    assertEquals("auth", seen.getFirst().entityId());
+    assertEquals("in_progress", seen.getFirst().to());
+  }
+
+  @Test
+  void aReSyncedUnchangedSpecEmitsNoTransition() throws Exception {
+    nodeSpecs.create(spec("auth", "Auth"));
+    var token = tokenFor("member");
+    syncWithToken(token);
+    var seen = new java.util.ArrayList<SyncTransition>();
+
+    syncWithToken(token, "spec", nodeReplica, seen::add);
+
+    assertTrue(seen.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
Closes out `sail-slack-from-main` (Brick 1 shipped in #151). Main is now the single, state-derived notification authority: a node's dispatch and every subsequent loop event are announced in Slack by main, reconstructed from replicated state — the node needs no Slack configuration.

## Brick 2 — sync-apply fires lifecycle events on main (the bridge)

- **Core, pure**: `SyncTransitions` diffs the before/after comparable snapshots around an accepted `MainReplica.commit` — spec/run status moves, review status moves, and each stage's status with finding counts. Identical re-applies and tombstones emit nothing. `SyncRpcServer` invokes a `SyncTransitionSink` per transition, shielded so a sink failure can never turn a durable commit into a `Failed` reply (which would make the node retry forever).
- **Infra**: `SyncTransitionEvents` (pure, `api`, 100% line+method covered) maps transitions back to today's event vocabulary — `spec_dispatched`, the `spec_restarted` + `spec_dispatched` re-dispatch pair, the authoritative agent stop with exit code and its `agent_failed` follow-up, `review_stage_started/passed/failed` with lowercase severity counts, `review_completed`/`review_escalated`/`review_errored`, and `review_iteration_started` (disambiguated from a restart via main's synced latest-review status). `SyncServerCommand` publishes them from the short-lived `_sync` process to main's running sail-api over the local socket path `notifyBoardUpdated` already proved — best-effort, never failing the sync.
- Every derived event carries `data.source = "sync"`, so narration input is distinguishable from local execution:
  - `ReviewPipelineController` ignores sync-sourced stops — kicking a pipeline on main would review the wrong box's checkout.
  - `WebhookReactor` skips sync-sourced events — the origin node already sent its webhooks; no doubles.

## Brick 3 — Slack main-only (the switch)

- `ServerStartCommand` subscribes `SlackReactor` only when the box is not a node (main or standalone), deleting the per-node Slack path. Exactly one notifier per fleet.
- Copy, thread rooting (dispatch roots, later steps reply in-thread), and the escalation broadcast are unchanged. `SlackFromSyncNarrationTest` drives the full acceptance loop — dispatched → stopped → review → stage failed → fix iteration → stage passed → review passed — from synced snapshots through detection, mapping, and the reactor, asserting today's exact message text, one root, and no duplicates on re-applied state.

## Tests

- Pure detection round-trips (`SyncTransitionsTest`), sink semantics on accepted/rejected/throwing paths (`SyncRpcServerTest`), full mapping vocabulary (`SyncTransitionEventsTest`), a real node→main push handing transitions to the sink over the piped `_sync` session (`SyncServerCommandTest`), reactor guards (`ReviewPipelineControllerTest`, `WebhookReactorTest`), the role gate (`ServerStartCommandTest`), and the end-to-end narration loop (`SlackFromSyncNarrationTest`).
- `mvn clean verify` green locally, including the `ai.singlr.sail.api.*` 100% line/method jacoco gate.