### PR TITLE
Clean stop: one lane to cancel a running spec, honored by the reaper

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/config/SpecDirectory.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/SpecDirectory.java
@@ -176,7 +176,7 @@ public final class SpecDirectory {
 
   /**
    * Returns a map of status counts: {pending: N, in_progress: N, review: N, awaiting_merge: N,
-   * done: N}.
+   * done: N, cancelled: N}.
    */
   public static Map<String, Integer> statusCounts(List<Spec> specs) {
     var counts = new LinkedHashMap<String, Integer>();
@@ -185,6 +185,7 @@ public final class SpecDirectory {
     counts.put(SpecStatus.REVIEW.wire(), 0);
     counts.put(SpecStatus.AWAITING_MERGE.wire(), 0);
     counts.put(SpecStatus.DONE.wire(), 0);
+    counts.put(SpecStatus.CANCELLED.wire(), 0);
     for (var spec : specs) {
       counts.merge(spec.status().wire(), 1, Integer::sum);
     }

--- a/sail-core/src/main/java/ai/singlr/sail/config/SpecStatus.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/SpecStatus.java
@@ -20,6 +20,13 @@ import java.util.stream.Collectors;
  * including a status synced from a newer peer that this binary does not know yet, which lands in
  * the draft column instead of crashing; {@link #ARCHIVED} is hidden from the default board. Only
  * {@link SpecDirectory#CLI_SETTABLE} statuses may be assigned by hand via {@code sail spec status}.
+ *
+ * <p>{@link #CANCELLED} is the terminal record of an operator's clean stop: the spec's run was
+ * deliberately halted, not finished. It is intentionally outside every set the lifecycle machinery
+ * acts on — not {@code in_progress}/{@code review} (the missed-stop reconciler and the review
+ * pipeline), not {@code pending} (dispatch) — so a cancel is honored by the existing contracts
+ * rather than special-cased in each component. Re-running a cancelled spec is an explicit operator
+ * re-open (dispatch {@code --restart}), never an automatic transition.
  */
 public enum SpecStatus {
   DRAFT,
@@ -28,6 +35,7 @@ public enum SpecStatus {
   REVIEW,
   AWAITING_MERGE,
   DONE,
+  CANCELLED,
   ARCHIVED;
 
   /** The persisted/serialized form: the lowercased enum name. */

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -163,8 +163,10 @@ public final class RunStore implements ConflictResolver {
    * write lock up front serializes concurrent dispatches, including a CLI dispatch in another
    * process against the same database file, so the second reservation always observes the first's
    * row; a check-then-insert split across transactions could admit both into the same repo. Returns
-   * the blocking conflict, or empty when the run was reserved. Any database failure propagates — a
-   * dispatch must never launch without the row every later overlap check depends on.
+   * the blocking conflict, or empty when the run was reserved. A run mid-stop ({@code stopping})
+   * still occupies its repos — its agent is not verified dead until the claim is finalized — so it
+   * conflicts exactly like a running one. Any database failure propagates — a dispatch must never
+   * launch without the row every later overlap check depends on.
    */
   public Optional<DispatchGate.Conflict> reserveDispatch(
       String id,
@@ -184,7 +186,7 @@ public final class RunStore implements ConflictResolver {
               db.query(
                   "SELECT "
                       + COLUMNS
-                      + " FROM runs WHERE project = ? AND status = 'running'"
+                      + " FROM runs WHERE project = ? AND status IN ('running', 'stopping')"
                       + " AND IFNULL(node, '') = ?",
                   this::mapRow,
                   project,
@@ -244,19 +246,34 @@ public final class RunStore implements ConflictResolver {
   }
 
   /**
-   * The running build run of {@code project} that executed on this box, or empty. Node-scoped like
-   * {@link #latestForProjectOnNode}.
+   * The active build run of {@code project} that executed on this box, or empty. {@code stopping}
+   * counts as active: an interrupted stop's claim must stay addressable so a project-targeted stop
+   * retry resumes it instead of falling through to the ad-hoc identity. Node-scoped like {@link
+   * #latestForProjectOnNode}.
    */
   public Optional<RunRow> runningForProjectOnNode(String project, String localHandle) {
     return db.queryOne(
         "SELECT "
             + COLUMNS
-            + " FROM runs WHERE project = ? AND status = 'running' AND IFNULL(node, '') = ?"
-            + " AND IFNULL(role, 'build') = 'build'"
+            + " FROM runs WHERE project = ? AND status IN ('running', 'stopping')"
+            + " AND IFNULL(node, '') = ? AND IFNULL(role, 'build') = 'build'"
             + " ORDER BY started_at DESC LIMIT 1",
         this::mapRow,
         project,
         ownerKey(localHandle));
+  }
+
+  /**
+   * Every build run holding an unfinished stop claim ({@code stopping}) — a stop that recorded its
+   * terminal intent but was interrupted before the halt was verified. The reconciler's
+   * interrupted-stop pass finalizes these once their unit is gone.
+   */
+  public List<RunRow> stopping() {
+    return db.query(
+        "SELECT "
+            + COLUMNS
+            + " FROM runs WHERE status = 'stopping' AND IFNULL(role, 'build') = 'build'",
+        this::mapRow);
   }
 
   /**
@@ -336,6 +353,38 @@ public final class RunStore implements ConflictResolver {
           return null;
         });
   }
+
+  /**
+   * Status transition that commits only if the run still holds {@code expected}, running {@code
+   * alongside} inside the same immediate transaction once the transition has won — the seam a stop
+   * claim uses to move its spec terminal in the very same commit. Returns whether the transition
+   * happened; a false return wrote nothing and never ran {@code alongside}, and an {@code
+   * alongside} that throws rolls the transition back. A terminal target status stamps {@code
+   * completed_at}; a non-terminal one clears it.
+   */
+  public boolean transition(String id, String expected, String status, Runnable alongside) {
+    return db.immediateTransaction(
+        () -> {
+          db.execute(
+              "UPDATE runs SET status = ?, completed_at = ? WHERE id = ? AND status = ?",
+              status,
+              TERMINAL_STATUSES.contains(status) ? DateTimeUtils.now().toString() : null,
+              id,
+              expected);
+          if (db.changes() == 0) {
+            return false;
+          }
+          alongside.run();
+          recordRevision(id, "local", false);
+          return true;
+        });
+  }
+
+  public boolean transition(String id, String expected, String status) {
+    return transition(id, expected, status, () -> {});
+  }
+
+  private static final Set<String> TERMINAL_STATUSES = Set.of("completed", "stopped", "failed");
 
   /** Marks a run finished with its final status and the agent process's exit code (nullable). */
   public void complete(String id, String status, Integer exitCode) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -322,6 +322,21 @@ public final class RunStore implements ConflictResolver {
     return db.query("SELECT " + COLUMNS + " FROM runs ORDER BY started_at DESC", this::mapRow);
   }
 
+  /**
+   * As {@link #complete(String, String, Integer)}, also running {@code alongside} inside the same
+   * immediate transaction — the seam for a caller that must drive two aggregates terminal as one
+   * intent (a stop cancelling a spec while releasing its run). Any failure rolls back both writes,
+   * so a partial terminal state is never exposed.
+   */
+  public void complete(String id, String status, Integer exitCode, Runnable alongside) {
+    db.immediateTransaction(
+        () -> {
+          alongside.run();
+          complete(id, status, exitCode);
+          return null;
+        });
+  }
+
   /** Marks a run finished with its final status and the agent process's exit code (nullable). */
   public void complete(String id, String status, Integer exitCode) {
     db.transaction(

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -72,7 +72,13 @@ public final class RunStore implements ConflictResolver {
       String unit,
       String startedAt,
       String completedAt,
-      List<String> repos) {}
+      List<String> repos) {
+
+    /** Whether this row is a build attempt; a null role predates roles and always meant build. */
+    public boolean buildRole() {
+      return "build".equals(Objects.requireNonNullElse(role, "build"));
+    }
+  }
 
   private static final String COLUMNS =
       "id, project, spec_id, node, role, agent, branch, task, pid, watcher_pid, status,"
@@ -314,7 +320,7 @@ public final class RunStore implements ConflictResolver {
 
   public List<RunRow> listForSpec(String specId) {
     return db.query(
-        "SELECT " + COLUMNS + " FROM runs WHERE spec_id = ? ORDER BY started_at DESC",
+        "SELECT " + COLUMNS + " FROM runs WHERE spec_id = ? ORDER BY started_at DESC, id DESC",
         this::mapRow,
         specId);
   }
@@ -363,12 +369,33 @@ public final class RunStore implements ConflictResolver {
    * completed_at}; a non-terminal one clears it.
    */
   public boolean transition(String id, String expected, String status, Runnable alongside) {
+    return transition(id, expected, status, null, alongside);
+  }
+
+  public boolean transition(String id, String expected, String status) {
+    return transition(id, expected, status, null, () -> {});
+  }
+
+  /**
+   * As {@link #transition(String, String, String, Runnable)}, also stamping {@code exitCode} (when
+   * non-null) in the same UPDATE, so a finisher that knows the process outcome commits the terminal
+   * status and its exit code as one atomic, single-revision write — a crash or a sync push can
+   * never observe the terminal status without its exit code.
+   */
+  public boolean transition(String id, String expected, String status, Integer exitCode) {
+    return transition(id, expected, status, exitCode, () -> {});
+  }
+
+  private boolean transition(
+      String id, String expected, String status, Integer exitCode, Runnable alongside) {
     return db.immediateTransaction(
         () -> {
           db.execute(
-              "UPDATE runs SET status = ?, completed_at = ? WHERE id = ? AND status = ?",
+              "UPDATE runs SET status = ?, completed_at = ?, exit_code = COALESCE(?, exit_code)"
+                  + " WHERE id = ? AND status = ?",
               status,
               TERMINAL_STATUSES.contains(status) ? DateTimeUtils.now().toString() : null,
+              exitCode != null ? exitCode.longValue() : null,
               id,
               expected);
           if (db.changes() == 0) {
@@ -380,26 +407,25 @@ public final class RunStore implements ConflictResolver {
         });
   }
 
-  public boolean transition(String id, String expected, String status) {
-    return transition(id, expected, status, () -> {});
-  }
-
   /**
    * Runs {@code work} inside one {@code BEGIN IMMEDIATE} transaction, only if {@code id} is still
-   * {@code specId}'s latest attempt at commit time. Taking the write lock before the check
-   * serializes it against {@link #reserveDispatch}, so a restart that reserves a newer attempt
-   * either lands before this (the check fails, nothing runs) or waits until after (the newer row
-   * sees whatever {@code work} committed) — a check-then-write split across transactions could let
-   * a stop aimed at an old run cancel the spec out from under the newer attempt. Ties on {@code
-   * started_at} break on the UUIDv7 id, which orders by mint time. Returns whether {@code work}
-   * ran; {@code work} throwing rolls the whole transaction back.
+   * {@code specId}'s latest <em>build</em> attempt at commit time. Review-lane rows are not
+   * attempts — the pipeline mints them for the same spec while it negotiates review, and counting
+   * them would make every reviewed spec's build run permanently "stale". Taking the write lock
+   * before the check serializes it against {@link #reserveDispatch}, so a restart that reserves a
+   * newer attempt either lands before this (the check fails, nothing runs) or waits until after
+   * (the newer row sees whatever {@code work} committed) — a check-then-write split across
+   * transactions could let a stop aimed at an old run cancel the spec out from under the newer
+   * attempt. Ties on {@code started_at} break on the UUIDv7 id, which orders by mint time. Returns
+   * whether {@code work} ran; {@code work} throwing rolls the whole transaction back.
    */
   public boolean runIfLatestAttempt(String id, String specId, Runnable work) {
     return db.immediateTransaction(
         () -> {
           var latest =
               db.queryOne(
-                  "SELECT id FROM runs WHERE spec_id = ? ORDER BY started_at DESC, id DESC LIMIT 1",
+                  "SELECT id FROM runs WHERE spec_id = ? AND IFNULL(role, 'build') = 'build'"
+                      + " ORDER BY started_at DESC, id DESC LIMIT 1",
                   row -> row.text(0),
                   specId);
           if (latest.isEmpty() || !latest.get().equals(id)) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -384,6 +384,32 @@ public final class RunStore implements ConflictResolver {
     return transition(id, expected, status, () -> {});
   }
 
+  /**
+   * Runs {@code work} inside one {@code BEGIN IMMEDIATE} transaction, only if {@code id} is still
+   * {@code specId}'s latest attempt at commit time. Taking the write lock before the check
+   * serializes it against {@link #reserveDispatch}, so a restart that reserves a newer attempt
+   * either lands before this (the check fails, nothing runs) or waits until after (the newer row
+   * sees whatever {@code work} committed) — a check-then-write split across transactions could let
+   * a stop aimed at an old run cancel the spec out from under the newer attempt. Ties on {@code
+   * started_at} break on the UUIDv7 id, which orders by mint time. Returns whether {@code work}
+   * ran; {@code work} throwing rolls the whole transaction back.
+   */
+  public boolean runIfLatestAttempt(String id, String specId, Runnable work) {
+    return db.immediateTransaction(
+        () -> {
+          var latest =
+              db.queryOne(
+                  "SELECT id FROM runs WHERE spec_id = ? ORDER BY started_at DESC, id DESC LIMIT 1",
+                  row -> row.text(0),
+                  specId);
+          if (latest.isEmpty() || !latest.get().equals(id)) {
+            return false;
+          }
+          work.run();
+          return true;
+        });
+  }
+
   private static final Set<String> TERMINAL_STATUSES = Set.of("completed", "stopped", "failed");
 
   /** Marks a run finished with its final status and the agent process's exit code (nullable). */

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -427,7 +427,41 @@ public final class SchemaManager {
                   rev, base_rev FROM specs""",
           "DROP TABLE specs",
           "ALTER TABLE specs_v3 RENAME TO specs",
-          "CREATE INDEX IF NOT EXISTS idx_specs_project ON specs(project)");
+          "CREATE INDEX IF NOT EXISTS idx_specs_project ON specs(project)",
+          """
+          CREATE TABLE runs_v2 (
+              id TEXT PRIMARY KEY,
+              project TEXT NOT NULL,
+              spec_id TEXT,
+              agent TEXT NOT NULL,
+              branch TEXT,
+              task TEXT,
+              pid INTEGER,
+              status TEXT NOT NULL DEFAULT 'running'
+                  CHECK (status IN ('running', 'stopping', 'completed', 'stopped', 'failed')),
+              started_at TEXT NOT NULL,
+              completed_at TEXT,
+              exit_code INTEGER,
+              watcher_pid INTEGER,
+              node TEXT,
+              role TEXT NOT NULL DEFAULT 'build',
+              log_path TEXT,
+              rev TEXT,
+              base_rev TEXT,
+              unit TEXT,
+              repos TEXT
+          )""",
+          """
+          INSERT INTO runs_v2 (id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos)
+              SELECT id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos FROM runs""",
+          "DROP TABLE runs",
+          "ALTER TABLE runs_v2 RENAME TO runs",
+          "CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project)",
+          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)");
 
   /**
    * The last schema version whose {@code specs.status} CHECK predates {@code awaiting_merge}. The

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -395,7 +395,39 @@ public final class SchemaManager {
           "CREATE INDEX IF NOT EXISTS idx_reviews_spec ON reviews(spec_id)",
           "ALTER TABLE change_log ADD COLUMN peer TEXT",
           "ALTER TABLE runs ADD COLUMN unit TEXT",
-          "ALTER TABLE runs ADD COLUMN repos TEXT");
+          "ALTER TABLE runs ADD COLUMN repos TEXT",
+          """
+          CREATE TABLE specs_v3 (
+              id TEXT PRIMARY KEY,
+              title TEXT NOT NULL,
+              status TEXT NOT NULL DEFAULT 'draft'
+                  CHECK (status IN ('draft', 'pending', 'in_progress', 'review', 'awaiting_merge',
+                      'done', 'cancelled', 'archived')),
+              assignee TEXT,
+              agent TEXT,
+              model TEXT,
+              reasoning_effort TEXT
+                  CHECK (reasoning_effort IS NULL OR reasoning_effort IN ('none', 'low', 'medium', 'high', 'xhigh')),
+              branch TEXT,
+              priority INTEGER NOT NULL DEFAULT 0,
+              created_by TEXT,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              project TEXT NOT NULL DEFAULT 'unassigned',
+              updated_by TEXT,
+              rev TEXT,
+              base_rev TEXT
+          )""",
+          """
+          INSERT INTO specs_v3 (id, title, status, assignee, agent, model, reasoning_effort,
+                  branch, priority, created_by, created_at, updated_at, project, updated_by,
+                  rev, base_rev)
+              SELECT id, title, status, assignee, agent, model, reasoning_effort,
+                  branch, priority, created_by, created_at, updated_at, project, updated_by,
+                  rev, base_rev FROM specs""",
+          "DROP TABLE specs",
+          "ALTER TABLE specs_v3 RENAME TO specs",
+          "CREATE INDEX IF NOT EXISTS idx_specs_project ON specs(project)");
 
   /**
    * The last schema version whose {@code specs.status} CHECK predates {@code awaiting_merge}. The

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -90,6 +90,7 @@ public final class SpecStore implements ConflictResolver {
       int review,
       int awaitingMerge,
       int done,
+      int cancelled,
       int archived,
       String nextReadyId) {}
 
@@ -778,6 +779,7 @@ public final class SpecStore implements ConflictResolver {
     var review = 0;
     var awaitingMerge = 0;
     var done = 0;
+    var cancelled = 0;
     var archived = 0;
     for (var row : counts) {
       var count = (int) (long) row[1];
@@ -788,6 +790,7 @@ public final class SpecStore implements ConflictResolver {
         case "review" -> review = count;
         case "awaiting_merge" -> awaitingMerge = count;
         case "done" -> done = count;
+        case "cancelled" -> cancelled = count;
         case "archived" -> archived = count;
         default -> {}
       }
@@ -795,7 +798,7 @@ public final class SpecStore implements ConflictResolver {
     var ready = readySpecs(projectFilter);
     var nextReadyId = ready.isEmpty() ? null : ready.getFirst().id();
     return new BoardSummary(
-        draft, pending, inProgress, review, awaitingMerge, done, archived, nextReadyId);
+        draft, pending, inProgress, review, awaitingMerge, done, cancelled, archived, nextReadyId);
   }
 
   private SpecRow mapSpec(Sqlite.Row row) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -246,6 +246,31 @@ public final class SpecStore implements ConflictResolver {
   }
 
   /**
+   * Status transition that commits only if the spec still holds {@code expected}, returning whether
+   * it did. The check and the write are one statement under the write lock ({@code BEGIN
+   * IMMEDIATE}), so a lifecycle writer racing another transition — above all an operator's {@code
+   * cancelled}, which must stay terminal — fails cleanly on its stale read instead of overwriting
+   * the transition that won. Every automated status writer must use this; the unconditional {@link
+   * #updateStatus} is for deliberate operator edits.
+   */
+  public boolean compareAndSetStatus(String id, SpecStatus expected, SpecStatus status) {
+    return db.immediateTransaction(
+        () -> {
+          db.execute(
+              "UPDATE specs SET status = ?, updated_at = ? WHERE id = ? AND status = ?",
+              status.wire(),
+              DateTimeUtils.now().toString(),
+              id,
+              expected.wire());
+          if (db.changes() == 0) {
+            return false;
+          }
+          recordRevision(id, "local", false);
+          return true;
+        });
+  }
+
+  /**
    * Status transition that also persists the spec's resolved target repos and its dispatch branch
    * in the same transaction. Dispatch resolves repo overrides and computes the branch name at
    * launch time; recording them here keeps later store reads (the review pipeline builds its prompt

--- a/sail-core/src/main/java/ai/singlr/sail/store/Sqlite.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/Sqlite.java
@@ -30,7 +30,9 @@ import java.util.function.Supplier;
  * would sporadically die with {@code cannot start a transaction within a transaction} (surfacing as
  * a scrambled {@code sqlite3_errmsg} like "another row available"), which is exactly how the review
  * pipeline silently lost agent stops in the field. The lock is reentrant so statements inside a
- * {@link #transaction} body nest without deadlock.
+ * {@link #transaction} body nest without deadlock, and a nested {@link #transaction} call joins the
+ * enclosing transaction: the outermost scope alone begins, commits, or rolls back, so store methods
+ * that each open their own transaction compose into one atomic write when a caller wraps them.
  *
  * <p>Not a JDBC driver. Exposes exactly the surface Sail needs: execute, query, and transactions.
  */
@@ -50,6 +52,7 @@ public final class Sqlite implements AutoCloseable {
   private final MemorySegment db;
   private final SqliteLib lib;
   private final ReentrantLock lock = new ReentrantLock();
+  private int transactionDepth;
   private volatile boolean closed;
 
   private Sqlite(Arena arena, MemorySegment db, SqliteLib lib) {
@@ -179,7 +182,16 @@ public final class Sqlite implements AutoCloseable {
   private <T> T transaction(String begin, Supplier<T> work) {
     lock.lock();
     try {
+      if (transactionDepth > 0) {
+        transactionDepth++;
+        try {
+          return work.get();
+        } finally {
+          transactionDepth--;
+        }
+      }
       execute(begin);
+      transactionDepth = 1;
       try {
         var result = work.get();
         execute("COMMIT");
@@ -191,6 +203,8 @@ public final class Sqlite implements AutoCloseable {
           e.addSuppressed(rollbackEx);
         }
         throw e;
+      } finally {
+        transactionDepth = 0;
       }
     } finally {
       lock.unlock();

--- a/sail-core/src/test/java/ai/singlr/sail/engine/ScriptedShellExecutor.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/ScriptedShellExecutor.java
@@ -63,6 +63,14 @@ public final class ScriptedShellExecutor implements ShellExec {
     return on(pattern, new Result(1, "", stderr));
   }
 
+  /**
+   * Shorthand: command containing pattern succeeds once, then falls through to default on reuse.
+   */
+  public ScriptedShellExecutor onceOnOk(String pattern) {
+    consumable.add(pattern);
+    return on(pattern, new Result(0, "", ""));
+  }
+
   /** Returns an unmodifiable list of all commands that were executed, in order. */
   public List<String> invocations() {
     return Collections.unmodifiableList(invocations);

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.singlr.sail.common.DateTimeUtils;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,6 +74,103 @@ class RunStoreTest {
     assertEquals("/home/dev/.sail/runs/r/agent.log", run.logPath());
     assertNotNull(run.startedAt());
     assertNull(run.completedAt());
+  }
+
+  @Test
+  void transitionCommitsOnlyFromTheExpectedStatus() {
+    var id = newRun("backend", "auth");
+
+    assertFalse(store.transition(id, "stopping", "stopped"));
+    assertEquals("running", store.findById(id).orElseThrow().status());
+
+    assertTrue(store.transition(id, "running", "stopping"));
+    var claimed = store.findById(id).orElseThrow();
+    assertEquals("stopping", claimed.status());
+    assertNull(claimed.completedAt(), "a claim is not terminal, so nothing is stamped complete");
+
+    assertTrue(store.transition(id, "stopping", "stopped"));
+    var stopped = store.findById(id).orElseThrow();
+    assertEquals("stopped", stopped.status());
+    assertNotNull(stopped.completedAt());
+  }
+
+  @Test
+  void transitionBackToRunningClearsCompletedAt() {
+    var id = newRun("backend", "auth");
+    store.transition(id, "running", "stopping");
+
+    assertTrue(store.transition(id, "stopping", "running"));
+
+    var restored = store.findById(id).orElseThrow();
+    assertEquals("running", restored.status());
+    assertNull(restored.completedAt());
+  }
+
+  @Test
+  void transitionRunsAlongsideOnlyWhenItWinsAndRollsBackWithIt() {
+    var id = newRun("backend", "auth");
+    var ran = new AtomicBoolean();
+
+    assertFalse(store.transition(id, "stopping", "stopped", () -> ran.set(true)));
+    assertFalse(ran.get(), "a lost transition must never run its alongside work");
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            store.transition(
+                id,
+                "running",
+                "stopping",
+                () -> {
+                  throw new IllegalStateException("conflict");
+                }));
+    assertEquals(
+        "running",
+        store.findById(id).orElseThrow().status(),
+        "an alongside failure rolls the transition back with it");
+  }
+
+  @Test
+  void transitionJournalsARevisionSoTheClaimReplicates() {
+    var id = newRun("backend", "auth");
+    var before = store.latestRev(id);
+
+    store.transition(id, "running", "stopping");
+
+    assertNotEquals(before, store.latestRev(id));
+  }
+
+  @Test
+  void stoppingListsOnlyBuildRunsHoldingAClaim() {
+    var claimed = newRun("backend", "auth");
+    store.transition(claimed, "running", "stopping");
+    newRun("backend", "other");
+    var review =
+        store.createReview(
+            DateTimeUtils.newId().toString(),
+            "backend",
+            "auth",
+            "node-a",
+            "codex",
+            "feat/x",
+            "review",
+            "/home/dev/.sail/runs/rev/review.log");
+    db.execute("UPDATE runs SET status = 'stopping' WHERE id = ?", review);
+
+    var claims = store.stopping();
+
+    assertEquals(1, claims.size());
+    assertEquals(claimed, claims.getFirst().id());
+  }
+
+  @Test
+  void aStoppingRunStaysTheActiveRunForItsProjectAndNode() {
+    var id = newRun("backend", "auth");
+    store.transition(id, "running", "stopping");
+
+    var active = store.runningForProjectOnNode("backend", "node-a").orElseThrow();
+
+    assertEquals(id, active.id());
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -160,6 +160,41 @@ class RunStoreTest {
   }
 
   @Test
+  void runIfLatestAttemptIgnoresReviewRowsWhenPickingTheLatestAttempt() {
+    var build = newRun("backend", "auth");
+    store.createReview(
+        DateTimeUtils.newId().toString(),
+        "backend",
+        "auth",
+        "node-a",
+        "claude-code",
+        "feat/x",
+        "review",
+        "/home/dev/.sail/runs/r/agent.log");
+    var ran = new AtomicBoolean();
+
+    assertTrue(
+        store.runIfLatestAttempt(build, "auth", () -> ran.set(true)),
+        "a review-lane row is pipeline negotiation, not a newer attempt");
+    assertTrue(ran.get());
+  }
+
+  @Test
+  void transitionWithExitCodeStampsStatusAndCodeInOneWrite() {
+    var id = newRun("backend", "auth");
+
+    assertTrue(store.transition(id, "running", "failed", 2));
+
+    var run = store.findById(id).orElseThrow();
+    assertEquals("failed", run.status());
+    assertEquals(2, run.exitCode());
+    assertNotNull(run.completedAt());
+
+    assertFalse(store.transition(id, "running", "completed", 0));
+    assertEquals(2, store.findById(id).orElseThrow().exitCode());
+  }
+
+  @Test
   void runIfLatestAttemptRollsBackWorkThatFails() {
     var id = newRun("backend", "auth");
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -141,6 +141,45 @@ class RunStoreTest {
   }
 
   @Test
+  void runIfLatestAttemptRunsTheWorkForTheSpecsNewestRun() {
+    var id = newRun("backend", "auth");
+    var ran = new AtomicBoolean();
+
+    assertTrue(store.runIfLatestAttempt(id, "auth", () -> ran.set(true)));
+    assertTrue(ran.get());
+  }
+
+  @Test
+  void runIfLatestAttemptRefusesOnceANewerAttemptExists() {
+    var older = newRun("backend", "auth");
+    newRun("backend", "auth");
+    var ran = new AtomicBoolean();
+
+    assertFalse(store.runIfLatestAttempt(older, "auth", () -> ran.set(true)));
+    assertFalse(ran.get(), "a superseded run must never act on its spec");
+  }
+
+  @Test
+  void runIfLatestAttemptRollsBackWorkThatFails() {
+    var id = newRun("backend", "auth");
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            store.runIfLatestAttempt(
+                id,
+                "auth",
+                () -> {
+                  store.complete(id, "stopped", null);
+                  throw new IllegalStateException("conflict");
+                }));
+    assertEquals(
+        "running",
+        store.findById(id).orElseThrow().status(),
+        "failing work rolls back everything it wrote inside the guard");
+  }
+
+  @Test
   void stoppingListsOnlyBuildRunsHoldingAClaim() {
     var claimed = newRun("backend", "auth");
     store.transition(claimed, "running", "stopping");

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.common.DateTimeUtils;
@@ -176,6 +177,38 @@ class RunStoreTest {
     store.complete(id, "stopped", 137);
 
     assertEquals(137, store.findById(id).orElseThrow().exitCode());
+  }
+
+  @Test
+  void completeRunsAlongsideWorkInTheSameTransaction() {
+    var id = newRun("backend", "auth");
+    var other = newRun("backend", "auth");
+
+    store.complete(id, "stopped", null, () -> store.complete(other, "stopped", null));
+
+    assertEquals("stopped", store.findById(id).orElseThrow().status());
+    assertEquals("stopped", store.findById(other).orElseThrow().status());
+  }
+
+  @Test
+  void aFailureAfterAlongsideWorkRollsBackBothWrites() {
+    var id = newRun("backend", "auth");
+    var other = newRun("backend", "auth");
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            store.complete(
+                id,
+                "stopped",
+                null,
+                () -> {
+                  store.complete(other, "stopped", null);
+                  throw new IllegalStateException("boom");
+                }));
+
+    assertEquals("running", store.findById(id).orElseThrow().status());
+    assertEquals("running", store.findById(other).orElseThrow().status());
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SpecStatus;
@@ -232,6 +233,31 @@ class SpecStoreTest {
 
     var found = store.findById("a").orElseThrow();
     assertEquals(SpecStatus.IN_PROGRESS, found.status());
+  }
+
+  @Test
+  void compareAndSetStatusCommitsOnlyFromTheExpectedStatus() {
+    store.create(spec("a", "Test", "in_progress"));
+
+    assertTrue(store.compareAndSetStatus("a", SpecStatus.IN_PROGRESS, SpecStatus.CANCELLED));
+    assertEquals(SpecStatus.CANCELLED, store.findById("a").orElseThrow().status());
+
+    assertFalse(
+        store.compareAndSetStatus("a", SpecStatus.IN_PROGRESS, SpecStatus.REVIEW),
+        "a writer holding a stale read must lose to the transition that won");
+    assertEquals(SpecStatus.CANCELLED, store.findById("a").orElseThrow().status());
+  }
+
+  @Test
+  void compareAndSetStatusJournalsARevisionOnlyWhenItWins() {
+    store.create(spec("a", "Test", "in_progress"));
+    var created = store.revOf("a");
+
+    store.compareAndSetStatus("a", SpecStatus.REVIEW, SpecStatus.AWAITING_MERGE);
+    assertEquals(created, store.revOf("a"), "a lost CAS writes nothing, so no revision is minted");
+
+    store.compareAndSetStatus("a", SpecStatus.IN_PROGRESS, SpecStatus.REVIEW);
+    assertNotEquals(created, store.revOf("a"), "a won CAS journals like any other mutation");
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
@@ -350,6 +350,7 @@ class SpecStoreTest {
     store.create(spec("f", "F", "done"));
     store.create(spec("g", "G", "archived"));
     store.create(spec("h", "H", "awaiting_merge"));
+    store.create(spec("i", "I", "cancelled"));
 
     var board = store.board();
     assertEquals(1, board.draft());
@@ -358,8 +359,44 @@ class SpecStoreTest {
     assertEquals(1, board.review());
     assertEquals(1, board.awaitingMerge());
     assertEquals(1, board.done());
+    assertEquals(1, board.cancelled());
     assertEquals(1, board.archived());
     assertEquals("b", board.nextReadyId());
+  }
+
+  @Test
+  void cancelledPersistsAndReadsBack() {
+    store.create(spec("killed", "Killed", "in_progress"));
+
+    store.updateStatus("killed", SpecStatus.CANCELLED);
+
+    assertEquals(SpecStatus.CANCELLED, store.findById("killed").get().status());
+  }
+
+  @Test
+  void cancelledDependencyDoesNotUnblockDependents() {
+    store.create(spec("base", "Base", "cancelled"));
+    var dependent =
+        new SpecStore.SpecRow(
+            "child",
+            "test-project",
+            "Child",
+            SpecStatus.PENDING,
+            null,
+            null,
+            null,
+            null,
+            null,
+            0,
+            null,
+            "",
+            "",
+            null,
+            List.of("base"),
+            List.of());
+    store.create(dependent);
+
+    assertTrue(store.readySpecs().isEmpty(), "cancelled work must not satisfy a dependency");
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/SqliteTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SqliteTest.java
@@ -120,6 +120,60 @@ class SqliteTest {
   }
 
   @Test
+  void nestedTransactionJoinsTheOuterScope() {
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+
+    db.transaction(
+        () -> {
+          db.execute("INSERT INTO t VALUES (?)", 1);
+          db.transaction(() -> db.execute("INSERT INTO t VALUES (?)", 2));
+          db.immediateTransaction(
+              () -> {
+                db.execute("INSERT INTO t VALUES (?)", 3);
+                return null;
+              });
+        });
+
+    var count = db.query("SELECT COUNT(*) FROM t", row -> row.integer(0));
+    assertEquals(3L, count.getFirst());
+  }
+
+  @Test
+  void aFailureAfterANestedJoinRollsBackItsWritesToo() {
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            db.immediateTransaction(
+                () -> {
+                  db.transaction(() -> db.execute("INSERT INTO t VALUES (?)", 1));
+                  throw new RuntimeException("boom");
+                }));
+
+    var count = db.query("SELECT COUNT(*) FROM t", row -> row.integer(0));
+    assertEquals(0L, count.getFirst());
+  }
+
+  @Test
+  void aNewTransactionAfterANestedJoinBeginsItsOwnScope() {
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+    db.transaction(() -> db.transaction(() -> db.execute("INSERT INTO t VALUES (?)", 1)));
+
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            db.transaction(
+                () -> {
+                  db.execute("INSERT INTO t VALUES (?)", 2);
+                  throw new RuntimeException("boom");
+                }));
+
+    var count = db.query("SELECT COUNT(*) FROM t", row -> row.integer(0));
+    assertEquals(1L, count.getFirst());
+  }
+
+  @Test
   void changesReturnsAffectedRows() {
     db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)");
     db.execute("INSERT INTO t VALUES (?, ?)", 1, "alice");

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
@@ -230,7 +230,11 @@ public final class AgentSession {
     killAgent(containerName, AgentUnit.BUILD);
   }
 
-  /** Kills the given role's running agent inside the container. SIGTERM first, then SIGKILL. */
+  /**
+   * Kills the given role's running agent inside the container. SIGTERM first, then SIGKILL. A
+   * SIGKILL that fails against a still-live process throws instead of returning normally, so a
+   * caller can never record a successful stop for an agent that survived the signal.
+   */
   public void killAgent(String containerName, AgentUnit unit)
       throws IOException, InterruptedException, TimeoutException {
     var pidCmd = ContainerExec.asDevUser(containerName, List.of("cat", unit.pidPath()));
@@ -252,7 +256,16 @@ public final class AgentSession {
 
     var aliveCmd = ContainerExec.asDevUser(containerName, List.of("kill", "-0", pidStr));
     if (shell.exec(aliveCmd).ok()) {
-      shell.exec(ContainerExec.asDevUser(containerName, List.of("kill", "-9", pidStr)));
+      var kill = shell.exec(ContainerExec.asDevUser(containerName, List.of("kill", "-9", pidStr)));
+      if (!kill.ok()) {
+        throw new IOException(
+            "SIGKILL for agent PID "
+                + pidStr
+                + " in "
+                + containerName
+                + " failed: "
+                + kill.stderr().trim());
+      }
     }
 
     shell.exec(ContainerExec.asDevUser(containerName, List.of("rm", "-f", unit.pidPath())));

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
@@ -257,14 +257,15 @@ public final class AgentSession {
     var aliveCmd = ContainerExec.asDevUser(containerName, List.of("kill", "-0", pidStr));
     if (shell.exec(aliveCmd).ok()) {
       var kill = shell.exec(ContainerExec.asDevUser(containerName, List.of("kill", "-9", pidStr)));
-      if (!kill.ok()) {
+      if (!kill.ok() && shell.exec(aliveCmd).ok()) {
         throw new IOException(
             "SIGKILL for agent PID "
                 + pidStr
                 + " in "
                 + containerName
                 + " failed: "
-                + kill.stderr().trim());
+                + kill.stderr().trim()
+                + ". Check the process in the container and retry the stop.");
       }
     }
 

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
@@ -178,6 +178,23 @@ class AgentSessionTest {
   }
 
   @Test
+  void killAgentTreatsSigkillOfAnAlreadyDeadProcessAsSuccess() throws Exception {
+    var shell =
+        new ScriptedShellExecutor()
+            .onOk("cat /home/dev/.sail/agent.pid", "9999\n")
+            .onOk("kill 9999")
+            .onOk("sleep 3")
+            .onceOnOk("kill -0 9999")
+            .onFail("kill -9 9999", "No such process")
+            .onOk("rm -f");
+    var session = new AgentSession(shell);
+
+    session.killAgent("acme-health");
+
+    assertTrue(shell.invocations().stream().anyMatch(c -> c.contains("rm -f")));
+  }
+
+  @Test
   void killAgentIgnoresNonNumericPid() throws Exception {
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
@@ -9,9 +9,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SailYaml;
+import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -158,6 +160,21 @@ class AgentSessionTest {
     var cmds = shell.invocations();
     assertFalse(cmds.stream().anyMatch(c -> c.contains("kill -9 9999")));
     assertTrue(cmds.stream().anyMatch(c -> c.contains("rm -f")));
+  }
+
+  @Test
+  void killAgentThrowsWhenSigkillFailsOnALiveProcess() {
+    var shell =
+        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+            .onOk("cat /home/dev/.sail/agent.pid", "9999\n")
+            .onFail("kill -9 9999", "Operation not permitted");
+    var session = new AgentSession(shell);
+
+    var failure = assertThrows(IOException.class, () -> session.killAgent("acme-health"));
+
+    assertTrue(failure.getMessage().contains("SIGKILL"));
+    assertTrue(failure.getMessage().contains("9999"));
+    assertFalse(shell.invocations().stream().anyMatch(c -> c.contains("rm -f")));
   }
 
   @Test

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -806,6 +806,7 @@ record GlobalBoardResponse(SpecStore.BoardSummary board, int doneOpenFindings) i
     m.put("review", board.review());
     m.put("awaiting_merge", board.awaitingMerge());
     m.put("done", board.done());
+    m.put("cancelled", board.cancelled());
     m.put("archived", board.archived());
     m.put("next_ready_id", board.nextReadyId());
     m.put("done_open_findings", doneOpenFindings);
@@ -1018,7 +1019,8 @@ record RunLogResponse(String runId, List<String> lines, String error) implements
   }
 }
 
-record StopRunResponse(String runId, boolean stopped, String reason, Integer pid)
+record StopRunResponse(
+    String runId, boolean stopped, String reason, Integer pid, boolean specCancelled)
     implements Mappable {
   @Override
   public Map<String, Object> toMap() {
@@ -1027,6 +1029,7 @@ record StopRunResponse(String runId, boolean stopped, String reason, Integer pid
     m.put("stopped", stopped);
     if (reason != null) m.put("reason", reason);
     if (pid != null) m.put("pid", pid);
+    m.put("spec_cancelled", specCancelled);
     return m;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * The single dispatch executor behind every lane. Owns the whole procedure — resolve, policy,
@@ -722,17 +723,19 @@ public final class DispatchOperations {
 
   /**
    * The project's runs this box is executing right now, each with the repo set its dispatch
-   * reserved. A box that keeps no run aggregate has nothing to consult and allows the dispatch. A
-   * run recorded before repos were persisted reads as no repos, which the gate treats as
-   * whole-container: refusing is the safe reading of a row it cannot scope, and it heals when the
-   * run finishes.
+   * reserved. Uses the same {@link #ownsLiveAgent} reading as the live reservation, so the dry lane
+   * counts a mid-stop ({@code stopping}) run as occupying its repos exactly like {@code
+   * reserveDispatch} does. A box that keeps no run aggregate has nothing to consult and allows the
+   * dispatch. A run recorded before repos were persisted reads as no repos, which the gate treats
+   * as whole-container: refusing is the safe reading of a row it cannot scope, and it heals when
+   * the run finishes.
    */
   private List<DispatchGate.RunningRun> runningLocalRuns(String project, String localHandle) {
     if (runStore == null) {
       return List.of();
     }
     return runStore.listForProject(project).stream()
-        .filter(run -> "running".equals(run.status()))
+        .filter(DispatchOperations::ownsLiveAgent)
         .filter(run -> SailOperations.ownsRun(run.node(), localHandle))
         .map(run -> new DispatchGate.RunningRun(run.id(), run.specId(), run.repos()))
         .toList();
@@ -812,7 +815,7 @@ public final class DispatchOperations {
           runs.stream()
               .filter(DispatchOperations::ownsLiveAgent)
               .map(RunStore.RunRow::id)
-              .collect(java.util.stream.Collectors.toUnmodifiableSet());
+              .collect(Collectors.toUnmodifiableSet());
       var pruned = RunRetention.prune(shell, project, ids, active, RunRetention.DEFAULT_KEEP);
       listener.runsPruned(pruned.size());
     } catch (Exception e) {
@@ -845,12 +848,23 @@ public final class DispatchOperations {
   /**
    * Completes a foreground run explicitly: its launch command blocks until the agent exits, so the
    * exit code is known here and the run must not be left {@code running} waiting for a terminal
-   * hook event that may never arrive.
+   * hook event that may never arrive. Compare-and-set from {@code running}, exactly like {@link
+   * RunTracker}: an operator stop that already recorded the run terminal wins, and this finisher
+   * only enriches the missing exit code instead of overwriting the cancel with {@code completed}.
    */
   private void completeForegroundRun(String runId, int exitCode) {
     runBookkeeping(
         "complete run " + runId,
-        () -> runStore.complete(runId, exitCode == 0 ? "completed" : "failed", exitCode));
+        () -> {
+          if (runStore.transition(
+              runId, "running", exitCode == 0 ? "completed" : "failed", exitCode)) {
+            return;
+          }
+          var current = runStore.findById(runId).orElse(null);
+          if (current != null && current.exitCode() == null) {
+            runStore.recordExitCode(runId, exitCode);
+          }
+        });
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -808,16 +808,26 @@ public final class DispatchOperations {
     try {
       var runs = runStore.listForProject(project);
       var ids = runs.stream().map(RunStore.RunRow::id).toList();
-      var running =
+      var active =
           runs.stream()
-              .filter(run -> "running".equals(run.status()))
+              .filter(DispatchOperations::ownsLiveAgent)
               .map(RunStore.RunRow::id)
               .collect(java.util.stream.Collectors.toUnmodifiableSet());
-      var pruned = RunRetention.prune(shell, project, ids, running, RunRetention.DEFAULT_KEEP);
+      var pruned = RunRetention.prune(shell, project, ids, active, RunRetention.DEFAULT_KEEP);
       listener.runsPruned(pruned.size());
     } catch (Exception e) {
       System.err.println("  [api] Warning: could not prune runs: " + e.getMessage());
     }
+  }
+
+  /**
+   * Whether a run may still own a live agent process, so its run-scoped files (the pid file the
+   * stop's kill reads, the log an operator is following) must survive retention. A {@code stopping}
+   * run is mid-stop, not terminal: pruning its directory would turn {@code killAgent} into a no-op
+   * that can never verify, wedging the claim until the process exits on its own.
+   */
+  static boolean ownsLiveAgent(RunStore.RunRow run) {
+    return "running".equals(run.status()) || StopOperations.STOPPING.equals(run.status());
   }
 
   /** Stamps the agent + watcher pids on a background run once launch has resolved them. */

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
@@ -62,6 +62,14 @@ public record Event(
     public static final String AGENT_SESSION_COMPLETED = "agent_session_completed";
 
     /**
+     * An operator deliberately cancelled a running spec: the terminal intent was recorded (spec
+     * {@code cancelled}, run {@code stopped}) before the agent process was halted. Carries {@code
+     * data.source=operator} and the run id; the event's {@code agent} field names the acting FDE.
+     * Distinct from {@link #AGENT_SESSION_STOPPED} so a kill is never mistaken for a finish.
+     */
+    public static final String AGENT_CANCELLED = "agent_cancelled";
+
+    /**
      * The stop-hook readiness gate blocked a premature turn-end (uncommitted or unpushed work) and
      * nudged the agent to finish the protocol. Carries the nudge text in {@code data.reason}. A
      * blocked stop publishes this instead of {@link #AGENT_SESSION_STOPPED} — the stop never
@@ -104,6 +112,9 @@ public record Event(
 
     /** {@link #SOURCE} value: the guardrail watcher, which observed the process exit code. */
     public static final String SOURCE_WATCHER = "watcher";
+
+    /** {@link #SOURCE} value: a deliberate operator cancel through the clean-stop lane. */
+    public static final String SOURCE_OPERATOR = "operator";
 
     /**
      * {@link #SOURCE} value: a reconciler replay of a stop the control plane missed — at daemon

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -267,7 +267,7 @@ public final class MissedStopReconciler implements AutoCloseable {
       if (!SailOperations.ownsRun(run.node(), node)) {
         continue;
       }
-      var unit = Strings.isBlank(run.unit()) ? AgentUnit.BUILD.unitName() : run.unit();
+      var unit = StopOperations.runUnit(run).unitName();
       try {
         if (unitProbe.active(run.project(), run.id(), unit)) {
           continue;
@@ -296,16 +296,7 @@ public final class MissedStopReconciler implements AutoCloseable {
   }
 
   private static Event cancelledEvent(RunStore.RunRow run) {
-    var data = new LinkedHashMap<String, Object>();
-    data.put(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_RECONCILE);
-    data.put(Event.WellKnownData.RUN_ID, run.id());
-    return Event.of(
-        run.project(),
-        run.specId(),
-        Event.WellKnownTypes.AGENT_CANCELLED,
-        Event.SAIL_AGENT,
-        HostInfo.hostname(),
-        data);
+    return StopOperations.cancelEvent(run, Event.WellKnownData.SOURCE_RECONCILE, Event.SAIL_AGENT);
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -254,18 +254,22 @@ public final class MissedStopReconciler implements AutoCloseable {
    * is the same compare-and-set the live stop uses, so racing a concurrent stop retry can never
    * double-finalize or double-publish. A claim whose unit is still active is left alone — a live
    * stop is mid-halt, or an interrupted one still has its agent to kill and the operator's retry
-   * owns that. A blank-unit claim cannot be probed and is likewise left to the retry lane; foreign
-   * claims are their executing box's to finalize.
+   * owns that. A blank-unit claim (a run launched before units were run-scoped) probes the fixed
+   * ad-hoc identity — the same compatibility mapping the stop itself uses — so a legacy claim whose
+   * agent is verifiably gone still finalizes instead of reserving its repos forever; if a newer
+   * ad-hoc session holds that shared unit, the probe reads active and the claim is left untouched.
+   * Foreign claims are their executing box's to finalize.
    */
   int finalizeInterruptedStops() {
     var node = localHandle.get();
     var finalized = 0;
     for (var run : sessionStore.stopping()) {
-      if (!SailOperations.ownsRun(run.node(), node) || Strings.isBlank(run.unit())) {
+      if (!SailOperations.ownsRun(run.node(), node)) {
         continue;
       }
+      var unit = Strings.isBlank(run.unit()) ? AgentUnit.BUILD.unitName() : run.unit();
       try {
-        if (unitProbe.active(run.project(), run.id(), run.unit())) {
+        if (unitProbe.active(run.project(), run.id(), unit)) {
           continue;
         }
         if (sessionStore.transition(run.id(), "stopping", "stopped")) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -173,6 +173,7 @@ public final class MissedStopReconciler implements AutoCloseable {
       }
       replayed += rescueStrandedReviews(handledThisSweep);
       replayed += releaseStrandedReservations(handledThisSweep);
+      replayed += finalizeInterruptedStops();
     } catch (Exception e) {
       System.err.println("  [reconcile] missed-stop sweep aborted: " + e.getMessage());
     }
@@ -243,6 +244,64 @@ public final class MissedStopReconciler implements AutoCloseable {
       released++;
     }
     return released;
+  }
+
+  /**
+   * Finalizes stop claims interrupted before their verified finish: a run left {@code stopping} —
+   * its spec already cancelled by the claim — whose recorded unit is now dead is released as {@code
+   * stopped} and its withheld {@code agent_cancelled} event published, so a crash between a stop's
+   * claim and its finalization heals within a sweep instead of parking the run forever. The finish
+   * is the same compare-and-set the live stop uses, so racing a concurrent stop retry can never
+   * double-finalize or double-publish. A claim whose unit is still active is left alone — a live
+   * stop is mid-halt, or an interrupted one still has its agent to kill and the operator's retry
+   * owns that. A blank-unit claim cannot be probed and is likewise left to the retry lane; foreign
+   * claims are their executing box's to finalize.
+   */
+  int finalizeInterruptedStops() {
+    var node = localHandle.get();
+    var finalized = 0;
+    for (var run : sessionStore.stopping()) {
+      if (!SailOperations.ownsRun(run.node(), node) || Strings.isBlank(run.unit())) {
+        continue;
+      }
+      try {
+        if (unitProbe.active(run.project(), run.id(), run.unit())) {
+          continue;
+        }
+        if (sessionStore.transition(run.id(), "stopping", "stopped")) {
+          System.err.println(
+              "  [reconcile] finalized interrupted stop "
+                  + run.id()
+                  + " for "
+                  + run.project()
+                  + "/"
+                  + run.specId()
+                  + " (claim held with its unit gone)");
+          bus.publish(cancelledEvent(run));
+          finalized++;
+        }
+      } catch (Exception e) {
+        System.err.println(
+            "  [reconcile] interrupted-stop finalize failed for "
+                + run.id()
+                + ": "
+                + e.getMessage());
+      }
+    }
+    return finalized;
+  }
+
+  private static Event cancelledEvent(RunStore.RunRow run) {
+    var data = new LinkedHashMap<String, Object>();
+    data.put(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_RECONCILE);
+    data.put(Event.WellKnownData.RUN_ID, run.id());
+    return Event.of(
+        run.project(),
+        run.specId(),
+        Event.WellKnownTypes.AGENT_CANCELLED,
+        Event.SAIL_AGENT,
+        HostInfo.hostname(),
+        data);
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -156,9 +156,24 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     this.localHandle = runStore == null ? null : Objects.requireNonNull(localHandle, "localHandle");
   }
 
-  /** Sets a spec's status and immediately signals sync so the transition reaches main. */
+  /**
+   * Advances a spec's status and signals sync so the transition reaches main. Compare-and-set from
+   * the two states the pipeline owns ({@code in_progress}, {@code review}): once any other
+   * transition wins — above all an operator's {@code cancelled}, which is terminal — the pipeline's
+   * stale write is dropped instead of resurrecting the spec.
+   */
   private void advanceSpec(String specId, SpecStatus status) {
-    specStore.updateStatus(specId, status);
+    var advanced =
+        specStore.compareAndSetStatus(specId, SpecStatus.IN_PROGRESS, status)
+            || specStore.compareAndSetStatus(specId, SpecStatus.REVIEW, status);
+    if (!advanced) {
+      System.err.println(
+          "review-pipeline: spec "
+              + specId
+              + " no longer in a pipeline-owned status; not advancing it to "
+              + status.wire());
+      return;
+    }
     syncTrigger.run();
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RunTracker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RunTracker.java
@@ -97,15 +97,15 @@ public final class RunTracker implements EventSubscriber {
   }
 
   private void completeOrRecord(RunStore.RunRow run, String status, Integer exitCode) {
-    if (runStore.transition(run.id(), "running", status)) {
-      if (exitCode != null) {
-        runStore.recordExitCode(run.id(), exitCode);
-      }
+    if (runStore.transition(run.id(), "running", status, exitCode)) {
       syncScheduler.afterWrite();
       return;
     }
+    if (exitCode == null) {
+      return;
+    }
     var current = runStore.findById(run.id()).orElse(null);
-    if (current != null && exitCode != null && current.exitCode() == null) {
+    if (current != null && current.exitCode() == null) {
       runStore.recordExitCode(run.id(), exitCode);
       syncScheduler.afterWrite();
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RunTracker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RunTracker.java
@@ -23,6 +23,12 @@ import java.util.function.Supplier;
  * On main and standalone boxes the injected {@link SyncScheduler} is {@link
  * SyncScheduler#disabled()}, so the trigger is a no-op there.
  *
+ * <p>Completion is a {@code running → terminal} compare-and-set, so it is mutually exclusive with a
+ * clean stop's claim: a stop that moves the run to {@code stopping} after this tracker read the row
+ * wins the write, and the tracker falls back to enriching the exit code without ever overwriting
+ * {@code stopping} or {@code stopped} — a cancelled spec can never end up paired with a {@code
+ * completed} run.
+ *
  * <p>Completion addresses the exact run by the {@code run_id} the terminal event carries, not "the
  * newest running run of the project". EventBus delivery is asynchronous, so a stop for run A can
  * arrive after run B has started in the same project; resolving by project alone would let A's
@@ -91,10 +97,15 @@ public final class RunTracker implements EventSubscriber {
   }
 
   private void completeOrRecord(RunStore.RunRow run, String status, Integer exitCode) {
-    if ("running".equals(run.status())) {
-      runStore.complete(run.id(), status, exitCode);
+    if (runStore.transition(run.id(), "running", status)) {
+      if (exitCode != null) {
+        runStore.recordExitCode(run.id(), exitCode);
+      }
       syncScheduler.afterWrite();
-    } else if (exitCode != null && run.exitCode() == null) {
+      return;
+    }
+    var current = runStore.findById(run.id()).orElse(null);
+    if (current != null && exitCode != null && current.exitCode() == null) {
       runStore.recordExitCode(run.id(), exitCode);
       syncScheduler.afterWrite();
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -53,6 +53,7 @@ public final class SailOperations implements Operations {
   private final GlobalSpecOperations globalSpecOps;
   private final ReviewOperations reviewOps;
   private final DispatchOperations dispatchOps;
+  private final StopOperations stopOps;
   private final FdeStore fdeStore;
 
   public SailOperations() {
@@ -295,6 +296,17 @@ public final class SailOperations implements Operations {
             DispatchOperations.autoSnapshotter(shell),
             DispatchOperations.shellLauncher(shell),
             DispatchOperations.Listener.NONE);
+    this.stopOps =
+        specStore != null && runStore != null
+            ? new StopOperations(
+                shell,
+                file,
+                specStore,
+                runStore,
+                this::publishOnBus,
+                StopOperations.sessionHalter(shell),
+                StopOperations.Listener.NONE)
+            : null;
   }
 
   private void publishOnBus(Event event) {
@@ -399,9 +411,47 @@ public final class SailOperations implements Operations {
     return onLocalRun(runId, localHandle, actor, run -> safe(() -> runLogValue(run, tail)));
   }
 
+  /**
+   * Delegates to {@link StopOperations} — the single clean-stop lane shared with {@code sail agent
+   * stop} — and renders its outcome. Any mutation (a halted agent, a cancelled spec, a released
+   * run) schedules sync-on-write so the terminal state reaches every peer promptly.
+   */
   @Override
   public Result<StopRunResponse> stopRun(String runId, String localHandle, Actor actor) {
-    return onLocalRun(runId, localHandle, actor, run -> safe(() -> stopRunValue(run)));
+    if (stopOps == null) {
+      return Result.failure(
+          ErrorCode.INTERNAL,
+          "Run store not available. Start the server with 'sail server start'.");
+    }
+    var outcome =
+        safe(() -> stopOps.stop(new StopOperations.RunTarget(runId), actor, localHandle, false));
+    if (outcome instanceof Result.Failure<StopOperations.Outcome>) {
+      return outcome.asFailure();
+    }
+    var value = outcome.orThrow();
+    if (value.mutated()) {
+      triggerSyncAfterWrite();
+    }
+    return Result.success(stopResponse(value));
+  }
+
+  private static StopRunResponse stopResponse(StopOperations.Outcome outcome) {
+    return switch (outcome) {
+      case StopOperations.Stopped stopped ->
+          new StopRunResponse(stopped.runId(), true, null, stopped.pid(), stopped.specCancelled());
+      case StopOperations.NotRunning notRunning ->
+          new StopRunResponse(
+              notRunning.runId(),
+              false,
+              notRunning.runReleased() ? "no_agent_running" : "run_not_running",
+              null,
+              notRunning.specCancelled());
+      case StopOperations.AlreadyTerminal terminal ->
+          new StopRunResponse(terminal.runId(), false, "run_not_running", null, false);
+      case StopOperations.NotActive notActive ->
+          new StopRunResponse(
+              notActive.runId(), false, "run_not_active", notActive.livePid(), false);
+    };
   }
 
   /**
@@ -638,9 +688,12 @@ public final class SailOperations implements Operations {
     }
     var runs =
         running.stream()
-            .map(run -> agentRunView(run, querySession(agentSession, project, runUnit(run))))
+            .map(
+                run ->
+                    agentRunView(
+                        run, querySession(agentSession, project, StopOperations.runUnit(run))))
             .toList();
-    var newest = querySession(agentSession, project, runUnit(running.getFirst()));
+    var newest = querySession(agentSession, project, StopOperations.runUnit(running.getFirst()));
     return agentStatusResponse(project, newest, runs);
   }
 
@@ -666,15 +719,6 @@ public final class SailOperations implements Operations {
         info != null ? info.pid() : null,
         run.startedAt(),
         run.logPath());
-  }
-
-  /**
-   * The systemd/file identity of a local run: rebuilt from the unit name recorded at launch, or the
-   * fixed ad-hoc identity for a run launched before units were run-scoped — that agent runs as
-   * {@code sail-agent}, so the fixed paths are exactly where it lives.
-   */
-  private static AgentUnit runUnit(RunStore.RunRow run) {
-    return Strings.isBlank(run.unit()) ? AgentUnit.BUILD : AgentUnit.recorded(run.id(), run.unit());
   }
 
   /**
@@ -705,35 +749,6 @@ public final class SailOperations implements Operations {
     }
     var lines = Arrays.stream(result.stdout().split("\n")).filter(line -> !line.isEmpty()).toList();
     return new RunLogResponse(run.id(), lines, null);
-  }
-
-  /**
-   * Stops the agent process only when {@code run} is genuinely the one executing now, addressing
-   * the run's own recorded unit so a concurrent run of the same project is untouched: an
-   * already-finished run, or a run whose recorded pid does not match the live agent, is a no-op —
-   * so stopping a stale run id can never kill a different, newer run. The provenance guard has
-   * already established the run is local.
-   */
-  private StopRunResponse stopRunValue(RunStore.RunRow run) {
-    projects.requireExists(run.project());
-    if (!"running".equals(run.status())) {
-      return new StopRunResponse(run.id(), false, "run_not_running", null);
-    }
-    var unit = runUnit(run);
-    var agentSession = new AgentSession(shell);
-    var info = querySession(agentSession, run.project(), unit);
-    if (info == null || !info.running()) {
-      return new StopRunResponse(run.id(), false, "no_agent_running", null);
-    }
-    if (run.pid() == null || info.pid() != run.pid()) {
-      return new StopRunResponse(run.id(), false, "run_not_active", info.pid());
-    }
-    try {
-      agentSession.killAgent(run.project(), unit);
-    } catch (Exception e) {
-      throw new ApiException(ErrorCode.AGENT_STOP_FAILED, "Failed to stop agent.", e);
-    }
-    return new StopRunResponse(run.id(), true, null, info.pid());
   }
 
   private AgentReportResponse agentReportValue(String project, String localHandle) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -441,16 +441,12 @@ public final class SailOperations implements Operations {
           new StopRunResponse(stopped.runId(), true, null, stopped.pid(), stopped.specCancelled());
       case StopOperations.NotRunning notRunning ->
           new StopRunResponse(
-              notRunning.runId(),
-              false,
-              notRunning.runReleased() ? "no_agent_running" : "run_not_running",
-              null,
-              notRunning.specCancelled());
+              notRunning.runId(), false, notRunning.reason(), null, notRunning.specCancelled());
       case StopOperations.AlreadyTerminal terminal ->
-          new StopRunResponse(terminal.runId(), false, "run_not_running", null, false);
+          new StopRunResponse(terminal.runId(), false, terminal.reason(), null, false);
       case StopOperations.NotActive notActive ->
           new StopRunResponse(
-              notActive.runId(), false, "run_not_active", notActive.livePid(), false);
+              notActive.runId(), false, notActive.reason(), notActive.livePid(), false);
     };
   }
 
@@ -678,8 +674,8 @@ public final class SailOperations implements Operations {
         runStore == null
             ? List.<RunStore.RunRow>of()
             : runStore.listForProject(project).stream()
-                .filter(run -> "running".equals(run.status()))
-                .filter(run -> "build".equals(Objects.requireNonNullElse(run.role(), "build")))
+                .filter(DispatchOperations::ownsLiveAgent)
+                .filter(RunStore.RunRow::buildRole)
                 .filter(run -> ownsRun(run.node(), localHandle))
                 .toList();
     if (running.isEmpty()) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SpecLifecycleReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SpecLifecycleReactor.java
@@ -13,10 +13,12 @@ import java.util.function.Predicate;
 
 /**
  * Bus subscriber that advances a spec's lifecycle in the database when its agent session ends: on
- * {@code agent_session_stopped} it transitions the spec from {@code in_progress} to {@code review}.
- * The dispatch-time transition to {@code in_progress} lives with dispatch; this handles the back
- * half once the agent reports it is done. The database is the single source of truth — there is no
- * container file to keep in step.
+ * {@code agent_session_stopped} it transitions the spec from {@code in_progress} to {@code review}
+ * — compare-and-set, so a transition that landed in between (above all an operator's {@code
+ * cancelled}, which is terminal) makes this advance a no-op instead of being overwritten from a
+ * stale read. The dispatch-time transition to {@code in_progress} lives with dispatch; this handles
+ * the back half once the agent reports it is done. The database is the single source of truth —
+ * there is no container file to keep in step.
  *
  * <p>The audit trail is not this reactor's job: every lifecycle event is already persisted to the
  * {@code EventStore} by {@link SpecStoreAuditPersister}. Failures here are logged and swallowed so
@@ -46,10 +48,7 @@ public final class SpecLifecycleReactor implements EventSubscriber {
   @Override
   public void onEvent(Event event) {
     try {
-      specStore
-          .findById(event.spec())
-          .filter(spec -> spec.status() == SpecStatus.IN_PROGRESS)
-          .ifPresent(spec -> specStore.updateStatus(spec.id(), SpecStatus.REVIEW));
+      specStore.compareAndSetStatus(event.spec(), SpecStatus.IN_PROGRESS, SpecStatus.REVIEW);
     } catch (Exception e) {
       System.err.println(
           "  [spec-lifecycle] Warning: failed to advance "

--- a/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
@@ -74,6 +74,20 @@ public final class StopOperations {
         case NotActive ignored -> false;
       };
     }
+
+    /**
+     * The single wire vocabulary for why nothing was killed — null for {@link Stopped} — shared by
+     * the API response and the CLI's {@code --json} view so scripts see one set of reasons.
+     */
+    default String reason() {
+      return switch (this) {
+        case Stopped ignored -> null;
+        case NotRunning notRunning ->
+            notRunning.runReleased() ? "no_agent_running" : "run_not_running";
+        case AlreadyTerminal ignored -> "run_not_running";
+        case NotActive ignored -> "run_not_active";
+      };
+    }
   }
 
   /**
@@ -176,6 +190,17 @@ public final class StopOperations {
           "Run " + run.id() + " executed on " + node + "; only its executing box can stop it.",
           "Stop it from " + node + "'s box.");
     }
+    if (!run.buildRole()) {
+      throw new ApiException(
+          ErrorCode.INVALID_ROLE,
+          "Run "
+              + run.id()
+              + " is a "
+              + run.role()
+              + " run driven by the review pipeline, not a"
+              + " stoppable agent session.",
+          "Stop the spec's build run instead, or let the pipeline finish.");
+    }
     authorize(actor, run);
     projects.requireExists(run.project());
     return stopResolved(run, actor, dryRun);
@@ -215,11 +240,26 @@ public final class StopOperations {
   private Outcome rescueStaleLegacyRun(
       String project, RunStore.RunRow run, Actor actor, boolean dryRun) {
     var staleSpec = specOf(run);
-    var cancelled = dryRun ? previewCancel(run, staleSpec) : recordIntent(run, staleSpec, actor);
+    var cancelled = dryRun ? previewCancel(run, staleSpec) : releaseStale(run, staleSpec, actor);
     if (stopAdHoc(project, dryRun) instanceof Stopped stopped) {
       return new Stopped(null, run.specId(), stopped.pid(), cancelled);
     }
     return new NotRunning(run.id(), run.specId(), cancelled, true);
+  }
+
+  /**
+   * Releases a stale legacy row whose own agent is provably gone (a different process owns the
+   * shared fixed unit). A {@code running} row records the full terminal intent; a {@code stopping}
+   * row is an interrupted claim whose intent is already durable — the spec was cancelled by the
+   * claim — so it is finalized instead of re-claimed, which would conflict on every retry and wedge
+   * the project lane.
+   */
+  private boolean releaseStale(RunStore.RunRow run, SpecStore.SpecRow spec, Actor actor) {
+    if (STOPPING.equals(run.status())) {
+      finishStop(run, actor);
+      return false;
+    }
+    return recordIntent(run, spec, actor);
   }
 
   /**
@@ -246,7 +286,7 @@ public final class StopOperations {
       if (!runStore.runIfLatestAttempt(run.id(), run.specId(), () -> commitCancel(spec))) {
         return new AlreadyTerminal(run.id(), run.specId(), run.status());
       }
-      events.publish(cancelEvent(run, actor));
+      events.publish(operatorCancelEvent(run, actor));
       return new NotRunning(run.id(), run.specId(), true, false);
     }
     var unit = runUnit(run);
@@ -336,19 +376,30 @@ public final class StopOperations {
    * whether the spec was cancelled.
    */
   private boolean claimStop(RunStore.RunRow run, SpecStore.SpecRow spec) {
+    return transitionAndCancel(run, spec, STOPPING);
+  }
+
+  /**
+   * The one gated-cancel write both stop shapes share: run {@code running → status} and, when this
+   * run is still cancelable and its spec's latest build attempt, the spec cancel — one transaction,
+   * every check compare-and-set inside it. A lost run CAS means a concurrent transition consumed
+   * the resolved state first; the stop refuses with a conflict rather than committing over it.
+   * Returns whether the spec was cancelled.
+   */
+  private boolean transitionAndCancel(RunStore.RunRow run, SpecStore.SpecRow spec, String status) {
     var cancelled = new AtomicBoolean();
-    var claimed =
+    var moved =
         runStore.transition(
             run.id(),
             "running",
-            STOPPING,
+            status,
             () -> {
               if (cancelable(spec)) {
                 cancelled.set(
                     runStore.runIfLatestAttempt(run.id(), run.specId(), () -> commitCancel(spec)));
               }
             });
-    if (!claimed) {
+    if (!moved) {
       throw new ApiException(
           ErrorCode.CONFLICT,
           "Run " + run.id() + " changed status while stopping.",
@@ -362,7 +413,7 @@ public final class StopOperations {
    */
   private void finishStop(RunStore.RunRow run, Actor actor) {
     if (runStore.transition(run.id(), STOPPING, "stopped")) {
-      events.publish(cancelEvent(run, actor));
+      events.publish(operatorCancelEvent(run, actor));
     }
   }
 
@@ -408,6 +459,7 @@ public final class StopOperations {
    */
   private boolean isCurrentAttempt(RunStore.RunRow run) {
     return runStore.listForSpec(run.specId()).stream()
+        .filter(RunStore.RunRow::buildRole)
         .findFirst()
         .map(latest -> latest.id().equals(run.id()))
         .orElse(false);
@@ -468,32 +520,24 @@ public final class StopOperations {
    * the spec was cancelled.
    */
   private boolean recordIntent(RunStore.RunRow run, SpecStore.SpecRow spec, Actor actor) {
-    var cancelled = new AtomicBoolean();
-    var released =
-        runStore.transition(
-            run.id(),
-            "running",
-            "stopped",
-            () -> {
-              if (cancelable(spec)) {
-                cancelled.set(
-                    runStore.runIfLatestAttempt(run.id(), run.specId(), () -> commitCancel(spec)));
-              }
-            });
-    if (!released) {
-      throw new ApiException(
-          ErrorCode.CONFLICT,
-          "Run " + run.id() + " completed while stopping.",
-          "Refresh the run and retry if it is still active.");
-    }
-    events.publish(cancelEvent(run, actor));
-    return cancelled.get();
+    var cancelled = transitionAndCancel(run, spec, "stopped");
+    events.publish(operatorCancelEvent(run, actor));
+    return cancelled;
   }
 
-  private static Event cancelEvent(RunStore.RunRow run, Actor actor) {
+  private static Event operatorCancelEvent(RunStore.RunRow run, Actor actor) {
     var agent = Strings.isNotBlank(actor.handle()) ? actor.handle() : Event.SAIL_AGENT;
+    return cancelEvent(run, Event.WellKnownData.SOURCE_OPERATOR, agent);
+  }
+
+  /**
+   * The one {@code agent_cancelled} event shape every cancel lane publishes — the operator stop and
+   * the reconciler's interrupted-stop finalization differ only in {@code source} and acting agent,
+   * so a field added here reaches every SSE/audit consumer from both.
+   */
+  static Event cancelEvent(RunStore.RunRow run, String source, String agent) {
     var data = new LinkedHashMap<String, Object>();
-    data.put(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_OPERATOR);
+    data.put(Event.WellKnownData.SOURCE, source);
     data.put(Event.WellKnownData.RUN_ID, run.id());
     return Event.of(
         run.project(),

--- a/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
@@ -23,16 +23,21 @@ import java.util.Objects;
  * events go, how the kill runs, what the operator sees). {@code sail agent stop} and {@code POST
  * /v1/runs/{id}/stop} both delegate here and add nothing but rendering.
  *
- * <p>The order is the whole point: the spec moves to {@link SpecStatus#CANCELLED} <em>before</em>
- * the process is signalled, so every existing guard makes the cancel win the race with the
- * watcher's own stop. {@link RunTracker} only stamps a run still {@code running}; the review
- * pipeline only acts on a reviewable spec; the missed-stop reconciler sweeps only {@code
- * in_progress} and {@code review}; dispatch selects only {@code pending}. {@link
- * SpecStatus#CANCELLED} sits outside all of those sets, so a deliberate stop is honored by the
- * existing contracts with no new special cases. The rest of the terminal intent — run {@code
- * stopped}, an {@link Event.WellKnownTypes#AGENT_CANCELLED} event — is recorded only once the halt
- * is verified: a kill that fails or leaves the agent alive restores the spec and throws, so the
- * database never claims a live agent is terminal in a state no reconciler owns.
+ * <p>The order is the whole point: one transaction — the stop claim — moves the run {@code running
+ * → stopping} and the spec to {@link SpecStatus#CANCELLED} <em>before</em> the process is
+ * signalled, so every existing guard makes the cancel win the race with the watcher's own stop.
+ * {@link RunTracker} only stamps a run still {@code running}; the review pipeline only acts on a
+ * reviewable spec; the missed-stop reconciler sweeps only {@code in_progress} and {@code review};
+ * dispatch selects only {@code pending}. {@link SpecStatus#CANCELLED} sits outside all of those
+ * sets, so a deliberate stop is honored by the existing contracts with no new special cases. Both
+ * claim writes are compare-and-set from the freshly resolved states, so a lifecycle transition that
+ * lands first fails the claim with a conflict instead of being silently overwritten. The rest of
+ * the terminal intent — run {@code stopped}, an {@link Event.WellKnownTypes#AGENT_CANCELLED} event
+ * — is finalized only once the halt is verified to have left no live process on the run's unit: a
+ * kill that fails restores the claim and throws, and a crash mid-stop leaves the explicit {@code
+ * stopping} claim — resumed by the next stop of the same target, finalized by the reconciler's
+ * interrupted-stop pass once the unit is gone — so the database never claims a live agent is
+ * terminal in a state no reconciler owns.
  *
  * <p>The lane is also the clean way out of a stranded spec, not only a process kill: a resolved run
  * whose agent already died still gets its intent recorded atomically (spec cancelled, a
@@ -43,6 +48,9 @@ import java.util.Objects;
  * {@link AlreadyTerminal} without signalling anything.
  */
 public final class StopOperations {
+
+  /** The run status a committed stop claim holds between the claim and its verified finish. */
+  static final String STOPPING = "stopping";
 
   /** What a stop should act on: one project's active run (CLI) or an exact run id (API). */
   public sealed interface Target permits RunTarget, ProjectTarget {}
@@ -197,12 +205,16 @@ public final class StopOperations {
 
   /**
    * The clean-stop procedure over the resolved, owned, authorized run: probe liveness on the run's
-   * own recorded unit, cancel the spec, halt, and record the rest of the terminal intent once the
-   * kill is verified. Every no-op branch is structured and write-free except the stranded rescues,
-   * which record intent without a kill.
+   * own recorded unit, claim the stop (spec cancelled, run {@code stopping}, one transaction),
+   * halt, and finalize the claim once the kill is verified. A run already holding a claim is an
+   * interrupted stop and resumes instead. Every no-op branch is structured and write-free except
+   * the stranded rescues, which record intent without a kill.
    */
   private Outcome stopResolved(RunStore.RunRow run, Actor actor, boolean dryRun) {
     var spec = specOf(run);
+    if (STOPPING.equals(run.status())) {
+      return resumeStop(run, actor, dryRun);
+    }
     if (!"running".equals(run.status())) {
       if (!cancelable(spec) || !isCurrentAttempt(run)) {
         return new AlreadyTerminal(run.id(), run.specId(), run.status());
@@ -231,33 +243,123 @@ public final class StopOperations {
   }
 
   /**
-   * The live-kill sequence: cancel the spec first so the cancel wins the race with the watcher's
-   * own stop while the signal is in flight, then halt and verify the agent is actually gone. Only a
-   * verified halt records the rest of the terminal intent — a kill that fails or leaves the run's
-   * pid alive restores the spec and throws, so the run stays {@code running} and reconcilable
-   * instead of being recorded terminal under a live process.
+   * The live-kill sequence over a durable claim. {@link #claimStop} commits the whole terminal
+   * intent atomically — run {@code running → stopping}, spec {@code → cancelled}, both
+   * compare-and-set — so the cancel wins the race with the watcher's own stop while the signal is
+   * in flight, and an interruption at any later point leaves the explicit claim rather than a
+   * cancelled spec over a run still recorded {@code running}. A verified halt finalizes the claim
+   * ({@code stopping → stopped}) and publishes the operator event; a kill that fails or leaves a
+   * live process on the unit restores the claim and throws, so the run is again {@code running} and
+   * reconcilable.
    */
   private Outcome killVerified(
       RunStore.RunRow run, SpecStore.SpecRow spec, Actor actor, AgentUnit unit, int pid) {
-    var cancelled = cancelSpec(spec);
+    var cancelled = claimStop(run, spec);
     try {
       halt(run.project(), unit);
-      var remaining = probe(run.project(), unit);
-      if (remaining != null && remaining.running() && remaining.pid() == pid) {
-        throw new ApiException(
-            ErrorCode.AGENT_STOP_FAILED,
-            "Agent PID " + pid + " is still running after the stop signal.",
-            "Retry the stop; the run is still recorded as running.");
-      }
+      verifyHalted(run.project(), unit);
     } catch (RuntimeException failure) {
-      if (cancelled) {
-        specStore.updateStatus(spec.id(), spec.status());
-      }
+      abortStop(run, spec, cancelled);
       throw failure;
     }
-    runStore.complete(run.id(), "stopped", null);
-    events.publish(cancelEvent(run, actor));
+    finishStop(run, actor);
     return new Stopped(run.id(), run.specId(), pid, cancelled);
+  }
+
+  /**
+   * Resumes a stop claim left behind by an interrupted kill — a crash between the claim and its
+   * finalization. The terminal intent is already durable (the spec is cancelled), so only the
+   * process side remains: a dead unit just finalizes the claim and publishes the withheld operator
+   * event, a live one is halted, verified, and then finalized. A failure leaves the claim in place
+   * for the next retry or the reconciler's interrupted-stop pass — never restored, because the
+   * original operator intent still stands.
+   */
+  private Outcome resumeStop(RunStore.RunRow run, Actor actor, boolean dryRun) {
+    var unit = runUnit(run);
+    var info = probe(run.project(), unit);
+    if (info == null || !info.running()) {
+      if (!dryRun) {
+        finishStop(run, actor);
+      }
+      return new NotRunning(run.id(), run.specId(), false, true);
+    }
+    listener.halting(run.project(), unit.unitName(), info.pid());
+    if (dryRun) {
+      return new Stopped(run.id(), run.specId(), info.pid(), false);
+    }
+    halt(run.project(), unit);
+    verifyHalted(run.project(), unit);
+    finishStop(run, actor);
+    return new Stopped(run.id(), run.specId(), info.pid(), false);
+  }
+
+  /**
+   * Commits the stop claim: run {@code running → stopping} and spec {@code → cancelled} in one
+   * transaction, each compare-and-set from the state this stop resolved. Either CAS losing means a
+   * concurrent transition (a watcher completion, a lifecycle advance) won the race after this stop
+   * read its snapshot — the claim rolls back entirely and the stop refuses with a conflict rather
+   * than cancelling from stale state. Returns whether the spec was cancelled.
+   */
+  private boolean claimStop(RunStore.RunRow run, SpecStore.SpecRow spec) {
+    var cancelling = cancelable(spec);
+    var claimed =
+        runStore.transition(
+            run.id(),
+            "running",
+            STOPPING,
+            () -> {
+              if (cancelling) {
+                commitCancel(spec);
+              }
+            });
+    if (!claimed) {
+      throw new ApiException(
+          ErrorCode.CONFLICT,
+          "Run " + run.id() + " changed status while stopping.",
+          "Retry the stop.");
+    }
+    return cancelling;
+  }
+
+  /**
+   * Finalizes a claim whose halt is verified; the event is the winner's to publish, exactly once.
+   */
+  private void finishStop(RunStore.RunRow run, Actor actor) {
+    if (runStore.transition(run.id(), STOPPING, "stopped")) {
+      events.publish(cancelEvent(run, actor));
+    }
+  }
+
+  /**
+   * Restores a failed claim — run back to {@code running}, spec back to its pre-claim status — in
+   * one transaction, each side conditional on the claim still being held, so a finalization that
+   * won in between is never overwritten.
+   */
+  private void abortStop(RunStore.RunRow run, SpecStore.SpecRow spec, boolean cancelled) {
+    runStore.transition(
+        run.id(),
+        STOPPING,
+        "running",
+        () -> {
+          if (cancelled) {
+            specStore.compareAndSetStatus(spec.id(), SpecStatus.CANCELLED, spec.status());
+          }
+        });
+  }
+
+  /**
+   * A verified halt leaves no live process on the addressed unit. Rejecting <em>any</em> running
+   * result — not only the original pid — keeps a replacement process (a unit restart, a pid reused
+   * mid-halt) from being mistaken for a successful termination.
+   */
+  private void verifyHalted(String project, AgentUnit unit) {
+    var remaining = probe(project, unit);
+    if (remaining != null && remaining.running()) {
+      throw new ApiException(
+          ErrorCode.AGENT_STOP_FAILED,
+          "Agent PID " + remaining.pid() + " is still running after the stop signal.",
+          "Retry the stop.");
+    }
   }
 
   /**
@@ -272,18 +374,27 @@ public final class StopOperations {
         .orElse(false);
   }
 
-  private boolean cancelSpec(SpecStore.SpecRow spec) {
-    if (!cancelable(spec)) {
-      return false;
+  /**
+   * Cancels the spec compare-and-set from the status this stop resolved; a CAS that loses means a
+   * concurrent transition consumed that status first, and the stop must be retried against the new
+   * state, not committed over it. Runs inside the caller's transaction, so the thrown conflict
+   * rolls back the rest of the intent with it.
+   */
+  private void commitCancel(SpecStore.SpecRow spec) {
+    if (!specStore.compareAndSetStatus(spec.id(), spec.status(), SpecStatus.CANCELLED)) {
+      throw new ApiException(
+          ErrorCode.CONFLICT,
+          "Spec " + spec.id() + " changed status while stopping.",
+          "Retry the stop.");
     }
-    specStore.updateStatus(spec.id(), SpecStatus.CANCELLED);
-    return true;
   }
 
   /**
    * The ad-hoc fallback for a project with no active run row: a {@code sail agent start} session
-   * owns no run and no spec, so there is no intent to record — the kill is the whole stop, and
-   * nothing exists for the reaper or the pipeline to resume.
+   * owns no run and no spec, so there is no intent to record — the verified kill is the whole stop,
+   * and nothing exists for the reaper or the pipeline to resume. Verified matters here too: the
+   * halter is a no-op when the pid file is missing while the probe can still see the live process
+   * through systemd, and only a re-probe keeps that state from being reported stopped.
    */
   private Outcome stopAdHoc(String project, boolean dryRun) {
     var info = probe(project, AgentUnit.BUILD);
@@ -293,6 +404,7 @@ public final class StopOperations {
     listener.halting(project, AgentUnit.BUILD.unitName(), info.pid());
     if (!dryRun) {
       halt(project, AgentUnit.BUILD);
+      verifyHalted(project, AgentUnit.BUILD);
     }
     return new Stopped(null, null, info.pid(), false);
   }
@@ -316,11 +428,11 @@ public final class StopOperations {
           null,
           () -> {
             if (cancelling) {
-              specStore.updateStatus(spec.id(), SpecStatus.CANCELLED);
+              commitCancel(spec);
             }
           });
     } else if (cancelling) {
-      specStore.updateStatus(spec.id(), SpecStatus.CANCELLED);
+      commitCancel(spec);
     }
     events.publish(cancelEvent(run, actor));
     return cancelling;

--- a/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.AgentSession;
+import ai.singlr.sail.engine.AgentUnit;
+import ai.singlr.sail.engine.HostInfo;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SpecStore;
+import java.util.LinkedHashMap;
+import java.util.Objects;
+
+/**
+ * The single clean-stop executor behind every lane, a peer of {@link DispatchOperations} built the
+ * same way: the procedure — resolve the active owned run, record the terminal intent, halt the
+ * process — lives here exactly once, and only the seams that differ per lane are injected (where
+ * events go, how the kill runs, what the operator sees). {@code sail agent stop} and {@code POST
+ * /v1/runs/{id}/stop} both delegate here and add nothing but rendering.
+ *
+ * <p>The order is the whole point: the terminal intent — spec {@code cancelled}, run {@code
+ * stopped}, an {@link Event.WellKnownTypes#AGENT_CANCELLED} event — is recorded <em>before</em> the
+ * process is signalled, so every existing guard makes the cancel win the race with the watcher's
+ * own stop. {@link RunTracker} only stamps a run still {@code running}; the review pipeline only
+ * acts on a reviewable spec; the missed-stop reconciler sweeps only {@code in_progress} and {@code
+ * review}; dispatch selects only {@code pending}. {@link SpecStatus#CANCELLED} sits outside all of
+ * those sets, so a deliberate stop is honored by the existing contracts with no new special cases.
+ *
+ * <p>The lane is also the clean way out of a stranded spec, not only a process kill: a resolved run
+ * whose agent already died still gets its intent recorded (spec cancelled, a still-{@code running}
+ * run released as {@code stopped}). A pid mismatch is a structured no-op — stopping a stale run id
+ * can never kill a different, newer run — and a second stop of the same run is idempotent by
+ * construction, returning {@link AlreadyTerminal} without signalling anything.
+ */
+public final class StopOperations {
+
+  /** What a stop should act on: one project's active run (CLI) or an exact run id (API). */
+  public sealed interface Target permits RunTarget, ProjectTarget {}
+
+  /** Stop the exact run {@code runId}, the API lane's address. */
+  public record RunTarget(String runId) implements Target {}
+
+  /** Stop {@code project}'s active run — or its ad-hoc session — the CLI lane's address. */
+  public record ProjectTarget(String project) implements Target {}
+
+  /** What a stop produced; each lane renders it without duplicating any decision. */
+  public sealed interface Outcome permits Stopped, NotRunning, AlreadyTerminal, NotActive {
+    /** Whether this stop wrote anything — a halted agent, a cancelled spec, a released run. */
+    default boolean mutated() {
+      return switch (this) {
+        case Stopped ignored -> true;
+        case NotRunning notRunning -> notRunning.specCancelled() || notRunning.runReleased();
+        case AlreadyTerminal ignored -> false;
+        case NotActive ignored -> false;
+      };
+    }
+  }
+
+  /**
+   * The live agent was halted after its terminal intent was recorded. {@code runId} and {@code
+   * specId} are null for an ad-hoc session that minted no run; {@code specCancelled} reports
+   * whether the spec moved to {@link SpecStatus#CANCELLED}.
+   */
+  public record Stopped(String runId, String specId, Integer pid, boolean specCancelled)
+      implements Outcome {}
+
+  /**
+   * No live agent process was found for the target, so nothing was signalled — but any stranded
+   * state was still cancelled: {@code specCancelled} reports a spec rescued out of {@code
+   * in_progress}/{@code review}, and {@code runReleased} a still-{@code running} run row released
+   * as {@code stopped}. All-false means there was simply nothing to stop.
+   */
+  public record NotRunning(String runId, String specId, boolean specCancelled, boolean runReleased)
+      implements Outcome {}
+
+  /** The run and its spec are already terminal — a repeated stop, a pure no-op. */
+  public record AlreadyTerminal(String runId, String specId, String runStatus) implements Outcome {}
+
+  /**
+   * The live agent on the run's unit is not this run's process ({@code livePid} differs from the
+   * run's recorded pid), so nothing was killed and nothing was written.
+   */
+  public record NotActive(String runId, String specId, Integer livePid) implements Outcome {}
+
+  /** How the kill runs — the only side effect that differs from a store write. */
+  @FunctionalInterface
+  public interface AgentHalter {
+    void halt(String project, AgentUnit unit) throws Exception;
+  }
+
+  /** The real halter: {@link AgentSession#killAgent} — SIGTERM, wait, SIGKILL, pid-file cleanup. */
+  public static AgentHalter sessionHalter(ShellExec shell) {
+    var session = new AgentSession(shell);
+    return session::killAgent;
+  }
+
+  /**
+   * Presentation hook fired with the kill about to be issued (also on a dry run, which stops
+   * there), so an interactive lane can narrate without the executor knowing about terminals.
+   */
+  public interface Listener {
+    Listener NONE = new Listener() {};
+
+    default void halting(String project, String unit, Integer pid) {}
+  }
+
+  private final ShellExec shell;
+  private final ProjectLoader projects;
+  private final SpecStore specStore;
+  private final RunStore runStore;
+  private final DispatchOperations.EventSink events;
+  private final AgentHalter halter;
+  private final Listener listener;
+
+  public StopOperations(
+      ShellExec shell,
+      String file,
+      SpecStore specStore,
+      RunStore runStore,
+      DispatchOperations.EventSink events,
+      AgentHalter halter,
+      Listener listener) {
+    this.shell = Objects.requireNonNull(shell, "shell");
+    this.projects = new ProjectLoader(shell, Objects.requireNonNull(file, "file"));
+    this.specStore = Objects.requireNonNull(specStore, "specStore");
+    this.runStore = Objects.requireNonNull(runStore, "runStore");
+    this.events = Objects.requireNonNull(events, "events");
+    this.halter = Objects.requireNonNull(halter, "halter");
+    this.listener = Objects.requireNonNull(listener, "listener");
+  }
+
+  /**
+   * Executes one clean stop. Refusals throw {@link ApiException} with a structured code before any
+   * mutation: an unknown run is a 404, a run that executed elsewhere a {@code run_on_other_node},
+   * and a caller who is neither the run's spec assignee nor an admin a {@code
+   * forbidden_not_assignee} (the same {@link RunPolicy} the log routes enforce). A dry run resolves
+   * and probes but writes and signals nothing, returning the outcome it would produce.
+   */
+  public Outcome stop(Target target, Actor actor, String localHandle, boolean dryRun) {
+    return switch (target) {
+      case RunTarget run -> stopRun(run.runId(), actor, localHandle, dryRun);
+      case ProjectTarget project -> stopProject(project.project(), actor, localHandle, dryRun);
+    };
+  }
+
+  private Outcome stopRun(String runId, Actor actor, String localHandle, boolean dryRun) {
+    var run =
+        runStore
+            .findById(runId)
+            .orElseThrow(
+                () -> new ApiException(ErrorCode.RUN_NOT_FOUND, "No run '" + runId + "'."));
+    if (!SailOperations.ownsRun(run.node(), localHandle)) {
+      var node = Strings.isBlank(run.node()) ? "an unknown node" : run.node();
+      throw new ApiException(
+          ErrorCode.RUN_ON_OTHER_NODE,
+          "Run " + run.id() + " executed on " + node + "; only its executing box can stop it.",
+          "Stop it from " + node + "'s box.");
+    }
+    authorize(actor, run);
+    projects.requireExists(run.project());
+    return stopResolved(run, actor, dryRun);
+  }
+
+  private Outcome stopProject(String project, Actor actor, String localHandle, boolean dryRun) {
+    projects.requireExists(project);
+    var run = runStore.runningForProjectOnNode(project, localHandle).orElse(null);
+    if (run == null) {
+      return stopAdHoc(project, dryRun);
+    }
+    authorize(actor, run);
+    return stopResolved(run, actor, dryRun);
+  }
+
+  /**
+   * The clean-stop procedure over the resolved, owned, authorized run: probe liveness on the run's
+   * own recorded unit, record the terminal intent, and only then halt. Every no-op branch is
+   * structured and write-free except the stranded rescues, which record intent without a kill.
+   */
+  private Outcome stopResolved(RunStore.RunRow run, Actor actor, boolean dryRun) {
+    var spec = specOf(run);
+    if (!"running".equals(run.status())) {
+      if (!cancelable(spec)) {
+        return new AlreadyTerminal(run.id(), run.specId(), run.status());
+      }
+      if (!dryRun) {
+        recordIntent(run, spec, actor, false);
+      }
+      return new NotRunning(run.id(), run.specId(), true, false);
+    }
+    var unit = runUnit(run);
+    var info = probe(run.project(), unit);
+    if (info == null || !info.running()) {
+      if (!dryRun) {
+        recordIntent(run, spec, actor, true);
+      }
+      return new NotRunning(run.id(), run.specId(), cancelable(spec), true);
+    }
+    if (run.pid() == null || info.pid() != run.pid()) {
+      return new NotActive(run.id(), run.specId(), info.pid());
+    }
+    listener.halting(run.project(), unit.unitName(), info.pid());
+    if (dryRun) {
+      return new Stopped(run.id(), run.specId(), info.pid(), cancelable(spec));
+    }
+    var cancelled = recordIntent(run, spec, actor, true);
+    halt(run.project(), unit);
+    return new Stopped(run.id(), run.specId(), info.pid(), cancelled);
+  }
+
+  /**
+   * The ad-hoc fallback for a project with no active run row: a {@code sail agent start} session
+   * owns no run and no spec, so there is no intent to record — the kill is the whole stop, and
+   * nothing exists for the reaper or the pipeline to resume.
+   */
+  private Outcome stopAdHoc(String project, boolean dryRun) {
+    var info = probe(project, AgentUnit.BUILD);
+    if (info == null || !info.running()) {
+      return new NotRunning(null, null, false, false);
+    }
+    listener.halting(project, AgentUnit.BUILD.unitName(), info.pid());
+    if (!dryRun) {
+      halt(project, AgentUnit.BUILD);
+    }
+    return new Stopped(null, null, info.pid(), false);
+  }
+
+  /**
+   * Records the operator's terminal intent, atomically ahead of any signal: the spec (when still
+   * {@code in_progress}/{@code review}) moves to {@link SpecStatus#CANCELLED}, a still-{@code
+   * running} run is released as {@code stopped} with no exit code, and one {@code agent_cancelled}
+   * event carrying {@code source=operator} and the acting FDE marks the run as deliberately
+   * cancelled. Both writes are ordinary synced revisions, so every peer adopts the terminal state.
+   */
+  private boolean recordIntent(
+      RunStore.RunRow run, SpecStore.SpecRow spec, Actor actor, boolean releaseRun) {
+    var cancelling = cancelable(spec);
+    if (cancelling) {
+      specStore.updateStatus(spec.id(), SpecStatus.CANCELLED);
+    }
+    if (releaseRun) {
+      runStore.complete(run.id(), "stopped", null);
+    }
+    events.publish(cancelEvent(run, actor));
+    return cancelling;
+  }
+
+  private static Event cancelEvent(RunStore.RunRow run, Actor actor) {
+    var agent = Strings.isNotBlank(actor.handle()) ? actor.handle() : Event.SAIL_AGENT;
+    var data = new LinkedHashMap<String, Object>();
+    data.put(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_OPERATOR);
+    data.put(Event.WellKnownData.RUN_ID, run.id());
+    return Event.of(
+        run.project(),
+        run.specId(),
+        Event.WellKnownTypes.AGENT_CANCELLED,
+        agent,
+        HostInfo.hostname(),
+        data);
+  }
+
+  private SpecStore.SpecRow specOf(RunStore.RunRow run) {
+    if (Strings.isBlank(run.specId())) {
+      return null;
+    }
+    return specStore.findById(run.specId()).orElse(null);
+  }
+
+  private static boolean cancelable(SpecStore.SpecRow spec) {
+    return spec != null
+        && (spec.status() == SpecStatus.IN_PROGRESS || spec.status() == SpecStatus.REVIEW);
+  }
+
+  private void authorize(Actor actor, RunStore.RunRow run) {
+    var assignee =
+        Strings.isBlank(run.specId())
+            ? null
+            : specStore.findById(run.specId()).map(SpecStore.SpecRow::assignee).orElse(null);
+    if (RunPolicy.access(actor, run.id(), run.specId(), assignee)
+        instanceof AccessDecision.Refused refused) {
+      throw new ApiException(refused.code(), refused.message(), refused.fix());
+    }
+  }
+
+  /**
+   * The systemd/file identity of a run: rebuilt from the unit name recorded at launch, or the fixed
+   * ad-hoc identity for a run launched before units were run-scoped — that agent runs as {@code
+   * sail-agent}, so the fixed paths are exactly where it lives.
+   */
+  static AgentUnit runUnit(RunStore.RunRow run) {
+    return Strings.isBlank(run.unit()) ? AgentUnit.BUILD : AgentUnit.recorded(run.id(), run.unit());
+  }
+
+  private AgentSession.SessionInfo probe(String project, AgentUnit unit) {
+    try {
+      return new AgentSession(shell).queryStatus(project, unit);
+    } catch (Exception e) {
+      throw new ApiException(ErrorCode.AGENT_STATUS_FAILED, "Failed to query agent status.", e);
+    }
+  }
+
+  private void halt(String project, AgentUnit unit) {
+    try {
+      halter.halt(project, unit);
+    } catch (Exception e) {
+      throw new ApiException(ErrorCode.AGENT_STOP_FAILED, "Failed to stop agent.", e);
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
@@ -184,7 +184,11 @@ public final class StopOperations {
    * separate fixed ad-hoc session: a dispatched agent that died without completing its row leaves a
    * {@code running} row behind while a later {@code sail agent start} session is the live process
    * the operator means to stop. When the resolved run turns out dead ({@link NotRunning}), the
-   * stranded rescue still happens and the ad-hoc identity is probed and stopped as well.
+   * stranded rescue still happens and the ad-hoc identity is probed and stopped as well. A
+   * blank-unit run (launched before units were run-scoped) shares that fixed identity, so a pid
+   * mismatch there ({@link NotActive}) proves the live process is a newer ad-hoc session and the
+   * stale run's own agent is gone — the project lane rescues the stale state and stops the actual
+   * session, while an exact run-target request stays a conservative no-op.
    */
   private Outcome stopProject(String project, Actor actor, String localHandle, boolean dryRun) {
     projects.requireExists(project);
@@ -194,6 +198,9 @@ public final class StopOperations {
     }
     authorize(actor, run);
     var resolved = stopResolved(run, actor, dryRun);
+    if (resolved instanceof NotActive && Strings.isBlank(run.unit())) {
+      return rescueStaleLegacyRun(project, run, actor, dryRun);
+    }
     if (!(resolved instanceof NotRunning stranded)) {
       return resolved;
     }
@@ -201,6 +208,19 @@ public final class StopOperations {
       return new Stopped(null, stranded.specId(), stopped.pid(), stranded.specCancelled());
     }
     return stranded;
+  }
+
+  private Outcome rescueStaleLegacyRun(
+      String project, RunStore.RunRow run, Actor actor, boolean dryRun) {
+    var staleSpec = specOf(run);
+    var cancelled = cancelable(staleSpec);
+    if (!dryRun) {
+      recordIntent(run, staleSpec, actor);
+    }
+    if (stopAdHoc(project, dryRun) instanceof Stopped stopped) {
+      return new Stopped(null, run.specId(), stopped.pid(), cancelled);
+    }
+    return new NotRunning(run.id(), run.specId(), cancelled, true);
   }
 
   /**
@@ -216,19 +236,25 @@ public final class StopOperations {
       return resumeStop(run, actor, dryRun);
     }
     if (!"running".equals(run.status())) {
-      if (!cancelable(spec) || !isCurrentAttempt(run)) {
+      if (!cancelable(spec)) {
         return new AlreadyTerminal(run.id(), run.specId(), run.status());
       }
-      if (!dryRun) {
-        recordIntent(run, spec, actor, false);
+      if (dryRun) {
+        return isCurrentAttempt(run)
+            ? new NotRunning(run.id(), run.specId(), true, false)
+            : new AlreadyTerminal(run.id(), run.specId(), run.status());
       }
+      if (!runStore.runIfLatestAttempt(run.id(), run.specId(), () -> commitCancel(spec))) {
+        return new AlreadyTerminal(run.id(), run.specId(), run.status());
+      }
+      events.publish(cancelEvent(run, actor));
       return new NotRunning(run.id(), run.specId(), true, false);
     }
     var unit = runUnit(run);
     var info = probe(run.project(), unit);
     if (info == null || !info.running()) {
       if (!dryRun) {
-        recordIntent(run, spec, actor, true);
+        recordIntent(run, spec, actor);
       }
       return new NotRunning(run.id(), run.specId(), cancelable(spec), true);
     }
@@ -270,9 +296,12 @@ public final class StopOperations {
    * Resumes a stop claim left behind by an interrupted kill — a crash between the claim and its
    * finalization. The terminal intent is already durable (the spec is cancelled), so only the
    * process side remains: a dead unit just finalizes the claim and publishes the withheld operator
-   * event, a live one is halted, verified, and then finalized. A failure leaves the claim in place
-   * for the next retry or the reconciler's interrupted-stop pass — never restored, because the
-   * original operator intent still stands.
+   * event, a live one is halted, verified, and then finalized. The same pid identity guard as the
+   * first stop applies — a durable claim is never authority to kill a different process that later
+   * occupies the unit, which matters most for a migrated blank-unit run whose fixed ad-hoc identity
+   * a newer {@code sail agent start} session may now own. A failure leaves the claim in place for
+   * the next retry or the reconciler's interrupted-stop pass — never restored, because the original
+   * operator intent still stands.
    */
   private Outcome resumeStop(RunStore.RunRow run, Actor actor, boolean dryRun) {
     var unit = runUnit(run);
@@ -282,6 +311,9 @@ public final class StopOperations {
         finishStop(run, actor);
       }
       return new NotRunning(run.id(), run.specId(), false, true);
+    }
+    if (run.pid() == null || info.pid() != run.pid()) {
+      return new NotActive(run.id(), run.specId(), info.pid());
     }
     listener.halting(run.project(), unit.unitName(), info.pid());
     if (dryRun) {
@@ -365,7 +397,10 @@ public final class StopOperations {
   /**
    * Whether this run is still its spec's latest attempt. A terminal run may rescue a stranded spec
    * only while it is the current attempt: after a restart, stopping an older run id must be an
-   * idempotent no-op, never a lever that cancels the spec out from under the newer active run.
+   * idempotent no-op, never a lever that cancels the spec out from under the newer active run. This
+   * read only previews the dry-run outcome — the live path decides inside {@link
+   * RunStore#runIfLatestAttempt}, atomically with the cancel, so a restart reserving a newer
+   * attempt between the check and the write can never lose its spec.
    */
   private boolean isCurrentAttempt(RunStore.RunRow run) {
     return runStore.listForSpec(run.specId()).stream()
@@ -411,31 +446,25 @@ public final class StopOperations {
 
   /**
    * Records the operator's terminal intent for a run with no live process to kill: the spec (when
-   * still {@code in_progress}/{@code review}) moves to {@link SpecStatus#CANCELLED} and a
-   * still-{@code running} run is released as {@code stopped} with no exit code — in one transaction
-   * when both apply, so a failure between the writes can never expose a cancelled spec whose run is
-   * still {@code running} (a state no reconciler owns). One {@code agent_cancelled} event carrying
-   * {@code source=operator} and the acting FDE is published after the commit. Both writes are
-   * ordinary synced revisions, so every peer adopts the terminal state.
+   * still {@code in_progress}/{@code review}) moves to {@link SpecStatus#CANCELLED} and the run is
+   * released as {@code stopped} with no exit code — in one transaction when both apply, so a
+   * failure between the writes can never expose a cancelled spec whose run is still {@code running}
+   * (a state no reconciler owns). One {@code agent_cancelled} event carrying {@code
+   * source=operator} and the acting FDE is published after the commit. Both writes are ordinary
+   * synced revisions, so every peer adopts the terminal state.
    */
-  private boolean recordIntent(
-      RunStore.RunRow run, SpecStore.SpecRow spec, Actor actor, boolean releaseRun) {
+  private void recordIntent(RunStore.RunRow run, SpecStore.SpecRow spec, Actor actor) {
     var cancelling = cancelable(spec);
-    if (releaseRun) {
-      runStore.complete(
-          run.id(),
-          "stopped",
-          null,
-          () -> {
-            if (cancelling) {
-              commitCancel(spec);
-            }
-          });
-    } else if (cancelling) {
-      commitCancel(spec);
-    }
+    runStore.complete(
+        run.id(),
+        "stopped",
+        null,
+        () -> {
+          if (cancelling) {
+            commitCancel(spec);
+          }
+        });
     events.publish(cancelEvent(run, actor));
-    return cancelling;
   }
 
   private static Event cancelEvent(RunStore.RunRow run, Actor actor) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
@@ -23,19 +23,24 @@ import java.util.Objects;
  * events go, how the kill runs, what the operator sees). {@code sail agent stop} and {@code POST
  * /v1/runs/{id}/stop} both delegate here and add nothing but rendering.
  *
- * <p>The order is the whole point: the terminal intent — spec {@code cancelled}, run {@code
- * stopped}, an {@link Event.WellKnownTypes#AGENT_CANCELLED} event — is recorded <em>before</em> the
- * process is signalled, so every existing guard makes the cancel win the race with the watcher's
- * own stop. {@link RunTracker} only stamps a run still {@code running}; the review pipeline only
- * acts on a reviewable spec; the missed-stop reconciler sweeps only {@code in_progress} and {@code
- * review}; dispatch selects only {@code pending}. {@link SpecStatus#CANCELLED} sits outside all of
- * those sets, so a deliberate stop is honored by the existing contracts with no new special cases.
+ * <p>The order is the whole point: the spec moves to {@link SpecStatus#CANCELLED} <em>before</em>
+ * the process is signalled, so every existing guard makes the cancel win the race with the
+ * watcher's own stop. {@link RunTracker} only stamps a run still {@code running}; the review
+ * pipeline only acts on a reviewable spec; the missed-stop reconciler sweeps only {@code
+ * in_progress} and {@code review}; dispatch selects only {@code pending}. {@link
+ * SpecStatus#CANCELLED} sits outside all of those sets, so a deliberate stop is honored by the
+ * existing contracts with no new special cases. The rest of the terminal intent — run {@code
+ * stopped}, an {@link Event.WellKnownTypes#AGENT_CANCELLED} event — is recorded only once the halt
+ * is verified: a kill that fails or leaves the agent alive restores the spec and throws, so the
+ * database never claims a live agent is terminal in a state no reconciler owns.
  *
  * <p>The lane is also the clean way out of a stranded spec, not only a process kill: a resolved run
- * whose agent already died still gets its intent recorded (spec cancelled, a still-{@code running}
- * run released as {@code stopped}). A pid mismatch is a structured no-op — stopping a stale run id
- * can never kill a different, newer run — and a second stop of the same run is idempotent by
- * construction, returning {@link AlreadyTerminal} without signalling anything.
+ * whose agent already died still gets its intent recorded atomically (spec cancelled, a
+ * still-{@code running} run released as {@code stopped}, in one transaction). A pid mismatch is a
+ * structured no-op — stopping a stale run id can never kill a different, newer run — a terminal run
+ * that is no longer its spec's latest attempt is {@link AlreadyTerminal} rather than a lever to
+ * cancel newer work, and a second stop of the same run is idempotent by construction, returning
+ * {@link AlreadyTerminal} without signalling anything.
  */
 public final class StopOperations {
 
@@ -166,6 +171,13 @@ public final class StopOperations {
     return stopResolved(run, actor, dryRun);
   }
 
+  /**
+   * A project-targeted stop resolves the active run row first, but a stale row must not mask the
+   * separate fixed ad-hoc session: a dispatched agent that died without completing its row leaves a
+   * {@code running} row behind while a later {@code sail agent start} session is the live process
+   * the operator means to stop. When the resolved run turns out dead ({@link NotRunning}), the
+   * stranded rescue still happens and the ad-hoc identity is probed and stopped as well.
+   */
   private Outcome stopProject(String project, Actor actor, String localHandle, boolean dryRun) {
     projects.requireExists(project);
     var run = runStore.runningForProjectOnNode(project, localHandle).orElse(null);
@@ -173,18 +185,26 @@ public final class StopOperations {
       return stopAdHoc(project, dryRun);
     }
     authorize(actor, run);
-    return stopResolved(run, actor, dryRun);
+    var resolved = stopResolved(run, actor, dryRun);
+    if (!(resolved instanceof NotRunning stranded)) {
+      return resolved;
+    }
+    if (stopAdHoc(project, dryRun) instanceof Stopped stopped) {
+      return new Stopped(null, stranded.specId(), stopped.pid(), stranded.specCancelled());
+    }
+    return stranded;
   }
 
   /**
    * The clean-stop procedure over the resolved, owned, authorized run: probe liveness on the run's
-   * own recorded unit, record the terminal intent, and only then halt. Every no-op branch is
-   * structured and write-free except the stranded rescues, which record intent without a kill.
+   * own recorded unit, cancel the spec, halt, and record the rest of the terminal intent once the
+   * kill is verified. Every no-op branch is structured and write-free except the stranded rescues,
+   * which record intent without a kill.
    */
   private Outcome stopResolved(RunStore.RunRow run, Actor actor, boolean dryRun) {
     var spec = specOf(run);
     if (!"running".equals(run.status())) {
-      if (!cancelable(spec)) {
+      if (!cancelable(spec) || !isCurrentAttempt(run)) {
         return new AlreadyTerminal(run.id(), run.specId(), run.status());
       }
       if (!dryRun) {
@@ -207,9 +227,57 @@ public final class StopOperations {
     if (dryRun) {
       return new Stopped(run.id(), run.specId(), info.pid(), cancelable(spec));
     }
-    var cancelled = recordIntent(run, spec, actor, true);
-    halt(run.project(), unit);
-    return new Stopped(run.id(), run.specId(), info.pid(), cancelled);
+    return killVerified(run, spec, actor, unit, info.pid());
+  }
+
+  /**
+   * The live-kill sequence: cancel the spec first so the cancel wins the race with the watcher's
+   * own stop while the signal is in flight, then halt and verify the agent is actually gone. Only a
+   * verified halt records the rest of the terminal intent — a kill that fails or leaves the run's
+   * pid alive restores the spec and throws, so the run stays {@code running} and reconcilable
+   * instead of being recorded terminal under a live process.
+   */
+  private Outcome killVerified(
+      RunStore.RunRow run, SpecStore.SpecRow spec, Actor actor, AgentUnit unit, int pid) {
+    var cancelled = cancelSpec(spec);
+    try {
+      halt(run.project(), unit);
+      var remaining = probe(run.project(), unit);
+      if (remaining != null && remaining.running() && remaining.pid() == pid) {
+        throw new ApiException(
+            ErrorCode.AGENT_STOP_FAILED,
+            "Agent PID " + pid + " is still running after the stop signal.",
+            "Retry the stop; the run is still recorded as running.");
+      }
+    } catch (RuntimeException failure) {
+      if (cancelled) {
+        specStore.updateStatus(spec.id(), spec.status());
+      }
+      throw failure;
+    }
+    runStore.complete(run.id(), "stopped", null);
+    events.publish(cancelEvent(run, actor));
+    return new Stopped(run.id(), run.specId(), pid, cancelled);
+  }
+
+  /**
+   * Whether this run is still its spec's latest attempt. A terminal run may rescue a stranded spec
+   * only while it is the current attempt: after a restart, stopping an older run id must be an
+   * idempotent no-op, never a lever that cancels the spec out from under the newer active run.
+   */
+  private boolean isCurrentAttempt(RunStore.RunRow run) {
+    return runStore.listForSpec(run.specId()).stream()
+        .findFirst()
+        .map(latest -> latest.id().equals(run.id()))
+        .orElse(false);
+  }
+
+  private boolean cancelSpec(SpecStore.SpecRow spec) {
+    if (!cancelable(spec)) {
+      return false;
+    }
+    specStore.updateStatus(spec.id(), SpecStatus.CANCELLED);
+    return true;
   }
 
   /**
@@ -230,20 +298,29 @@ public final class StopOperations {
   }
 
   /**
-   * Records the operator's terminal intent, atomically ahead of any signal: the spec (when still
-   * {@code in_progress}/{@code review}) moves to {@link SpecStatus#CANCELLED}, a still-{@code
-   * running} run is released as {@code stopped} with no exit code, and one {@code agent_cancelled}
-   * event carrying {@code source=operator} and the acting FDE marks the run as deliberately
-   * cancelled. Both writes are ordinary synced revisions, so every peer adopts the terminal state.
+   * Records the operator's terminal intent for a run with no live process to kill: the spec (when
+   * still {@code in_progress}/{@code review}) moves to {@link SpecStatus#CANCELLED} and a
+   * still-{@code running} run is released as {@code stopped} with no exit code — in one transaction
+   * when both apply, so a failure between the writes can never expose a cancelled spec whose run is
+   * still {@code running} (a state no reconciler owns). One {@code agent_cancelled} event carrying
+   * {@code source=operator} and the acting FDE is published after the commit. Both writes are
+   * ordinary synced revisions, so every peer adopts the terminal state.
    */
   private boolean recordIntent(
       RunStore.RunRow run, SpecStore.SpecRow spec, Actor actor, boolean releaseRun) {
     var cancelling = cancelable(spec);
-    if (cancelling) {
-      specStore.updateStatus(spec.id(), SpecStatus.CANCELLED);
-    }
     if (releaseRun) {
-      runStore.complete(run.id(), "stopped", null);
+      runStore.complete(
+          run.id(),
+          "stopped",
+          null,
+          () -> {
+            if (cancelling) {
+              specStore.updateStatus(spec.id(), SpecStatus.CANCELLED);
+            }
+          });
+    } else if (cancelling) {
+      specStore.updateStatus(spec.id(), SpecStatus.CANCELLED);
     }
     events.publish(cancelEvent(run, actor));
     return cancelling;

--- a/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
@@ -15,6 +15,7 @@ import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
 import java.util.LinkedHashMap;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * The single clean-stop executor behind every lane, a peer of {@link DispatchOperations} built the
@@ -42,10 +43,11 @@ import java.util.Objects;
  * <p>The lane is also the clean way out of a stranded spec, not only a process kill: a resolved run
  * whose agent already died still gets its intent recorded atomically (spec cancelled, a
  * still-{@code running} run released as {@code stopped}, in one transaction). A pid mismatch is a
- * structured no-op — stopping a stale run id can never kill a different, newer run — a terminal run
- * that is no longer its spec's latest attempt is {@link AlreadyTerminal} rather than a lever to
- * cancel newer work, and a second stop of the same run is idempotent by construction, returning
- * {@link AlreadyTerminal} without signalling anything.
+ * structured no-op — stopping a stale run id can never kill a different, newer run — a run that is
+ * no longer its spec's latest attempt is never a lever to cancel newer work (a terminal one is
+ * {@link AlreadyTerminal}; a live or dead one is halted or released without touching the spec), and
+ * a second stop of the same run is idempotent by construction, returning {@link AlreadyTerminal}
+ * without signalling anything.
  */
 public final class StopOperations {
 
@@ -213,10 +215,7 @@ public final class StopOperations {
   private Outcome rescueStaleLegacyRun(
       String project, RunStore.RunRow run, Actor actor, boolean dryRun) {
     var staleSpec = specOf(run);
-    var cancelled = cancelable(staleSpec);
-    if (!dryRun) {
-      recordIntent(run, staleSpec, actor);
-    }
+    var cancelled = dryRun ? previewCancel(run, staleSpec) : recordIntent(run, staleSpec, actor);
     if (stopAdHoc(project, dryRun) instanceof Stopped stopped) {
       return new Stopped(null, run.specId(), stopped.pid(), cancelled);
     }
@@ -253,17 +252,17 @@ public final class StopOperations {
     var unit = runUnit(run);
     var info = probe(run.project(), unit);
     if (info == null || !info.running()) {
-      if (!dryRun) {
-        recordIntent(run, spec, actor);
+      if (dryRun) {
+        return new NotRunning(run.id(), run.specId(), previewCancel(run, spec), true);
       }
-      return new NotRunning(run.id(), run.specId(), cancelable(spec), true);
+      return new NotRunning(run.id(), run.specId(), recordIntent(run, spec, actor), true);
     }
     if (run.pid() == null || info.pid() != run.pid()) {
       return new NotActive(run.id(), run.specId(), info.pid());
     }
     listener.halting(run.project(), unit.unitName(), info.pid());
     if (dryRun) {
-      return new Stopped(run.id(), run.specId(), info.pid(), cancelable(spec));
+      return new Stopped(run.id(), run.specId(), info.pid(), previewCancel(run, spec));
     }
     return killVerified(run, spec, actor, unit, info.pid());
   }
@@ -330,18 +329,23 @@ public final class StopOperations {
    * transaction, each compare-and-set from the state this stop resolved. Either CAS losing means a
    * concurrent transition (a watcher completion, a lifecycle advance) won the race after this stop
    * read its snapshot — the claim rolls back entirely and the stop refuses with a conflict rather
-   * than cancelling from stale state. Returns whether the spec was cancelled.
+   * than cancelling from stale state. The cancel itself is further gated on this run still being
+   * its spec's latest attempt, inside the same transaction: a restarted attempt may be live
+   * elsewhere while this box still owns an older {@code running} row, and stopping that older row
+   * must halt its process without cancelling the spec out from under the newer agent. Returns
+   * whether the spec was cancelled.
    */
   private boolean claimStop(RunStore.RunRow run, SpecStore.SpecRow spec) {
-    var cancelling = cancelable(spec);
+    var cancelled = new AtomicBoolean();
     var claimed =
         runStore.transition(
             run.id(),
             "running",
             STOPPING,
             () -> {
-              if (cancelling) {
-                commitCancel(spec);
+              if (cancelable(spec)) {
+                cancelled.set(
+                    runStore.runIfLatestAttempt(run.id(), run.specId(), () -> commitCancel(spec)));
               }
             });
     if (!claimed) {
@@ -350,7 +354,7 @@ public final class StopOperations {
           "Run " + run.id() + " changed status while stopping.",
           "Retry the stop.");
     }
-    return cancelling;
+    return cancelled.get();
   }
 
   /**
@@ -409,6 +413,11 @@ public final class StopOperations {
         .orElse(false);
   }
 
+  /** The dry-run preview of the live paths' gated cancel: cancelable and still current. */
+  private boolean previewCancel(RunStore.RunRow run, SpecStore.SpecRow spec) {
+    return cancelable(spec) && isCurrentAttempt(run);
+  }
+
   /**
    * Cancels the spec compare-and-set from the status this stop resolved; a CAS that loses means a
    * concurrent transition consumed that status first, and the stop must be retried against the new
@@ -449,22 +458,36 @@ public final class StopOperations {
    * still {@code in_progress}/{@code review}) moves to {@link SpecStatus#CANCELLED} and the run is
    * released as {@code stopped} with no exit code — in one transaction when both apply, so a
    * failure between the writes can never expose a cancelled spec whose run is still {@code running}
-   * (a state no reconciler owns). One {@code agent_cancelled} event carrying {@code
-   * source=operator} and the acting FDE is published after the commit. Both writes are ordinary
-   * synced revisions, so every peer adopts the terminal state.
+   * (a state no reconciler owns). The release is compare-and-set from {@code running}: a watcher
+   * completion landing between the dead probe and this commit wins, and the rescue refuses with a
+   * conflict instead of overwriting a successful finish with {@code stopped}. The cancel is gated
+   * on this run still being its spec's latest attempt, exactly as {@link #claimStop} gates the live
+   * path, so a stale dead row can never cancel a newer attempt's spec. One {@code agent_cancelled}
+   * event carrying {@code source=operator} and the acting FDE is published after the commit. Both
+   * writes are ordinary synced revisions, so every peer adopts the terminal state. Returns whether
+   * the spec was cancelled.
    */
-  private void recordIntent(RunStore.RunRow run, SpecStore.SpecRow spec, Actor actor) {
-    var cancelling = cancelable(spec);
-    runStore.complete(
-        run.id(),
-        "stopped",
-        null,
-        () -> {
-          if (cancelling) {
-            commitCancel(spec);
-          }
-        });
+  private boolean recordIntent(RunStore.RunRow run, SpecStore.SpecRow spec, Actor actor) {
+    var cancelled = new AtomicBoolean();
+    var released =
+        runStore.transition(
+            run.id(),
+            "running",
+            "stopped",
+            () -> {
+              if (cancelable(spec)) {
+                cancelled.set(
+                    runStore.runIfLatestAttempt(run.id(), run.specId(), () -> commitCancel(spec)));
+              }
+            });
+    if (!released) {
+      throw new ApiException(
+          ErrorCode.CONFLICT,
+          "Run " + run.id() + " completed while stopping.",
+          "Refresh the run and retry if it is still active.");
+    }
     events.publish(cancelEvent(run, actor));
+    return cancelled.get();
   }
 
   private static Event cancelEvent(RunStore.RunRow run, Actor actor) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStopCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStopCommand.java
@@ -5,23 +5,40 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.api.Actor;
+import ai.singlr.sail.api.DispatchOperations;
+import ai.singlr.sail.api.Event;
+import ai.singlr.sail.api.SailEventPublisher;
+import ai.singlr.sail.api.StopOperations;
+import ai.singlr.sail.api.SyncScheduler;
 import ai.singlr.sail.config.YamlUtil;
-import ai.singlr.sail.engine.AgentSession;
-import ai.singlr.sail.engine.ContainerManager;
-import ai.singlr.sail.engine.ContainerStateGuard;
+import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.NameValidator;
+import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
 import java.util.LinkedHashMap;
+import java.util.Objects;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Spec;
 
+/**
+ * Stops the project's running agent through the shared {@link StopOperations} lane — the same
+ * executor behind {@code POST /v1/runs/{id}/stop} — so a CLI stop records the operator's terminal
+ * intent (spec {@code cancelled}, run {@code stopped}) before the process is signalled, exactly
+ * like an API stop. Pure presentation: this command resolves nothing and kills nothing itself.
+ */
 @Command(
     name = "stop",
-    description = "Stop a running agent session.",
+    description = "Stop a running agent session and cancel its spec.",
     mixinStandardHelpOptions = true)
 public final class AgentStopCommand implements Runnable {
 
@@ -31,13 +48,17 @@ public final class AgentStopCommand implements Runnable {
       description = "Project name (default: the current project).")
   private String name;
 
-  @Option(names = "--dry-run", description = "Print commands instead of executing them.")
+  @Option(names = "--dry-run", description = "Print what would be stopped instead of stopping.")
   private boolean dryRun;
 
   @Option(names = "--json", description = "Output in JSON format.")
   private boolean json;
 
+  @Mixin private SyncOptions syncOptions;
+
   @Spec private CommandSpec spec;
+
+  private SailEventPublisher eventPublisher;
 
   @Override
   public void run() {
@@ -47,42 +68,195 @@ public final class AgentStopCommand implements Runnable {
   private void execute() throws Exception {
     name = CurrentProject.require(name);
     NameValidator.requireValidProjectName(name);
-    var shell = new ShellExecutor(dryRun);
-    var mgr = new ContainerManager(shell);
+    try (var sync = NodeSync.scheduler(syncOptions.noSync())) {
+      execute(sync);
+    }
+  }
 
-    var state = mgr.queryState(name);
-    ContainerStateGuard.requireRunning(state, name);
+  private void execute(SyncScheduler sync) throws Exception {
+    sync.freshenRead();
+    var shell = new ShellExecutor(false);
+    var handle = Objects.toString(HostSync.handle(), "");
+    try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+      var operations = operations(db, shell, this::publishLifecycle, listener());
+      var outcome =
+          operations.stop(
+              new StopOperations.ProjectTarget(name), Actor.cliOperator(handle), handle, dryRun);
+      render(outcome);
+      if (!dryRun && outcome.mutated()) {
+        sync.syncNow();
+      }
+    }
+  }
 
-    var agentSession = new AgentSession(shell);
-    var resolved = RunScopedSessions.resolve(shell, name);
-    var info = resolved.info();
+  /**
+   * The CLI lane's wiring of the shared stop executor: both stores come from the one control-plane
+   * database, so an in-process stop records exactly what a server-lane stop would.
+   */
+  static StopOperations operations(
+      Sqlite db,
+      ShellExec shell,
+      DispatchOperations.EventSink events,
+      StopOperations.Listener listener) {
+    return new StopOperations(
+        shell,
+        SailPaths.PROJECT_DESCRIPTOR,
+        new SpecStore(db),
+        new RunStore(db),
+        events,
+        StopOperations.sessionHalter(shell),
+        listener);
+  }
 
-    if (info == null || !info.running()) {
-      if (json) {
-        var map = new LinkedHashMap<String, Object>();
-        map.put("name", name);
+  private StopOperations.Listener listener() {
+    return new StopOperations.Listener() {
+      @Override
+      public void halting(String project, String unit, Integer pid) {
+        if (json) {
+          return;
+        }
+        var verb = dryRun ? "Would stop" : "Stopping";
+        System.out.println(
+            Ansi.AUTO.string(
+                "  @|bold "
+                    + verb
+                    + ":|@ agent PID "
+                    + pid
+                    + " (unit "
+                    + unit
+                    + ") in "
+                    + project));
+      }
+    };
+  }
+
+  private void render(StopOperations.Outcome outcome) {
+    if (json) {
+      System.out.println(YamlUtil.dumpJson(jsonView(outcome)));
+      return;
+    }
+    switch (outcome) {
+      case StopOperations.Stopped stopped -> {
+        System.out.println(
+            Ansi.AUTO.string(
+                "  @|green ✓|@ Agent "
+                    + (dryRun ? "would be stopped" : "stopped")
+                    + " (PID "
+                    + stopped.pid()
+                    + ") in "
+                    + name));
+        printCancelled(stopped.specId(), stopped.specCancelled());
+      }
+      case StopOperations.NotRunning notRunning -> {
+        System.out.println(
+            Ansi.AUTO.string("  @|faint No running agent session for " + name + ".|@"));
+        if (notRunning.runReleased()) {
+          System.out.println(
+              Ansi.AUTO.string("  @|green ✓|@ Released stranded run " + notRunning.runId() + "."));
+        }
+        printCancelled(notRunning.specId(), notRunning.specCancelled());
+      }
+      case StopOperations.AlreadyTerminal terminal ->
+          System.out.println(
+              Ansi.AUTO.string(
+                  "  @|faint Run "
+                      + terminal.runId()
+                      + " is already "
+                      + terminal.runStatus()
+                      + "; nothing to stop.|@"));
+      case StopOperations.NotActive notActive ->
+          System.err.println(
+              Banner.errorLine(
+                  "The live agent (PID "
+                      + notActive.livePid()
+                      + ") does not belong to run "
+                      + notActive.runId()
+                      + "; nothing was stopped.",
+                  Ansi.AUTO));
+    }
+  }
+
+  private void printCancelled(String specId, boolean cancelled) {
+    if (!cancelled) {
+      return;
+    }
+    System.out.println(
+        Ansi.AUTO.string(
+            "  @|green ✓|@ Spec " + specId + (dryRun ? " would be cancelled." : " cancelled.")));
+  }
+
+  private LinkedHashMap<String, Object> jsonView(StopOperations.Outcome outcome) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("name", name);
+    map.put("dry_run", dryRun);
+    switch (outcome) {
+      case StopOperations.Stopped stopped -> {
+        map.put("stopped", true);
+        map.put("pid", stopped.pid());
+        putRunAndSpec(map, stopped.runId(), stopped.specId(), stopped.specCancelled());
+      }
+      case StopOperations.NotRunning notRunning -> {
         map.put("stopped", false);
         map.put("reason", "no agent running");
-        System.out.println(YamlUtil.dumpJson(map));
-        return;
+        map.put("run_released", notRunning.runReleased());
+        putRunAndSpec(map, notRunning.runId(), notRunning.specId(), notRunning.specCancelled());
       }
-      System.out.println(
-          Ansi.AUTO.string("  @|faint No running agent session for " + name + ".|@"));
-      return;
+      case StopOperations.AlreadyTerminal terminal -> {
+        map.put("stopped", false);
+        map.put("reason", "run already " + terminal.runStatus());
+        putRunAndSpec(map, terminal.runId(), terminal.specId(), false);
+      }
+      case StopOperations.NotActive notActive -> {
+        map.put("stopped", false);
+        map.put("reason", "live agent is not this run");
+        map.put("live_pid", notActive.livePid());
+        putRunAndSpec(map, notActive.runId(), notActive.specId(), false);
+      }
     }
+    return map;
+  }
 
-    agentSession.killAgent(name, resolved.unit());
+  private static void putRunAndSpec(
+      LinkedHashMap<String, Object> map, String runId, String specId, boolean cancelled) {
+    if (runId != null) {
+      map.put("run_id", runId);
+    }
+    if (specId != null) {
+      map.put("spec_id", specId);
+    }
+    map.put("spec_cancelled", cancelled);
+  }
 
+  /**
+   * Publishes the cancel {@link Event} to the running sail-api so SSE subscribers and the audit
+   * trail see the same stop story regardless of surface. Failures are non-fatal: the control-plane
+   * database already holds the terminal state, so an unreachable sail-api must not fail the stop.
+   */
+  private void publishLifecycle(Event event) {
+    try {
+      if (eventPublisher == null) {
+        eventPublisher = SailEventPublisher.localDefault();
+      }
+      eventPublisher.publish(event);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      warnLifecyclePublishFailed(event.type(), e);
+    } catch (Exception e) {
+      warnLifecyclePublishFailed(event.type(), e);
+    }
+  }
+
+  private void warnLifecyclePublishFailed(String type, Exception cause) {
     if (json) {
-      var map = new LinkedHashMap<String, Object>();
-      map.put("name", name);
-      map.put("stopped", true);
-      map.put("pid", info.pid());
-      System.out.println(YamlUtil.dumpJson(map));
       return;
     }
-
-    System.out.println(
-        Ansi.AUTO.string("  @|green \u2713|@ Agent stopped (PID " + info.pid() + ") in " + name));
+    System.err.println(
+        Banner.errorLine(
+            "Could not publish "
+                + type
+                + " event ("
+                + cause.getMessage()
+                + "). sail-api may be unreachable; the stop itself is unaffected.",
+            Ansi.AUTO));
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStopCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStopCommand.java
@@ -171,7 +171,7 @@ public final class AgentStopCommand implements Runnable {
                       + notActive.livePid()
                       + ") does not belong to run "
                       + notActive.runId()
-                      + "; nothing was stopped.",
+                      + "; nothing was stopped. Check 'sail agent status' and retry.",
                   Ansi.AUTO));
     }
   }
@@ -197,18 +197,19 @@ public final class AgentStopCommand implements Runnable {
       }
       case StopOperations.NotRunning notRunning -> {
         map.put("stopped", false);
-        map.put("reason", "no agent running");
+        map.put("reason", notRunning.reason());
         map.put("run_released", notRunning.runReleased());
         putRunAndSpec(map, notRunning.runId(), notRunning.specId(), notRunning.specCancelled());
       }
       case StopOperations.AlreadyTerminal terminal -> {
         map.put("stopped", false);
-        map.put("reason", "run already " + terminal.runStatus());
+        map.put("reason", terminal.reason());
+        map.put("run_status", terminal.runStatus());
         putRunAndSpec(map, terminal.runId(), terminal.specId(), false);
       }
       case StopOperations.NotActive notActive -> {
         map.put("stopped", false);
-        map.put("reason", "live agent is not this run");
+        map.put("reason", notActive.reason());
         map.put("live_pid", notActive.livePid());
         putRunAndSpec(map, notActive.runId(), notActive.specId(), false);
       }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecBoardCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecBoardCommand.java
@@ -73,6 +73,8 @@ public final class ApiSpecBoardCommand implements Runnable {
               : "";
       System.out.println(
           Ansi.AUTO.string("    @|green Done:|@            " + result.get("done") + doneSuffix));
+      System.out.println(
+          Ansi.AUTO.string("    @|red Cancelled:|@       " + result.get("cancelled")));
 
       var nextReady = result.get("next_ready_id");
       if (nextReady != null) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecListCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecListCommand.java
@@ -181,6 +181,7 @@ public final class ApiSpecListCommand implements Runnable {
       case "review" -> "Review";
       case "awaiting_merge" -> "Awaiting Merge";
       case "done" -> "Done";
+      case "cancelled" -> "Cancelled";
       case "archived" -> "Archived";
       default -> status;
     };
@@ -194,6 +195,7 @@ public final class ApiSpecListCommand implements Runnable {
       case "review" -> "yellow";
       case "awaiting_merge" -> "magenta";
       case "done" -> "green";
+      case "cancelled" -> "red";
       case "archived" -> "faint";
       default -> "white";
     };

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecListCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecListCommand.java
@@ -129,7 +129,15 @@ public final class ApiSpecListCommand implements Runnable {
   @SuppressWarnings("unchecked")
   static void printGroupedByProjectAndStatus(List<Map<String, Object>> specs) {
     var statusOrder =
-        List.of("draft", "pending", "in_progress", "review", "awaiting_merge", "done", "archived");
+        List.of(
+            "draft",
+            "pending",
+            "in_progress",
+            "review",
+            "awaiting_merge",
+            "done",
+            "cancelled",
+            "archived");
     var byProject = new LinkedHashMap<String, List<Map<String, Object>>>();
     for (var spec : specs) {
       var proj = (String) spec.getOrDefault("project", "unassigned");

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/Banner.java
@@ -1124,6 +1124,7 @@ public final class Banner {
               case IN_PROGRESS -> "@|yellow \u25cb|@";
               case REVIEW -> "@|cyan \u25cb|@";
               case AWAITING_MERGE -> "@|magenta \u25cb|@";
+              case CANCELLED -> "@|red \u2717|@";
               default -> "@|faint \u25cb|@";
             };
         var idPad = String.format("%-16s", spec.id());

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -1244,7 +1244,7 @@ class ApiRouterTest {
 
     @Override
     public Result<StopRunResponse> stopRun(String runId, String localHandle, Actor actor) {
-      return Result.success(new StopRunResponse(runId, false, null, null));
+      return Result.success(new StopRunResponse(runId, false, null, null, false));
     }
 
     @Override
@@ -1445,7 +1445,7 @@ class ApiRouterTest {
     public Result<GlobalBoardResponse> globalBoard(String project) {
       return Result.success(
           new GlobalBoardResponse(
-              new ai.singlr.sail.store.SpecStore.BoardSummary(0, 0, 0, 0, 0, 0, 0, null), 0));
+              new ai.singlr.sail.store.SpecStore.BoardSummary(0, 0, 0, 0, 0, 0, 0, 0, null), 0));
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/CleanStopNoResumeIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/CleanStopNoResumeIT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SpecStatus;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The fleet invariant behind the clean-stop lane: an operator cancel is terminal
+ * <em>everywhere</em>. The stop records the intent (spec {@code cancelled}, run {@code stopped}) as
+ * ordinary synced revisions, so every peer adopts a terminal spec it will never resume — no box
+ * holds it {@code in_progress}/{@code review}, no review is ever created, and a maximally
+ * aggressive missed-stop reconciler pass on every box replays nothing. Before the clean-stop lane
+ * existed, a killed agent left its spec {@code in_progress} and the executing box's reconciler
+ * replayed the stop a sweep later, firing a review for deliberately abandoned work — reverting the
+ * cancel's status write makes this test fail exactly that way.
+ */
+class CleanStopNoResumeIT {
+
+  @TempDir Path root;
+
+  @Test
+  void anOperatorCancelIsTerminalOnEveryBoxAndNothingResumesIt() throws Exception {
+    try (var fleet = Fleet.of(root)) {
+      var main = fleet.main("uday");
+      var sumesh = fleet.node("sumesh", main);
+      var mady = fleet.node("mady", main);
+      fleet.scenario("s", "sumesh", sumesh, mady);
+
+      sumesh.dispatch("s");
+      fleet.sync(sumesh);
+      main.assertSpecStatus("s", SpecStatus.IN_PROGRESS);
+
+      var outcome = sumesh.stop();
+      var notRunning = assertInstanceOf(StopOperations.NotRunning.class, outcome);
+      assertTrue(notRunning.specCancelled(), "the stop must cancel the in-progress spec");
+      assertTrue(notRunning.runReleased(), "the stop must release the running run");
+
+      fleet.sync(sumesh);
+      fleet.sync(mady);
+
+      for (var box : new Fleet.Box[] {main, sumesh, mady}) {
+        box.assertSpecStatus("s", SpecStatus.CANCELLED);
+        assertEquals(
+            "stopped",
+            box.runs("s").getFirst().status(),
+            "the cancelled run must be terminal on " + box.handle());
+        assertEquals(
+            0,
+            box.reviewCount("s"),
+            "no review may ever be created for a cancelled spec on " + box.handle());
+        assertEquals(
+            0,
+            box.reconcileSweep(),
+            "the reaper must replay nothing for a cancelled spec on " + box.handle());
+        box.assertSpecStatus("s", SpecStatus.CANCELLED);
+      }
+    }
+  }
+
+  @Test
+  void aRepeatedStopAfterTheCancelIsAPureNoOp() throws Exception {
+    try (var fleet = Fleet.of(root)) {
+      var main = fleet.main("uday");
+      var sumesh = fleet.node("sumesh", main);
+      fleet.scenario("s", "sumesh", sumesh);
+
+      sumesh.dispatch("s");
+      sumesh.stop();
+
+      var second = sumesh.stop();
+
+      var notRunning = assertInstanceOf(StopOperations.NotRunning.class, second);
+      assertEquals(false, notRunning.mutated(), "a repeated stop must write nothing");
+      sumesh.assertSpecStatus("s", SpecStatus.CANCELLED);
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/DispatchRetentionTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/DispatchRetentionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.store.RunStore;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The retention protection rule: any run that may still own a live agent keeps its run-scoped
+ * directory — including a {@code stopping} run, whose pid file the stop's kill still needs. Pruning
+ * it would turn the kill into a no-op that can never verify, wedging the claim.
+ */
+class DispatchRetentionTest {
+
+  @Test
+  void runningAndStoppingRunsAreProtectedFromRetention() {
+    assertTrue(DispatchOperations.ownsLiveAgent(row("running")));
+    assertTrue(
+        DispatchOperations.ownsLiveAgent(row("stopping")),
+        "a mid-stop run still needs its pid file for the kill and its verification");
+  }
+
+  @Test
+  void terminalRunsArePrunable() {
+    assertFalse(DispatchOperations.ownsLiveAgent(row("completed")));
+    assertFalse(DispatchOperations.ownsLiveAgent(row("stopped")));
+    assertFalse(DispatchOperations.ownsLiveAgent(row("failed")));
+  }
+
+  private static RunStore.RunRow row(String status) {
+    return new RunStore.RunRow(
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "acme",
+        "auth",
+        "me",
+        "build",
+        "claude-code",
+        "feat/auth",
+        "do it",
+        123,
+        null,
+        status,
+        null,
+        "/home/dev/.sail/runs/r/agent.log",
+        "sail-agent-r",
+        null,
+        null,
+        List.of());
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/Fleet.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/Fleet.java
@@ -22,6 +22,7 @@ import ai.singlr.sail.engine.SlackPoster;
 import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.store.AuthSessionStore;
 import ai.singlr.sail.store.ChangeLog;
+import ai.singlr.sail.store.EventStore;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.ReviewStore;
@@ -225,12 +226,14 @@ public final class Fleet implements AutoCloseable {
     private final boolean main;
     private final Path home;
     private final Path bin;
+    private final Path descriptor;
     private final Sqlite db;
     private final EventBus bus;
     private final ReviewPipelineController reviewsController;
     private final SailApiServer server;
     private final CapturingPoster slack;
     private final DispatchOperations dispatcher;
+    private final StopOperations stopper;
     private final SailOperations operations;
     private final SpecStore specs;
     private final ProjectStore projects;
@@ -244,6 +247,7 @@ public final class Fleet implements AutoCloseable {
       this.main = main;
       this.home = home;
       this.bin = bin;
+      this.descriptor = descriptor;
       this.db = db;
       specs = new SpecStore(db);
       projects = new ProjectStore(db);
@@ -276,6 +280,15 @@ public final class Fleet implements AutoCloseable {
               (project, config) -> "",
               command -> 0,
               DispatchOperations.Listener.NONE);
+      stopper =
+          new StopOperations(
+              shell,
+              descriptor.toString(),
+              specs,
+              runs,
+              bus::publish,
+              StopOperations.sessionHalter(shell),
+              StopOperations.Listener.NONE);
       operations =
           new SailOperations(
               shell,
@@ -354,6 +367,30 @@ public final class Fleet implements AutoCloseable {
 
     public void updateStatus(String specId, SpecStatus status) {
       specs.updateStatus(specId, status);
+    }
+
+    public StopOperations.Outcome stop() {
+      return stopper.stop(
+          new StopOperations.ProjectTarget(PROJECT), Actor.cliOperator(handle), handle, false);
+    }
+
+    /**
+     * One missed-stop reconciliation pass under maximally aggressive conditions — every unit probes
+     * dead and every run is past the launch grace — so anything the reaper could ever replay for
+     * this box, it replays here. Returns how many stops were replayed.
+     */
+    public int reconcileSweep() {
+      var reconciler =
+          new MissedStopReconciler(
+              specs,
+              runs,
+              new EventStore(db),
+              reviews,
+              bus,
+              (project, runId, unit) -> false,
+              () -> handle,
+              () -> java.time.Instant.now().plus(Duration.ofHours(1)));
+      return reconciler.sweep();
     }
 
     public void authoritativeStop(String specId) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -15,6 +15,7 @@ import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.ReviewPipelineConfig;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.AgentUnit;
 import ai.singlr.sail.engine.HostInfo;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.store.EventStore;
@@ -75,6 +76,7 @@ class MissedStopReconcilerTest {
   private static final class CountingProbe implements MissedStopReconciler.UnitProbe {
     final AtomicInteger calls = new AtomicInteger();
     volatile boolean active;
+    volatile String lastUnit;
 
     CountingProbe(boolean active) {
       this.active = active;
@@ -83,6 +85,7 @@ class MissedStopReconcilerTest {
     @Override
     public boolean active(String project, String runId, String unit) {
       calls.incrementAndGet();
+      lastUnit = unit;
       return active;
     }
   }
@@ -237,7 +240,7 @@ class MissedStopReconcilerTest {
   }
 
   @Test
-  void aBlankUnitInterruptedStopIsLeftToTheStopRetryLane() {
+  void aBlankUnitInterruptedStopIsFinalizedThroughTheFixedAdHocIdentity() {
     createSpec("auth", SpecStatus.CANCELLED);
     var runId = preUpgradeRunningSession("auth");
     sessionStore.transition(runId, "running", "stopping");
@@ -245,9 +248,30 @@ class MissedStopReconcilerTest {
 
     var finalized = reconciler(probe, PAST_GRACE).sweep();
 
+    assertEquals(1, finalized);
+    assertEquals(
+        AgentUnit.BUILD.unitName(),
+        probe.lastUnit,
+        "a legacy claim is probed on the same compatibility identity the stop itself uses");
+    assertEquals(
+        "stopped",
+        sessionStore.findById(runId).orElseThrow().status(),
+        "a dead legacy claim must not reserve its repos forever");
+  }
+
+  @Test
+  void aBlankUnitInterruptedStopWithALiveAdHocSessionKeepsItsClaim() {
+    createSpec("auth", SpecStatus.CANCELLED);
+    var runId = preUpgradeRunningSession("auth");
+    sessionStore.transition(runId, "running", "stopping");
+
+    var finalized = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+
     assertEquals(0, finalized);
-    assertEquals(0, probe.calls.get());
-    assertEquals("stopping", sessionStore.findById(runId).orElseThrow().status());
+    assertEquals(
+        "stopping",
+        sessionStore.findById(runId).orElseThrow().status(),
+        "an active shared unit may be a newer ad-hoc session; the claim stays untouched");
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -176,6 +176,20 @@ class MissedStopReconcilerTest {
   }
 
   @Test
+  void aCancelledSpecWithItsReleasedRunIsNeverReconciledOrReplayed() {
+    createSpec("auth", SpecStatus.CANCELLED);
+    finishedSession("auth", "stopped", null);
+
+    var replayed = reconciler(new CountingProbe(false), PAST_GRACE).sweep();
+
+    assertEquals(0, replayed);
+    assertEquals(
+        SpecStatus.CANCELLED,
+        specStore.findById("auth").orElseThrow().status(),
+        "an operator cancel is terminal; no sweep may drive the spec forward");
+  }
+
+  @Test
   void keepsARunningReservationForAnInProgressSpec() {
     createInProgressSpec("auth");
     runningSession("auth");

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -23,6 +23,7 @@ import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -190,6 +191,81 @@ class MissedStopReconcilerTest {
   }
 
   @Test
+  void finalizesAnInterruptedStopOnceItsUnitIsGone() throws Exception {
+    createSpec("auth", SpecStatus.CANCELLED);
+    var runId = interruptedStopSession("auth");
+    var latch = new CountDownLatch(1);
+    var cancels = captureCancels(latch);
+
+    var finalized = reconciler(new CountingProbe(false), PAST_GRACE).sweep();
+
+    assertEquals(1, finalized);
+    assertEquals("stopped", sessionStore.findById(runId).orElseThrow().status());
+    BusTesting.awaitDelivery(latch);
+    assertEquals(1, cancels.size());
+    assertEquals(
+        Event.WellKnownData.SOURCE_RECONCILE,
+        cancels.peek().data().get(Event.WellKnownData.SOURCE));
+    assertEquals(runId, cancels.peek().data().get(Event.WellKnownData.RUN_ID));
+  }
+
+  @Test
+  void anInterruptedStopWithALiveUnitKeepsItsClaim() {
+    createSpec("auth", SpecStatus.CANCELLED);
+    var runId = interruptedStopSession("auth");
+
+    var finalized = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+
+    assertEquals(0, finalized);
+    assertEquals(
+        "stopping",
+        sessionStore.findById(runId).orElseThrow().status(),
+        "an active unit means a stop is mid-halt or a retry owns the kill; the claim stays");
+  }
+
+  @Test
+  void aForeignInterruptedStopIsLeftToItsExecutingBox() {
+    createSpec("auth", SpecStatus.CANCELLED);
+    var runId = interruptedStopSession("auth");
+    var probe = new CountingProbe(false);
+
+    var finalized = reconciler(probe, () -> "node-b", PAST_GRACE).sweep();
+
+    assertEquals(0, finalized);
+    assertEquals(0, probe.calls.get());
+    assertEquals("stopping", sessionStore.findById(runId).orElseThrow().status());
+  }
+
+  @Test
+  void aBlankUnitInterruptedStopIsLeftToTheStopRetryLane() {
+    createSpec("auth", SpecStatus.CANCELLED);
+    var runId = preUpgradeRunningSession("auth");
+    sessionStore.transition(runId, "running", "stopping");
+    var probe = new CountingProbe(false);
+
+    var finalized = reconciler(probe, PAST_GRACE).sweep();
+
+    assertEquals(0, finalized);
+    assertEquals(0, probe.calls.get());
+    assertEquals("stopping", sessionStore.findById(runId).orElseThrow().status());
+  }
+
+  @Test
+  void aProbeFailureOnAnInterruptedStopIsLoggedAndRetriedNextSweep() {
+    createSpec("auth", SpecStatus.CANCELLED);
+    var runId = interruptedStopSession("auth");
+    MissedStopReconciler.UnitProbe failing =
+        (project, id, unit) -> {
+          throw new IOException("container unreachable");
+        };
+
+    var finalized = reconciler(failing, PAST_GRACE).sweep();
+
+    assertEquals(0, finalized);
+    assertEquals("stopping", sessionStore.findById(runId).orElseThrow().status());
+  }
+
+  @Test
   void keepsARunningReservationForAnInProgressSpec() {
     createInProgressSpec("auth");
     runningSession("auth");
@@ -285,6 +361,36 @@ class MissedStopReconcilerTest {
             "claude-code",
             HostInfo.hostname(),
             YamlUtil.dumpJson(data)));
+  }
+
+  private String interruptedStopSession(String specId) {
+    var id = runningSession(specId);
+    sessionStore.transition(id, "running", "stopping");
+    return id;
+  }
+
+  private ConcurrentLinkedQueue<Event> captureCancels(CountDownLatch latch) {
+    var captured = new ConcurrentLinkedQueue<Event>();
+    bus.subscribe(
+        BusTesting.latching(
+            new EventSubscriber() {
+              @Override
+              public String name() {
+                return "capture-cancels";
+              }
+
+              @Override
+              public Predicate<Event> filter() {
+                return e -> Event.WellKnownTypes.AGENT_CANCELLED.equals(e.type());
+              }
+
+              @Override
+              public void onEvent(Event event) {
+                captured.add(event);
+              }
+            },
+            latch));
+    return captured;
   }
 
   private ConcurrentLinkedQueue<Event> captureStops(CountDownLatch latch) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -425,6 +425,25 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
+  void anOperatorCancelLandingMidPipelineIsNeverOverwrittenByThePass() {
+    createSpec("auth", "in_progress");
+    var ctrl =
+        controller(
+            singleAgentStage("no_critical"),
+            (p, a, pr, rid) -> {
+              specStore.updateStatus("auth", SpecStatus.CANCELLED);
+              return "[]";
+            });
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    assertEquals(
+        SpecStatus.CANCELLED,
+        specStore.findById("auth").orElseThrow().status(),
+        "cancelled is terminal; the pipeline's stale advance must lose, not resurrect the spec");
+  }
+
+  @Test
   void aWatcherStopAndAReconcilerReplayBackToBackProduceExactlyOneReview() {
     createSpec("auth", "in_progress");
     var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid) -> "[]");

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -376,6 +376,17 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
+  void aStopArrivingAfterAnOperatorCancelNeverKicksAReview() {
+    createSpec("auth", "cancelled");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid) -> "[]");
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    assertTrue(reviewStore.reviewsForSpec("auth").isEmpty());
+    assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
   void ignoresAStopForASpecAlreadyAwaitingMerge() {
     createSpec("auth", "awaiting_merge");
     var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid) -> "[]");

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RunTrackerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RunTrackerTest.java
@@ -189,6 +189,26 @@ class RunTrackerTest {
   }
 
   @Test
+  void aWatcherStopArrivingAfterAnOperatorCancelDoesNotReopenTheRun() {
+    var id = runningRun("backend", "auth");
+    runStore.complete(id, "stopped", null);
+
+    tracker.onEvent(
+        stopped(
+            "backend",
+            id,
+            Map.of(
+                Event.WellKnownData.EXIT_CODE,
+                143,
+                Event.WellKnownData.SOURCE,
+                Event.WellKnownData.SOURCE_WATCHER)));
+
+    var run = runStore.findById(id).orElseThrow();
+    assertEquals("stopped", run.status());
+    assertEquals(143, run.exitCode());
+  }
+
+  @Test
   void anAuthoritativeStopUpgradesTheExitCodeOfAnAlreadyFinishedRun() {
     var id = runningRun("backend", "auth");
     runStore.complete(id, "stopped", null);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RunTrackerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RunTrackerTest.java
@@ -189,6 +189,28 @@ class RunTrackerTest {
   }
 
   @Test
+  void aWatcherCompletionNeverOverwritesACommittedStopClaim() {
+    var id = runningRun("backend", "auth");
+    runStore.transition(id, "running", "stopping");
+
+    tracker.onEvent(
+        Event.of(
+            "backend",
+            "auth",
+            Event.WellKnownTypes.AGENT_SESSION_COMPLETED,
+            "claude-code",
+            "host",
+            Map.of(Event.WellKnownData.RUN_ID, id, Event.WellKnownData.EXIT_CODE, 0)));
+
+    var run = runStore.findById(id).orElseThrow();
+    assertEquals(
+        "stopping",
+        run.status(),
+        "the stop claim owns the run's terminal state; completion only enriches the exit code");
+    assertEquals(0, run.exitCode());
+  }
+
+  @Test
   void aWatcherStopArrivingAfterAnOperatorCancelDoesNotReopenTheRun() {
     var id = runningRun("backend", "auth");
     runStore.complete(id, "stopped", null);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -2038,6 +2038,42 @@ class SailOperationsTest {
   }
 
   @Test
+  void stopRunCancelsTheInProgressSpecBeforeKilling() throws Exception {
+    var operations =
+        operationsWithStores(
+            baseYaml(),
+            shell()
+                .on("incus list ^acme$", RUNNING_JSON)
+                .on("cat /home/dev/.sail/agent.pid", "123")
+                .on("kill -0 123", "")
+                .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"work\"}")
+                .on("kill 123", "")
+                .on("sleep 3", "")
+                .on("kill -9 123", "")
+                .on("rm -f /home/dev/.sail/agent.pid", ""),
+            null,
+            s -> seedAssigned(s, "auth", "in_progress", LOCAL_HANDLE),
+            runs ->
+                runs.create(
+                    R1,
+                    "acme",
+                    "auth",
+                    "node-a",
+                    "build",
+                    "claude-code",
+                    "feat/auth",
+                    "do it",
+                    123,
+                    null,
+                    RUN_LOG));
+
+    var result = operations.stopRun(R1, "node-a", ADMIN);
+
+    assertEquals(true, get(result, "stopped"));
+    assertEquals(true, get(result, "spec_cancelled"));
+  }
+
+  @Test
   void stopRunMapsKillFailure() throws Exception {
     var operations =
         opsWithRun(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -1216,7 +1216,8 @@ class SailOperationsTest {
         shell()
             .on("incus list ^acme$", RUNNING_JSON)
             .on("runs/" + R1 + "/agent.pid", "123")
-            .on("kill -0 123", "");
+            .onSequence(
+                "kill -0 123", new ShellExec.Result(0, "", ""), new ShellExec.Result(1, "", ""));
     var operations =
         operationsWithStores(
             baseYaml(),
@@ -2024,7 +2025,11 @@ class SailOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sail/agent.pid", "123")
-                .on("kill -0 123", "")
+                .onSequence(
+                    "kill -0 123",
+                    new ShellExec.Result(0, "", ""),
+                    new ShellExec.Result(0, "", ""),
+                    new ShellExec.Result(1, "", ""))
                 .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"work\"}")
                 .on("kill 123", "")
                 .on("sleep 3", "")
@@ -2045,7 +2050,11 @@ class SailOperationsTest {
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
                 .on("cat /home/dev/.sail/agent.pid", "123")
-                .on("kill -0 123", "")
+                .onSequence(
+                    "kill -0 123",
+                    new ShellExec.Result(0, "", ""),
+                    new ShellExec.Result(0, "", ""),
+                    new ShellExec.Result(1, "", ""))
                 .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"work\"}")
                 .on("kill 123", "")
                 .on("sleep 3", "")

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SpecLifecycleReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SpecLifecycleReactorTest.java
@@ -125,6 +125,15 @@ class SpecLifecycleReactorTest {
   }
 
   @Test
+  void stoppedAfterAnOperatorCancelLeavesTheSpecCancelled() {
+    seed("auth", "cancelled");
+
+    reactor.onEvent(stopped("auth"));
+
+    assertEquals(SpecStatus.CANCELLED, store.findById("auth").orElseThrow().status());
+  }
+
+  @Test
   void stoppedForAnUnknownSpecIsANoOp() {
     reactor.onEvent(stopped("ghost"));
     assertTrue(store.findById("ghost").isEmpty());

--- a/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
@@ -74,7 +74,7 @@ class StopOperationsTest {
     assertEquals(123, stopped.pid());
     assertTrue(stopped.specCancelled());
     assertTrue(stopped.mutated());
-    assertEquals(List.of("halt " + UNIT, "spec cancelled", "run running"), order);
+    assertEquals(List.of("halt " + UNIT, "spec cancelled", "run stopping"), order);
     assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
   }
 
@@ -383,7 +383,10 @@ class StopOperationsTest {
     var ops =
         stopOps(
             shell,
-            (project, unit) -> haltedUnits.add(unit.unitName()),
+            (project, unit) -> {
+              haltedUnits.add(unit.unitName());
+              adHocAgentDies(shell);
+            },
             StopOperations.Listener.NONE);
 
     var outcome = ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false);
@@ -408,7 +411,10 @@ class StopOperationsTest {
     var ops =
         stopOps(
             shell,
-            (project, unit) -> haltedUnits.add(unit.unitName()),
+            (project, unit) -> {
+              haltedUnits.add(unit.unitName());
+              adHocAgentDies(shell);
+            },
             StopOperations.Listener.NONE);
     seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
     seedRun(123, UNIT);
@@ -566,6 +572,178 @@ class StopOperationsTest {
   }
 
   @Test
+  void aReplacementPidAfterTheHaltFailsTheStopAndRestoresEverything() throws Exception {
+    var shell = liveAgentShell();
+    var ops =
+        stopOps(
+            shell,
+            (project, unit) -> {
+              shell.on("cat " + RUN_PID_FILE, "456");
+              shell.on("kill -0 456", "");
+              shell.on("kill -0 123", new ShellExec.Result(1, "", ""));
+            },
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.AGENT_STOP_FAILED, refusal.failure().errorCode());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void anAdHocHaltThatLeavesTheAgentAliveFailsInsteadOfReportingStopped() throws Exception {
+    var halts = new ArrayList<String>();
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("cat /home/dev/.sail/agent.pid", "55")
+            .on("kill -0 55", "")
+            .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"ad hoc\"}");
+    var ops =
+        stopOps(shell, (project, unit) -> halts.add(unit.unitName()), StopOperations.Listener.NONE);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.AGENT_STOP_FAILED, refusal.failure().errorCode());
+    assertEquals(1, halts.size());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void aRunCompletedBetweenProbeAndClaimRefusesWithAConflict() throws Exception {
+    var listener =
+        new StopOperations.Listener() {
+          @Override
+          public void halting(String project, String unit, Integer pid) {
+            runStore.complete(R1, "completed", 0);
+          }
+        };
+    var ops = stopOps(liveAgentShell(), failingHalter(), listener);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.CONFLICT, refusal.failure().errorCode());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    assertEquals("completed", runStore.findById(R1).orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void aSpecTransitionBetweenProbeAndClaimRollsTheWholeClaimBack() throws Exception {
+    var listener =
+        new StopOperations.Listener() {
+          @Override
+          public void halting(String project, String unit, Integer pid) {
+            specStore.updateStatus("auth", SpecStatus.REVIEW);
+          }
+        };
+    var ops = stopOps(liveAgentShell(), failingHalter(), listener);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.CONFLICT, refusal.failure().errorCode());
+    assertEquals(SpecStatus.REVIEW, specStore.findById("auth").orElseThrow().status());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void aStopRetryFinalizesAnInterruptedClaimWhoseAgentDied() throws Exception {
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("cat " + RUN_PID_FILE, "123")
+            .on("kill -0 123", new ShellExec.Result(1, "", ""));
+    var ops = stopOps(shell, failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    interruptStop();
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var notRunning = assertInstanceOf(StopOperations.NotRunning.class, outcome);
+    assertEquals(R1, notRunning.runId());
+    assertTrue(notRunning.runReleased());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+    assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
+    assertEquals(1, events.size());
+    assertEquals(Event.WellKnownTypes.AGENT_CANCELLED, events.getFirst().type());
+  }
+
+  @Test
+  void aStopRetryKillsALiveAgentStillUnderAnInterruptedClaim() throws Exception {
+    var shell = liveAgentShell();
+    var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    interruptStop();
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals(123, stopped.pid());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+    assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
+    assertEquals(1, events.size());
+  }
+
+  @Test
+  void aDryRunOverAnInterruptedClaimProbesButWritesNothing() throws Exception {
+    var ops = stopOps(liveAgentShell(), failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    interruptStop();
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, true);
+
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals(123, stopped.pid());
+    assertEquals("stopping", runStore.findById(R1).orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void aFinishThatLostTheClaimToAConcurrentFinalizerPublishesNoSecondEvent() throws Exception {
+    var shell = liveAgentShell();
+    var ops =
+        stopOps(
+            shell,
+            (project, unit) -> {
+              agentDies(shell);
+              runStore.transition(R1, "stopping", "stopped");
+            },
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
   void stoppingAnOlderTerminalRunCannotCancelANewerActiveRun() throws Exception {
     var ops =
         stopOps(
@@ -639,6 +817,22 @@ class StopOperationsTest {
 
   private static void agentDies(FakeShell shell) {
     shell.on("kill -0 123", new ShellExec.Result(1, "", ""));
+  }
+
+  private static void adHocAgentDies(FakeShell shell) {
+    shell.on("kill -0 55", new ShellExec.Result(1, "", ""));
+  }
+
+  private void interruptStop() {
+    assertTrue(
+        runStore.transition(
+            R1,
+            "running",
+            "stopping",
+            () ->
+                specStore.compareAndSetStatus(
+                    "auth", SpecStatus.IN_PROGRESS, SpecStatus.CANCELLED)),
+        "seeding the claim an interrupted stop leaves behind");
   }
 
   private FakeShell liveAgentShell() {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
 class StopOperationsTest {
 
   private static final String R1 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  private static final String R2 = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
   private static final String UNIT = "sail-agent-" + R1;
   private static final String RUN_LOG = "/home/dev/.sail/runs/" + R1 + "/agent.log";
   private static final String RUN_PID_FILE = "/home/dev/.sail/runs/" + R1 + "/agent.pid";
@@ -51,7 +52,7 @@ class StopOperationsTest {
   private final List<Event> events = new ArrayList<>();
 
   @Test
-  void stopRecordsTerminalIntentBeforeHalting() throws Exception {
+  void stopCancelsTheSpecBeforeHaltingAndReleasesTheRunAfterTheVerifiedKill() throws Exception {
     var shell = liveAgentShell();
     var order = new ArrayList<String>();
     var ops =
@@ -61,6 +62,7 @@ class StopOperationsTest {
               order.add("halt " + unit.unitName());
               order.add("spec " + specStore.findById("auth").orElseThrow().status().wire());
               order.add("run " + runStore.findById(R1).orElseThrow().status());
+              agentDies(shell);
             },
             StopOperations.Listener.NONE);
     seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
@@ -72,12 +74,14 @@ class StopOperationsTest {
     assertEquals(123, stopped.pid());
     assertTrue(stopped.specCancelled());
     assertTrue(stopped.mutated());
-    assertEquals(List.of("halt " + UNIT, "spec cancelled", "run stopped"), order);
+    assertEquals(List.of("halt " + UNIT, "spec cancelled", "run running"), order);
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
   }
 
   @Test
   void stopPublishesOperatorCancelEventCarryingTheActingFde() throws Exception {
-    var ops = stopOps(liveAgentShell(), (project, unit) -> {}, StopOperations.Listener.NONE);
+    var shell = liveAgentShell();
+    var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);
     seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
     seedRun(123, UNIT);
 
@@ -95,10 +99,14 @@ class StopOperationsTest {
   @Test
   void aSecondStopIsAlreadyTerminalAndSignalsNothing() throws Exception {
     var halts = new ArrayList<String>();
+    var shell = liveAgentShell();
     var ops =
         stopOps(
-            liveAgentShell(),
-            (project, unit) -> halts.add(unit.unitName()),
+            shell,
+            (project, unit) -> {
+              halts.add(unit.unitName());
+              agentDies(shell);
+            },
             StopOperations.Listener.NONE);
     seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
     seedRun(123, UNIT);
@@ -162,7 +170,8 @@ class StopOperationsTest {
 
   @Test
   void aReviewSpecIsCancelledToo() throws Exception {
-    var ops = stopOps(liveAgentShell(), (project, unit) -> {}, StopOperations.Listener.NONE);
+    var shell = liveAgentShell();
+    var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);
     seedSpec("auth", SpecStatus.REVIEW, LOCAL_HANDLE);
     seedRun(123, UNIT);
 
@@ -220,7 +229,10 @@ class StopOperationsTest {
     var ops =
         stopOps(
             shell,
-            (project, unit) -> haltedUnits.add(unit.unitName()),
+            (project, unit) -> {
+              haltedUnits.add(unit.unitName());
+              agentDies(shell);
+            },
             StopOperations.Listener.NONE);
     seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
     seedRun(123, null);
@@ -292,7 +304,8 @@ class StopOperationsTest {
 
   @Test
   void theAssigneeMemberMayStopTheirOwnRun() throws Exception {
-    var ops = stopOps(liveAgentShell(), (project, unit) -> {}, StopOperations.Listener.NONE);
+    var shell = liveAgentShell();
+    var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);
     seedSpec("auth", SpecStatus.IN_PROGRESS, "raj");
     seedRun(123, UNIT);
 
@@ -304,7 +317,8 @@ class StopOperationsTest {
 
   @Test
   void aRunWithoutASpecStillStopsButCancelsNothing() throws Exception {
-    var ops = stopOps(liveAgentShell(), (project, unit) -> {}, StopOperations.Listener.NONE);
+    var shell = liveAgentShell();
+    var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);
     seedRun(123, UNIT);
 
     var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
@@ -318,7 +332,8 @@ class StopOperationsTest {
 
   @Test
   void aRunWithNoSpecIdAtAllStillStops() throws Exception {
-    var ops = stopOps(liveAgentShell(), (project, unit) -> {}, StopOperations.Listener.NONE);
+    var shell = liveAgentShell();
+    var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);
     runStore.create(
         R1,
         "acme",
@@ -344,7 +359,8 @@ class StopOperationsTest {
 
   @Test
   void projectTargetResolvesTheActiveRunAndStopsIt() throws Exception {
-    var ops = stopOps(liveAgentShell(), (project, unit) -> {}, StopOperations.Listener.NONE);
+    var shell = liveAgentShell();
+    var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);
     seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
     seedRun(123, UNIT);
 
@@ -378,6 +394,55 @@ class StopOperationsTest {
     assertFalse(stopped.specCancelled());
     assertEquals(List.of(AgentUnit.BUILD.unitName()), haltedUnits);
     assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void aStaleRunningRowDoesNotMaskTheLiveAdHocAgent() throws Exception {
+    var haltedUnits = new ArrayList<String>();
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("cat /home/dev/.sail/agent.pid", "55")
+            .on("kill -0 55", "")
+            .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"ad hoc\"}");
+    var ops =
+        stopOps(
+            shell,
+            (project, unit) -> haltedUnits.add(unit.unitName()),
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var outcome = ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false);
+
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals(55, stopped.pid());
+    assertNull(stopped.runId());
+    assertEquals("auth", stopped.specId());
+    assertTrue(stopped.specCancelled());
+    assertEquals(List.of(AgentUnit.BUILD.unitName()), haltedUnits);
+    assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+    assertEquals(1, events.size());
+  }
+
+  @Test
+  void aDeadRunWithNoAdHocAgentStillReportsTheStrandedRescue() throws Exception {
+    var ops =
+        stopOps(
+            shell().on("incus list ^acme$", RUNNING_JSON),
+            failingHalter(),
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var outcome = ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false);
+
+    var notRunning = assertInstanceOf(StopOperations.NotRunning.class, outcome);
+    assertEquals(R1, notRunning.runId());
+    assertTrue(notRunning.specCancelled());
+    assertTrue(notRunning.runReleased());
+    assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
   }
 
   @Test
@@ -461,7 +526,7 @@ class StopOperationsTest {
   }
 
   @Test
-  void aKillFailureMapsToAgentStopFailedWithTheIntentAlreadyRecorded() throws Exception {
+  void aKillFailureRestoresTheSpecAndLeavesTheRunReconcilable() throws Exception {
     var ops =
         stopOps(
             liveAgentShell(),
@@ -478,8 +543,60 @@ class StopOperationsTest {
             () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
 
     assertEquals(ErrorCode.AGENT_STOP_FAILED, refusal.failure().errorCode());
-    assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
-    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void aHaltThatLeavesTheAgentAliveRestoresTheSpecAndFails() throws Exception {
+    var ops = stopOps(liveAgentShell(), (project, unit) -> {}, StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.AGENT_STOP_FAILED, refusal.failure().errorCode());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void stoppingAnOlderTerminalRunCannotCancelANewerActiveRun() throws Exception {
+    var ops =
+        stopOps(
+            shell().on("incus list ^acme$", RUNNING_JSON),
+            failingHalter(),
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    runStore.complete(R1, "completed", 0);
+    runStore.create(
+        R2,
+        "acme",
+        "auth",
+        LOCAL_HANDLE,
+        "build",
+        "codex",
+        "feat/auth",
+        "do it",
+        456,
+        null,
+        RUN_LOG,
+        "sail-agent-" + R2);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var terminal = assertInstanceOf(StopOperations.AlreadyTerminal.class, outcome);
+    assertEquals(R1, terminal.runId());
+    assertFalse(terminal.mutated());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    assertEquals("running", runStore.findById(R2).orElseThrow().status());
+    assertTrue(events.isEmpty());
   }
 
   @Test
@@ -514,6 +631,14 @@ class StopOperationsTest {
     StopOperations.sessionHalter(shell).halt("acme", AgentUnit.BUILD);
 
     assertTrue(shell.invocations().stream().anyMatch(cmd -> cmd.contains("kill 77")));
+  }
+
+  private StopOperations.AgentHalter killingHalter(FakeShell shell) {
+    return (project, unit) -> agentDies(shell);
+  }
+
+  private static void agentDies(FakeShell shell) {
+    shell.on("kill -0 123", new ShellExec.Result(1, "", ""));
   }
 
   private FakeShell liveAgentShell() {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
@@ -1,0 +1,650 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.AgentUnit;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class StopOperationsTest {
+
+  private static final String R1 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  private static final String UNIT = "sail-agent-" + R1;
+  private static final String RUN_LOG = "/home/dev/.sail/runs/" + R1 + "/agent.log";
+  private static final String RUN_PID_FILE = "/home/dev/.sail/runs/" + R1 + "/agent.pid";
+  private static final String LOCAL_HANDLE = "me";
+  private static final Actor ADMIN = new Actor(LOCAL_HANDLE, Role.ADMIN, Actor.Lane.API);
+
+  private static final String RUNNING_JSON =
+      """
+      [{"name": "acme", "status": "Running", "state": {}}]
+      """;
+
+  @TempDir Path tempDir;
+
+  private SpecStore specStore;
+  private RunStore runStore;
+  private final List<Event> events = new ArrayList<>();
+
+  @Test
+  void stopRecordsTerminalIntentBeforeHalting() throws Exception {
+    var shell = liveAgentShell();
+    var order = new ArrayList<String>();
+    var ops =
+        stopOps(
+            shell,
+            (project, unit) -> {
+              order.add("halt " + unit.unitName());
+              order.add("spec " + specStore.findById("auth").orElseThrow().status().wire());
+              order.add("run " + runStore.findById(R1).orElseThrow().status());
+            },
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals(123, stopped.pid());
+    assertTrue(stopped.specCancelled());
+    assertTrue(stopped.mutated());
+    assertEquals(List.of("halt " + UNIT, "spec cancelled", "run stopped"), order);
+  }
+
+  @Test
+  void stopPublishesOperatorCancelEventCarryingTheActingFde() throws Exception {
+    var ops = stopOps(liveAgentShell(), (project, unit) -> {}, StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    assertEquals(1, events.size());
+    var event = events.getFirst();
+    assertEquals(Event.WellKnownTypes.AGENT_CANCELLED, event.type());
+    assertEquals("auth", event.spec());
+    assertEquals(LOCAL_HANDLE, event.agent());
+    assertEquals(Event.WellKnownData.SOURCE_OPERATOR, event.data().get(Event.WellKnownData.SOURCE));
+    assertEquals(R1, event.data().get(Event.WellKnownData.RUN_ID));
+  }
+
+  @Test
+  void aSecondStopIsAlreadyTerminalAndSignalsNothing() throws Exception {
+    var halts = new ArrayList<String>();
+    var ops =
+        stopOps(
+            liveAgentShell(),
+            (project, unit) -> halts.add(unit.unitName()),
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+    var second = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var terminal = assertInstanceOf(StopOperations.AlreadyTerminal.class, second);
+    assertEquals(R1, terminal.runId());
+    assertEquals("stopped", terminal.runStatus());
+    assertEquals("auth", terminal.specId());
+    assertFalse(terminal.mutated());
+    assertEquals(1, halts.size());
+    assertEquals(1, events.size());
+  }
+
+  @Test
+  void aDeadAgentStillGetsItsIntentRecorded() throws Exception {
+    var halts = new ArrayList<String>();
+    var shell = shell().on("incus list ^acme$", RUNNING_JSON);
+    var ops =
+        stopOps(shell, (project, unit) -> halts.add(unit.unitName()), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var notRunning = assertInstanceOf(StopOperations.NotRunning.class, outcome);
+    assertEquals(R1, notRunning.runId());
+    assertEquals("auth", notRunning.specId());
+    assertTrue(notRunning.specCancelled());
+    assertTrue(notRunning.runReleased());
+    assertTrue(notRunning.mutated());
+    assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+    assertTrue(halts.isEmpty());
+    assertEquals(1, events.size());
+  }
+
+  @Test
+  void aTerminalRunWithAnActiveSpecCancelsTheStrandedSpec() throws Exception {
+    var ops =
+        stopOps(
+            shell().on("incus list ^acme$", RUNNING_JSON),
+            failingHalter(),
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    runStore.complete(R1, "completed", 0);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var notRunning = assertInstanceOf(StopOperations.NotRunning.class, outcome);
+    assertTrue(notRunning.specCancelled());
+    assertFalse(notRunning.runReleased());
+    assertTrue(notRunning.mutated());
+    assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
+    assertEquals("completed", runStore.findById(R1).orElseThrow().status());
+    assertEquals(1, events.size());
+  }
+
+  @Test
+  void aReviewSpecIsCancelledToo() throws Exception {
+    var ops = stopOps(liveAgentShell(), (project, unit) -> {}, StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.REVIEW, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    assertTrue(assertInstanceOf(StopOperations.Stopped.class, outcome).specCancelled());
+    assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void aPidMismatchKillsNothingAndWritesNothing() throws Exception {
+    var halts = new ArrayList<String>();
+    var ops =
+        stopOps(
+            liveAgentShell(999),
+            (project, unit) -> halts.add(unit.unitName()),
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var notActive = assertInstanceOf(StopOperations.NotActive.class, outcome);
+    assertEquals(999, notActive.livePid());
+    assertEquals(R1, notActive.runId());
+    assertEquals("auth", notActive.specId());
+    assertFalse(notActive.mutated());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+    assertTrue(halts.isEmpty());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void aRunWithNoRecordedPidIsNeverKilled() throws Exception {
+    var ops = stopOps(liveAgentShell(), failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(null, UNIT);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    assertInstanceOf(StopOperations.NotActive.class, outcome);
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void aRunWithABlankUnitFallsBackToTheAdHocIdentity() throws Exception {
+    var haltedUnits = new ArrayList<String>();
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("cat /home/dev/.sail/agent.pid", "123")
+            .on("kill -0 123", "")
+            .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"work\"}");
+    var ops =
+        stopOps(
+            shell,
+            (project, unit) -> haltedUnits.add(unit.unitName()),
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, null);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals(List.of(AgentUnit.BUILD.unitName()), haltedUnits);
+  }
+
+  @Test
+  void anUnknownRunIsRefusedWithRunNotFound() throws Exception {
+    var ops = stopOps(shell(), failingHalter(), StopOperations.Listener.NONE);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.RUN_NOT_FOUND, refusal.failure().errorCode());
+  }
+
+  @Test
+  void aForeignRunIsRefusedWithRunOnOtherNode() throws Exception {
+    var ops = stopOps(shell(), failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, "sumesh", false));
+
+    assertEquals(ErrorCode.RUN_ON_OTHER_NODE, refusal.failure().errorCode());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void aBlankNodeRunFailsClosedToForeignForAHandledBox() throws Exception {
+    var ops = stopOps(shell(), failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    runStore.create(
+        R1, "acme", "auth", null, "build", "codex", "feat/auth", "do it", 123, null, RUN_LOG, UNIT);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.RUN_ON_OTHER_NODE, refusal.failure().errorCode());
+  }
+
+  @Test
+  void aMemberWhoIsNotTheAssigneeIsRefused() throws Exception {
+    var ops = stopOps(liveAgentShell(), failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var other = new Actor("raj", Role.MEMBER, Actor.Lane.API);
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), other, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.FORBIDDEN_NOT_ASSIGNEE, refusal.failure().errorCode());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+  }
+
+  @Test
+  void theAssigneeMemberMayStopTheirOwnRun() throws Exception {
+    var ops = stopOps(liveAgentShell(), (project, unit) -> {}, StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, "raj");
+    seedRun(123, UNIT);
+
+    var assignee = new Actor("raj", Role.MEMBER, Actor.Lane.API);
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), assignee, LOCAL_HANDLE, false);
+
+    assertInstanceOf(StopOperations.Stopped.class, outcome);
+  }
+
+  @Test
+  void aRunWithoutASpecStillStopsButCancelsNothing() throws Exception {
+    var ops = stopOps(liveAgentShell(), (project, unit) -> {}, StopOperations.Listener.NONE);
+    seedRun(123, UNIT);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertFalse(stopped.specCancelled());
+    assertEquals("auth", stopped.specId());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+    assertEquals(1, events.size());
+  }
+
+  @Test
+  void aRunWithNoSpecIdAtAllStillStops() throws Exception {
+    var ops = stopOps(liveAgentShell(), (project, unit) -> {}, StopOperations.Listener.NONE);
+    runStore.create(
+        R1,
+        "acme",
+        null,
+        LOCAL_HANDLE,
+        "build",
+        "codex",
+        "feat/x",
+        "do it",
+        123,
+        null,
+        RUN_LOG,
+        UNIT);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertFalse(stopped.specCancelled());
+    assertNull(stopped.specId());
+    assertEquals(1, events.size());
+    assertNull(events.getFirst().spec());
+  }
+
+  @Test
+  void projectTargetResolvesTheActiveRunAndStopsIt() throws Exception {
+    var ops = stopOps(liveAgentShell(), (project, unit) -> {}, StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var outcome = ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false);
+
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals(R1, stopped.runId());
+    assertTrue(stopped.specCancelled());
+  }
+
+  @Test
+  void projectTargetWithoutARunStopsTheAdHocSession() throws Exception {
+    var haltedUnits = new ArrayList<String>();
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("cat /home/dev/.sail/agent.pid", "55")
+            .on("kill -0 55", "")
+            .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"ad hoc\"}");
+    var ops =
+        stopOps(
+            shell,
+            (project, unit) -> haltedUnits.add(unit.unitName()),
+            StopOperations.Listener.NONE);
+
+    var outcome = ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false);
+
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals(55, stopped.pid());
+    assertNull(stopped.runId());
+    assertFalse(stopped.specCancelled());
+    assertEquals(List.of(AgentUnit.BUILD.unitName()), haltedUnits);
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void projectTargetWithNothingRunningIsAQuietNoOp() throws Exception {
+    var ops =
+        stopOps(
+            shell().on("incus list ^acme$", RUNNING_JSON),
+            failingHalter(),
+            StopOperations.Listener.NONE);
+
+    var outcome = ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false);
+
+    var notRunning = assertInstanceOf(StopOperations.NotRunning.class, outcome);
+    assertFalse(notRunning.specCancelled());
+    assertFalse(notRunning.runReleased());
+    assertFalse(notRunning.mutated());
+  }
+
+  @Test
+  void aDryRunResolvesAndProbesButWritesAndSignalsNothing() throws Exception {
+    var halted = new ArrayList<String>();
+    var announced = new ArrayList<String>();
+    var listener =
+        new StopOperations.Listener() {
+          @Override
+          public void halting(String project, String unit, Integer pid) {
+            announced.add(project + "/" + unit + "/" + pid);
+          }
+        };
+    var ops = stopOps(liveAgentShell(), (project, unit) -> halted.add(unit.unitName()), listener);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, true);
+
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertTrue(stopped.specCancelled());
+    assertEquals(List.of("acme/" + UNIT + "/123"), announced);
+    assertTrue(halted.isEmpty());
+    assertTrue(events.isEmpty());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+  }
+
+  @Test
+  void aDryRunOverADeadAgentReportsTheRescueWithoutWriting() throws Exception {
+    var ops =
+        stopOps(
+            shell().on("incus list ^acme$", RUNNING_JSON),
+            failingHalter(),
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, true);
+
+    var notRunning = assertInstanceOf(StopOperations.NotRunning.class, outcome);
+    assertTrue(notRunning.specCancelled());
+    assertTrue(notRunning.runReleased());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void aTerminalRunWithATerminalSpecIsUntouchedOnADryRun() throws Exception {
+    var ops =
+        stopOps(
+            shell().on("incus list ^acme$", RUNNING_JSON),
+            failingHalter(),
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    runStore.complete(R1, "completed", 0);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, true);
+
+    var notRunning = assertInstanceOf(StopOperations.NotRunning.class, outcome);
+    assertTrue(notRunning.specCancelled());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void aKillFailureMapsToAgentStopFailedWithTheIntentAlreadyRecorded() throws Exception {
+    var ops =
+        stopOps(
+            liveAgentShell(),
+            (project, unit) -> {
+              throw new IOException("permission denied");
+            },
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.AGENT_STOP_FAILED, refusal.failure().errorCode());
+    assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+  }
+
+  @Test
+  void aProbeFailureMapsToAgentStatusFailed() throws Exception {
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .throwOn("cat " + RUN_PID_FILE, new IOException("container unreachable"));
+    var ops = stopOps(shell, failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.AGENT_STATUS_FAILED, refusal.failure().errorCode());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void sessionHalterKillsThroughTheAgentSession() throws Exception {
+    var shell =
+        shell()
+            .on("cat /home/dev/.sail/agent.pid", "77")
+            .on("kill 77", "")
+            .on("sleep 3", "")
+            .on("kill -0 77", new ShellExec.Result(1, "", ""))
+            .on("rm -f /home/dev/.sail/agent.pid", "");
+
+    StopOperations.sessionHalter(shell).halt("acme", AgentUnit.BUILD);
+
+    assertTrue(shell.invocations().stream().anyMatch(cmd -> cmd.contains("kill 77")));
+  }
+
+  private FakeShell liveAgentShell() {
+    return liveAgentShell(123);
+  }
+
+  private FakeShell liveAgentShell(int pid) {
+    return shell()
+        .on("incus list ^acme$", RUNNING_JSON)
+        .on("cat " + RUN_PID_FILE, String.valueOf(pid))
+        .on("kill -0 " + pid, "")
+        .on("cat /home/dev/.sail/runs/" + R1 + "/agent-session.json", "{\"task\": \"work\"}");
+  }
+
+  private StopOperations stopOps(
+      FakeShell shell, StopOperations.AgentHalter halter, StopOperations.Listener listener)
+      throws Exception {
+    var yaml = tempDir.resolve("sail-" + System.nanoTime() + ".yaml");
+    Files.writeString(
+        yaml,
+        """
+        name: acme
+        ssh:
+          user: dev
+        agent:
+          type: claude-code
+          specs_dir: specs
+        """);
+    var db = Sqlite.open(tempDir.resolve("stop-" + System.nanoTime() + ".db"));
+    new SchemaManager(db).migrate();
+    specStore = new SpecStore(db);
+    runStore = new RunStore(db);
+    return new StopOperations(
+        shell, yaml.toString(), specStore, runStore, events::add, halter, listener);
+  }
+
+  private void seedSpec(String id, SpecStatus status, String assignee) {
+    specStore.create(
+        new SpecStore.SpecRow(
+            id,
+            "acme",
+            "Spec " + id,
+            status,
+            assignee,
+            "codex",
+            null,
+            null,
+            null,
+            0,
+            "me",
+            null,
+            null,
+            "me",
+            List.of(),
+            List.of()));
+  }
+
+  private void seedRun(Integer pid, String unit) {
+    runStore.create(
+        R1,
+        "acme",
+        "auth",
+        LOCAL_HANDLE,
+        "build",
+        "codex",
+        "feat/auth",
+        "do it",
+        pid,
+        null,
+        RUN_LOG,
+        unit);
+  }
+
+  private StopOperations.AgentHalter failingHalter() {
+    return (project, unit) -> {
+      throw new AssertionError("the halter must not be invoked");
+    };
+  }
+
+  private static FakeShell shell() {
+    return new FakeShell();
+  }
+
+  private static final class FakeShell implements ShellExec {
+    private final Map<String, Result> scripts = new LinkedHashMap<>();
+    private final Map<String, Exception> failures = new LinkedHashMap<>();
+    private final List<String> invocations = new ArrayList<>();
+
+    FakeShell on(String pattern, String stdout) {
+      return on(pattern, new Result(0, stdout, ""));
+    }
+
+    FakeShell on(String pattern, Result result) {
+      scripts.put(pattern, result);
+      return this;
+    }
+
+    FakeShell throwOn(String pattern, Exception failure) {
+      failures.put(pattern, failure);
+      return this;
+    }
+
+    @Override
+    public Result exec(List<String> command) throws IOException {
+      var joined = String.join(" ", command);
+      invocations.add(joined);
+      for (var entry : failures.entrySet()) {
+        if (joined.contains(entry.getKey())) {
+          throw (IOException) entry.getValue();
+        }
+      }
+      for (var entry : scripts.entrySet()) {
+        if (joined.contains(entry.getKey())) {
+          return entry.getValue();
+        }
+      }
+      return new Result(1, "", "no script for " + joined);
+    }
+
+    @Override
+    public Result exec(List<String> command, Path workDir, Duration timeout) throws IOException {
+      return exec(command);
+    }
+
+    @Override
+    public boolean isDryRun() {
+      return false;
+    }
+
+    List<String> invocations() {
+      return List.copyOf(invocations);
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
@@ -846,19 +846,7 @@ class StopOperationsTest {
     seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
     seedRun(123, UNIT);
     runStore.complete(R1, "completed", 0);
-    runStore.create(
-        R2,
-        "acme",
-        "auth",
-        LOCAL_HANDLE,
-        "build",
-        "codex",
-        "feat/auth",
-        "do it",
-        456,
-        null,
-        RUN_LOG,
-        "sail-agent-" + R2);
+    seedNewerRun();
 
     var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
 
@@ -880,24 +868,75 @@ class StopOperationsTest {
     seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
     seedRun(123, UNIT);
     runStore.complete(R1, "completed", 0);
-    runStore.create(
-        R2,
-        "acme",
-        "auth",
-        LOCAL_HANDLE,
-        "build",
-        "codex",
-        "feat/auth",
-        "do it",
-        456,
-        null,
-        RUN_LOG,
-        "sail-agent-" + R2);
+    seedNewerRun();
 
     var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, true);
 
     assertInstanceOf(StopOperations.AlreadyTerminal.class, outcome);
     assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void stoppingAnOlderLiveRunHaltsItWithoutCancellingTheNewerAttempt() throws Exception {
+    var shell = liveAgentShell();
+    var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    seedNewerRun();
+
+    var preview = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, true);
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    assertFalse(assertInstanceOf(StopOperations.Stopped.class, preview).specCancelled());
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals(123, stopped.pid());
+    assertFalse(stopped.specCancelled());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+    assertEquals("running", runStore.findById(R2).orElseThrow().status());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void anOlderDeadRunIsReleasedWithoutCancellingTheNewerAttempt() throws Exception {
+    var ops =
+        stopOps(
+            shell().on("incus list ^acme$", RUNNING_JSON),
+            failingHalter(),
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    seedNewerRun();
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var notRunning = assertInstanceOf(StopOperations.NotRunning.class, outcome);
+    assertFalse(notRunning.specCancelled());
+    assertTrue(notRunning.runReleased());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+    assertEquals("running", runStore.findById(R2).orElseThrow().status());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void aWatcherCompletionDuringTheDeadRunRescueIsNeverOverwritten() throws Exception {
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .hookOn("cat " + RUN_PID_FILE, () -> runStore.complete(R1, "completed", 0));
+    var ops = stopOps(shell, failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.CONFLICT, refusal.failure().errorCode());
+    assertEquals("completed", runStore.findById(R1).orElseThrow().status());
+    assertEquals(0, runStore.findById(R1).orElseThrow().exitCode());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    assertTrue(events.isEmpty());
   }
 
   @Test
@@ -1064,6 +1103,22 @@ class StopOperationsTest {
         unit);
   }
 
+  private void seedNewerRun() {
+    runStore.create(
+        R2,
+        "acme",
+        "auth",
+        LOCAL_HANDLE,
+        "build",
+        "codex",
+        "feat/auth",
+        "do it",
+        456,
+        null,
+        RUN_LOG,
+        "sail-agent-" + R2);
+  }
+
   private StopOperations.AgentHalter failingHalter() {
     return (project, unit) -> {
       throw new AssertionError("the halter must not be invoked");
@@ -1077,6 +1132,7 @@ class StopOperationsTest {
   private static final class FakeShell implements ShellExec {
     private final Map<String, Result> scripts = new LinkedHashMap<>();
     private final Map<String, Exception> failures = new LinkedHashMap<>();
+    private final Map<String, Runnable> hooks = new LinkedHashMap<>();
     private final List<String> invocations = new ArrayList<>();
 
     FakeShell on(String pattern, String stdout) {
@@ -1093,10 +1149,20 @@ class StopOperationsTest {
       return this;
     }
 
+    FakeShell hookOn(String pattern, Runnable action) {
+      hooks.put(pattern, action);
+      return this;
+    }
+
     @Override
     public Result exec(List<String> command) throws IOException {
       var joined = String.join(" ", command);
       invocations.add(joined);
+      for (var entry : hooks.entrySet()) {
+        if (joined.contains(entry.getKey())) {
+          entry.getValue().run();
+        }
+      }
       for (var entry : failures.entrySet()) {
         if (joined.contains(entry.getKey())) {
           throw (IOException) entry.getValue();

--- a/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
@@ -433,6 +433,60 @@ class StopOperationsTest {
   }
 
   @Test
+  void aStaleLegacyRunWhoseIdentityAnAdHocSessionTookIsRescuedAndTheSessionStopped()
+      throws Exception {
+    var haltedUnits = new ArrayList<String>();
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("cat /home/dev/.sail/agent.pid", "55")
+            .on("kill -0 55", "")
+            .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"ad hoc\"}");
+    var ops =
+        stopOps(
+            shell,
+            (project, unit) -> {
+              haltedUnits.add(unit.unitName());
+              adHocAgentDies(shell);
+            },
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, null);
+
+    var outcome = ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false);
+
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals(55, stopped.pid());
+    assertNull(stopped.runId());
+    assertEquals("auth", stopped.specId());
+    assertTrue(stopped.specCancelled());
+    assertEquals(List.of(AgentUnit.BUILD.unitName()), haltedUnits);
+    assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+    assertEquals(1, events.size());
+  }
+
+  @Test
+  void anExactRunTargetOnAStaleLegacyRunStaysAConservativeNoOp() throws Exception {
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("cat /home/dev/.sail/agent.pid", "55")
+            .on("kill -0 55", "")
+            .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"ad hoc\"}");
+    var ops = stopOps(shell, failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, null);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    assertInstanceOf(StopOperations.NotActive.class, outcome);
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
   void aDeadRunWithNoAdHocAgentStillReportsTheStrandedRescue() throws Exception {
     var ops =
         stopOps(
@@ -708,6 +762,45 @@ class StopOperationsTest {
   }
 
   @Test
+  void aResumedClaimNeverKillsAReplacementProcess() throws Exception {
+    var ops = stopOps(liveAgentShell(456), failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    interruptStop();
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var notActive = assertInstanceOf(StopOperations.NotActive.class, outcome);
+    assertEquals(456, notActive.livePid());
+    assertEquals(
+        "stopping",
+        runStore.findById(R1).orElseThrow().status(),
+        "the claim stays for the reconciler; the replacement process is untouched");
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void aResumedLegacyClaimNeverKillsTheAdHocSessionThatTookItsIdentity() throws Exception {
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("cat /home/dev/.sail/agent.pid", "456")
+            .on("kill -0 456", "")
+            .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"ad hoc\"}");
+    var ops = stopOps(shell, failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, null);
+    interruptStop();
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var notActive = assertInstanceOf(StopOperations.NotActive.class, outcome);
+    assertEquals(456, notActive.livePid());
+    assertEquals("stopping", runStore.findById(R1).orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
   void aDryRunOverAnInterruptedClaimProbesButWritesNothing() throws Exception {
     var ops = stopOps(liveAgentShell(), failingHalter(), StopOperations.Listener.NONE);
     seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
@@ -775,6 +868,63 @@ class StopOperationsTest {
     assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
     assertEquals("running", runStore.findById(R2).orElseThrow().status());
     assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void aDryRunOverAnOlderTerminalRunPreviewsAlreadyTerminal() throws Exception {
+    var ops =
+        stopOps(
+            shell().on("incus list ^acme$", RUNNING_JSON),
+            failingHalter(),
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    runStore.complete(R1, "completed", 0);
+    runStore.create(
+        R2,
+        "acme",
+        "auth",
+        LOCAL_HANDLE,
+        "build",
+        "codex",
+        "feat/auth",
+        "do it",
+        456,
+        null,
+        RUN_LOG,
+        "sail-agent-" + R2);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, true);
+
+    assertInstanceOf(StopOperations.AlreadyTerminal.class, outcome);
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void aStaleLegacyRescueWhoseAdHocSessionJustDiedStillReportsTheRescue() throws Exception {
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("cat /home/dev/.sail/agent.pid", "55")
+            .on("kill -0 55", "")
+            .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"ad hoc\"}");
+    DispatchOperations.EventSink sink =
+        event -> {
+          events.add(event);
+          adHocAgentDies(shell);
+        };
+    var ops = stopOps(shell, failingHalter(), StopOperations.Listener.NONE, sink);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, null);
+
+    var outcome = ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false);
+
+    var notRunning = assertInstanceOf(StopOperations.NotRunning.class, outcome);
+    assertEquals(R1, notRunning.runId());
+    assertTrue(notRunning.specCancelled());
+    assertTrue(notRunning.runReleased());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+    assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
   }
 
   @Test
@@ -850,6 +1000,15 @@ class StopOperationsTest {
   private StopOperations stopOps(
       FakeShell shell, StopOperations.AgentHalter halter, StopOperations.Listener listener)
       throws Exception {
+    return stopOps(shell, halter, listener, events::add);
+  }
+
+  private StopOperations stopOps(
+      FakeShell shell,
+      StopOperations.AgentHalter halter,
+      StopOperations.Listener listener,
+      DispatchOperations.EventSink sink)
+      throws Exception {
     var yaml = tempDir.resolve("sail-" + System.nanoTime() + ".yaml");
     Files.writeString(
         yaml,
@@ -865,8 +1024,7 @@ class StopOperationsTest {
     new SchemaManager(db).migrate();
     specStore = new SpecStore(db);
     runStore = new RunStore(db);
-    return new StopOperations(
-        shell, yaml.toString(), specStore, runStore, events::add, halter, listener);
+    return new StopOperations(shell, yaml.toString(), specStore, runStore, sink, halter, listener);
   }
 
   private void seedSpec(String id, SpecStatus status, String assignee) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
@@ -940,6 +940,84 @@ class StopOperationsTest {
   }
 
   @Test
+  void outcomeReasonsShareOneWireVocabulary() {
+    assertNull(new StopOperations.Stopped(R1, "auth", 1, true).reason());
+    assertEquals(
+        "no_agent_running", new StopOperations.NotRunning(R1, "auth", false, true).reason());
+    assertEquals(
+        "run_not_running", new StopOperations.NotRunning(R1, "auth", false, false).reason());
+    assertEquals(
+        "run_not_running", new StopOperations.AlreadyTerminal(R1, "auth", "stopped").reason());
+    assertEquals("run_not_active", new StopOperations.NotActive(R1, "auth", 9).reason());
+  }
+
+  @Test
+  void aNewerReviewRowDoesNotBlockTheOperatorCancel() throws Exception {
+    var shell = liveAgentShell();
+    var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.REVIEW, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    seedReviewRun();
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    assertTrue(assertInstanceOf(StopOperations.Stopped.class, outcome).specCancelled());
+    assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+  }
+
+  @Test
+  void stoppingAReviewRunIsRefusedWithInvalidRole() throws Exception {
+    var ops = stopOps(liveAgentShell(), failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.REVIEW, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    seedReviewRun();
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R2), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.INVALID_ROLE, refusal.failure().errorCode());
+    assertEquals("running", runStore.findById(R2).orElseThrow().status());
+    assertEquals(SpecStatus.REVIEW, specStore.findById("auth").orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void aWedgedLegacyStopClaimIsFinalizedAndTheAdHocSessionStopped() throws Exception {
+    var haltedUnits = new ArrayList<String>();
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("cat /home/dev/.sail/agent.pid", "55")
+            .on("kill -0 55", "")
+            .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"ad hoc\"}");
+    var ops =
+        stopOps(
+            shell,
+            (project, unit) -> {
+              haltedUnits.add(unit.unitName());
+              adHocAgentDies(shell);
+            },
+            StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, null);
+    interruptStop();
+
+    var outcome = ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false);
+
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals(55, stopped.pid());
+    assertFalse(stopped.specCancelled());
+    assertEquals(List.of(AgentUnit.BUILD.unitName()), haltedUnits);
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+    assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
+    assertEquals(1, events.size());
+    assertEquals(Event.WellKnownTypes.AGENT_CANCELLED, events.getFirst().type());
+  }
+
+  @Test
   void aStaleLegacyRescueWhoseAdHocSessionJustDiedStillReportsTheRescue() throws Exception {
     var shell =
         shell()
@@ -1101,6 +1179,11 @@ class StopOperationsTest {
         null,
         RUN_LOG,
         unit);
+  }
+
+  private void seedReviewRun() {
+    runStore.createReview(
+        R2, "acme", "auth", LOCAL_HANDLE, "codex", "feat/auth", "review", RUN_LOG);
   }
 
   private void seedNewerRun() {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -114,7 +114,7 @@ class TestOperations implements Operations {
 
   @Override
   public Result<StopRunResponse> stopRun(String runId, String localHandle, Actor actor) {
-    return Result.success(new StopRunResponse(runId, false, null, null));
+    return Result.success(new StopRunResponse(runId, false, null, null, false));
   }
 
   @Override
@@ -308,7 +308,7 @@ class TestOperations implements Operations {
   @Override
   public Result<GlobalBoardResponse> globalBoard(String project) {
     return Result.success(
-        new GlobalBoardResponse(new SpecStore.BoardSummary(0, 0, 0, 0, 0, 0, 0, null), 0));
+        new GlobalBoardResponse(new SpecStore.BoardSummary(0, 0, 0, 0, 0, 0, 0, 0, null), 0));
   }
 
   @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SpecListCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SpecListCommandTest.java
@@ -275,6 +275,25 @@ class SpecListCommandTest {
     assertTrue(output.contains("(unassigned)"));
   }
 
+  @Test
+  void listRendersCancelledSpecs() {
+    var output =
+        render(
+            List.of(
+                Map.of(
+                    "project",
+                    "sail",
+                    "status",
+                    "cancelled",
+                    "id",
+                    "sail-clean-stop",
+                    "title",
+                    "Clean stop")));
+
+    assertTrue(output.contains("Cancelled (1)"));
+    assertTrue(output.contains("sail-clean-stop"));
+  }
+
   private static String render(List<Map<String, Object>> specs) {
     var captured = new ByteArrayOutputStream();
     var original = System.out;


### PR DESCRIPTION
## Why

There was no clean way to stop a dispatched agent. `sail agent stop` (CLI) and `POST /v1/runs/{id}/stop` (API) were two separate lanes that both just killed the process — no intent, no terminal state. The moment the agent died, the rescue machinery did exactly what it is designed to do: the watcher/`MissedStopReconciler` replayed the stop and the pipeline "let review judge the work" — **a killed agent fired a review a minute later.** The operator's intent existed nowhere in the system, and a stop did not sync, so peers kept trying to reconcile a spec the operator had abandoned.

## The single lane

`StopOperations` is now the sole performer of a clean stop — a peer of `DispatchOperations`, built the same way: the procedure is identical on every lane, and only the seams that differ are injected (`EventSink` for events, `AgentHalter` for the kill, `Listener` for operator-facing output). Both callers delegate to it and add nothing but rendering:

- `sail agent stop [project]` → `StopOperations.stop(ProjectTarget, …)`
- `POST /v1/runs/{id}/stop` → `SailOperations.stopRun` → `StopOperations.stop(RunTarget, …)`

The duplicated kill logic in `AgentStopCommand` and `SailOperations.stopRunValue` is deleted. `stop` returns a sealed `Outcome` (`Stopped` / `NotRunning` / `AlreadyTerminal` / `NotActive`) that each lane renders — text/JSON for the CLI, `StopRunResponse` for the API — with no branching duplicated.

## Record intent first, kill second

The order is the whole point. Before the process is signalled, the lane writes the terminal intent: spec → `cancelled`, run → `stopped` (no exit code), plus one `agent_cancelled` event carrying `source=operator` and the acting FDE. Because the terminal state exists before the kill, every existing guard makes the cancel win the race with the watcher's own stop — with **zero changes** to `RunTracker`, `ReviewPipelineController`, `MissedStopReconciler`, or dispatch:

- `RunTracker.completeOrRecord` only stamps a run still `running` → the watcher's later stop can't undo the cancel (it only records the exit code as evidence).
- `ReviewPipelineController` only acts when `reviewable(status)` → a `cancelled` spec never kicks a review.
- `MissedStopReconciler` sweeps only `in_progress`/`review` → a cancel is never reconciled or replayed.
- Dispatch selects only `pending` → an autonomous loop can't re-dispatch what the operator just stopped.

## The terminal `CANCELLED` status

`CANCELLED` joins the vocabulary as a terminal status, deliberately outside every set the machinery acts on — the KISS win: the stop is honored by *respecting* existing contracts, not by teaching each component a new special case. Re-running a cancelled spec is an explicit operator re-open (dispatch `--restart`), never automatic.

Rejected alternatives: returning to `pending` invites an autonomous loop to re-dispatch the very thing just stopped; reusing `draft` means "never ran" and loses the record; reusing `archived`/`done` misreports the outcome. A distinct terminal state is the honest model.

The SQLite `specs.status` CHECK is widened via a table-rebuild migration (`specs_v3`), the same pattern `awaiting_merge` used. Board/list surfaces render the new status (board count, list label/color, banner icon).

## Cross-box

The cancel is an ordinary spec-status revision and the run an ordinary run revision, so both propagate through the existing sync with no new transport. **`CleanStopNoResumeIT`** (Fleet suite) proves the invariant: dispatch on a node, sync, stop on the executing box, sync the fleet — every box shows `cancelled`, no box holds it `in_progress`/`review`, no review exists anywhere, and a maximally aggressive reconciler pass on every box replays nothing. Teeth verified: reverting the status write makes the IT fail with the exact pre-fix behavior (`expected: <CANCELLED> but was: <IN_PROGRESS>`).

## Edges

- **No live run but `in_progress`:** the lane still cancels the spec (and releases a still-`running` run row) — it is the clean way out of a stranded `in_progress`, not only a process kill.
- **Stale run id / pid mismatch / already terminal:** structured no-op outcomes; never a kill of a different run. Idempotent by construction.
- **Authz:** the acting FDE must be the spec's assignee or an admin — the same `RunPolicy` the run-log routes enforce, now evaluated inside the lane.
- **Ad-hoc sessions** (`sail agent start`, no run/spec): the CLI lane still stops them; there is no intent to record, so the kill is the whole stop.
- CLI keeps `--dry-run` (resolves and probes, writes and signals nothing, prints what it would stop) and `--json`.

## Testing

- `StopOperationsTest` (25 tests): intent-before-kill ordering via an injected halter that captures store state at halt time; idempotence; dead-agent and stranded-spec rescues; pid-mismatch/no-pid no-ops; foreign/404/authz refusals; dry-run; kill/probe failure mapping; the `agent_cancelled` event payload.
- Post-cancel guards asserted in `RunTrackerTest`, `ReviewPipelineControllerTest`, `SpecLifecycleReactorTest`, `MissedStopReconcilerTest`.
- `CleanStopNoResumeIT` fleet IT (above) plus a repeated-stop no-op case.
- `mvn clean verify` green (JaCoCo `api.*` 100% line/method for the new `StopOperations`, spotless); full fleet IT suite green under `-Pintegration -Dsail.it.requireIncus=false`.
