### PR TITLE
Record review pipeline executions as runs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -414,6 +414,13 @@ a plain agent's re-review is never fed a prior iteration's findings) via `Stream
 clean (empty `SAIL_SPEC_ID`, no hooks) so its own completion never re-enters the pipeline.
 Follow it live with `sail agent log <project> --review`.
 
+The run aggregate records that negotiation as a `role=review` run using the review UUID. A
+stage UUID would be less truthful: reviewer and fix invocations deliberately share the review's
+file set, while a stage-scoped run ID would resolve to a directory they never write. The run is
+created before the first agent process starts, completes after the review's foreground work ends,
+and syncs like a build run. Retention always protects running run directories, including review
+runs that fall outside the normal keep window during concurrent work.
+
 **Recovery without losing work.** The git branch is the durable record: every coding agent
 (build and fix) commits before it stops, and neither a guardrail stop nor an escalation ever
 discards it. So an FDE always recovers by returning to the branch. When a spec is stuck: a

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -139,6 +139,24 @@ public final class RunStore implements ConflictResolver {
   }
 
   /**
+   * Records a review negotiation under the review UUID that owns its prompt, session, and log
+   * files. Reviewer and fix invocations deliberately share that identity, so one run row remains
+   * addressable as {@code ~/.sail/runs/<reviewId>/review.log} throughout the negotiation.
+   */
+  public String createReview(
+      String reviewId,
+      String project,
+      String specId,
+      String node,
+      String agent,
+      String branch,
+      String task,
+      String logPath) {
+    return create(
+        reviewId, project, specId, node, "review", agent, branch, task, null, null, logPath, "");
+  }
+
+  /**
    * Atomically reserves a dispatch: within one {@code BEGIN IMMEDIATE} transaction, checks every
    * running local run of the project for a repo overlap or a same-spec run and inserts the new
    * {@code running} run — with its reserved repos persisted — only when none conflicts. Taking the
@@ -207,17 +225,18 @@ public final class RunStore implements ConflictResolver {
   }
 
   /**
-   * The latest run of {@code project} that executed on this box, or empty. Ownership is by node: a
-   * box with a handle owns exactly the runs stamped with it; a box with no handle owns exactly its
-   * own blank-node runs and never a run adopted from another box via sync. So "the project's latest
-   * run" can never resolve to a foreign run — the guarantee the completion and report paths rely on
-   * now that the {@code runs} table also holds synced foreign rows.
+   * The latest build run of {@code project} that executed on this box, or empty. Review runs remain
+   * in the aggregate but do not replace the build session used by agent status, log, and report
+   * commands. Ownership is by node: a box with a handle owns exactly the runs stamped with it; a
+   * box with no handle owns exactly its own blank-node runs and never a run adopted from another
+   * box via sync.
    */
   public Optional<RunRow> latestForProjectOnNode(String project, String localHandle) {
     return db.queryOne(
         "SELECT "
             + COLUMNS
-            + " FROM runs WHERE project = ? AND IFNULL(node, '') = ? ORDER BY started_at DESC"
+            + " FROM runs WHERE project = ? AND IFNULL(node, '') = ?"
+            + " AND IFNULL(role, 'build') = 'build' ORDER BY started_at DESC"
             + " LIMIT 1",
         this::mapRow,
         project,
@@ -225,14 +244,15 @@ public final class RunStore implements ConflictResolver {
   }
 
   /**
-   * The running run of {@code project} that executed on this box, or empty. Node-scoped like {@link
-   * #latestForProjectOnNode}.
+   * The running build run of {@code project} that executed on this box, or empty. Node-scoped like
+   * {@link #latestForProjectOnNode}.
    */
   public Optional<RunRow> runningForProjectOnNode(String project, String localHandle) {
     return db.queryOne(
         "SELECT "
             + COLUMNS
             + " FROM runs WHERE project = ? AND status = 'running' AND IFNULL(node, '') = ?"
+            + " AND IFNULL(role, 'build') = 'build'"
             + " ORDER BY started_at DESC LIMIT 1",
         this::mapRow,
         project,
@@ -240,12 +260,28 @@ public final class RunStore implements ConflictResolver {
   }
 
   /**
-   * Every run still in the {@code running} state, across all projects and nodes — the reaper's full
-   * input. Ownership is filtered by the caller so it matches exactly what the dispatch gate counts,
-   * including rows with a blank node.
+   * Every build run still in the {@code running} state, across all projects and nodes — the
+   * build-session reaper's full input. Review executions are foreground work owned and completed by
+   * the review controller, so the systemd reaper must not probe them as build units.
    */
   public List<RunRow> running() {
-    return db.query("SELECT " + COLUMNS + " FROM runs WHERE status = 'running'", this::mapRow);
+    return db.query(
+        "SELECT "
+            + COLUMNS
+            + " FROM runs WHERE status = 'running' AND IFNULL(role, 'build') = 'build'",
+        this::mapRow);
+  }
+
+  /** Marks local review executions orphaned by a server restart failed. */
+  public int failRunningReviewsOnNode(String localHandle) {
+    var ids =
+        db.query(
+            "SELECT id FROM runs WHERE status = 'running' AND role = 'review'"
+                + " AND IFNULL(node, '') = ?",
+            row -> row.text(0),
+            ownerKey(localHandle));
+    ids.forEach(id -> complete(id, "failed", null));
+    return ids.size();
   }
 
   private static String ownerKey(String localHandle) {

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.common.DateTimeUtils;
 import java.nio.file.Path;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,6 +72,32 @@ class RunStoreTest {
     assertEquals("/home/dev/.sail/runs/r/agent.log", run.logPath());
     assertNotNull(run.startedAt());
     assertNull(run.completedAt());
+  }
+
+  @Test
+  void createAndCompleteReviewRun() {
+    var id = DateTimeUtils.newId().toString();
+    var logPath = "/home/dev/.sail/runs/" + id + "/review.log";
+
+    store.createReview(id, "backend", "auth", "node-a", "codex", "feat/auth", "review it", logPath);
+
+    var running = store.findById(id).orElseThrow();
+    assertEquals("review", running.role());
+    assertEquals("running", running.status());
+    assertEquals("node-a", running.node());
+    assertEquals("codex", running.agent());
+    assertEquals("feat/auth", running.branch());
+    assertEquals("review it", running.task());
+    assertEquals(logPath, running.logPath());
+    assertTrue(running.unit().isBlank());
+    assertEquals("review", store.comparableSnapshot(id).get("role"));
+
+    store.complete(id, "completed", 0);
+
+    var completed = store.findById(id).orElseThrow();
+    assertEquals("completed", completed.status());
+    assertEquals(0, completed.exitCode());
+    assertNotNull(completed.completedAt());
   }
 
   @Test
@@ -184,6 +211,39 @@ class RunStoreTest {
     assertEquals(
         "spec-2", store.latestForProjectOnNode("backend", "node-a").orElseThrow().specId());
     assertTrue(store.latestForProjectOnNode("nonexistent", "node-a").isEmpty());
+  }
+
+  @Test
+  void buildSessionQueriesIgnoreRunningReviewRows() {
+    var buildId = newRun("backend", "auth");
+    var reviewId = DateTimeUtils.newId().toString();
+    store.createReview(
+        reviewId,
+        "backend",
+        "auth",
+        "node-a",
+        "codex",
+        "feat/x",
+        "review it",
+        "/home/dev/.sail/runs/" + reviewId + "/review.log");
+
+    assertEquals(buildId, store.latestForProjectOnNode("backend", "node-a").orElseThrow().id());
+    assertEquals(buildId, store.runningForProjectOnNode("backend", "node-a").orElseThrow().id());
+    assertEquals(List.of(buildId), store.running().stream().map(RunStore.RunRow::id).toList());
+    assertEquals(2, store.listForProject("backend").size(), "the aggregate still lists both roles");
+  }
+
+  @Test
+  void startupFailsOnlyLocalRunningReviewRows() {
+    var local = DateTimeUtils.newId().toString();
+    var foreign = DateTimeUtils.newId().toString();
+    store.createReview(local, "backend", "auth", "node-a", "codex", "b", "t", "/runs/" + local);
+    store.createReview(foreign, "backend", "auth", "node-b", "codex", "b", "t", "/runs/" + foreign);
+
+    assertEquals(1, store.failRunningReviewsOnNode("node-a"));
+    assertEquals("failed", store.findById(local).orElseThrow().status());
+    assertNotNull(store.findById(local).orElseThrow().completedAt());
+    assertEquals("running", store.findById(foreign).orElseThrow().status());
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/sync/RunSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/RunSyncTest.java
@@ -104,6 +104,29 @@ class RunSyncTest {
   }
 
   @Test
+  void aReviewRunReplicatesAsMetadataButRemainsOwnedByItsExecutingNode() {
+    var id = DateTimeUtils.newId().toString();
+    node.runs.createReview(
+        id,
+        "backend",
+        "auth",
+        "node",
+        "codex",
+        "feat/auth",
+        "review it",
+        "/home/dev/.sail/runs/" + id + "/review.log");
+
+    sync(node);
+    sync(other);
+
+    var replicated = other.runs.findById(id).orElseThrow();
+    assertEquals("review", replicated.role());
+    assertEquals("node", replicated.node());
+    assertEquals("running", replicated.status());
+    assertFalse(other.replica.mayPush(id));
+  }
+
+  @Test
   void aLifecycleTransitionOnTheOwningNodePropagates() {
     var id = startRun(node, "node");
     sync(node);

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/RunRetention.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/RunRetention.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
 /**
@@ -34,9 +35,27 @@ public final class RunRetention {
   public static List<String> prune(
       ShellExec shell, String container, List<String> runIdsNewestFirst, int keep)
       throws IOException, InterruptedException, TimeoutException {
+    return prune(shell, container, runIdsNewestFirst, Set.of(), keep);
+  }
+
+  /**
+   * As {@link #prune(ShellExec, String, List, int)}, while retaining every protected run even when
+   * it falls beyond the keep window. Callers protect live runs so concurrent build and review
+   * executions never lose their directory while an agent still has the log open.
+   */
+  public static List<String> prune(
+      ShellExec shell,
+      String container,
+      List<String> runIdsNewestFirst,
+      Set<String> protectedRunIds,
+      int keep)
+      throws IOException, InterruptedException, TimeoutException {
     var pruned = new ArrayList<String>();
     for (var i = Math.max(keep, 0); i < runIdsNewestFirst.size(); i++) {
       var runId = runIdsNewestFirst.get(i);
+      if (protectedRunIds.contains(runId)) {
+        continue;
+      }
       var result =
           shell.exec(ContainerExec.asDevUser(container, List.of("rm", "-rf", runDir(runId))));
       if (result.ok()) {

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/RunRetentionTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/RunRetentionTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
@@ -94,5 +95,17 @@ class RunRetentionTest {
     var shell = new RecordingShell();
 
     assertEquals(3, RunRetention.prune(shell, "acme", runIds(3), -1).size());
+  }
+
+  @Test
+  void aRunningReviewBeyondTheKeepWindowIsNeverPruned() throws Exception {
+    var shell = new RecordingShell();
+
+    var pruned = RunRetention.prune(shell, "acme", runIds(5), Set.of(runId(3)), 2);
+
+    assertEquals(List.of(runId(2), runId(4)), pruned);
+    assertTrue(
+        shell.commands.stream().noneMatch(command -> command.contains(AgentUnit.runDir(runId(3)))),
+        "a live review keeps its shared prompt, session, and log directory");
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ContainerReviewAgentRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ContainerReviewAgentRunner.java
@@ -71,7 +71,7 @@ final class ContainerReviewAgentRunner implements ReviewAgentRunner {
         shell.exec(
             ContainerExec.asDevUser(project, List.of("bash", "-lc", command)), null, AGENT_TIMEOUT);
     if (!result.ok()) {
-      throw new IllegalStateException(
+      throw new ReviewAgentExecutionException(
           "Review agent '"
               + agent
               + "' exited non-zero in '"
@@ -79,7 +79,8 @@ final class ContainerReviewAgentRunner implements ReviewAgentRunner {
               + "' (see "
               + unit.logPath()
               + "): "
-              + result.stderr());
+              + result.stderr(),
+          result.exitCode());
     }
 
     return StreamJsonResult.extract(readLogSince(project, unit, startOffset));

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -806,8 +806,14 @@ public final class DispatchOperations {
 
   private void pruneRuns(String project) {
     try {
-      var ids = runStore.listForProject(project).stream().map(RunStore.RunRow::id).toList();
-      var pruned = RunRetention.prune(shell, project, ids, RunRetention.DEFAULT_KEEP);
+      var runs = runStore.listForProject(project);
+      var ids = runs.stream().map(RunStore.RunRow::id).toList();
+      var running =
+          runs.stream()
+              .filter(run -> "running".equals(run.status()))
+              .map(RunStore.RunRow::id)
+              .collect(java.util.stream.Collectors.toUnmodifiableSet());
+      var pruned = RunRetention.prune(shell, project, ids, running, RunRetention.DEFAULT_KEEP);
       listener.runsPruned(pruned.size());
     } catch (Exception e) {
       System.err.println("  [api] Warning: could not prune runs: " + e.getMessage());

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewAgentRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewAgentRunner.java
@@ -25,3 +25,17 @@ public interface ReviewAgentRunner {
    */
   String run(String project, String agent, String prompt, String reviewId) throws Exception;
 }
+
+final class ReviewAgentExecutionException extends IllegalStateException {
+
+  private final int exitCode;
+
+  ReviewAgentExecutionException(String message, int exitCode) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+
+  int exitCode() {
+    return exitCode;
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -9,11 +9,13 @@ import ai.singlr.sail.config.ReviewPipelineConfig;
 import ai.singlr.sail.config.ReviewPipelineConfig.StageConfig;
 import ai.singlr.sail.config.ReviewPipelineConfig.StageType;
 import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.AgentUnit;
 import ai.singlr.sail.engine.FindingParser;
 import ai.singlr.sail.engine.FixTaskBuilder;
 import ai.singlr.sail.engine.ReviewPromptBuilder;
 import ai.singlr.sail.store.Finding;
 import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
 import java.net.InetAddress;
 import java.util.LinkedHashMap;
@@ -31,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * Orchestrates the review pipeline when an agent completes a spec. Subscribes to the event bus,
@@ -56,6 +59,8 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
   private final ReviewAgentRunner agentRunner;
   private final EventBus eventBus;
   private final Runnable syncTrigger;
+  private final RunStore runStore;
+  private final Supplier<String> localHandle;
   private final ConcurrentHashMap<String, CompletableFuture<Void>> inFlight =
       new ConcurrentHashMap<>();
   private final ExecutorService pipelineExecutor;
@@ -81,7 +86,9 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
         agentRunner,
         eventBus,
         syncTrigger,
-        Executors.newVirtualThreadPerTaskExecutor());
+        Executors.newVirtualThreadPerTaskExecutor(),
+        null,
+        null);
   }
 
   /**
@@ -105,6 +112,30 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       EventBus eventBus,
       Runnable syncTrigger,
       ExecutorService pipelineExecutor) {
+    this(
+        specStore,
+        reviewStore,
+        configResolver,
+        reviewerResolver,
+        agentRunner,
+        eventBus,
+        syncTrigger,
+        pipelineExecutor,
+        null,
+        null);
+  }
+
+  ReviewPipelineController(
+      SpecStore specStore,
+      ReviewStore reviewStore,
+      Function<String, ReviewPipelineConfig> configResolver,
+      Function<String, String> reviewerResolver,
+      ReviewAgentRunner agentRunner,
+      EventBus eventBus,
+      Runnable syncTrigger,
+      ExecutorService pipelineExecutor,
+      RunStore runStore,
+      Supplier<String> localHandle) {
     this.specStore = specStore;
     this.reviewStore = reviewStore;
     this.configResolver = configResolver;
@@ -113,6 +144,8 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     this.eventBus = eventBus;
     this.syncTrigger = Objects.requireNonNull(syncTrigger, "syncTrigger");
     this.pipelineExecutor = pipelineExecutor;
+    this.runStore = runStore;
+    this.localHandle = runStore == null ? null : Objects.requireNonNull(localHandle, "localHandle");
   }
 
   /** Sets a spec's status and immediately signals sync so the transition reaches main. */
@@ -311,6 +344,9 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
               + e.getMessage());
       reviewStore.updateReviewStatus(reviewId, "failed");
       syncTrigger.run();
+      failReviewRun(reviewId, e);
+    } finally {
+      completeReviewRun(reviewId);
     }
   }
 
@@ -341,6 +377,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       var repos = spec.map(SpecStore.SpecRow::repos).orElse(List.of());
       var prompt = ReviewPromptBuilder.build(branch, repos, stageConfig.categories());
 
+      startReviewRun(stage.reviewId(), project, specId, agent, branch, prompt);
       var output = agentRunner.run(project, agent, prompt, stage.reviewId());
       var parseResult = FindingParser.parse(output);
       if (parseResult.findings().isEmpty() && !parseResult.warnings().isEmpty()) {
@@ -371,6 +408,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       System.err.println(
           "review-pipeline: agent stage '" + stage.name() + "' errored: " + e.getMessage());
       reviewStore.completeStage(stage.id(), "failed", e.getMessage());
+      failReviewRun(stage.reviewId(), e);
       return new StageOutcome.Errored(e.getMessage());
     }
   }
@@ -444,11 +482,52 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
 
     try {
       var agent = spec.get().agent() != null ? spec.get().agent() : "claude-code";
+      startReviewRun(reviewId, project, specId, agent, spec.get().branch(), fixTask);
       agentRunner.run(project, agent, fixTask, reviewId);
     } catch (Exception e) {
+      failReviewRun(reviewId, e);
       System.err.println(
           "review-pipeline: fix iteration failed for spec " + specId + ": " + e.getMessage());
     }
+    completeReviewRun(reviewId);
+  }
+
+  private void startReviewRun(
+      String reviewId, String project, String specId, String agent, String branch, String task) {
+    if (runStore == null || runStore.findById(reviewId).isPresent()) {
+      return;
+    }
+    var unit = AgentUnit.forReview(reviewId);
+    runStore.createReview(
+        reviewId, project, specId, localHandle.get(), agent, branch, task, unit.logPath());
+    syncTrigger.run();
+  }
+
+  private void failReviewRun(String reviewId, Exception failure) {
+    if (runStore == null) {
+      return;
+    }
+    var exitCode =
+        failure instanceof ReviewAgentExecutionException execution ? execution.exitCode() : null;
+    runStore
+        .findById(reviewId)
+        .filter(run -> "running".equals(run.status()))
+        .ifPresent(run -> completeReviewRun(reviewId, "failed", exitCode));
+  }
+
+  private void completeReviewRun(String reviewId) {
+    if (runStore == null) {
+      return;
+    }
+    runStore
+        .findById(reviewId)
+        .filter(run -> "running".equals(run.status()))
+        .ifPresent(run -> completeReviewRun(reviewId, "completed", 0));
+  }
+
+  private void completeReviewRun(String reviewId, String status, Integer exitCode) {
+    runStore.complete(reviewId, status, exitCode);
+    syncTrigger.run();
   }
 
   private void escalate(String project, String specId, String reviewId) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewWiring.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewWiring.java
@@ -10,8 +10,10 @@ import ai.singlr.sail.config.ReviewPipelineConfig;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Builds the per-project resolvers the {@link ReviewPipelineController} needs from a loader that
@@ -37,6 +39,19 @@ public final class ReviewWiring {
       Function<String, SailYaml> projectLoader,
       ShellExec shell,
       Runnable syncTrigger) {
+    return controller(
+        specStore, reviewStore, eventBus, projectLoader, shell, syncTrigger, null, null);
+  }
+
+  public static ReviewPipelineController controller(
+      SpecStore specStore,
+      ReviewStore reviewStore,
+      EventBus eventBus,
+      Function<String, SailYaml> projectLoader,
+      ShellExec shell,
+      Runnable syncTrigger,
+      RunStore runStore,
+      Supplier<String> localHandle) {
     return new ReviewPipelineController(
         specStore,
         reviewStore,
@@ -44,7 +59,10 @@ public final class ReviewWiring {
         reviewerResolver(projectLoader),
         new ContainerReviewAgentRunner(shell),
         eventBus,
-        syncTrigger);
+        syncTrigger,
+        java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor(),
+        runStore,
+        localHandle);
   }
 
   /** Resolves a project's review pipeline: its configured one, or the mandatory default. */

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -629,6 +629,7 @@ public final class SailOperations implements Operations {
             ? List.<RunStore.RunRow>of()
             : runStore.listForProject(project).stream()
                 .filter(run -> "running".equals(run.status()))
+                .filter(run -> "build".equals(Objects.requireNonNullElse(run.role(), "build")))
                 .filter(run -> ownsRun(run.node(), localHandle))
                 .toList();
     if (running.isEmpty()) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -186,6 +186,10 @@ public final class ServerStartCommand implements Runnable {
             syncScheduler,
             new FdeStore(db));
     var orphaned = reviewStore.failOrphanedRunning();
+    var orphanedRuns = runStore.failRunningReviewsOnNode(NodeIdentity.handle());
+    if (orphanedRuns > 0) {
+      syncScheduler.afterWrite();
+    }
     if (orphaned > 0) {
       System.out.println(
           Ansi.AUTO.string(
@@ -200,7 +204,9 @@ public final class ServerStartCommand implements Runnable {
             bus,
             ServerStartCommand::loadProjectYaml,
             new ShellExecutor(false),
-            syncScheduler::afterWrite);
+            syncScheduler::afterWrite,
+            runStore,
+            NodeIdentity::handle);
     bus.subscribe(new RunTracker(runStore, syncScheduler, NodeIdentity::handle));
     if (narratesSlack(HostSync.config())) {
       bus.subscribe(SlackReactor.withDefaults(new SlackThreadStore(db), specStore));

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AgentLogStreamerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AgentLogStreamerTest.java
@@ -38,12 +38,16 @@ class AgentLogStreamerTest {
   }
 
   private static RunStore.RunRow run(String node, String logPath) {
+    return run(node, "build", logPath);
+  }
+
+  private static RunStore.RunRow run(String node, String role, String logPath) {
     return new RunStore.RunRow(
         "r1",
         "acme",
         "auth",
         node,
-        "build",
+        role,
         "claude-code",
         "feat/x",
         "do it",
@@ -74,7 +78,11 @@ class AgentLogStreamerTest {
   void streamRefusesAMemberWhoIsNotTheRunSpecAssignee() throws Exception {
     var out = new CapturingExchange("/v1/runs/r1/stream").as("raj", "member");
 
-    streamer(id -> Optional.of(runOn("node-a")), id -> Optional.of("uday"), "node-a").handle(out);
+    streamer(
+            id -> Optional.of(run("node-a", "review", "/review.log")),
+            id -> Optional.of("uday"),
+            "node-a")
+        .handle(out);
 
     assertEquals(403, out.status);
     assertTrue(out.body().contains("forbidden_not_assignee"), out.body());
@@ -111,6 +119,16 @@ class AgentLogStreamerTest {
     assertEquals(409, out.status);
     assertTrue(out.body().contains("run_on_other_node"), out.body());
     assertTrue(out.body().contains("node-b"), out.body());
+  }
+
+  @Test
+  void foreignReviewRunUsesTheSameProvenanceGuard() throws Exception {
+    var out = new CapturingExchange("/v1/runs/r1/stream");
+
+    streamer(id -> Optional.of(run("node-b", "review", "/review.log")), "node-a").handle(out);
+
+    assertEquals(409, out.status);
+    assertTrue(out.body().contains("run_on_other_node"), out.body());
   }
 
   @Test
@@ -184,6 +202,13 @@ class AgentLogStreamerTest {
     assertEquals("backend", cmd[2]);
     assertTrue(String.join(" ", cmd).contains("tail -f"));
     assertTrue(Arrays.asList(cmd).contains(RUN_LOG), Arrays.toString(cmd));
+  }
+
+  @Test
+  void buildTailCommandUsesTheReviewersRunScopedLog() {
+    var cmd = AgentLogStreamer.buildTailCommand("backend", RUN_UUID, "review", 0);
+
+    assertTrue(Arrays.asList(cmd).contains("/home/dev/.sail/runs/" + RUN_UUID + "/review.log"));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ContainerReviewAgentRunnerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ContainerReviewAgentRunnerTest.java
@@ -104,6 +104,7 @@ class ContainerReviewAgentRunnerTest {
     var ex =
         assertThrows(Exception.class, () -> runner(shell).run("acme", "codex", "p", REVIEW_ID));
     assertTrue(ex.getMessage().contains("boom"), ex.getMessage());
+    assertEquals(1, ((ReviewAgentExecutionException) ex).exitCode());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopIT.java
@@ -11,11 +11,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.singlr.sail.config.ReviewPipelineConfig;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.engine.AbstractIncusIT;
+import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerFilePush;
 import ai.singlr.sail.engine.FindingParser;
 import ai.singlr.sail.engine.ReviewPromptBuilder;
 import ai.singlr.sail.store.Finding;
 import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
@@ -47,6 +49,11 @@ class ReviewAgentLoopIT extends AbstractIncusIT {
   private static final String FAKE_AGENT =
       """
       #!/usr/bin/env bash
+      if [ -f "$HOME/.sail/review-hold" ]; then
+        printf 'review started\n'
+        touch "$HOME/.sail/review-started"
+        while [ -f "$HOME/.sail/review-hold" ]; do sleep 0.1; done
+      fi
       case "$*" in
         *"Output your findings"*)
           n_file="$HOME/.sail/review-count"
@@ -112,6 +119,7 @@ class ReviewAgentLoopIT extends AbstractIncusIT {
       new SchemaManager(db).migrate();
       var specStore = new SpecStore(db);
       var reviewStore = new ReviewStore(db);
+      var runStore = new RunStore(db);
       specStore.create(
           new SpecStore.SpecRow(
               "auth",
@@ -156,7 +164,14 @@ class ReviewAgentLoopIT extends AbstractIncusIT {
               new ContainerReviewAgentRunner(shell),
               null,
               () -> {},
-              new DirectExecutorService());
+              java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor(),
+              runStore,
+              () -> "node-a");
+
+      var hold =
+          shell.exec(
+              ContainerExec.asDevUser(CONTAINER, List.of("touch", "/home/dev/.sail/review-hold")));
+      assertTrue(hold.ok(), hold.stderr());
 
       controller.onEvent(
           Event.of(
@@ -167,10 +182,54 @@ class ReviewAgentLoopIT extends AbstractIncusIT {
               "host",
               Map.of(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_WATCHER)));
 
+      RunStore.RunRow running = awaitRunningReview(runStore);
+      assertEquals("review", running.role());
+      assertEquals("auth", running.specId());
+      assertEquals("node-a", running.node());
+      assertEquals("codex", running.agent());
+      assertEquals("feat/test", running.branch());
+      assertTrue(awaitLiveReviewLog(running.logPath()).contains("review started"));
+
+      var release =
+          shell.exec(
+              ContainerExec.asDevUser(
+                  CONTAINER, List.of("rm", "-f", "/home/dev/.sail/review-hold")));
+      assertTrue(release.ok(), release.stderr());
+      controller.awaitCompletion(30_000);
+
       assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
       assertEquals(2, reviewStore.reviewsForSpec("auth").size());
+      var completed = runStore.findById(running.id()).orElseThrow();
+      assertEquals("completed", completed.status());
+      assertEquals(0, completed.exitCode());
+      assertTrue(completed.completedAt() != null && !completed.completedAt().isBlank());
+      controller.close();
     } finally {
       deleteRecursively(stateDir);
     }
+  }
+
+  private static RunStore.RunRow awaitRunningReview(RunStore runStore) throws Exception {
+    var deadline = System.nanoTime() + java.time.Duration.ofSeconds(10).toNanos();
+    while (System.nanoTime() < deadline) {
+      var runs = runStore.listForSpec("auth");
+      if (!runs.isEmpty() && "running".equals(runs.getFirst().status())) {
+        return runs.getFirst();
+      }
+      Thread.sleep(50);
+    }
+    throw new AssertionError("review run did not become visible while the agent was active");
+  }
+
+  private String awaitLiveReviewLog(String logPath) throws Exception {
+    var deadline = System.nanoTime() + java.time.Duration.ofSeconds(10).toNanos();
+    while (System.nanoTime() < deadline) {
+      var log = shell.exec(ContainerExec.asDevUser(CONTAINER, List.of("cat", logPath)));
+      if (log.ok() && log.stdout().contains("review started")) {
+        return log.stdout();
+      }
+      Thread.sleep(50);
+    }
+    throw new AssertionError("review log did not stream output while the run was active");
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -15,6 +15,7 @@ import ai.singlr.sail.config.ReviewPipelineConfig;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.store.Finding;
 import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
@@ -974,6 +975,79 @@ class ReviewPipelineControllerTest {
 
     var review = reviewStore.latestReviewForSpec("auth").orElseThrow();
     assertEquals("passed", review.status());
+  }
+
+  @Test
+  void reviewRunIsVisibleWhileTheAgentRunsAndCompletedOnExit() throws Exception {
+    createSpec("auth", "in_progress");
+    var started = new CountDownLatch(1);
+    var release = new CountDownLatch(1);
+    ReviewAgentRunner gated =
+        (p, a, pr, rid) -> {
+          started.countDown();
+          await(release);
+          return "[]";
+        };
+    var runs = new RunStore(db);
+    var ctrl =
+        new ReviewPipelineController(
+            specStore,
+            reviewStore,
+            p -> singleAgentStage("no_critical"),
+            p -> "codex",
+            gated,
+            null,
+            () -> {},
+            java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor(),
+            runs,
+            () -> "node-a");
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+    assertTrue(started.await(5, TimeUnit.SECONDS), "pipeline should reach the agent runner");
+
+    var running = runs.listForSpec("auth").getFirst();
+    assertEquals("review", running.role());
+    assertEquals("running", running.status());
+    assertEquals("node-a", running.node());
+    assertEquals("codex", running.agent());
+    assertEquals("feat/test", running.branch());
+    assertEquals("/home/dev/.sail/runs/" + running.id() + "/review.log", running.logPath());
+
+    release.countDown();
+    ctrl.awaitCompletion(5000);
+
+    var completed = runs.findById(running.id()).orElseThrow();
+    assertEquals("completed", completed.status());
+    assertEquals(0, completed.exitCode());
+    assertNotNull(completed.completedAt());
+    ctrl.close();
+  }
+
+  @Test
+  void reviewRunRecordsTheAgentExitCodeOnFailure() {
+    createSpec("auth", "in_progress");
+    var runs = new RunStore(db);
+    var ctrl =
+        new ReviewPipelineController(
+            specStore,
+            reviewStore,
+            p -> singleAgentStage("no_critical"),
+            p -> "codex",
+            (p, a, pr, rid) -> {
+              throw new ReviewAgentExecutionException("quota", 17);
+            },
+            null,
+            () -> {},
+            new DirectExecutorService(),
+            runs,
+            () -> "node-a");
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    var failed = runs.listForSpec("auth").getFirst();
+    assertEquals("failed", failed.status());
+    assertEquals(17, failed.exitCode());
+    assertNotNull(failed.completedAt());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -917,6 +917,7 @@ class SailOperationsTest {
 
   private static final String R1 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
   private static final String R2 = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+  private static final String R3 = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
   private static final String RUN_LOG = "/home/dev/.sail/runs/" + R1 + "/agent.log";
   private static final String R2_LOG = "/home/dev/.sail/runs/" + R2 + "/agent.log";
 
@@ -1249,6 +1250,15 @@ class SailOperationsTest {
                   null,
                   R2_LOG,
                   "sail-agent-" + R2);
+              runs.createReview(
+                  R3,
+                  "acme",
+                  "auth",
+                  "node-a",
+                  "codex",
+                  "feat/auth",
+                  "review it",
+                  "/home/dev/.sail/runs/" + R3 + "/review.log");
             });
 
     var result = operations.stopRun(R1, "node-a", ADMIN);
@@ -1316,6 +1326,7 @@ class SailOperationsTest {
     assertEquals(2, runs.size(), "every local running run is listed");
     var encoded = ApiJson.withSchema(result.orThrow()).toString();
     assertTrue(encoded.contains(R1) && encoded.contains(R2), encoded);
+    assertFalse(encoded.contains("review.log"), "build agent status excludes review executions");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- record each review negotiation in the run aggregate under its review UUID before agent execution starts
- complete review runs with status, exit code, timestamps, sync metadata, and restart recovery
- keep live build and review directories safe from retention while preserving build-session command behavior
- verify review log routing, authorization/provenance, replication, and running/completed lifecycle behavior

## Testing
- mvn clean verify
- Incus integration coverage added to ReviewAgentLoopIT; the local dev container does not expose the incus CLI, so the repository's Incus CI lane executes it
