### PR TITLE
Record sync provenance: which box pushed each synced revision

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/ChangeLog.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ChangeLog.java
@@ -36,7 +36,8 @@ public final class ChangeLog {
       String recordedAt,
       String origin,
       boolean deleted,
-      String snapshot) {}
+      String snapshot,
+      String peer) {}
 
   /** Appends a revision. {@code snapshot} is the entity's full state as JSON at this revision. */
   public void append(
@@ -49,7 +50,7 @@ public final class ChangeLog {
       String snapshot) {
     db.execute(
         "INSERT INTO change_log (entity_type, entity_id, rev, actor, recorded_at, origin,"
-            + " deleted, snapshot) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            + " deleted, snapshot, peer) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         entityType,
         entityId,
         rev,
@@ -57,7 +58,8 @@ public final class ChangeLog {
         DateTimeUtils.now().toString(),
         origin,
         deleted ? 1 : 0,
-        snapshot);
+        snapshot,
+        SyncPeer.current());
   }
 
   /** Returns every revision of an entity in chronological order (oldest first). */
@@ -89,8 +91,8 @@ public final class ChangeLog {
   }
 
   private static final String SELECT =
-      "SELECT seq, entity_type, entity_id, rev, actor, recorded_at, origin, deleted, snapshot"
-          + " FROM change_log";
+      "SELECT seq, entity_type, entity_id, rev, actor, recorded_at, origin, deleted, snapshot,"
+          + " peer FROM change_log";
 
   private static Entry map(Sqlite.Row row) {
     return new Entry(
@@ -102,6 +104,7 @@ public final class ChangeLog {
         row.text(5),
         row.text(6),
         row.integer(7) != 0,
-        row.text(8));
+        row.text(8),
+        row.text(9));
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -392,7 +392,8 @@ public final class SchemaManager {
               decided_by, superseded_at, error, rev, base_rev FROM reviews""",
           "DROP TABLE reviews",
           "ALTER TABLE reviews_v2 RENAME TO reviews",
-          "CREATE INDEX IF NOT EXISTS idx_reviews_spec ON reviews(spec_id)");
+          "CREATE INDEX IF NOT EXISTS idx_reviews_spec ON reviews(spec_id)",
+          "ALTER TABLE change_log ADD COLUMN peer TEXT");
 
   /**
    * The last schema version whose {@code specs.status} CHECK predates {@code awaiting_merge}. The

--- a/sail-core/src/main/java/ai/singlr/sail/store/SyncPeer.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SyncPeer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import java.util.ArrayList;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+
+/**
+ * The provenance of a synced revision: the box that pushed or served it, bound as a {@link
+ * ScopedValue} around the sync apply so {@link ChangeLog#append} records it without every store and
+ * replica threading an extra argument. On main receiving a node's push it is the pushing FDE's
+ * handle; on a node adopting main's state it is main. Unbound — a purely local mutation — records
+ * no peer, and {@code origin=local} already says "this box".
+ *
+ * <p>This turns an opaque {@code origin=sync} row, whose {@code actor} is the inherited author and
+ * so cannot say which box acted, into one that names the source. Same-thread by construction: the
+ * append runs synchronously inside the commit/adopt the peer is bound around.
+ */
+public final class SyncPeer {
+
+  private static final ScopedValue<String> CURRENT = ScopedValue.newInstance();
+
+  private SyncPeer() {}
+
+  /** The peer the current sync apply is bound to, or {@code null} for a local mutation. */
+  public static String current() {
+    return CURRENT.isBound() ? CURRENT.get() : null;
+  }
+
+  /** Runs {@code work} with {@code peer} recorded as the provenance of any revision it journals. */
+  public static void with(String peer, Runnable work) {
+    if (peer == null) {
+      work.run();
+    } else {
+      ScopedValue.where(CURRENT, peer).run(work);
+    }
+  }
+
+  /** As {@link #with(String, Runnable)} for work that returns a value. */
+  public static <T> T with(String peer, Supplier<T> work) {
+    if (peer == null) {
+      return work.get();
+    }
+    var holder = new ArrayList<T>(1);
+    ScopedValue.where(CURRENT, peer).run(() -> holder.add(work.get()));
+    return holder.getFirst();
+  }
+
+  /** As {@link #with(String, Supplier)} for work that may throw — the node's reconcile session. */
+  public static <T> T withChecked(String peer, Callable<T> work) throws Exception {
+    return peer == null ? work.call() : ScopedValue.where(CURRENT, peer).call(work::call);
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.sync;
 
+import ai.singlr.sail.store.SyncPeer;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
@@ -131,7 +132,11 @@ public final class SyncRpcServer {
               + "'s.");
     }
     var before = main.current(commit.entityId());
-    return switch (main.commit(commit.entityId(), commit.snapshot(), commit.expectedRev())) {
+    var outcome =
+        SyncPeer.with(
+            principal.handle(),
+            () -> main.commit(commit.entityId(), commit.snapshot(), commit.expectedRev()));
+    return switch (outcome) {
       case CommitOutcome.Accepted accepted -> {
         emitTransitions(commit, before, main);
         yield new SyncWire.Committed(accepted.rev(), main.maxSeq());

--- a/sail-core/src/test/java/ai/singlr/sail/store/ChangeLogTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ChangeLogTest.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
@@ -31,6 +32,33 @@ class ChangeLogTest {
   @AfterEach
   void tearDown() {
     if (db != null) db.close();
+  }
+
+  @Test
+  void aLocalMutationRecordsNoPeer() {
+    log.append("spec", "a", "1-x", "uday", "local", false, "{}");
+
+    assertNull(log.history("spec", "a").getFirst().peer());
+  }
+
+  @Test
+  void aRevisionAppendedUnderASyncPeerRecordsThatPeerAsItsProvenance() {
+    SyncPeer.with("sumesh", () -> log.append("spec", "a", "1-x", "uday", "sync", false, "{}"));
+
+    var entry = log.history("spec", "a").getFirst();
+    assertEquals("sumesh", entry.peer());
+    assertEquals("sync", entry.origin());
+    assertEquals(
+        "uday", entry.actor(), "actor stays the inherited author; peer names the box that pushed");
+  }
+
+  @Test
+  void thePeerBindingIsScopedAndDoesNotLeakToLaterAppends() {
+    SyncPeer.with("sumesh", () -> log.append("spec", "a", "1-x", "uday", "sync", false, "{}"));
+    log.append("spec", "b", "1-y", "uday", "local", false, "{}");
+
+    assertEquals("sumesh", log.history("spec", "a").getFirst().peer());
+    assertNull(log.history("spec", "b").getFirst().peer());
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
@@ -79,6 +79,28 @@ class SyncRpcServerTest {
   }
 
   @Test
+  void theCommitBindsThePushingHandleAsSyncProvenance() throws Exception {
+    var seenPeer = new java.util.concurrent.atomic.AtomicReference<String>("unset");
+    MainReplica capturing =
+        new FakeMain() {
+          @Override
+          public CommitOutcome commit(String id, Map<String, Object> snapshot, String expectedRev) {
+            seenPeer.set(ai.singlr.sail.store.SyncPeer.current());
+            return new CommitOutcome.Accepted("1-x");
+          }
+        };
+    var out = new StringWriter();
+    new SyncRpcServer(Map.of("spec", capturing), new SyncPrincipal("sumesh", true), FdeRoster.EMPTY)
+        .serve(
+            new StringReader(
+                SyncWire.encode(new SyncWire.Commit("spec", "a", Map.of(), null)) + "\n"),
+            out);
+
+    assertEquals(
+        "sumesh", seenPeer.get(), "the change_log written during the commit must name the pusher");
+  }
+
+  @Test
   void aReadOnlyServerRefusesACommit() throws Exception {
     assertInstanceOf(
         SyncWire.Failed.class, serve(false, new SyncWire.Commit("spec", "a", Map.of(), null)));

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -575,10 +575,12 @@ record SpecRestoreRequest(String rev) {
   }
 }
 
-record SpecRevisionView(String rev, String actor, String recordedAt, String origin, boolean deleted)
+record SpecRevisionView(
+    String rev, String actor, String recordedAt, String origin, boolean deleted, String peer)
     implements Mappable {
   static SpecRevisionView from(ChangeLog.Entry e) {
-    return new SpecRevisionView(e.rev(), e.actor(), e.recordedAt(), e.origin(), e.deleted());
+    return new SpecRevisionView(
+        e.rev(), e.actor(), e.recordedAt(), e.origin(), e.deleted(), e.peer());
   }
 
   @Override
@@ -589,6 +591,7 @@ record SpecRevisionView(String rev, String actor, String recordedAt, String orig
     m.put("recorded_at", recordedAt);
     m.put("origin", origin);
     m.put("deleted", deleted);
+    if (peer != null) m.put("peer", peer);
     return m;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
@@ -26,6 +26,7 @@ import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.SyncConflicts;
+import ai.singlr.sail.store.SyncPeer;
 import ai.singlr.sail.store.SyncState;
 import ai.singlr.sail.sync.FileReplica;
 import ai.singlr.sail.sync.ProjectReplica;
@@ -211,6 +212,10 @@ public final class SyncCommand implements Callable<Integer> {
   }
 
   private SyncEngine.Report reconcile(Boxes boxes, String target) throws Exception {
+    return SyncPeer.withChecked("main", () -> reconcileSession(boxes, target));
+  }
+
+  private SyncEngine.Report reconcileSession(Boxes boxes, String target) throws Exception {
     try (var channel = SshSyncChannel.open(target);
         var session = new SyncSession(channel.reader(), channel.writer())) {
       var specReport = new SyncEngine().reconcile(boxes.spec(), session.replica("spec"));

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -1370,7 +1370,8 @@ class ApiRouterTest {
           new GlobalSpecHistoryResponse(
               specId,
               java.util.List.of(
-                  new SpecRevisionView("1-abc", "uday", "2026-06-13T00:00:00Z", "local", false))));
+                  new SpecRevisionView(
+                      "1-abc", "uday", "2026-06-13T00:00:00Z", "local", false, null))));
     }
 
     @Override


### PR DESCRIPTION
Answers the standing question 'ensure we see where the sync came from', and cracks the recurring mystery of specs getting silently moved to `review` via `origin=sync`.

**The gap.** `change_log` recorded `origin` (`local`/`sync`/`resolve`) and `actor` — but `actor` is the *inherited author* (it showed `uday` even when uday didn't act, because `updateStatus` doesn't re-stamp), and there was **no column for the pushing box**. Even though the sync server knows who's pushing (`SyncPrincipal.handle()`), that identity was thrown away before the change_log row was written. So a synced status change could not be traced to its source.

**The fix.**
- `SyncPeer`: a `ScopedValue` bound around the sync apply, read by `ChangeLog.append` — provenance without threading an argument through all 5 stores' `recordRevision`, both replica interfaces, and every implementation. Same-thread by construction (the append runs synchronously inside the commit/adopt).
- `change_log` gains a `peer` column (migration appended at the end, not inserted mid-list). On **main** receiving a node's push, `SyncRpcServer` binds the pushing FDE's handle; on a **node** adopting main's state, the reconcile session binds `main`. A purely local mutation binds nothing (`origin=local` already says 'this box').
- `spec history` (and the history API) surface `peer`, so provenance is visible without raw SQL.

**Concurrency & standardization** (the other two asks) were already in place — `commitRevision` is compare-and-set so concurrent pushes can't lose updates, the connection lock serializes, and every entity syncs through one uniform `*Replica` + `SyncEngine` + `change_log` path. This adds the missing provenance leg.

TDD: a local append records no peer; a revision appended under a bound peer records it while `actor` stays the author; the binding is scoped and doesn't leak to later appends; and a commit through `SyncRpcServer` binds the pushing handle during the commit. Full `mvn clean verify` green incl. the 100% api.* gate.

Now: the next time a spec's status changes via sync, its `change_log` row (and `spec history`) names the exact box that pushed it — no more guessing.