### PR TITLE
Probe the unit before replaying a terminal run's stop (live-unit veto)

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -41,15 +41,17 @@ import java.util.function.Supplier;
  * selecting the newest run, never before: filtering first would fall back to a superseded local
  * session and replay its stop over a newer foreign run that is still executing. Database-only
  * checks come first, so a pass with nothing to reconcile issues no systemctl calls. A terminal
- * session replays the stop with its recorded exit code. A running session past the launch grace
- * period whose <em>recorded</em> systemd unit is inactive or absent gets a synthesized stop — a
- * running session with no recorded unit (launched before units were run-scoped) is skipped instead:
- * this sweep cannot know that unit's liveness, and the run's own detached watcher already owns its
- * stop. The synthesized stop carries <em>no exit code</em>: the transient unit is garbage-collected
- * on exit, so the real code is unrecoverable, and the replay path makes the same choice for a
- * terminal session that never recorded one — the pipeline treats the absent code as not-a-failure
- * and lets review judge the work. Every replayed stop carries {@code source=reconcile} so the event
- * log shows it was reconstructed, not observed.
+ * session replays the stop with its recorded exit code — after probing its recorded unit, because
+ * the row may be a hook-backstop claim for an agent that is still running (an active unit vetoes
+ * the replay). A running session past the launch grace period whose <em>recorded</em> systemd unit
+ * is inactive or absent gets a synthesized stop — a running session with no recorded unit (launched
+ * before units were run-scoped) is skipped instead: this sweep cannot know that unit's liveness,
+ * and the run's own detached watcher already owns its stop. The synthesized stop carries <em>no
+ * exit code</em>: the transient unit is garbage-collected on exit, so the real code is
+ * unrecoverable, and the replay path makes the same choice for a terminal session that never
+ * recorded one — the pipeline treats the absent code as not-a-failure and lets review judge the
+ * work. Every replayed stop carries {@code source=reconcile} so the event log shows it was
+ * reconstructed, not observed.
  *
  * <p>Best-effort by design: a failing spec is logged and skipped, a failing pass is logged and
  * retried on the next tick, and passes never overlap. Run after the bus subscribers are wired.
