### PR TITLE
Make the missed-stop sweep internally consistent (de-flake the reconciler)

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -17,6 +17,7 @@ import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
@@ -147,9 +148,13 @@ public final class MissedStopReconciler implements AutoCloseable {
   public int sweep() {
     var replayed = 0;
     try {
+      var handledThisSweep = new HashSet<String>();
       for (var spec : specStore.list(IN_PROGRESS)) {
         try {
-          replayed += reconcile(spec) ? 1 : 0;
+          if (reconcile(spec)) {
+            handledThisSweep.add(spec.id());
+            replayed++;
+          }
         } catch (Exception e) {
           System.err.println(
               "  [reconcile] failed for "
@@ -160,14 +165,34 @@ public final class MissedStopReconciler implements AutoCloseable {
                   + e.getMessage());
         }
       }
-      for (var spec : specStore.list(REVIEW)) {
-        replayed += rescueStrandedReview(spec) ? 1 : 0;
-      }
-      replayed += releaseStrandedReservations();
+      replayed += rescueStrandedReviews(handledThisSweep);
+      replayed += releaseStrandedReservations(handledThisSweep);
     } catch (Exception e) {
       System.err.println("  [reconcile] missed-stop sweep aborted: " + e.getMessage());
     }
     return replayed;
+  }
+
+  /**
+   * Rescues every spec stranded in {@code review}, skipping any whose stop was already replayed
+   * earlier in this same sweep. Without the skip a spec that the in-progress pass just reconciled —
+   * whose replayed stop drives it {@code in_progress → review} on an async subscriber thread —
+   * would be seen in {@code review} by this pass and have its stop replayed a second time,
+   * double-handling the one run. The sweep is thereby internally consistent regardless of when the
+   * async transition lands.
+   */
+  int rescueStrandedReviews(Set<String> handledThisSweep) {
+    var rescued = 0;
+    for (var spec : specStore.list(REVIEW)) {
+      if (handledThisSweep.contains(spec.id())) {
+        continue;
+      }
+      if (rescueStrandedReview(spec)) {
+        handledThisSweep.add(spec.id());
+        rescued++;
+      }
+    }
+    return rescued;
   }
 
   /**
@@ -177,14 +202,17 @@ public final class MissedStopReconciler implements AutoCloseable {
    * dispatch. Only a run older than {@link #LAUNCH_GRACE} is touched, so a run still inside the
    * microsecond reserve-then-claim window of a healthy dispatch is never disturbed. The spec was
    * never claimed, so it stays {@code pending} and dispatchable; only the dead reservation is
-   * cleared. Foreign runs are left to their executing box.
+   * cleared. Foreign runs are left to their executing box. A run whose spec was already handled
+   * earlier in this same sweep is skipped, so an async status flip caused by the sweep's own
+   * replayed stop can never make one pass both reconcile and release the one run.
    */
-  private int releaseStrandedReservations() {
+  int releaseStrandedReservations(Set<String> handledThisSweep) {
     var node = localHandle.get();
     var deadline = clock.get().minus(LAUNCH_GRACE);
     var released = 0;
     for (var run : sessionStore.running()) {
-      if (!SailOperations.ownsRun(run.node(), node)
+      if (handledThisSweep.contains(run.specId())
+          || !SailOperations.ownsRun(run.node(), node)
           || !MissedStops.parseOr(run.startedAt(), Instant.MAX).isBefore(deadline)
           || specBeingWorked(run.specId())) {
         continue;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -26,8 +26,10 @@ import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -391,6 +393,40 @@ class MissedStopReconcilerTest {
     var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
 
     assertEquals(0, replayed, "no run to replay a stop from");
+  }
+
+  @Test
+  void aSpecReconciledThisSweepIsNotAlsoRescuedInReview() {
+    createReviewSpec("auth");
+    finishedSession("auth", "stopped", 0);
+
+    assertEquals(
+        0,
+        reconciler(new CountingProbe(true), Instant::now)
+            .rescueStrandedReviews(new HashSet<>(Set.of("auth"))),
+        "a spec whose stop was replayed earlier this sweep — which flips it into review on an async"
+            + " subscriber thread — must not have its stop replayed a second time by the review pass");
+    assertEquals(
+        1,
+        reconciler(new CountingProbe(true), Instant::now).rescueStrandedReviews(new HashSet<>()),
+        "the same genuinely stranded review spec IS rescued when nothing handled it this sweep");
+  }
+
+  @Test
+  void aRunReconciledThisSweepIsNotAlsoReleasedAsStranded() {
+    createSpec("auth", SpecStatus.AWAITING_MERGE);
+    runningSession("auth");
+    var rec = reconciler(new CountingProbe(true), PAST_GRACE);
+
+    assertEquals(
+        0,
+        rec.releaseStrandedReservations(Set.of("auth")),
+        "a run whose stop was replayed earlier this sweep is not also released as a stranded"
+            + " reservation, even once its spec has left in_progress");
+    assertEquals(
+        1,
+        rec.releaseStrandedReservations(Set.of()),
+        "the same run IS released as stranded when nothing handled it this sweep");
   }
 
   private void createReviewSpec(String id) {


### PR DESCRIPTION
## The flake (surfaced blocking the v0.13.168 release)

`MissedStopReconcilerTest.replaysACleanMissedStopAndDrivesTheSpecToAwaitingMerge` failed on the macOS release runner — `expected 1 but was 2` — while Linux (and local verify) passed. PR CI is Ubuntu-only, so this macOS-only timing surface only appears at release time and intermittently blocks it.

## Root cause

`MissedStopReconciler.sweep()` ran three passes reading **live** spec status:

1. in-progress specs → `reconcile` (replays the missed stop)
2. review specs → `rescueStrandedReview`
3. `releaseStrandedReservations`

The in-progress pass publishes each replayed stop onto the **async** event bus (one drain virtual thread per subscriber). The review pipeline subscriber, reacting to that stop, flips the reconciled spec `in_progress → review` on its own thread. When that transition landed *mid-sweep*, pass 2's `specStore.list(REVIEW)` returned the very spec pass 1 had just reconciled, and it replayed the stop a **second time** → count 2. Purely timing-dependent, hence flaky, hence macOS-only in practice.

## Fix

Thread a single mutable `handledThisSweep` set through the passes. A spec whose stop the in-progress pass replayed is skipped by both the review-rescue and the stranded-release passes. The sweep is now internally consistent regardless of when the async transition lands — and the previously-flaky integration test is now deterministic (always 1).

Genuine terminal-state cleanup is preserved: a spec the sweep did **not** reconcile (e.g. a `done` spec whose run outlived it) is still released as stranded — only same-sweep double-handling is prevented.

## Tests (deterministic, no async timing)

`rescueStrandedReviews` and `releaseStrandedReservations` are now package-private so the exclusion is table-tested directly:

- `aSpecReconciledThisSweepIsNotAlsoRescuedInReview` — a spec in the handled set is skipped by the review pass; the same genuinely-stranded review spec IS rescued when nothing handled it.
- `aRunReconciledThisSweepIsNotAlsoReleasedAsStranded` — a running run whose spec is in the handled set is skipped by the release pass; the same run IS released when nothing handled it.

Full `mvn clean verify` green, including the api.* **100%** coverage gate (`MissedStopReconciler` is not excluded) — both new branches covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EdCZoPqgpGs3e5vp9twpj
