### PR TITLE
Make the review loop resilient to out-of-band status writes

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -152,17 +152,7 @@ public final class MissedStopReconciler implements AutoCloseable {
         }
       }
       for (var spec : specStore.list(REVIEW)) {
-        try {
-          replayed += rescueStrandedReview(spec) ? 1 : 0;
-        } catch (Exception e) {
-          System.err.println(
-              "  [reconcile] review-strand check failed for "
-                  + spec.project()
-                  + "/"
-                  + spec.id()
-                  + ": "
-                  + e.getMessage());
-        }
+        replayed += rescueStrandedReview(spec) ? 1 : 0;
       }
     } catch (Exception e) {
       System.err.println("  [reconcile] missed-stop sweep aborted: " + e.getMessage());

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -17,6 +17,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 /**
@@ -60,6 +62,11 @@ public final class MissedStopReconciler implements AutoCloseable {
   private static final SpecStore.SpecFilter IN_PROGRESS =
       new SpecStore.SpecFilter(null, "in_progress", null, null, null);
 
+  private static final SpecStore.SpecFilter REVIEW =
+      new SpecStore.SpecFilter(null, "review", null, null, null);
+
+  private static final Set<String> TERMINAL_RUN_STATUSES = Set.of("completed", "stopped", "failed");
+
   /** Answers whether a project's agent systemd unit is still active. */
   @FunctionalInterface
   public interface UnitProbe {
@@ -74,6 +81,7 @@ public final class MissedStopReconciler implements AutoCloseable {
   private final Supplier<String> localHandle;
   private final Supplier<Instant> clock;
   private final PeriodicPass pass;
+  private final Set<String> reviewRescueAttempted = ConcurrentHashMap.newKeySet();
 
   public MissedStopReconciler(
       SpecStore specStore,
@@ -143,10 +151,59 @@ public final class MissedStopReconciler implements AutoCloseable {
                   + e.getMessage());
         }
       }
+      for (var spec : specStore.list(REVIEW)) {
+        try {
+          replayed += rescueStrandedReview(spec) ? 1 : 0;
+        } catch (Exception e) {
+          System.err.println(
+              "  [reconcile] review-strand check failed for "
+                  + spec.project()
+                  + "/"
+                  + spec.id()
+                  + ": "
+                  + e.getMessage());
+        }
+      }
     } catch (Exception e) {
       System.err.println("  [reconcile] missed-stop sweep aborted: " + e.getMessage());
     }
     return replayed;
+  }
+
+  /**
+   * Rescues a spec stranded in {@code review} with no review ever started — the shape a dropped
+   * kickoff leaves: an out-of-band status write (a manual edit, or a sync revision from another
+   * box) moved the spec to {@code review} while its agent was still running here, so the
+   * authoritative stop hit the pipeline's guard against a non-{@code in_progress} spec and no
+   * review was created. Replaying the stop lets the review-resilient pipeline kick it off. A {@code
+   * review_stage_started} event means a review did run, so the spec is not stranded; and the rescue
+   * fires at most once per spec per server lifetime, so a project with no automated pipeline (its
+   * {@code review} is a human queue) is never replayed in a loop.
+   */
+  private boolean rescueStrandedReview(SpecStore.SpecRow spec) {
+    if (reviewRescueAttempted.contains(spec.id()) || reviewStarted(spec.id())) {
+      return false;
+    }
+    var node = localHandle.get();
+    var latest =
+        sessionStore.listForSpec(spec.id()).stream()
+            .findFirst()
+            .filter(run -> SailOperations.ownsRun(run.node(), node))
+            .filter(run -> TERMINAL_RUN_STATUSES.contains(run.status()));
+    if (latest.isEmpty()) {
+      return false;
+    }
+    reviewRescueAttempted.add(spec.id());
+    publishStop(
+        spec,
+        latest.get(),
+        latest.get().exitCode(),
+        "stranded in review with no review started; replaying the stop to kick it off");
+    return true;
+  }
+
+  private boolean reviewStarted(String specId) {
+    return !eventStore.forSpecAndType(specId, "review_stage_started").isEmpty();
   }
 
   private boolean reconcile(SpecStore.SpecRow spec) throws Exception {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -201,7 +201,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     var spec = specStore.findById(specId);
     if (spec.isEmpty()) return;
 
-    if (spec.get().status() != SpecStatus.IN_PROGRESS) return;
+    if (!reviewable(spec.get().status())) return;
 
     if (!isAuthoritative(event)) return;
 
@@ -245,6 +245,19 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
             () -> executePipeline(reviewId, config, event.project(), specId), pipelineExecutor);
     inFlight.put(reviewId, future);
     future.whenComplete((v, ex) -> inFlight.remove(reviewId));
