### PR TITLE
Add GET /v1/fdes — the org FDE roster as a member-tier read

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -44,6 +44,28 @@ record WhoamiResponse(
   }
 }
 
+record FdeSummaryView(String handle, String displayName, String email, String role)
+    implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("handle", handle);
+    m.put("display_name", displayName);
+    m.put("email", email);
+    m.put("role", role);
+    return m;
+  }
+}
+
+record FdesResponse(List<FdeSummaryView> fdes) implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("fdes", fdes);
+    return m;
+  }
+}
+
 record ProjectListItemView(String name, String containerStatus) implements Mappable {
   @Override
   public Map<String, Object> toMap() {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -32,6 +32,7 @@ public final class ApiRouter implements HttpHandler {
   private static final String V1 = "v1";
   private static final String HEALTH = "health";
   private static final String WHOAMI = "whoami";
+  private static final String FDES = "fdes";
   private static final String PROJECTS = "projects";
   private static final String SPECS = "specs";
   private static final String DISPATCH = "dispatch";
@@ -172,6 +173,10 @@ public final class ApiRouter implements HttpHandler {
 
     if (request.matches(GET, V1, WHOAMI)) {
       return whoami(exchange);
+    }
+
+    if (request.matches(GET, V1, FDES)) {
+      return ApiResponse.from(operations.fdes());
     }
 
     if (request.hasEventsPrefix()) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
@@ -22,6 +22,9 @@ public interface Operations {
   /** Lists every project on this node with its container status. */
   Result<ProjectListResponse> projects();
 
+  /** The org-wide FDE roster, sorted by handle — a member-tier read backed by the synced roster. */
+  Result<FdesResponse> fdes();
+
   Result<ProjectResponse> project(String project);
 
   /** Returns the two-hop SSH target (server jump + container) for a running project. */

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -53,6 +53,7 @@ public final class SailOperations implements Operations {
   private final GlobalSpecOperations globalSpecOps;
   private final ReviewOperations reviewOps;
   private final DispatchOperations dispatchOps;
+  private final FdeStore fdeStore;
 
   public SailOperations() {
     this(new ShellExecutor(false), SailPaths.PROJECT_DESCRIPTOR);
@@ -277,6 +278,7 @@ public final class SailOperations implements Operations {
     this.projectStore = projectStore;
     this.connectEnvironment = connectEnvironment;
     this.syncScheduler = syncScheduler;
+    this.fdeStore = fdeStore;
     this.projects = new ProjectLoader(shell, file);
     this.globalSpecOps = new GlobalSpecOperations(specStore, reviewStore, eventBus, runStore);
     this.reviewOps = new ReviewOperations(reviewStore, specStore);
@@ -309,6 +311,25 @@ public final class SailOperations implements Operations {
   @Override
   public Result<ProjectListResponse> projects() {
     return safe(this::projectsValue);
+  }
+
+  @Override
+  public Result<FdesResponse> fdes() {
+    if (fdeStore == null) {
+      return Result.failure(
+          ErrorCode.INTERNAL,
+          "FDE roster not available. Start the server with 'sail server start'.");
+    }
+    return safe(this::fdesValue);
+  }
+
+  private FdesResponse fdesValue() {
+    var roster =
+        fdeStore.list().stream()
+            .map(
+                fde -> new FdeSummaryView(fde.handle(), fde.displayName(), fde.email(), fde.role()))
+            .toList();
+    return new FdesResponse(roster);
   }
 
   @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -33,6 +33,34 @@ class ApiRouterTest {
   }
 
   @Test
+  void fdesListsTheRosterToAnAuthenticatedCaller() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/fdes", "token");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"handle\": \"ada\""));
+      assertTrue(response.body().contains("\"display_name\": \"Ada Lovelace\""));
+      assertTrue(response.body().contains("\"email\": \"ada@x.dev\""));
+      assertTrue(response.body().contains("\"role\": \"admin\""));
+      assertTrue(response.body().contains("\"handle\": \"bob\""));
+      assertTrue(response.body().contains("\"schema_version\": 1"));
+      assertTrue(
+          response.body().indexOf("\"ada\"") < response.body().indexOf("\"bob\""),
+          "the roster is served in the handle order the store returns");
+    }
+  }
+
+  @Test
+  void fdesRequiresABearerToken() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/fdes", null);
+
+      assertEquals(401, response.statusCode());
+      assertTrue(response.body().contains("missing_bearer_token"));
+    }
+  }
+
+  @Test
   void protectedRoutesRequireBearerToken() throws Exception {
     try (var server = server()) {
       var response = get(server, "/v1/projects/acme/agent", null);
@@ -1105,6 +1133,15 @@ class ApiRouterTest {
               java.util.List.of(
                   new ProjectListItemView("acme", "running"),
                   new ProjectListItemView("beta", "not_created"))));
+    }
+
+    @Override
+    public Result<FdesResponse> fdes() {
+      return Result.success(
+          new FdesResponse(
+              java.util.List.of(
+                  new FdeSummaryView("ada", "Ada Lovelace", "ada@x.dev", "admin"),
+                  new FdeSummaryView("bob", "Bob", "bob@x.dev", "member"))));
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -208,6 +208,43 @@ class SailOperationsTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  void fdesReturnsTheRosterSortedByHandle() throws Exception {
+    var db = Sqlite.open(tempDir.resolve("roster-" + System.nanoTime() + ".db"));
+    new SchemaManager(db).migrate();
+    var fdeStore = new FdeStore(db);
+    fdeStore.add("bob", "Bob", "bob@x.dev", "member");
+    fdeStore.add("ada", "Ada Lovelace", "ada@x.dev", "admin");
+    var operations =
+        new SailOperations(
+            new FakeShell(),
+            "sail.yaml",
+            null,
+            null,
+            new SpecStore(db),
+            new ReviewStore(db),
+            new RunStore(db),
+            new ProjectStore(db),
+            null,
+            fdeStore);
+
+    var roster = (List<Map<String, Object>>) get(operations.fdes(), "fdes");
+
+    assertEquals(
+        List.of("ada", "bob"),
+        roster.stream().map(row -> row.get("handle")).toList(),
+        "the roster is sorted by handle");
+    assertEquals("Ada Lovelace", roster.get(0).get("display_name"));
+    assertEquals("ada@x.dev", roster.get(0).get("email"));
+    assertEquals("admin", roster.get(0).get("role"));
+  }
+
+  @Test
+  void fdesFailsWhenTheRosterIsNotWired() {
+    assertError(ErrorCode.INTERNAL, new SailOperations(new FakeShell(), "sail.yaml").fdes());
+  }
+
+  @Test
   void connectReturnsTheTwoHopSshTarget() throws Exception {
     var operations =
         operationsWith(shell().on("incus list ^acme$", RUNNING_JSON), store -> {}, environment());

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -22,6 +22,11 @@ class TestOperations implements Operations {
   }
 
   @Override
+  public Result<FdesResponse> fdes() {
+    return Result.success(new FdesResponse(List.of()));
+  }
+
+  @Override
   public Result<ProjectResponse> project(String project) {
     return Result.success(new ProjectResponse(project, "running", null));
   }


### PR DESCRIPTION
## Why

Mast needs the org's FDE roster to gate the UI — showing a spec's assignee, enabling log viewing only for your own specs, etc. But the API exposed no way to list FDEs: `GET /v1/whoami` returns only the caller, and the router served nothing that enumerates the roster. The roster already exists in `FdeStore` and replicates org-wide via sync, so this is a thin read exposure — no new state, no new sync.

## Contract

`GET /v1/fdes` — member-tier read (READ capability, the same gate as `GET /v1/specs`), backed by `FdeStore.list()`, sorted by handle:

```json
{
  "schema_version": 1,
  "fdes": [
    {"handle": "ada", "display_name": "Ada Lovelace", "email": "ada@x.dev", "role": "admin"},
    {"handle": "bob", "display_name": "Bob", "email": "bob@x.dev", "role": "member"}
  ]
}
```

An unauthenticated call is `401 missing_bearer_token`. A box with no roster wired (not a server) fails with a structured `internal` error rather than an empty list that would read as an empty org.

## Shape

- `FdesResponse` / `FdeSummaryView` (ApiModels) carry the wire fields; `schema_version` is injected centrally by `ApiJson`.
- `Operations.fdes()` → `SailOperations.fdes()` maps `FdeStore.list()` rows (null-store → `internal`).
- `ApiRouter` routes the exact two-segment `GET v1/fdes`, after the standard auth → rate-limit → authorize(READ) sequence.
- The agent-facing local socket (`LocalApiRouter`, `/v1/specs` only) is intentionally untouched — the roster is a control-plane read.

## Tests (TDD)

- `ApiRouterTest` — end-to-end over HTTP: `/v1/fdes` returns the roster JSON in handle order with `schema_version`; unauthenticated is `401`.
- `SailOperationsTest` — the real impl returns the roster sorted by handle with all four fields; an unwired roster returns `internal`.
- Full `mvn clean verify` green, including the api.* 100% coverage gate (both response records) and the `DispatchOperations`/`SailOperations` ratchets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EdCZoPqgpGs3e5vp9twpj
