### PR TITLE
Reap stale running reservations for non-active specs

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -239,6 +239,15 @@ public final class RunStore implements ConflictResolver {
         ownerKey(localHandle));
   }
 
+  /**
+   * Every run still in the {@code running} state, across all projects and nodes — the reaper's full
+   * input. Ownership is filtered by the caller so it matches exactly what the dispatch gate counts,
+   * including rows with a blank node.
+   */
+  public List<RunRow> running() {
+    return db.query("SELECT " + COLUMNS + " FROM runs WHERE status = 'running'", this::mapRow);
+  }
+
   private static String ownerKey(String localHandle) {
     return Strings.isBlank(localHandle) ? "" : localHandle;
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -67,9 +67,6 @@ public final class MissedStopReconciler implements AutoCloseable {
   private static final SpecStore.SpecFilter IN_PROGRESS =
       new SpecStore.SpecFilter(null, "in_progress", null, null, null);
 
-  private static final SpecStore.SpecFilter PENDING =
-      new SpecStore.SpecFilter(null, "pending", null, null, null);
-
   private static final SpecStore.SpecFilter REVIEW =
       new SpecStore.SpecFilter(null, "review", null, null, null);
 
@@ -186,25 +183,37 @@ public final class MissedStopReconciler implements AutoCloseable {
     var node = localHandle.get();
     var deadline = clock.get().minus(LAUNCH_GRACE);
     var released = 0;
-    for (var spec : specStore.list(PENDING)) {
-      for (var run : sessionStore.listForSpec(spec.id())) {
-        if ("running".equals(run.status())
-            && SailOperations.ownsRun(run.node(), node)
-            && MissedStops.parseOr(run.startedAt(), Instant.MAX).isBefore(deadline)) {
-          System.err.println(
-              "  [reconcile] releasing stranded reservation for "
-                  + spec.project()
-                  + "/"
-                  + spec.id()
-                  + " (run "
-                  + run.id()
-                  + "): running with a still-pending spec past the launch grace");
-          sessionStore.complete(run.id(), "failed", null);
-          released++;
-        }
+    for (var run : sessionStore.running()) {
+      if (!SailOperations.ownsRun(run.node(), node)
+          || !MissedStops.parseOr(run.startedAt(), Instant.MAX).isBefore(deadline)
+          || specBeingWorked(run.specId())) {
+        continue;
       }
+      System.err.println(
+          "  [reconcile] releasing stranded reservation "
+              + run.id()
+              + " for spec "
+              + run.specId()
+              + " (running with no agent working it; spec is not in_progress or review)");
+      sessionStore.complete(run.id(), "stopped", null);
+      released++;
     }
     return released;
+  }
+
+  /**
+   * Whether the run's spec is actively being worked on this box, so a {@code running} run for it is
+   * legitimate and left to the in-progress and review sweeps. Any other spec state — pending (a
+   * crash between reserve and claim), or a terminal state the run outlived (a dropped completion,
+   * or a pre-run-scoped run carried across an upgrade) — means the reservation is dead and blocking
+   * the dispatch gate for no agent.
+   */
+  private boolean specBeingWorked(String specId) {
+    return specStore
+        .findById(specId)
+        .map(spec -> spec.status().wire())
+        .map(status -> "in_progress".equals(status) || "review".equals(status))
+        .orElse(false);
   }
 
   /**

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -117,12 +117,16 @@ class MissedStopReconcilerTest {
   }
 
   private void createPendingSpec(String id) {
+    createSpec(id, SpecStatus.PENDING);
+  }
+
+  private void createSpec(String id, SpecStatus status) {
     specStore.create(
         new SpecStore.SpecRow(
             id,
             "test-project",
             "Test spec",
-            SpecStatus.PENDING,
+            status,
             null,
             "claude-code",
             null,
@@ -146,13 +150,41 @@ class MissedStopReconcilerTest {
 
     assertEquals(1, released);
     assertEquals(
-        "failed",
+        "stopped",
         sessionStore.listForSpec("auth").getFirst().status(),
         "a run left running by a crash between reserve and claim is freed");
     assertEquals(
         SpecStatus.PENDING,
         specStore.findById("auth").orElseThrow().status(),
         "the never-claimed spec stays dispatchable");
+  }
+
+  @Test
+  void releasesAStrandedReservationForADoneSpecPastGrace() {
+    createSpec("auth", SpecStatus.DONE);
+    runningSession("auth");
+
+    var released = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+
+    assertEquals(1, released);
+    assertEquals(
+        "stopped",
+        sessionStore.listForSpec("auth").getFirst().status(),
+        "a run left running for a finished spec is freed so it stops blocking the dispatch gate");
+  }
+
+  @Test
+  void keepsARunningReservationForAnInProgressSpec() {
+    createInProgressSpec("auth");
+    runningSession("auth");
+
+    var released = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+
+    assertEquals(0, released);
+    assertEquals(
+        "running",
+        sessionStore.listForSpec("auth").getFirst().status(),
+        "a run whose spec is actively in progress is left to the in-progress sweep, not reaped");
   }
 
   @Test


### PR DESCRIPTION
The repo-overlap gate (0.13.163) counts every running run row, but the reaper only released `pending`-spec strands. A run left `running` for a spec that reached a terminal state — a dropped completion, or a pre-run-scoped run carried across the upgrade — was never released and blocked every overlapping dispatch forever with no agent behind it (observed right after 0.13.163: old `done`-spec runs with blank units blocking dispatch).

Generalizes `releaseStrandedReservations` to release any owned `running` run past the launch grace whose spec is not `in_progress`/`review`, matching exactly what the gate counts, so it self-clears within a sweep. Regression tests: done-spec run reaped; in-progress run left alone; fresh run untouched.

mvn clean verify: 2350 tests green, coverage met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)