+  }
+
+  /**
+   * Whether an authoritative stop for a spec in this status should kick off a review. Both {@code
+   * in_progress} (the normal path) and {@code review} qualify: a spec can be moved to {@code
+   * review} out of band — a manual edit, or a sync revision from another box — while its agent is
+   * still running here, and the old {@code == IN_PROGRESS} guard then dropped the real stop and
+   * stranded the spec in {@code review} with no review ever created. Terminal and pre-dispatch
+   * states ({@code done}, {@code awaiting_merge}, {@code archived}, {@code draft}, {@code pending})
+   * are not reviewable, so their stops are ignored.
+   */
+  private static boolean reviewable(SpecStatus status) {
+    return status == SpecStatus.IN_PROGRESS || status == SpecStatus.REVIEW;
   }
 
   private String createReviewWithStages(ReviewPipelineConfig config, String specId, int iteration) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -252,6 +252,67 @@ class MissedStopReconcilerTest {
   }
 
   @Test
+  void aSpecStrandedInReviewWithNoReviewStartedGetsItsStopReplayed() {
+    createReviewSpec("auth");
+    finishedSession("auth", "stopped", 0);
+
+    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
+
+    assertEquals(1, replayed, "a spec stranded in review with no review must be rescued");
+  }
+
+  @Test
+  void aReviewSpecWhoseReviewActuallyStartedIsNotRescued() {
+    createReviewSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    recordEvent("auth", "review_stage_started", Instant.now().toString());
+
+    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
+
+    assertEquals(0, replayed, "a review that ran is not stranded");
+  }
+
+  @Test
+  void theReviewStrandRescueRunsAtMostOncePerSpec() {
+    createReviewSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    var rec = reconciler(new CountingProbe(true), Instant::now);
+
+    assertEquals(1, rec.sweep());
+    assertEquals(0, rec.sweep(), "an empty-pipeline review must not be replayed forever");
+  }
+
+  @Test
+  void aReviewSpecWithNoOwnedRunIsNotRescued() {
+    createReviewSpec("auth");
+
+    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
+
+    assertEquals(0, replayed, "no run to replay a stop from");
+  }
+
+  private void createReviewSpec(String id) {
+    specStore.create(
+        new SpecStore.SpecRow(
+            id,
+            "test-project",
+            "Test spec",
+            SpecStatus.REVIEW,
+            null,
+            "claude-code",
+            null,
+            null,
+            "feat/test",
+            0,
+            null,
+            "",
+            "",
+            null,
+            List.of(),
+            List.of()));
+  }
+
+  @Test
   void replaysACrashedMissedStopAndLeavesTheSpecInProgress() throws Exception {
     createInProgressSpec("auth");
     finishedSession("auth", "stopped", 137);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -239,6 +239,43 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
+  void anAuthoritativeStopStillKicksOffReviewWhenStatusWasClobberedToReview() {
+    createSpec("auth", "review");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr) -> "[]");
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    var review = reviewStore.latestReviewForSpec("auth");
+    assertTrue(
+        review.isPresent(), "a spec clobbered to review out of band must still get its review");
+    assertEquals("passed", review.get().status());
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void aReviewAlreadyRunningIsNotRestartedWhenStatusIsReview() {
+    createSpec("auth", "review");
+    var reviewId = reviewStore.createReview("auth", 1);
+    reviewStore.updateReviewStatus(reviewId, "running");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr) -> "[]");
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    assertEquals(1, reviewStore.reviewsForSpec("auth").size());
+  }
+
+  @Test
+  void aTerminalSpecStatusIgnoresTheStop() {
+    createSpec("auth", "awaiting_merge");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr) -> "[]");
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    assertTrue(reviewStore.latestReviewForSpec("auth").isEmpty());
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
   void skipsAnUnknownSpec() {
     var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr) -> "[]");
 


### PR DESCRIPTION
Field incident: a dispatched spec finished coding but its review never fired and it sat stranded in `review` with `spec_stranded` firing every 15 minutes. The `change_log` was decisive — a `sync`-sourced revision moved the spec to `review` at 07:16:52 while its agent was still running locally (dispatched `in_progress` at 06:52), and the authoritative watcher stop at 07:27:58 was then dropped by the pipeline's `status != IN_PROGRESS` guard. No review was ever created; the spec dead-ended. This is the recurring 'review didn't fire', and it's the same shape as the `nexus-accounts-record` incident: an out-of-band status write stranding a locally-executing spec.

Per the agreed philosophy — allow the status write, make the loop recover — three parts:

1. **Resilient kickoff.** `ReviewPipelineController` now kicks off a review for a spec that is `in_progress` **or** `review` (a `reviewable(status)` guard), so a clobber can't drop the real stop. The 'no pipeline configured → advance to review for human review' behavior is preserved (verified against its tests; an over-eager reorder that broke it was reverted).
2. **No new dead-end.** `advanceSpec(REVIEW)` stays where the human-review path needs it; the resilient guard is what closes the strand.
3. **Reconciler self-heal.** A new sweep rescues specs **already** stranded in `review` (pre-fix, or when the stop never comes): a `review`-status spec with no `review_stage_started` event and a terminal owned run gets its stop replayed, bounded to one attempt per spec per server lifetime so an empty-pipeline (human) review queue is never looped.

TDD throughout: clobbered-to-review still gets its review, terminal/pre-dispatch statuses ignore the stop, running-review not restarted, empty-config human review preserved; reconciler rescues a review-strand once, skips one that actually started, skips with no owned run. Full `mvn clean verify` green incl. the 100% api.* gate.