### PR TITLE
Soft-reject un-owned run pushes instead of aborting the whole sync

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
@@ -123,13 +123,16 @@ public final class SyncRpcServer {
     if (main == null) {
       return new SyncWire.Failed("Unknown entity type: " + commit.entityType());
     }
-    if (RUN_ENTITY.equals(commit.entityType()) && !ownsRunCommit(commit, main)) {
-      return new SyncWire.Failed(
-          "A sync session may push only runs executed on its own node; run "
-              + commit.entityId()
-              + " is not "
-              + principal.handle()
-              + "'s.");
+    if (RUN_ENTITY.equals(commit.entityType())) {
+      if (principal.handle() == null || principal.handle().isBlank()) {
+        return new SyncWire.Failed(
+            "This sync session has no node handle, so a run cannot be attributed to it; "
+                + "set the node's sync handle before pushing runs.");
+      }
+      if (!ownsRunCommit(commit, main)) {
+        return new SyncWire.Rejected(
+            main.currentRev(commit.entityId()), main.current(commit.entityId()));
+      }
     }
     var before = main.current(commit.entityId());
     var outcome =

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
@@ -139,21 +139,32 @@ class SyncRpcServerTest {
   }
 
   @Test
-  void aRunStampedWithAnotherNodeIsRefused() throws Exception {
+  void aRunStampedWithAnotherNodeIsRejectedNotFailed() throws Exception {
     var commit = new SyncWire.Commit("run", "r1", Map.of("node", "grace"), null);
-    assertInstanceOf(SyncWire.Failed.class, serveRun("ada", null, commit));
+    assertInstanceOf(
+        SyncWire.Rejected.class,
+        serveRun("ada", null, commit),
+        "an un-owned run push is rejected, not failed, so one bad run cannot abort the whole sync");
   }
 
   @Test
-  void overwritingAnotherNodesRunWithOnesOwnStampIsRefused() throws Exception {
+  void overwritingAnotherNodesRunReturnsMainsVersionToAdopt() throws Exception {
     var commit = new SyncWire.Commit("run", "r1", Map.of("node", "ada"), "1-x");
-    assertInstanceOf(SyncWire.Failed.class, serveRun("ada", Map.of("node", "grace"), commit));
+    var rejected =
+        assertInstanceOf(SyncWire.Rejected.class, serveRun("ada", Map.of("node", "grace"), commit));
+    assertEquals("1-x", rejected.currentRev());
+    assertEquals(
+        "grace",
+        rejected.currentSnapshot().get("node"),
+        "the node is handed main's authoritative version to adopt, converging instead of clobbering");
   }
 
   @Test
-  void deletingAnotherNodesRunIsRefused() throws Exception {
+  void deletingAnotherNodesRunIsRejectedNotFailed() throws Exception {
     var commit = new SyncWire.Commit("run", "r1", null, "1-x");
-    assertInstanceOf(SyncWire.Failed.class, serveRun("ada", Map.of("node", "grace"), commit));
+    var rejected =
+        assertInstanceOf(SyncWire.Rejected.class, serveRun("ada", Map.of("node", "grace"), commit));
+    assertEquals("grace", rejected.currentSnapshot().get("node"));
   }
 
   @Test
@@ -163,9 +174,9 @@ class SyncRpcServerTest {
   }
 
   @Test
-  void recreatingATombstonedRunIdIsRefusedEvenWithOnesOwnStamp() throws Exception {
+  void recreatingATombstonedRunIdIsRejectedSoTheNodeAdoptsTheDeletion() throws Exception {
     var commit = new SyncWire.Commit("run", "r1", Map.of("node", "ada"), "2-x");
-    assertInstanceOf(SyncWire.Failed.class, serveRun("ada", null, "2-x", commit));
+    assertInstanceOf(SyncWire.Rejected.class, serveRun("ada", null, "2-x", commit));
   }
 
   @Test
@@ -175,9 +186,9 @@ class SyncRpcServerTest {
   }
 
   @Test
-  void aRunWithoutANodeStampFailsClosed() throws Exception {
+  void aRunWithoutANodeStampIsRejectedNotFailed() throws Exception {
     var commit = new SyncWire.Commit("run", "r1", Map.of("status", "running"), null);
-    assertInstanceOf(SyncWire.Failed.class, serveRun("ada", null, commit));
+    assertInstanceOf(SyncWire.Rejected.class, serveRun("ada", null, commit));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SyncServerCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SyncServerCommandTest.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -207,8 +208,10 @@ class SyncServerCommandTest {
     var runId = createNodeRun("grace");
     var token = tokenFor("member");
 
-    assertThrows(SyncTransportException.class, () -> syncWithToken(token, "run", nodeRunReplica()));
-    assertTrue(new RunStore(mainDb).findById(runId).isEmpty());
+    assertDoesNotThrow(() -> syncWithToken(token, "run", nodeRunReplica()));
+    assertTrue(
+        new RunStore(mainDb).findById(runId).isEmpty(),
+        "the forged run is refused (rejected, not applied) without aborting the whole sync session");
   }
 
   @Test


### PR DESCRIPTION
A node that offers a run it doesn't own (a diverged foreign run, a tombstone recreate, or a stampless pre-upgrade run) made main return `SyncWire.Failed`, which **aborts the entire sync session** — one bad run wedged all of a node's sync (surfacing as `run <id> is not <node>'s`). Main now returns a soft `Rejected` carrying its authoritative version: the node adopts it (converging so it stops re-offering) and the session continues. Security unchanged (main still never applies the un-owned push); a no-handle session stays a hard failure.

TDD: `SyncRpcServerTest` (un-owned/tombstone/stampless → Rejected with main's version; no-handle → Failed) + `SyncServerCommandTest` end-to-end proof that a forged run is refused without aborting the session.

mvn clean verify: 2350 green, coverage met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)