### PR TITLE
Never offer a foreign run for push (defense in depth)

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/sync/LocalReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/LocalReplica.java
@@ -20,6 +20,17 @@ public interface LocalReplica {
   /** Every entity id this node knows of, including tombstoned ones. */
   Set<String> entityIds();
 
+  /**
+   * Whether this node may push its own change to {@code id} up to main, or may only pull main's
+   * version. Multi-writer entities (specs, files, projects) always may — the default. A
+   * single-writer entity like a run overrides this so a reader box never pushes a run it did not
+   * author: when its local copy of a foreign run diverges, the engine adopts main's authoritative
+   * version instead of offering an un-owned push that main would only reject.
+   */
+  default boolean mayPush(String id) {
+    return true;
+  }
+
   /** Current comparable state; {@code null} if deleted or absent. */
   Map<String, Object> current(String id);
 

--- a/sail-core/src/main/java/ai/singlr/sail/sync/RunReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/RunReplica.java
@@ -34,14 +34,28 @@ public final class RunReplica implements LocalReplica, MainReplica {
   private static final String ENTITY = "run";
 
   private final String id;
+  private final String handle;
   private final RunStore runs;
   private final ChangeLog changeLog;
   private final SyncConflicts conflicts;
   private final SyncState syncState;
 
+  /**
+   * {@code id} is the box's sync-mesh identity (the checkpoint peer key); {@code handle} is the
+   * box's FDE handle, the value a run's {@code node} carries when this box executed it. The two
+   * differ in production — {@code id} is the machine hostname, {@code handle} the configured sync
+   * handle — so run ownership is checked against {@code handle}, never {@code id}. A blank handle
+   * (a box with no sync identity) defers ownership to main's guard.
+   */
   public RunReplica(
-      String id, RunStore runs, ChangeLog changeLog, SyncConflicts conflicts, SyncState syncState) {
+      String id,
+      String handle,
+      RunStore runs,
+      ChangeLog changeLog,
+      SyncConflicts conflicts,
+      SyncState syncState) {
     this.id = Objects.requireNonNull(id, "id");
+    this.handle = Objects.requireNonNull(handle, "handle");
     this.runs = Objects.requireNonNull(runs, "runs");
     this.changeLog = Objects.requireNonNull(changeLog, "changeLog");
     this.conflicts = Objects.requireNonNull(conflicts, "conflicts");
@@ -56,6 +70,23 @@ public final class RunReplica implements LocalReplica, MainReplica {
   @Override
   public Set<String> entityIds() {
     return runs.syncEntityIds();
+  }
+
+  /**
+   * A box may push only the runs it executed. A run stamped with another node is a foreign copy
+   * this box holds purely as a reader, so it is never pushed: the engine adopts main's version
+   * instead. A blank or absent stamp (a run from before node-stamping, or a tombstone whose owner
+   * is no longer readable), or a box with no handle of its own, is left to main's own ownership
+   * guard rather than denied here.
+   */
+  @Override
+  public boolean mayPush(String entityId) {
+    if (handle.isBlank()) {
+      return true;
+    }
+    return runs.findById(entityId)
+        .map(run -> run.node() == null || run.node().isBlank() || handle.equals(run.node()))
+        .orElse(true);
   }
 
   @Override

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncEngine.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncEngine.java
@@ -111,14 +111,29 @@ public final class SyncEngine {
         yield Outcome.PULLED;
       }
       case ConflictDetector.KeepLocal ignored ->
-          push(local, main, id, localSnap, remoteRev, Outcome.PUSHED, redetectsLeft);
+          local.mayPush(id)
+              ? push(local, main, id, localSnap, remoteRev, Outcome.PUSHED, redetectsLeft)
+              : pullInsteadOfPush(local, id, remoteSnap, remoteRev);
       case ConflictDetector.Merged m ->
-          push(local, main, id, m.result(), remoteRev, Outcome.MERGED, redetectsLeft);
+          local.mayPush(id)
+              ? push(local, main, id, m.result(), remoteRev, Outcome.MERGED, redetectsLeft)
+              : pullInsteadOfPush(local, id, remoteSnap, remoteRev);
       case ConflictDetector.Conflict c -> {
         local.recordConflict(id, base, localSnap, remoteSnap, c.fields());
         yield Outcome.CONFLICT;
       }
     };
+  }
+
+  /**
+   * The local diverged on an entity it may not push — a run it did not author. Discard the local
+   * divergence and adopt main's authoritative version, so a reader box converges instead of
+   * offering an un-owned push main would only reject.
+   */
+  private static Outcome pullInsteadOfPush(
+      LocalReplica local, String id, Map<String, Object> remoteSnap, String remoteRev) {
+    local.adopt(id, remoteSnap, remoteRev);
+    return Outcome.PULLED;
   }
 
   private Outcome push(

--- a/sail-core/src/test/java/ai/singlr/sail/sync/RunSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/RunSyncTest.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.sync;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.common.DateTimeUtils;
@@ -47,7 +48,7 @@ class RunSyncTest {
       new SchemaManager(db).migrate();
       this.runs = new RunStore(db);
       this.conflicts = new SyncConflicts(db);
-      this.replica = new RunReplica(id, runs, new ChangeLog(db), conflicts, new SyncState(db));
+      this.replica = new RunReplica(id, id, runs, new ChangeLog(db), conflicts, new SyncState(db));
     }
 
     @Override
@@ -115,6 +116,39 @@ class RunSyncTest {
     sync(other);
     assertEquals("completed", other.runs.findById(id).orElseThrow().status());
     assertEquals(0, other.runs.findById(id).orElseThrow().exitCode());
+  }
+
+  @Test
+  void aReplicaMayPushOnlyTheRunsItExecuted() {
+    var mine = startRun(node, "node");
+    var foreign = startRun(node, "other");
+    var stampless = startRun(node, "");
+
+    assertTrue(node.replica.mayPush(mine), "a node may push a run it executed");
+    assertFalse(node.replica.mayPush(foreign), "a node must not push a run another node executed");
+    assertTrue(
+        node.replica.mayPush(stampless),
+        "a stampless pre-upgrade run is left to main's ownership guard, not denied here");
+  }
+
+  @Test
+  void aReaderNeverPushesADivergedForeignRunAndAdoptsMainsVersion() {
+    var id = startRun(node, "node");
+    sync(node);
+    sync(other);
+
+    other.runs.complete(id, "stopped", 0);
+
+    sync(other);
+
+    assertEquals(
+        "running",
+        main.runs.findById(id).orElseThrow().status(),
+        "a reader box cannot clobber main's run with a change it did not author");
+    assertEquals(
+        "running",
+        other.runs.findById(id).orElseThrow().status(),
+        "the reader discards its illegitimate change and adopts main's authoritative version");
   }
 
   @Test

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
@@ -100,13 +100,15 @@ public final class SyncCommand implements Callable<Integer> {
           Banner.errorLine("--interval must be a positive number of seconds.", Ansi.AUTO));
       return 1;
     }
-    var resolution = resolveMain(main, HostSync.config());
+    var sync = HostSync.config();
+    var resolution = resolveMain(main, sync);
     if (resolution.target() == null) {
       System.out.println(Ansi.AUTO.string("  @|faint " + resolution.message() + "|@"));
       return 0;
     }
     var target = resolution.target();
     var host = HostInfo.hostname();
+    var handle = sync.handle() == null ? "" : sync.handle();
     SyncDatabase replicaDb;
     try {
       replicaDb = SyncDatabase.converge(SailPaths.controlPlaneDb(), host);
@@ -115,12 +117,12 @@ public final class SyncCommand implements Callable<Integer> {
       return 1;
     }
     try (replicaDb) {
-      var boxes = boxes(replicaDb, host);
+      var boxes = boxes(replicaDb, host, handle);
       return watch ? watchLoop(boxes, target) : runOnce(boxes, target);
     }
   }
 
-  private static Boxes boxes(SyncDatabase converged, String host) {
+  private static Boxes boxes(SyncDatabase converged, String host, String handle) {
     var db = converged.db();
     var changeLog = new ChangeLog(db);
     var conflicts = new SyncConflicts(db);
@@ -131,7 +133,7 @@ public final class SyncCommand implements Callable<Integer> {
         new SpecReplica(host, new SpecStore(db), changeLog, conflicts, syncState),
         new FileReplica(host, fileStore, changeLog, conflicts, syncState),
         new ProjectReplica(host, projectStore, changeLog, conflicts, syncState),
-        new RunReplica(host, new RunStore(db), changeLog, conflicts, syncState),
+        new RunReplica(host, handle, new RunStore(db), changeLog, conflicts, syncState),
         new ReviewReplica(host, new ReviewStore(db), changeLog, conflicts, syncState),
         new FdeStore(db),
         fileStore,

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
@@ -105,7 +105,8 @@ public final class SyncServerCommand implements Callable<Integer> {
             "file", new FileReplica(mainId, new FileStore(db), changeLog, conflicts, syncState),
             "project",
                 new ProjectReplica(mainId, new ProjectStore(db), changeLog, conflicts, syncState),
-            "run", new RunReplica(mainId, new RunStore(db), changeLog, conflicts, syncState),
+            "run",
+                new RunReplica(mainId, mainId, new RunStore(db), changeLog, conflicts, syncState),
             "review",
                 new ReviewReplica(mainId, new ReviewStore(db), changeLog, conflicts, syncState));
     new SyncRpcServer(replicas, principal(db, token), () -> roster(db), transitionSink)

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SyncServerCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SyncServerCommandTest.java
@@ -178,7 +178,8 @@ class SyncServerCommandTest {
 
   private RunReplica nodeRunReplica() {
     return new RunReplica(
-        "node",
+        "uday",
+        "uday",
         new RunStore(nodeDb),
         new ChangeLog(nodeDb),
         new SyncConflicts(nodeDb),
@@ -211,7 +212,8 @@ class SyncServerCommandTest {
     assertDoesNotThrow(() -> syncWithToken(token, "run", nodeRunReplica()));
     assertTrue(
         new RunStore(mainDb).findById(runId).isEmpty(),
-        "the forged run is refused (rejected, not applied) without aborting the whole sync session");
+        "a run the box did not author is never offered for push, so main never receives the forgery"
+            + " and the sync session still completes");
   }
 
   @Test


### PR DESCRIPTION
Enforces RunReplica's long-standing contract — a reader box never pushes a run it did not author. A generic `mayPush(id)` hook on `LocalReplica` (default true; multi-writer entities unchanged) is overridden by `RunReplica` to deny clearly-foreign runs; the engine adopts main's version instead of pushing when the local may not push. Complements the 0.13.165 soft-reject: that made an un-owned push harmless on the receiving side; this stops it being offered at all (no wasted round-trip, and no reader clobbering main at the direct-engine layer).

TDD in `RunSyncTest` (mayPush true/false/stampless; a diverged foreign run adopts main's version without clobbering — fails without the fix). `SyncServerCommandTest`'s forge case is now caught client-side.

mvn clean verify: 2350 green, coverage met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)