### PR TITLE
Cut agent branches off the latest fetched base

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -516,11 +516,16 @@ public final class DispatchOperations {
                       "--quiet",
                       "refs/heads/" + branch)))
               .ok();
-      var result =
-          exec(
-              ContainerExec.asDevUser(
-                  project,
-                  RestartResolution.branchCheckoutArgs(repoDir, branch, branchExists, restarted)));
+      List<String> checkoutArgs;
+      if (branchExists) {
+        checkoutArgs = RestartResolution.branchCheckoutArgs(repoDir, branch, true, restarted);
+      } else {
+        var base = baseBranch(project, repoDir, repo);
+        checkoutArgs =
+            RestartResolution.freshBranchArgs(
+                repoDir, branch, base, fetchLatestBase(project, repoDir, base));
+      }
+      var result = exec(ContainerExec.asDevUser(project, checkoutArgs));
       if (!result.ok()) {
         throw new ApiException(
             ErrorCode.BRANCH_CREATE_FAILED,
@@ -539,6 +544,55 @@ public final class DispatchOperations {
       listener.branchUnavailable(branch);
     }
     return created;
+  }
+
+  /**
+   * The mainline a fresh work branch forks from: the repo's configured branch when {@code
+   * sail.yaml} pins one, else origin's default branch (the clone's {@code origin/HEAD}), else
+   * blank. Deriving it from the repo config or the remote default — never the current {@code HEAD}
+   * — keeps a new branch off the mainline even when a prior dispatch left the checkout on an
+   * earlier work branch.
+   */
+  private String baseBranch(String project, String repoDir, SailYaml.Repo repo) {
+    if (Strings.isNotBlank(repo.branch())) {
+      return repo.branch();
+    }
+    var result =
+        exec(
+            ContainerExec.asDevUser(
+                project,
+                List.of("git", "-C", repoDir, "rev-parse", "--abbrev-ref", "origin/HEAD")));
+    if (!result.ok()) {
+      return "";
+    }
+    var ref = result.stdout().trim();
+    return ref.startsWith("origin/") ? ref.substring("origin/".length()) : ref;
+  }
+
+  /**
+   * Fetches {@code base} from origin so a fresh work branch forks from the current upstream tip
+   * rather than a stale local checkout. Best-effort: returns true only when {@code origin/<base>}
+   * is available to branch from afterwards, so an offline box, a repo with no {@code origin}, or a
+   * detached base falls back to the local {@code HEAD} instead of failing the dispatch.
+   */
+  private boolean fetchLatestBase(String project, String repoDir, String base) {
+    if (Strings.isBlank(base) || "HEAD".equals(base)) {
+      return false;
+    }
+    exec(
+        ContainerExec.asDevUser(
+            project, List.of("git", "-C", repoDir, "fetch", "--quiet", "origin", base)));
+    return exec(ContainerExec.asDevUser(
+            project,
+            List.of(
+                "git",
+                "-C",
+                repoDir,
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                "refs/remotes/origin/" + base)))
+        .ok();
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RestartResolution.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RestartResolution.java
@@ -27,7 +27,9 @@ import java.util.List;
  * <p>{@link #branchCheckoutArgs} is the branch half of the same decision: a restart force-checks
  * out the prior branch when it exists ({@code checkout -f}, so a dirty tree left by the previous
  * run cannot abort the re-dispatch) and creates it fresh otherwise, while a non-restart dispatch
- * fails loud on a collision, pointing the caller at the restart option.
+ * fails loud on a collision, pointing the caller at the restart option. {@link #freshBranchArgs}
+ * cuts a brand-new work branch off the latest fetched base so an agent never inherits a stale local
+ * checkout of {@code main}/{@code master}.
  */
 public sealed interface RestartResolution
     permits RestartResolution.Refused, RestartResolution.NotRestarted, RestartResolution.Restarted {
@@ -79,5 +81,19 @@ public sealed interface RestartResolution
     return branchExists
         ? List.of("git", "-C", repoDir, "checkout", "-f", branchName)
         : List.of("git", "-C", repoDir, "checkout", "-b", branchName);
+  }
+
+  /**
+   * The git command to cut a fresh work branch. When {@code originBaseAvailable}, it forks from
+   * {@code origin/<base>} — the just-fetched upstream tip — so an agent never inherits a stale
+   * local checkout of the base branch; otherwise (no remote, offline, or a detached base) it forks
+   * from the current {@code HEAD}, the prior behaviour, so a dispatch on a box that cannot reach
+   * origin still proceeds rather than failing.
+   */
+  static List<String> freshBranchArgs(
+      String repoDir, String branchName, String base, boolean originBaseAvailable) {
+    return originBaseAvailable
+        ? List.of("git", "-C", repoDir, "checkout", "-b", branchName, "origin/" + base)
+        : branchCheckoutArgs(repoDir, branchName, false, false);
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/DispatchBranchBaseTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/DispatchBranchBaseTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.WatcherSpawner;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * A fresh work branch must be cut off the latest upstream tip, not a stale local checkout of the
+ * base: before {@code checkout -b}, dispatch fetches the repo's current base branch from origin and
+ * forks the new branch from {@code origin/<base>}. When origin is unreachable (or the base cannot
+ * be resolved) it falls back to the local {@code HEAD} rather than failing the dispatch.
+ */
+class DispatchBranchBaseTest {
+
+  private static final String HANDLE = "me";
+  private static final Actor ADMIN = Actor.cliOperator(HANDLE);
+  private static final String REPO = "git -C /home/dev/workspace/app";
+
+  private static final String RUNNING_JSON =
+      """
+      [
+        {
+          "name": "acme",
+          "status": "Running",
+          "state": {
+            "network": {
+              "eth0": {
+                "addresses": [
+                  {"family": "inet", "address": "10.0.0.42", "scope": "global"}
+                ]
+              }
+            }
+          }
+        }
+      ]
+      """;
+
+  private static final String YAML =
+      """
+      name: acme
+      ssh:
+        user: dev
+      repos:
+        - url: https://github.com/acme/app.git
+          path: app
+      agent:
+        type: claude-code
+        specs_dir: specs
+        auto_branch: true
+        branch_prefix: sail/
+      """;
+
+  @TempDir Path tempDir;
+
+  @Test
+  void aFreshBranchForksOffTheFetchedOriginBase() throws IOException {
+    var shell =
+        happyPath()
+            .on(REPO + " rev-parse --verify --quiet refs/remotes/origin/main", "")
+            .on(REPO + " checkout -b sail/auth origin/main", "");
+
+    dispatch(shell);
+
+    assertTrue(
+        ranContaining(shell, REPO + " fetch --quiet origin main"),
+        "dispatch must fetch the base from origin before cutting the branch");
+    assertTrue(
+        ranContaining(shell, REPO + " checkout -b sail/auth origin/main"),
+        "the fresh branch must fork from the fetched origin/main, not the local base");
+  }
+
+  @Test
+  void anUnreachableOriginFallsBackToTheLocalHead() throws IOException {
+    var shell = happyPath().on(REPO + " checkout -b sail/auth", "");
+
+    dispatch(shell);
+
+    assertTrue(
+        ranContaining(shell, REPO + " checkout -b sail/auth"),
+        "a dispatch on a box that cannot reach origin still proceeds off the local HEAD");
+    assertFalse(
+        ranContaining(shell, REPO + " checkout -b sail/auth origin/main"),
+        "without a resolvable origin base the branch is never forked from a remote ref");
+  }
+
+  private void dispatch(RecordingShell shell) throws IOException {
+    var yaml = tempDir.resolve("sail.yaml");
+    Files.writeString(yaml, YAML);
+    var db = Sqlite.open(tempDir.resolve("sail.db"));
+    new SchemaManager(db).migrate();
+    var specStore = new SpecStore(db);
+    specStore.create(
+        new SpecStore.SpecRow(
+            "auth",
+            "acme",
+            "Add auth",
+            SpecStatus.PENDING,
+            HANDLE,
+            null,
+            null,
+            null,
+            null,
+            0,
+            "me",
+            null,
+            null,
+            "me",
+            List.of(),
+            List.of()));
+    specStore.setContent("auth", "Do auth", "");
+    new FdeStore(db).add(HANDLE, null, null, "admin");
+
+    var ops =
+        new DispatchOperations(
+            shell,
+            yaml.toString(),
+            specStore,
+            new ReviewStore(db),
+            new RunStore(db),
+            new FdeStore(db),
+            new CopyOnWriteArrayList<Event>()::add,
+            new WatcherSpawner(happyPath(), (command, logPath) -> 4242L),
+            (project, config) -> "",
+            command -> 0,
+            DispatchOperations.Listener.NONE);
+
+    var outcome =
+        ops.dispatch(
+            "acme",
+            new DispatchOperations.Request("auth", "background", false, null, false),
+            ADMIN,
+            HANDLE);
+    assertInstanceOf(DispatchOperations.Dispatched.class, outcome);
+  }
+
+  private static RecordingShell happyPath() {
+    return new RecordingShell()
+        .on("incus list ^acme$", RUNNING_JSON)
+        .on("mkdir -p /home/dev/.sail", "")
+        .on("printf '%s'", "")
+        .on("test -d /home/dev/workspace/app/.git", "")
+        .on(REPO + " rev-parse --abbrev-ref origin/HEAD", "origin/main\n")
+        .on(REPO + " fetch --quiet origin main", "")
+        .on("claude", "");
+  }
+
+  private static boolean ranContaining(RecordingShell shell, String fragment) {
+    return shell.executed.stream().anyMatch(command -> command.contains(fragment));
+  }
+
+  private static final class RecordingShell implements ShellExec {
+    private final Map<String, Result> scripts = new LinkedHashMap<>();
+    private final List<String> executed = new ArrayList<>();
+
+    RecordingShell on(String pattern, String stdout) {
+      scripts.put(pattern, new Result(0, stdout, ""));
+      return this;
+    }
+
+    @Override
+    public Result exec(List<String> command) {
+      var joined = String.join(" ", command);
+      executed.add(joined);
+      for (var entry : scripts.entrySet()) {
+        if (joined.contains(entry.getKey())) {
+          return entry.getValue();
+        }
+      }
+      return new Result(1, "", "no script for " + joined);
+    }
+
+    @Override
+    public Result exec(List<String> command, Path workDir, Duration timeout) {
+      return exec(command);
+    }
+
+    @Override
+    public boolean isDryRun() {
+      return false;
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RestartResolutionTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RestartResolutionTest.java
@@ -142,6 +142,26 @@ class RestartResolutionTest {
     assertFalse(ex.failure().action().contains("--restart"), "collision fix must be lane-neutral");
   }
 
+  @Test
+  void freshBranchForksOffTheFetchedUpstreamTipWhenOriginBaseIsAvailable() {
+    var args = RestartResolution.freshBranchArgs("/w/mast", "agent/x", "main", true);
+
+    assertEquals(
+        List.of("git", "-C", "/w/mast", "checkout", "-b", "agent/x", "origin/main"),
+        args,
+        "a fresh branch must fork from origin/main so it never inherits a stale local base");
+  }
+
+  @Test
+  void freshBranchFallsBackToLocalHeadWhenOriginBaseIsUnavailable() {
+    var offline = RestartResolution.freshBranchArgs("/w/mast", "agent/x", "main", false);
+    var detached = RestartResolution.freshBranchArgs("/w/mast", "agent/x", "", false);
+
+    var localCreate = List.of("git", "-C", "/w/mast", "checkout", "-b", "agent/x");
+    assertEquals(localCreate, offline, "an unreachable origin must not block the dispatch");
+    assertEquals(localCreate, detached, "a blank base falls back to the current HEAD");
+  }
+
   private static void assertLaneNeutral(RestartResolution.Refused refused) {
     assertFalse(refused.message().contains("--"), "refusal must not name a CLI flag spelling");
     assertFalse(refused.fix().contains("--"), "fix must not name a CLI flag spelling");


### PR DESCRIPTION
## Problem

Dispatch cut the agent work branch with `git checkout -b <branch>` from **whatever the container repo's HEAD happened to be** — no fetch, no fast-forward of the base first. So when the local `main`/`master` was behind origin (or a prior dispatch left the checkout on an earlier `sail/…` branch), the new branch forked from a **stale** commit. The agent then stomped files upstream had already changed, and the only way to land it was to restore those files to master state on the branch and merge — instead of a clean, harness-only diff you could read from history alone.

## Fix

Before creating a fresh branch, dispatch now:

1. Resolves the repo's **mainline** — its `sail.yaml` `branch` when pinned, else origin's default (`origin/HEAD`). Never the current `HEAD`, so a checkout left on an old work branch can't become the base.
2. `git fetch --quiet origin <base>` to update the remote-tracking ref.
3. Forks the new branch from `origin/<base>` — the just-fetched upstream tip.

**Best-effort / fail-soft:** an offline box, a repo with no `origin`, or an unresolvable base falls back to the prior local-`HEAD` create, so a dispatch is never blocked by an unreachable remote. **Restart** (existing branch) is untouched — it still force-checks-out the prior work over a dirty tree.

## Design

- `RestartResolution.freshBranchArgs(repoDir, branch, base, originBaseAvailable)` is the pure, I/O-free decision (forks `origin/<base>` or falls back to the plain create), table-tested alongside the existing `branchCheckoutArgs`.
- `DispatchOperations` owns the I/O: `baseBranch(...)` resolves the mainline, `fetchLatestBase(...)` fetches and reports whether `origin/<base>` is available.

## Tests

- `RestartResolutionTest` — `freshBranchArgs` forks off `origin/main` when available; falls back to the local create when not.
- `DispatchBranchBaseTest` — end-to-end through the dispatch executor with a recording shell: proves the `fetch origin <base>` → `checkout -b <branch> origin/<base>` sequence, and the offline fallback to the plain create.
- Existing `DispatchLaneParityTest` unchanged and green (unresolved base → graceful fallback = prior behaviour).
- Full `mvn clean verify` green, including the api.* 100% and `DispatchOperations` coverage gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EdCZoPqgpGs3e5vp9twpj