@@ -191,9 +193,19 @@ public final class MissedStopReconciler implements AutoCloseable {
       if (handledThisSweep.contains(spec.id())) {
         continue;
       }
-      if (rescueStrandedReview(spec)) {
-        handledThisSweep.add(spec.id());
-        rescued++;
+      try {
+        if (rescueStrandedReview(spec)) {
+          handledThisSweep.add(spec.id());
+          rescued++;
+        }
+      } catch (Exception e) {
+        System.err.println(
+            "  [reconcile] review rescue failed for "
+                + spec.project()
+                + "/"
+                + spec.id()
+                + ": "
+                + e.getMessage());
       }
     }
     return rescued;
@@ -263,7 +275,7 @@ public final class MissedStopReconciler implements AutoCloseable {
    * loop; an escalated or running review is left alone, since a human or a live pipeline owns the
    * spec then.
    */
-  private boolean rescueStrandedReview(SpecStore.SpecRow spec) {
+  private boolean rescueStrandedReview(SpecStore.SpecRow spec) throws Exception {
     var rescue = rescueFor(spec);
     if (rescue == null || reviewRescueAttempted.contains(rescue.key())) {
       return false;
@@ -274,7 +286,7 @@ public final class MissedStopReconciler implements AutoCloseable {
             .findFirst()
             .filter(run -> SailOperations.ownsRun(run.node(), node))
             .filter(run -> TERMINAL_RUN_STATUSES.contains(run.status()));
-    if (latest.isEmpty()) {
+    if (latest.isEmpty() || unitStillActive(spec, latest.get())) {
       return false;
     }
     reviewRescueAttempted.add(rescue.key());
@@ -323,14 +335,14 @@ public final class MissedStopReconciler implements AutoCloseable {
     var outcome = MissedStops.assess(session, coverage, clock.get(), LAUNCH_GRACE);
     return switch (outcome) {
       case MissedStops.Outcome.ReplayStop replay -> {
+        if (unitStillActive(spec, session)) {
+          yield false;
+        }
         publishStop(spec, session, replay.exitCode(), replay.why());
         yield true;
       }
       case MissedStops.Outcome.ProbeUnit probe -> {
-        if (Strings.isBlank(session.unit())) {
-          yield false;
-        }
-        if (unitProbe.active(spec.project(), session.id(), session.unit())) {
+        if (Strings.isBlank(session.unit()) || unitStillActive(spec, session)) {
           yield false;
         }
         publishStop(spec, session, null, "unit inactive or gone; " + probe.why());
@@ -338,6 +350,23 @@ public final class MissedStopReconciler implements AutoCloseable {
       }
       case MissedStops.Outcome.Skip ignored -> false;
     };
+  }
+
+  /**
+   * Whether the run's recorded systemd unit is still alive — the veto that keeps a lying terminal
+   * row from forging a stop. A hook turn-end completes the run row as a watcher-dead backstop, but
+   * a turn-end is not a process exit: in the field a gate-allowed mid-run stop marked the row
+   * terminal while the agent kept working, and the next sweep replayed the "finished" run — the
+   * review then judged half-done work and the fix agent raced the live agent in one clone. The unit
+   * is the authoritative liveness source, so an active unit means the run's own watcher owns the
+   * real stop and the sweep must wait. A row with no recorded unit cannot be probed and keeps the
+   * replay behavior; a probe failure propagates to the per-spec catch — logged, skipped, retried
+   * next sweep — so the sweep never forges a stop on data it cannot interpret, and never silently.
+   */
+  private boolean unitStillActive(SpecStore.SpecRow spec, RunStore.RunRow session)
+      throws Exception {
+    return !Strings.isBlank(session.unit())
+        && unitProbe.active(spec.project(), session.id(), session.unit());
   }
 
   /**

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -334,7 +334,7 @@ class MissedStopReconcilerTest {
     var latch = new CountDownLatch(1);
     subscribeController(latch);
 
-    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
+    var replayed = reconciler(new CountingProbe(false), Instant::now).sweep();
 
     assertEquals(1, replayed);
     BusTesting.awaitDelivery(latch);
@@ -348,7 +348,7 @@ class MissedStopReconcilerTest {
     var latch = new CountDownLatch(1);
     subscribeController(latch);
 
-    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
+    var replayed = reconciler(new CountingProbe(false), Instant::now).sweep();
 
     assertEquals(1, replayed);
     BusTesting.awaitDelivery(latch);
@@ -360,7 +360,7 @@ class MissedStopReconcilerTest {
     createReviewSpec("auth");
     finishedSession("auth", "stopped", 0);
 
-    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
+    var replayed = reconciler(new CountingProbe(false), Instant::now).sweep();
 
     assertEquals(1, replayed, "a spec stranded in review with no review must be rescued");
   }
@@ -371,7 +371,7 @@ class MissedStopReconcilerTest {
     finishedSession("auth", "stopped", 0);
     recordEvent("auth", "review_stage_started", Instant.now().toString());
 
-    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
+    var replayed = reconciler(new CountingProbe(false), Instant::now).sweep();
 
     assertEquals(0, replayed, "a review that ran is not stranded");
   }
@@ -380,7 +380,7 @@ class MissedStopReconcilerTest {
   void theReviewStrandRescueRunsAtMostOncePerSpec() {
     createReviewSpec("auth");
     finishedSession("auth", "stopped", 0);
-    var rec = reconciler(new CountingProbe(true), Instant::now);
+    var rec = reconciler(new CountingProbe(false), Instant::now);
 
     assertEquals(1, rec.sweep());
     assertEquals(0, rec.sweep(), "an empty-pipeline review must not be replayed forever");
@@ -395,7 +395,7 @@ class MissedStopReconcilerTest {
 
     assertEquals(
         1,
-        reconciler(new CountingProbe(true), Instant::now).sweep(),
+        reconciler(new CountingProbe(false), Instant::now).sweep(),
         "an errored review strands the spec in review forever unless its stop is replayed");
   }
 
@@ -405,7 +405,7 @@ class MissedStopReconcilerTest {
     finishedSession("auth", "stopped", 0);
     recordEvent("auth", "review_stage_started", Instant.now().toString());
     erroredReview("auth");
-    var rec = reconciler(new CountingProbe(true), Instant::now);
+    var rec = reconciler(new CountingProbe(false), Instant::now);
 
     assertEquals(1, rec.sweep());
     assertEquals(0, rec.sweep(), "one errored review, one replay; its retry decides what is next");
@@ -417,7 +417,7 @@ class MissedStopReconcilerTest {
     finishedSession("auth", "stopped", 0);
     recordEvent("auth", "review_stage_started", Instant.now().toString());
     erroredReview("auth");
-    var rec = reconciler(new CountingProbe(true), Instant::now);
+    var rec = reconciler(new CountingProbe(false), Instant::now);
 
     assertEquals(1, rec.sweep());
     erroredReview("auth");
@@ -437,7 +437,7 @@ class MissedStopReconcilerTest {
 
     assertEquals(
         0,
-        reconciler(new CountingProbe(true), Instant::now).sweep(),
+        reconciler(new CountingProbe(false), Instant::now).sweep(),
         "escalation parks the spec for a human; the sweep must not resurrect it");
   }
 
@@ -451,7 +451,7 @@ class MissedStopReconcilerTest {
 
     assertEquals(
         0,
-        reconciler(new CountingProbe(true), Instant::now).sweep(),
+        reconciler(new CountingProbe(false), Instant::now).sweep(),
         "the errored attempt already got its retry; a running review owns the spec now");
   }
 
@@ -478,13 +478,13 @@ class MissedStopReconcilerTest {
 
     assertEquals(
         0,
-        reconciler(new CountingProbe(true), Instant::now)
+        reconciler(new CountingProbe(false), Instant::now)
             .rescueStrandedReviews(new HashSet<>(Set.of("auth"))),
         "a spec whose stop was replayed earlier this sweep — which flips it into review on an async"
             + " subscriber thread — must not have its stop replayed a second time by the review pass");
     assertEquals(
         1,
-        reconciler(new CountingProbe(true), Instant::now).rescueStrandedReviews(new HashSet<>()),
+        reconciler(new CountingProbe(false), Instant::now).rescueStrandedReviews(new HashSet<>()),
         "the same genuinely stranded review spec IS rescued when nothing handled it this sweep");
   }
 
@@ -533,7 +533,7 @@ class MissedStopReconcilerTest {
     var latch = new CountDownLatch(1);
     subscribeController(latch);
 
-    reconciler(new CountingProbe(true), Instant::now).sweep();
+    reconciler(new CountingProbe(false), Instant::now).sweep();
 
     BusTesting.awaitDelivery(latch);
     assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
@@ -552,16 +552,58 @@ class MissedStopReconcilerTest {
   }
 
   @Test
-  void terminalReplaysAndSpecsWithoutSessionsNeverTouchSystemctl() {
+  void aTerminalRowWithALiveUnitIsNeverReplayed() {
     createInProgressSpec("auth");
     finishedSession("auth", "stopped", 0);
-    createInProgressSpec("billing");
     var probe = new CountingProbe(true);
 
     var replayed = reconciler(probe, Instant::now).sweep();
 
+    assertEquals(
+        0,
+        replayed,
+        "a terminal run row is a claim, not an observation — an active unit means the agent is"
+            + " still working and replaying its stop would review half-done work");
+    assertEquals(1, probe.calls.get(), "the row must be checked against the live unit");
+  }
+
+  @Test
+  void aVetoedReplayRetriesOnALaterSweepOnceTheUnitDies() {
+    createInProgressSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    var probe = new CountingProbe(true);
+    var rec = reconciler(probe, Instant::now);
+
+    assertEquals(0, rec.sweep());
+    probe.active = false;
+
+    assertEquals(1, rec.sweep(), "the veto skips, it never burns the replay");
+  }
+
+  @Test
+  void aLiveUnitAlsoVetoesTheStrandedReviewRescueWithoutBurningIt() {
+    createReviewSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    var probe = new CountingProbe(true);
+    var rec = reconciler(probe, Instant::now);
+
+    assertEquals(0, rec.sweep(), "the spec's agent is still alive; review must wait for it");
+    probe.active = false;
+
+    assertEquals(1, rec.sweep(), "once the unit dies the one rescue is still available");
+  }
+
+  @Test
+  void specsWithoutSessionsNeverTouchSystemctl() {
+    createInProgressSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    createInProgressSpec("billing");
+    var probe = new CountingProbe(false);
+
+    var replayed = reconciler(probe, Instant::now).sweep();
+
     assertEquals(1, replayed);
-    assertEquals(0, probe.calls.get());
+    assertEquals(1, probe.calls.get(), "only the terminal row is probed; billing has no session");
   }
 
   @Test
@@ -691,7 +733,7 @@ class MissedStopReconcilerTest {
             Event.WellKnownData.SOURCE,
             Event.WellKnownData.SOURCE_WATCHER));
 
-    var replayed = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+    var replayed = reconciler(new CountingProbe(false), PAST_GRACE).sweep();
 
     assertEquals(1, replayed);
   }
@@ -706,7 +748,7 @@ class MissedStopReconcilerTest {
         Map.of(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_WATCHER));
     recordEvent("auth", "review_stage_started", Instant.now().plusSeconds(2).toString());
 
-    var replayed = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+    var replayed = reconciler(new CountingProbe(false), PAST_GRACE).sweep();
 
     assertEquals(0, replayed);
   }
@@ -725,7 +767,7 @@ class MissedStopReconcilerTest {
             Event.WellKnownData.SOURCE_WATCHER));
     recordEvent("auth", Event.WellKnownTypes.AGENT_FAILED, Instant.now().plusSeconds(2).toString());
 
-    var replayed = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+    var replayed = reconciler(new CountingProbe(false), PAST_GRACE).sweep();
 
     assertEquals(0, replayed);
   }
@@ -741,7 +783,7 @@ class MissedStopReconcilerTest {
         Instant.now().plusSeconds(1).toString(),
         Map.of(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_WATCHER));
 
-    var replayed = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+    var replayed = reconciler(new CountingProbe(false), PAST_GRACE).sweep();
 
     assertEquals(1, replayed);
   }
@@ -752,7 +794,7 @@ class MissedStopReconcilerTest {
     finishedSession("auth", "stopped", null);
     recordStopEvent("auth", Instant.now().plusSeconds(1).toString(), Map.of());
 
-    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
+    var replayed = reconciler(new CountingProbe(false), Instant::now).sweep();
 
     assertEquals(1, replayed);
   }
@@ -766,7 +808,7 @@ class MissedStopReconcilerTest {
         Map.of(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_WATCHER));
     finishedSession("auth", "stopped", 0);
 
-    var replayed = reconciler(new CountingProbe(true), Instant::now).sweep();
+    var replayed = reconciler(new CountingProbe(false), Instant::now).sweep();
 
     assertEquals(1, replayed);
   }
@@ -806,19 +848,46 @@ class MissedStopReconcilerTest {
   @Test
   void aFailingProbeIsLoggedAndDoesNotShadowOtherSpecs() {
     createInProgressSpec("broken");
-    runningSession("broken");
+    var brokenRun = runningSession("broken");
     createInProgressSpec("auth");
     finishedSession("auth", "stopped", 0);
 
     var replayed =
         reconciler(
                 (project, runId, unit) -> {
-                  throw new IllegalStateException("container unreachable");
+                  if (unit.contains(brokenRun)) {
+                    throw new IllegalStateException("container unreachable");
+                  }
+                  return false;
                 },
                 PAST_GRACE)
             .sweep();
 
-    assertEquals(1, replayed);
+    assertEquals(
+        1,
+        replayed,
+        "the unreachable spec is deferred — never a forged stop — while the finished one replays");
+  }
+
+  @Test
+  void aFailingProbeDefersTheRescueWithoutBurningIt() {
+    createReviewSpec("auth");
+    finishedSession("auth", "stopped", 0);
+    var failing = new AtomicBoolean(true);
+    var rec =
+        reconciler(
+            (project, runId, unit) -> {
+              if (failing.get()) {
+                throw new IllegalStateException("container unreachable");
+              }
+              return false;
+            },
+            Instant::now);
+
+    assertEquals(0, assertDoesNotThrow(rec::sweep));
+    failing.set(false);
+
+    assertEquals(1, rec.sweep(), "the rescue is deferred, not burned");
   }
 
   @Test


### PR DESCRIPTION
## Field incident

`nexus-accounts-verify-on-email-change` (manatee): the review pipeline ran and passed **while the dispatch agent was still working**. Event-log forensics:

- 20:05:02 stop gate nudged the agent (unpushed branches) — correct.
- 20:05:50 the gate allowed its second stop attempt; the hook published a sourceless turn-end stop — but `agent_tool_*` events from the same run kept flowing without a gap until 20:27:20.
- `RunTracker` completed the run row on that hook stop (the watcher-dead backstop).
- 20:06:44 the reconciler sweep trusted the terminal row ("finished session never advanced its spec") and replayed an authoritative stop — **one second after a tool event from the run it declared finished**.
- The review judged mid-flight work, the fix agent ran concurrently with the live agent in the same clone, the commit guardrail swept up the live agent's WIP, and the agent's real stop (20:27:35, exit 0, watcher) was ignored because the spec was already `awaiting_merge`.

## Root cause

Brick 4 established that turn-end ≠ process exit and made the watcher the sole authoritative stop emitter — but the run-row hook backstop reintroduced that confusion through the side door: the reconciler's terminal-session replay path never consulted liveness at all (the unit probe only guarded the *running*-session path).

## Fix

**A terminal run row is a claim, not an observation.** Before replaying its stop, the reconciler probes the run's recorded systemd unit; an active unit vetoes the replay — the agent is alive and its watcher owns the real stop. The same veto guards the stranded-review rescue, placed before the once-per-key marker so a veto never burns the one rescue. A probe failure defers loudly (per-spec catch, logged, retried next sweep) instead of forging a stop, and the rescue loop gains the same per-spec isolation as the in-progress loop.

Contract changes made explicit in tests: terminal replays now cost one probe (previously guaranteed zero systemctl calls — the exact shortcut that forged this stop), and every replay-expecting test now models reality (finished agent ⇒ transient unit gone ⇒ probe inactive).

## Tests

5 new behavior tests (live-unit veto on both replay paths, veto-then-retry without burning the rescue, probe-failure deferral on both paths, sessionless specs still never touch systemctl) + semantic flips of the existing replay tests. Full suite: 2,382 green, coverage gates met.
