### PR TITLE
Make the review loop recover from errored reviews and uncommitted fix work

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
@@ -10,6 +10,7 @@ import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.store.Finding;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Parses structured JSON findings from review agent output. Extracts the JSON array between {@code
@@ -26,23 +27,28 @@ public final class FindingParser {
    * Parses the findings array out of a review agent's raw transcript. Transcripts are noisy: the
    * agent may echo the prompt (which itself names the {@code ```json} convention) and may emit
    * fenced blocks mid-reasoning, so candidates are tried <em>last to first</em> and the last block
-   * that parses as a JSON array wins — the response convention puts the verdict at the end. When
-   * nothing parses, the result carries warnings so the pipeline can refuse to treat an unreadable
-   * review as a clean pass.
+   * that parses as a JSON array wins — the response convention puts the verdict at the end. Fenced
+   * blocks are tried first; when none parses, the transcript is scanned for an unfenced findings
+   * array (or a bare {@code []} verdict line) before giving up — the format instruction is a
+   * request, not a guarantee, and JSON without its fence is still a verdict. When nothing parses,
+   * the result carries warnings so the pipeline can refuse to treat an unreadable review as a clean
+   * pass.
    */
   public static ParseResult parse(String agentOutput) {
-    var candidates = extractJsonBlocks(agentOutput);
-    if (candidates.isEmpty()) {
-      return new ParseResult(List.of(), List.of("No JSON block found in agent output."));
-    }
     var warnings = new ArrayList<String>();
-    for (var i = candidates.size() - 1; i >= 0; i--) {
-      var result = parseJsonArray(candidates.get(i));
-      if (result.findings().isEmpty() && !result.warnings().isEmpty()) {
-        warnings.addAll(result.warnings());
-        continue;
+    for (var candidates :
+        List.of(extractJsonBlocks(agentOutput), extractEmbeddedArrays(agentOutput))) {
+      for (var i = candidates.size() - 1; i >= 0; i--) {
+        var result = parseJsonArray(candidates.get(i));
+        if (result.findings().isEmpty() && !result.warnings().isEmpty()) {
+          warnings.addAll(result.warnings());
+          continue;
+        }
+        return result;
       }
-      return result;
+    }
+    if (warnings.isEmpty()) {
+      warnings.add("No JSON block found in agent output.");
     }
     return new ParseResult(List.of(), List.copyOf(warnings));
   }
@@ -86,11 +92,13 @@ public final class FindingParser {
    * Every marker occurrence starts an independent candidate (advancing past the marker, not the
    * closing fence): a prompt echo's mid-sentence marker would otherwise swallow the real block's
    * opening fence as its terminator. Overlap is harmless — candidates are validated by parsing.
+   * Markers match case-insensitively, so a {@code ```JSON} fence is not mistaken for prose.
    */
   private static void collectBlocks(String output, String marker, List<String> blocks) {
+    var haystack = output.toLowerCase(Locale.ROOT);
     var from = 0;
     while (true) {
-      var start = output.indexOf(marker, from);
+      var start = haystack.indexOf(marker, from);
       if (start < 0) return;
       from = start + marker.length();
       var contentStart = output.indexOf('\n', start);
@@ -100,6 +108,30 @@ public final class FindingParser {
       blocks.add(
           (end < 0 ? output.substring(contentStart) : output.substring(contentStart, end)).strip());
     }
+  }
+
+  /**
+   * Last-resort candidates for a reviewer that dropped the fence: every {@code [{} …{@code }]} span
+   * (an array of objects — the findings shape, rare in prose), and failing that a line that is
+   * exactly {@code []}. A mid-sentence {@code []} (the prompt echo names one) never matches — only
+   * a line the agent wrote as its whole verdict does.
+   */
+  static List<String> extractEmbeddedArrays(String output) {
+    if (Strings.isBlank(output)) return List.of();
+
+    var blocks = new ArrayList<String>();
+    var end = output.lastIndexOf("}]");
+    var from = 0;
+    while (end >= 0) {
+      var start = output.indexOf("[{", from);
+      if (start < 0 || start > end) break;
+      blocks.add(output.substring(start, end + 2));
+      from = start + 1;
+    }
+    if (blocks.isEmpty()) {
+      output.lines().map(String::strip).filter("[]"::equals).findFirst().ifPresent(blocks::add);
+    }
+    return List.copyOf(blocks);
   }
 
   private static String tryBareJson(String output) {

--- a/sail-core/src/main/java/ai/singlr/sail/engine/FixTaskBuilder.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/FixTaskBuilder.java
@@ -62,6 +62,14 @@ public final class FixTaskBuilder {
       sb.append("\n");
     }
 
+    sb.append(
+        """
+        When every finding is addressed: run the project's verification, commit all changes to
+        the current branch with a clear message, and push. Never leave uncommitted work in the
+        workspace — the re-review reads the branch, and uncommitted files contaminate the next
+        dispatch in this shared clone.
+        """);
+
     return sb.toString();
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
@@ -229,6 +229,78 @@ class FindingParserTest {
   }
 
   @Test
+  void parsesAnUppercaseFence() {
+    var output =
+        """
+        ```JSON
+        [{"severity": "LOW", "category": "LOGIC", "title": "Case", "description": "D"}]
+        ```
+        """;
+
+    var result = FindingParser.parse(output);
+
+    assertEquals(
+        1, result.findings().size(), "fence casing is not a verdict: " + result.warnings());
+    assertEquals("Case", result.findings().getFirst().title());
+  }
+
+  @Test
+  void findsTheArrayEmbeddedInProseWithoutAFence() {
+    var output =
+        """
+        I reviewed the branch and found one issue.
+        [{"severity": "HIGH", "category": "SECURITY", "title": "Leak", "description": "D"}]
+        Let me know if you need more detail.
+        """;
+
+    var result = FindingParser.parse(output);
+
+    assertEquals(1, result.findings().size(), "unfenced JSON is still JSON: " + result.warnings());
+    assertEquals("Leak", result.findings().getFirst().title());
+  }
+
+  @Test
+  void fallsThroughToAnEmbeddedArrayWhenTheOnlyFenceIsThePromptEcho() {
+    var output =
+        """
+        Begin your response with ```json and end with ```.
+        I inspected the diff and found one issue.
+        [{"severity": "MEDIUM", "category": "LOGIC", "title": "Bug", "description": "D"}]
+        """;
+
+    var result = FindingParser.parse(output);
+
+    assertEquals(
+        1,
+        result.findings().size(),
+        "an unparseable prompt-echo fence must not hide real findings: " + result.warnings());
+    assertEquals("Bug", result.findings().getFirst().title());
+  }
+
+  @Test
+  void aBareEmptyArrayLineInProseIsACleanVerdict() {
+    var output =
+        """
+        I examined every change on the branch.
+        []
+        No issues worth reporting.
+        """;
+
+    var result = FindingParser.parse(output);
+
+    assertTrue(result.findings().isEmpty());
+    assertTrue(result.warnings().isEmpty(), "a bare [] is a verdict: " + result.warnings());
+  }
+
+  @Test
+  void proseMentioningAnEmptyArrayMidSentenceIsNotAVerdict() {
+    var result = FindingParser.parse("If there are no issues, return an empty array: []");
+
+    assertTrue(result.findings().isEmpty());
+    assertFalse(result.warnings().isEmpty(), "a prompt echo must never count as a clean pass");
+  }
+
+  @Test
   void reportsAWarningWhenNoBlockParses() {
     var result = FindingParser.parse("Begin your response with ```json and end with ```.");
 

--- a/sail-core/src/test/java/ai/singlr/sail/engine/FixTaskBuilderTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/FixTaskBuilderTest.java
@@ -140,6 +140,28 @@ class FixTaskBuilderTest {
   }
 
   @Test
+  void taskEndsWithAnExplicitCommitProtocol() {
+    var finding =
+        Finding.create(
+            Finding.Severity.HIGH,
+            Finding.Category.LOGIC,
+            "a.java",
+            1,
+            1,
+            "Issue",
+            "Desc",
+            "",
+            null,
+            0.9);
+
+    var task = FixTaskBuilder.build("Spec", List.of(finding));
+
+    assertTrue(task.contains("commit"), "the fix agent must be told to commit, not just hinted");
+    assertTrue(task.contains("push"));
+    assertTrue(task.contains("Never leave uncommitted work"));
+  }
+
+  @Test
   void taskIncludesSpecTitleInHeader() {
     var finding =
         Finding.create(

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ContainerReviewAgentRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ContainerReviewAgentRunner.java
@@ -12,6 +12,7 @@ import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.StreamJsonResult;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -84,6 +85,56 @@ final class ContainerReviewAgentRunner implements ReviewAgentRunner {
     }
 
     return StreamJsonResult.extract(readLogSince(project, unit, startOffset));
+  }
+
+  /**
+   * A repo is rescued only when it is still checked out on the spec's branch — a repo parked
+   * anywhere else (another spec's branch, or main) is not this run's to commit, and auto-committing
+   * there is exactly how a shared clone gets contaminated. The commit is the rescue; the push is
+   * best-effort, since the branch already has an upstream from dispatch and a network blip must not
+   * fail the pipeline.
+   */
+  @Override
+  public List<String> ensureCommitted(String project, List<String> repos, String branch)
+      throws Exception {
+    if (branch == null || branch.isBlank()) {
+      return List.of();
+    }
+    var rescued = new ArrayList<String>();
+    for (var repo : repos) {
+      var dir = WORKSPACE + "/" + repo;
+      if (!onBranch(project, dir, branch) || git(project, dir, "status", "--porcelain").isBlank()) {
+        continue;
+      }
+      git(project, dir, "add", "-A");
+      git(project, dir, "commit", "-m", "fix: review-fix changes left uncommitted by the agent");
+      var push = shell.exec(ContainerExec.asDevUser(project, List.of("git", "-C", dir, "push")));
+      if (!push.ok()) {
+        System.err.println(
+            "review-pipeline: push failed for " + dir + " on " + branch + ": " + push.stderr());
+      }
+      rescued.add(repo);
+    }
+    return List.copyOf(rescued);
+  }
+
+  private boolean onBranch(String project, String dir, String branch) throws Exception {
+    var result =
+        shell.exec(
+            ContainerExec.asDevUser(
+                project, List.of("git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD")));
+    return result.ok() && branch.equals(result.stdout().strip());
+  }
+
+  private String git(String project, String dir, String... args) throws Exception {
+    var command = new ArrayList<>(List.of("git", "-C", dir));
+    command.addAll(List.of(args));
+    var result = shell.exec(ContainerExec.asDevUser(project, command));
+    if (!result.ok()) {
+      throw new IllegalStateException(
+          "git " + args[0] + " failed in " + dir + ": " + result.stderr());
+    }
+    return result.stdout();
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -13,6 +13,7 @@ import ai.singlr.sail.engine.HostInfo;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.store.EventStore;
 import ai.singlr.sail.store.MissedStops;
+import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
 import java.time.Duration;
@@ -85,6 +86,7 @@ public final class MissedStopReconciler implements AutoCloseable {
   private final SpecStore specStore;
   private final RunStore sessionStore;
   private final EventStore eventStore;
+  private final ReviewStore reviewStore;
   private final EventBus bus;
   private final UnitProbe unitProbe;
   private final Supplier<String> localHandle;
@@ -96,6 +98,7 @@ public final class MissedStopReconciler implements AutoCloseable {
       SpecStore specStore,
       RunStore sessionStore,
       EventStore eventStore,
+      ReviewStore reviewStore,
       EventBus bus,
       UnitProbe unitProbe,
       Supplier<String> localHandle,
@@ -103,6 +106,7 @@ public final class MissedStopReconciler implements AutoCloseable {
     this.specStore = specStore;
     this.sessionStore = sessionStore;
     this.eventStore = eventStore;
+    this.reviewStore = reviewStore;
     this.bus = bus;
     this.unitProbe = unitProbe;
     this.localHandle = localHandle;
@@ -245,17 +249,23 @@ public final class MissedStopReconciler implements AutoCloseable {
   }
 
   /**
-   * Rescues a spec stranded in {@code review} with no review ever started — the shape a dropped
-   * kickoff leaves: an out-of-band status write (a manual edit, or a sync revision from another
-   * box) moved the spec to {@code review} while its agent was still running here, so the
-   * authoritative stop hit the pipeline's guard against a non-{@code in_progress} spec and no
-   * review was created. Replaying the stop lets the review-resilient pipeline kick it off. A {@code
-   * review_stage_started} event means a review did run, so the spec is not stranded; and the rescue
-   * fires at most once per spec per server lifetime, so a project with no automated pipeline (its
-   * {@code review} is a human queue) is never replayed in a loop.
+   * Rescues a spec stranded in {@code review}, in either of the two shapes that leave it parked
+   * with nothing coming to move it. <em>Dropped kickoff</em>: an out-of-band status write (a manual
+   * edit, or a sync revision from another box) moved the spec to {@code review} while its agent was
+   * still running here, so the authoritative stop hit the pipeline's guard against a non-{@code
+   * in_progress} spec and no review was created. <em>Errored review</em>: the pipeline ran but its
+   * last attempt failed by infrastructure (unparseable reviewer output, an agent crash) — the
+   * design retries an errored attempt on the next stop, but the fix agent runs inline and produces
+   * no stop, so without a replay the retry never comes (the nexus-accounts-apis field incident).
+   * Replaying the stop lets the pipeline kick off or retry. Each rescue key — the spec for a
+   * dropped kickoff, the errored review row for a retry — fires at most once per server lifetime,
+   * and the pipeline's errored-attempt budget escalates a persistent failure, so neither shape can
+   * loop; an escalated or running review is left alone, since a human or a live pipeline owns the
+   * spec then.
    */
   private boolean rescueStrandedReview(SpecStore.SpecRow spec) {
-    if (reviewRescueAttempted.contains(spec.id()) || reviewStarted(spec.id())) {
+    var rescue = rescueFor(spec);
+    if (rescue == null || reviewRescueAttempted.contains(rescue.key())) {
       return false;
     }
     var node = localHandle.get();
@@ -267,13 +277,32 @@ public final class MissedStopReconciler implements AutoCloseable {
     if (latest.isEmpty()) {
       return false;
     }
-    reviewRescueAttempted.add(spec.id());
-    publishStop(
-        spec,
-        latest.get(),
-        latest.get().exitCode(),
-        "stranded in review with no review started; replaying the stop to kick it off");
+    reviewRescueAttempted.add(rescue.key());
+    publishStop(spec, latest.get(), latest.get().exitCode(), rescue.why());
     return true;
+  }
+
+  private record Rescue(String key, String why) {}
+
+  private Rescue rescueFor(SpecStore.SpecRow spec) {
+    if (!reviewStarted(spec.id())) {
+      return new Rescue(
+          spec.id(),
+          "stranded in review with no review started; replaying the stop to kick it off");
+    }
+    return reviewStore
+        .latestReviewForSpec(spec.id())
+        .filter(review -> review.errored() && "failed".equals(review.status()))
+        .map(
+            review ->
+                new Rescue(
+                    review.id(),
+                    "review "
+                        + review.id()
+                        + " errored ("
+                        + review.error()
+                        + "); replaying the stop to retry the iteration"))
+        .orElse(null);
   }
 
   private boolean reviewStarted(String specId) {
@@ -340,6 +369,7 @@ public final class MissedStopReconciler implements AutoCloseable {
           Event.WellKnownTypes.AGENT_FAILED,
           "review_stage_started",
           "review_stage_failed",
+          "review_errored",
           "review_escalated");
 
   private boolean actedOnSince(String specId, Instant since) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewAgentRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewAgentRunner.java
@@ -5,6 +5,8 @@
 
 package ai.singlr.sail.api;
 
+import java.util.List;
+
 /**
  * Runs a review agent in a container and returns its raw output. The controller delegates agent
  * execution to this interface so the orchestration logic is testable without containers.
@@ -24,6 +26,21 @@ public interface ReviewAgentRunner {
    * @throws Exception if the agent fails to start or exits with an error
    */
   String run(String project, String agent, String prompt, String reviewId) throws Exception;
+
+  /**
+   * Commits and pushes any work an agent left uncommitted on the spec's branch. The fix lane runs
+   * hook-free (so a reviewer's completion can never re-enter the pipeline), which also strips the
+   * dispatch lane's stop-readiness gate — so nothing stops a fix agent from ending its run with a
+   * dirty tree, contaminating the shared clone and starving the re-review of the very fixes it is
+   * about to judge. This is the deterministic backstop: a repo is rescued only when it is checked
+   * out on the spec's own branch, never any other.
+   *
+   * @return the repos that had uncommitted work, now committed
+   */
+  default List<String> ensureCommitted(String project, List<String> repos, String branch)
+      throws Exception {
+    return List.of();
+  }
 }
 
 final class ReviewAgentExecutionException extends IllegalStateException {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -52,6 +52,14 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
   private static final Set<String> TRIGGER_TYPES =
       Set.of(Event.WellKnownTypes.AGENT_SESSION_STOPPED);
 
+  /**
+   * How many errored (infrastructure-failed) review attempts of one iteration may accumulate before
+   * the spec escalates. Errored attempts retry without burning an iteration, and the reconciler
+   * replays a stop for each one — unbounded, that pair is an infinite loop of doomed reviews;
+   * bounded, a transient failure self-heals and a persistent one surfaces to a human.
+   */
+  static final int MAX_ERRORED_RETRIES = 3;
+
   private final SpecStore specStore;
   private final ReviewStore reviewStore;
   private final Function<String, ReviewPipelineConfig> configResolver;
@@ -272,6 +280,21 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       return;
     }
 
+    if (existing.isPresent()
+        && existing.get().errored()
+        && erroredAttempts(specId, iteration) >= MAX_ERRORED_RETRIES) {
+      System.err.println(
+          "review-pipeline: spec "
+              + specId
+              + " escalated — "
+              + MAX_ERRORED_RETRIES
+              + " review attempts errored in a row at iteration "
+              + iteration
+              + "; fix the reviewer, then re-dispatch with --restart");
+      escalate(event.project(), specId, existing.get().id());
+      return;
+    }
+
     var reviewId = createReviewWithStages(config, specId, iteration);
     var future =
         CompletableFuture.runAsync(
@@ -365,7 +388,6 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     if (agent == null) {
       var message = "no reviewer agent resolved; set stages[].agent or agent.install in sail.yaml";
       reviewStore.completeStage(stage.id(), "failed", message);
-      publishEvent(project, specId, "review_stage_failed", stage.name());
       return new StageOutcome.Errored(message);
     }
     reviewStore.startStage(stage.id(), agent);
@@ -383,7 +405,6 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       if (parseResult.findings().isEmpty() && !parseResult.warnings().isEmpty()) {
         var message = "reviewer output unparseable: " + String.join("; ", parseResult.warnings());
         reviewStore.completeStage(stage.id(), "failed", message);
-        publishEvent(project, specId, "review_stage_failed", stage.name());
         return new StageOutcome.Errored(message);
       }
 
@@ -470,7 +491,13 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     executePipeline(reviewId, config, project, specId);
   }
 
-  /** The fix agent runs under the failed review's identity, appending to that review's log. */
+  /**
+   * The fix agent runs under the failed review's identity, appending to that review's log. It runs
+   * hook-free, outside the dispatch lane's stop-readiness gate, so after it finishes {@link
+   * ReviewAgentRunner#ensureCommitted} rescues any work it left uncommitted — otherwise the
+   * re-review judges a branch without the fixes and the shared clone carries the leftovers into the
+   * next dispatch.
+   */
   private void triggerFixIteration(
       String reviewId, String specId, List<Finding> findings, String project) {
     var spec = specStore.findById(specId);
@@ -484,12 +511,39 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       var agent = spec.get().agent() != null ? spec.get().agent() : "claude-code";
       startReviewRun(reviewId, project, specId, agent, spec.get().branch(), fixTask);
       agentRunner.run(project, agent, fixTask, reviewId);
+      var rescued = agentRunner.ensureCommitted(project, spec.get().repos(), spec.get().branch());
+      if (!rescued.isEmpty()) {
+        publishGuardrail(
+            project,
+            specId,
+            "fix agent left uncommitted changes in " + String.join(", ", rescued),
+            "committed and pushed them to " + spec.get().branch());
+      }
     } catch (Exception e) {
       failReviewRun(reviewId, e);
       System.err.println(
           "review-pipeline: fix iteration failed for spec " + specId + ": " + e.getMessage());
     }
     completeReviewRun(reviewId);
+  }
+
+  /** Errored attempts of this iteration in the current dispatch attempt — the retry budget. */
+  private long erroredAttempts(String specId, int iteration) {
+    return reviewStore.reviewsForSpec(specId).stream()
+        .filter(r -> !r.superseded() && r.errored() && r.iteration() == iteration)
+        .count();
+  }
+
+  private void publishGuardrail(String project, String specId, String reason, String action) {
+    if (eventBus == null) return;
+    eventBus.publish(
+        Event.of(
+            project,
+            specId,
+            Event.WellKnownTypes.GUARDRAIL_TRIGGERED,
+            Event.SAIL_AGENT,
+            hostname(),
+            Map.of("reason", reason, "action", action)));
   }
 
   private void startReviewRun(

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -270,28 +270,25 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
 
     var iteration = existing.map(ReviewPipelineController::nextIteration).orElse(1);
     if (iteration > config.maxIterations()) {
-      System.err.println(
-          "review-pipeline: spec "
-              + specId
-              + " escalated — iterations exhausted ("
+      var reason =
+          "review iterations exhausted ("
               + config.maxIterations()
-              + "); re-dispatch with --restart to start a fresh attempt");
-      escalate(event.project(), specId, existing.get().id());
+              + "); re-dispatch with --restart to start a fresh attempt";
+      System.err.println("review-pipeline: spec " + specId + " escalated — " + reason);
+      escalate(event.project(), specId, existing.get().id(), reason);
       return;
     }
 
     if (existing.isPresent()
         && existing.get().errored()
         && erroredAttempts(specId, iteration) >= MAX_ERRORED_RETRIES) {
-      System.err.println(
-          "review-pipeline: spec "
-              + specId
-              + " escalated — "
-              + MAX_ERRORED_RETRIES
+      var reason =
+          MAX_ERRORED_RETRIES
               + " review attempts errored in a row at iteration "
               + iteration
-              + "; fix the reviewer, then re-dispatch with --restart");
-      escalate(event.project(), specId, existing.get().id());
+              + "; fix the reviewer, then re-dispatch with --restart";
+      System.err.println("review-pipeline: spec " + specId + " escalated — " + reason);
+      escalate(event.project(), specId, existing.get().id(), reason);
       return;
     }
 
@@ -468,7 +465,11 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     if (review.isEmpty()) return;
 
     if (review.get().iteration() >= config.maxIterations()) {
-      escalate(project, specId, reviewId);
+      escalate(
+          project,
+          specId,
+          reviewId,
+          "review iterations exhausted (" + config.maxIterations() + ")");
       return;
     }
 
@@ -584,10 +585,11 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     syncTrigger.run();
   }
 
-  private void escalate(String project, String specId, String reviewId) {
+  /** The reason travels as the event detail, so Slack says why — not a one-size-fits-all line. */
+  private void escalate(String project, String specId, String reviewId, String reason) {
     reviewStore.updateReviewStatus(reviewId, "escalated");
     advanceSpec(specId, SpecStatus.REVIEW);
-    publishEvent(project, specId, "review_escalated", null);
+    publishEvent(project, specId, "review_escalated", reason);
   }
 
   private void publishEvent(String project, String specId, String type, String detail) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SlackMessage.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SlackMessage.java
@@ -47,7 +47,9 @@ final class SlackMessage {
       case "review_errored" -> "Review errored: " + detailOr(event, "unknown error");
       case "review_iteration_started" -> "Fix iteration started.";
       case "review_escalated" ->
-          "Escalated: review iterations exhausted. This spec needs a human decision.";
+          "Escalated: "
+              + detailOr(event, "review iterations exhausted")
+              + ". This spec needs a human decision.";
       default -> "Event " + event.type() + " from " + event.agent() + ".";
     };
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -254,6 +254,7 @@ public final class ServerStartCommand implements Runnable {
             specStore,
             runStore,
             eventStore,
+            reviewStore,
             bus,
             unitProbe,
             NodeIdentity::handle,

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ContainerReviewAgentRunnerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ContainerReviewAgentRunnerTest.java
@@ -118,6 +118,29 @@ class ContainerReviewAgentRunnerTest {
   }
 
   @Test
+  void ensureCommittedSkipsASpecWithNoBranch() throws Exception {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
+
+    assertTrue(runner(shell).ensureCommitted("acme", List.of("api"), " ").isEmpty());
+    assertEquals(0, shell.invocations().size(), "no branch to guard means nothing to touch");
+  }
+
+  @Test
+  void ensureCommittedFailsLoudWhenTheCommitItselfFails() {
+    var shell =
+        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+            .onOk("rev-parse --abbrev-ref HEAD", "agent/spec\n")
+            .onOk("status --porcelain", " M Api.java\n")
+            .onFail("commit -m", "git identity not configured");
+
+    var ex =
+        assertThrows(
+            IllegalStateException.class,
+            () -> runner(shell).ensureCommitted("acme", List.of("api"), "agent/spec"));
+    assertTrue(ex.getMessage().contains("git identity not configured"), ex.getMessage());
+  }
+
+  @Test
   void ensureCommittedToleratesAPushFailure() throws Exception {
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ContainerReviewAgentRunnerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ContainerReviewAgentRunnerTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.ScriptedShellExecutor;
 import ai.singlr.sail.engine.ShellExec;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ContainerReviewAgentRunnerTest {
@@ -70,6 +71,64 @@ class ContainerReviewAgentRunnerTest {
     assertFalse(
         joined.contains("/home/dev/.sail/review.log"),
         "no invocation may touch the fixed shared review log");
+  }
+
+  @Test
+  void ensureCommittedRescuesWorkLeftUncommittedOnTheSpecBranch() throws Exception {
+    var shell =
+        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+            .onOk("rev-parse --abbrev-ref HEAD", "agent/spec\n")
+            .onOk("status --porcelain", " M Api.java\n");
+
+    var rescued = runner(shell).ensureCommitted("acme", List.of("api"), "agent/spec");
+
+    assertEquals(List.of("api"), rescued);
+    var joined = String.join("\n", shell.invocations());
+    assertTrue(joined.contains("git -C /home/dev/workspace/api add -A"));
+    assertTrue(joined.contains("git -C /home/dev/workspace/api commit -m"));
+    assertTrue(joined.contains("git -C /home/dev/workspace/api push"));
+  }
+
+  @Test
+  void ensureCommittedLeavesACleanRepoUntouched() throws Exception {
+    var shell =
+        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+            .onOk("rev-parse --abbrev-ref HEAD", "agent/spec\n");
+
+    var rescued = runner(shell).ensureCommitted("acme", List.of("api"), "agent/spec");
+
+    assertTrue(rescued.isEmpty());
+    assertFalse(String.join("\n", shell.invocations()).contains("add -A"));
+  }
+
+  @Test
+  void ensureCommittedNeverCommitsOnAForeignBranch() throws Exception {
+    var shell =
+        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+            .onOk("rev-parse --abbrev-ref HEAD", "main\n")
+            .onOk("status --porcelain", " M Api.java\n");
+
+    var rescued = runner(shell).ensureCommitted("acme", List.of("api"), "agent/spec");
+
+    assertTrue(
+        rescued.isEmpty(),
+        "a repo parked on another branch is not this run's to commit — auto-committing there is"
+            + " how a shared clone's main gets contaminated");
+    assertFalse(String.join("\n", shell.invocations()).contains("add -A"));
+  }
+
+  @Test
+  void ensureCommittedToleratesAPushFailure() throws Exception {
+    var shell =
+        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+            .onOk("rev-parse --abbrev-ref HEAD", "agent/spec\n")
+            .onOk("status --porcelain", " M Api.java\n")
+            .onFail("push", "no network");
+
+    assertEquals(
+        List.of("api"),
+        runner(shell).ensureCommitted("acme", List.of("api"), "agent/spec"),
+        "the commit is the rescue; a push failure must not fail the pipeline");
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -94,7 +94,7 @@ class MissedStopReconcilerTest {
   private MissedStopReconciler reconciler(
       MissedStopReconciler.UnitProbe probe, Supplier<String> localHandle, Supplier<Instant> clock) {
     return new MissedStopReconciler(
-        specStore, sessionStore, eventStore, bus, probe, localHandle, clock);
+        specStore, sessionStore, eventStore, reviewStore, bus, probe, localHandle, clock);
   }
 
   private void createInProgressSpec(String id) {
@@ -384,6 +384,82 @@ class MissedStopReconcilerTest {
 
     assertEquals(1, rec.sweep());
     assertEquals(0, rec.sweep(), "an empty-pipeline review must not be replayed forever");
+  }
+
+  @Test
+  void aSpecWhoseLatestReviewErroredGetsItsStopReplayed() {
+    createReviewSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    recordEvent("auth", "review_stage_started", Instant.now().toString());
+    erroredReview("auth");
+
+    assertEquals(
+        1,
+        reconciler(new CountingProbe(true), Instant::now).sweep(),
+        "an errored review strands the spec in review forever unless its stop is replayed");
+  }
+
+  @Test
+  void anErroredReviewEarnsExactlyOneReplay() {
+    createReviewSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    recordEvent("auth", "review_stage_started", Instant.now().toString());
+    erroredReview("auth");
+    var rec = reconciler(new CountingProbe(true), Instant::now);
+
+    assertEquals(1, rec.sweep());
+    assertEquals(0, rec.sweep(), "one errored review, one replay; its retry decides what is next");
+  }
+
+  @Test
+  void aFreshErroredRetryEarnsItsOwnReplay() {
+    createReviewSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    recordEvent("auth", "review_stage_started", Instant.now().toString());
+    erroredReview("auth");
+    var rec = reconciler(new CountingProbe(true), Instant::now);
+
+    assertEquals(1, rec.sweep());
+    erroredReview("auth");
+
+    assertEquals(
+        1,
+        rec.sweep(),
+        "each errored attempt is rescued once; the pipeline's error budget bounds the loop");
+  }
+
+  @Test
+  void anEscalatedReviewIsNeverReplayed() {
+    createReviewSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    recordEvent("auth", "review_stage_started", Instant.now().toString());
+    reviewStore.updateReviewStatus(erroredReview("auth"), "escalated");
+
+    assertEquals(
+        0,
+        reconciler(new CountingProbe(true), Instant::now).sweep(),
+        "escalation parks the spec for a human; the sweep must not resurrect it");
+  }
+
+  @Test
+  void aRunningRetryReviewIsLeftAlone() {
+    createReviewSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    recordEvent("auth", "review_stage_started", Instant.now().toString());
+    erroredReview("auth");
+    reviewStore.updateReviewStatus(reviewStore.createReview("auth", 1), "running");
+
+    assertEquals(
+        0,
+        reconciler(new CountingProbe(true), Instant::now).sweep(),
+        "the errored attempt already got its retry; a running review owns the spec now");
+  }
+
+  private String erroredReview(String specId) {
+    var reviewId = reviewStore.createReview(specId, 1);
+    reviewStore.failReviewWithError(
+        reviewId, "reviewer output unparseable: No JSON block found in agent output.");
+    return reviewId;
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -22,6 +22,7 @@ import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -53,6 +54,10 @@ class ReviewPipelineControllerTest {
   }
 
   private void createSpec(String id, String status) {
+    createSpec(id, status, List.of());
+  }
+
+  private void createSpec(String id, String status, List<String> repos) {
     specStore.create(
         new SpecStore.SpecRow(
             id,
@@ -70,7 +75,7 @@ class ReviewPipelineControllerTest {
             "",
             null,
             List.of(),
-            List.of()));
+            repos));
   }
 
   private Event agentStoppedEvent(String specId) {
@@ -798,6 +803,100 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
+  void erroredRetriesAreBoundedSoARescueLoopCanNeverBurnAgentsForever() {
+    createSpec("auth", "in_progress");
+    var ctrl =
+        controller(
+            singleAgentStage("no_critical"), (p, a, pr, rid) -> "prose with no fenced block");
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+    ctrl.onEvent(reconcilerStoppedEvent("auth"));
+    ctrl.onEvent(reconcilerStoppedEvent("auth"));
+
+    var reviews = reviewStore.reviewsForSpec("auth");
+    assertEquals(3, reviews.size());
+    assertTrue(
+        reviews.stream().allMatch(r -> r.errored() && r.iteration() == 1),
+        "errored attempts retry the same iteration");
+
+    ctrl.onEvent(reconcilerStoppedEvent("auth"));
+
+    assertEquals(
+        3,
+        reviewStore.reviewsForSpec("auth").size(),
+        "the fourth stop must escalate instead of starting a fourth doomed review");
+    assertEquals("escalated", reviewStore.latestReviewForSpec("auth").orElseThrow().status());
+  }
+
+  @Test
+  void anUnparseableReviewNarratesAsErroredNotAsAFailedGate() throws Exception {
+    createSpec("auth", "in_progress");
+
+    try (var bus = new EventBus()) {
+      var captured = captureEvents(bus, Set.of("review_errored", "review_stage_failed"), 1);
+      var ctrl =
+          controller(
+              p -> singleAgentStage("no_critical"),
+              p -> "codex",
+              (p, a, pr, rid) -> "no fenced block here",
+              bus);
+
+      ctrl.onEvent(agentStoppedEvent("auth"));
+      BusTesting.awaitDelivery(captured.latch());
+
+      assertEquals(
+          List.of("review_errored"),
+          captured.events().stream().map(Event::type).toList(),
+          "a parse failure is an infrastructure error, not a gate verdict — one message, not a"
+              + " misleading 'stage failed (no findings)' followed by 'errored'");
+    }
+  }
+
+  @Test
+  void aFixIterationCommitsWorkTheAgentLeftUncommitted() throws Exception {
+    createSpec("auth", "in_progress", List.of("api"));
+    var criticalOutput =
+        """
+        ```json
+        [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
+          "line_start": 1, "line_end": 1, "title": "Bad",
+          "description": "Very bad", "confidence": 0.9}]
+        ```
+        """;
+    var ensured = new AtomicReference<List<Object>>();
+    var calls = new AtomicInteger();
+    var runner =
+        new ReviewAgentRunner() {
+          @Override
+          public String run(String p, String a, String prompt, String rid) {
+            return calls.incrementAndGet() == 1 ? criticalOutput : "[]";
+          }
+
+          @Override
+          public List<String> ensureCommitted(String project, List<String> repos, String branch) {
+            ensured.set(List.of(project, repos, branch));
+            return List.of("api");
+          }
+        };
+
+    try (var bus = new EventBus()) {
+      var captured = captureEvents(bus, Set.of(Event.WellKnownTypes.GUARDRAIL_TRIGGERED), 1);
+      var ctrl = controller(p -> singleAgentStage("no_critical"), p -> "codex", runner, bus);
+
+      ctrl.onEvent(agentStoppedEvent("auth"));
+      BusTesting.awaitDelivery(captured.latch());
+
+      assertEquals(
+          List.of("test-project", List.of("api"), "feat/test"),
+          ensured.get(),
+          "after the fix agent runs, its work is verified committed on the spec branch");
+      var reason =
+          java.util.Objects.toString(captured.events().getFirst().data().get("reason"), "");
+      assertTrue(reason.contains("api"), "the guardrail names the contaminated repo");
+    }
+  }
+
+  @Test
   void executePipelinePublishesEventsWhenBusProvided() {
     createSpec("auth", "in_progress");
     specStore.updateStatus("auth", SpecStatus.REVIEW);
@@ -872,6 +971,10 @@ class ReviewPipelineControllerTest {
   private record Captured(List<Event> events, CountDownLatch latch) {}
 
   private static Captured captureStagePassedEvents(EventBus bus, int expected) {
+    return captureEvents(bus, Set.of("review_stage_passed"), expected);
+  }
+
+  private static Captured captureEvents(EventBus bus, Set<String> types, int expected) {
     var events = new java.util.concurrent.CopyOnWriteArrayList<Event>();
     var latch = new CountDownLatch(expected);
     bus.subscribe(
@@ -884,7 +987,7 @@ class ReviewPipelineControllerTest {
 
               @Override
               public java.util.function.Predicate<Event> filter() {
-                return e -> "review_stage_passed".equals(e.type());
+                return e -> types.contains(e.type());
               }
 
               @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -803,29 +803,42 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
-  void erroredRetriesAreBoundedSoARescueLoopCanNeverBurnAgentsForever() {
+  void erroredRetriesAreBoundedSoARescueLoopCanNeverBurnAgentsForever() throws Exception {
     createSpec("auth", "in_progress");
-    var ctrl =
-        controller(
-            singleAgentStage("no_critical"), (p, a, pr, rid) -> "prose with no fenced block");
 
-    ctrl.onEvent(agentStoppedEvent("auth"));
-    ctrl.onEvent(reconcilerStoppedEvent("auth"));
-    ctrl.onEvent(reconcilerStoppedEvent("auth"));
+    try (var bus = new EventBus()) {
+      var captured = captureEvents(bus, Set.of("review_escalated"), 1);
+      var ctrl =
+          controller(
+              p -> singleAgentStage("no_critical"),
+              p -> "codex",
+              (p, a, pr, rid) -> "prose with no fenced block",
+              bus);
 
-    var reviews = reviewStore.reviewsForSpec("auth");
-    assertEquals(3, reviews.size());
-    assertTrue(
-        reviews.stream().allMatch(r -> r.errored() && r.iteration() == 1),
-        "errored attempts retry the same iteration");
+      ctrl.onEvent(agentStoppedEvent("auth"));
+      ctrl.onEvent(reconcilerStoppedEvent("auth"));
+      ctrl.onEvent(reconcilerStoppedEvent("auth"));
 
-    ctrl.onEvent(reconcilerStoppedEvent("auth"));
+      var reviews = reviewStore.reviewsForSpec("auth");
+      assertEquals(3, reviews.size());
+      assertTrue(
+          reviews.stream().allMatch(r -> r.errored() && r.iteration() == 1),
+          "errored attempts retry the same iteration");
 
-    assertEquals(
-        3,
-        reviewStore.reviewsForSpec("auth").size(),
-        "the fourth stop must escalate instead of starting a fourth doomed review");
-    assertEquals("escalated", reviewStore.latestReviewForSpec("auth").orElseThrow().status());
+      ctrl.onEvent(reconcilerStoppedEvent("auth"));
+      BusTesting.awaitDelivery(captured.latch());
+
+      assertEquals(
+          3,
+          reviewStore.reviewsForSpec("auth").size(),
+          "the fourth stop must escalate instead of starting a fourth doomed review");
+      assertEquals("escalated", reviewStore.latestReviewForSpec("auth").orElseThrow().status());
+      var detail =
+          java.util.Objects.toString(captured.events().getFirst().data().get("detail"), "");
+      assertTrue(
+          detail.contains("errored"),
+          "escalation must say WHY — an error budget, not exhausted iterations: " + detail);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Field incident

Dispatch of `nexus-accounts-apis` (project manatee): iteration-1 review failed the gate (1 high, 2 medium, 1 low), the fix iteration ran, then the re-review emitted no ```json block → `Review errored: reviewer output unparseable` — and the spec stayed parked in `review` forever. The fix agent had also left 213 lines uncommitted in the shared clone (second occurrence in two days).

## Root causes

1. **No recovery from an errored review.** The design retries an errored iteration "on the next stop" — but a fix iteration runs inline and produces no stop, and `MissedStopReconciler`'s stranded-review rescue bails when any `review_stage_started` event exists. An errored review after a first successful kickoff was unrecoverable without manual re-dispatch.
2. **The fix lane has no commit guardrail.** It deliberately runs hook-free (so a reviewer's completion can't re-enter the pipeline), which also strips the dispatch lane's stop-readiness gate; and `FixTaskBuilder` only *hinted* at committing ("The reviewer will re-check after you commit") without instructing it.
3. **Misleading narration.** An unparseable review published both `review_stage_failed` (rendered "…(no findings)") and `review_errored` for the one failure.

## Fixes (TDD)

- **MissedStopReconciler** now also rescues a spec whose latest non-superseded review errored, replaying the stop so the pipeline retries the same iteration. Each errored review earns exactly one replay; escalated and running reviews are left alone. `review_errored` counts as acted-on stop evidence.
- **ReviewPipelineController** bounds the loop: after 3 errored attempts of one iteration it escalates instead of starting another doomed review — transient outages self-heal, persistent ones surface to a human.
- **ReviewAgentRunner.ensureCommitted** (new seam, implemented in `ContainerReviewAgentRunner`): after every fix iteration, any work left uncommitted is committed and pushed — only when the repo is checked out on the spec's own branch, never main or another spec's branch. Surfaced as a `guardrail_triggered` event naming the rescued repos.
- **FixTaskBuilder** ends the fix task with an explicit commit-and-push protocol.
- Errored stages no longer publish `review_stage_failed`; Slack shows one honest `Review errored: …`, and escalations carry their real reason (error budget vs exhausted iterations).
- **FindingParser does its best before erroring**: fence markers match case-insensitively, and when no fenced block parses the transcript is scanned for an embedded `[{...}]` findings array or a standalone `[]` verdict line. A mid-sentence `[]` (the prompt echo names one) still never counts as a clean pass.

## Tests

20 new tests across `ReviewPipelineControllerTest`, `MissedStopReconcilerTest`, `ContainerReviewAgentRunnerTest`, `FixTaskBuilderTest` — covering the exact incident shape (errored re-review → rescue → bounded escalation), the foreign-branch/clean-repo/push-failure edges of the commit guard, and the narration. Full suite: 2378 tests green.
