### PR TITLE
Legacy data migration: establish the 0.14 v1 floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 0.14.0
+
+Version 0.14.0 is the v1 upgrade floor. Upgrade every box in a fleet to 0.14.0 before
+installing a later v1 release.
+
+- Legacy runs, specs, projects, and reviews are carried to the current data shape by `sail
+  migrate`.
+- Legacy build runs without a run-scoped unit are stopped; foreground review runs are unchanged.
+- Synced entities receive content-addressed baseline revisions once.
+- API tokens owned by an FDE now cascade when that FDE is removed.
+- Sync refuses a peer below 0.14.0 before exchanging data.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ curl -fsSL https://raw.githubusercontent.com/standardapplied/sail/main/install.s
 `sail upgrade` replaces the binary in place and converges the database. Linux (amd64) runs
 a full host. macOS (arm64) runs as a thin client that drives a remote host over SSH.
 
+### Upgrade compatibility
+
+Version 0.14.0 is the v1 upgrade floor. Upgrade every main and node box to 0.14.0 before
+installing any later v1 release. A mixed fleet below that floor is refused before sync touches
+data, with an error naming the required version.
+
 ## The model: one main, many nodes
 
 An org runs one main box. It holds the team's specs and project definitions in a SQLite

--- a/sail-core/src/main/java/ai/singlr/sail/store/DataMigrator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/DataMigrator.java
@@ -8,14 +8,20 @@ package ai.singlr.sail.store;
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.ProjectRegistry;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Runs all registered {@link DataMigration}s that haven't been applied yet, tracking each one in
  * the {@code data_migrations} table so re-runs are no-ops. Mirrors {@link SchemaManager}'s
  * versioned-migration discipline but for content rather than schema.
+ *
+ * <p>Each migration claims, applies, and marks inside one {@code BEGIN IMMEDIATE} transaction. The
+ * in-process connection lock cannot serialize separate processes — every sync session converges the
+ * database in its own process — so a deferred check-then-apply lets two first runs both see a
+ * migration as pending and double-apply it, with the loser failing on the marker's primary key
+ * after its partial effects committed. Taking the write lock up front means the loser re-checks the
+ * marker after the winner commits and skips cleanly, and a failing migration rolls back whole:
+ * nested store transactions join this scope, so no partial migration ever persists.
  */
 public final class DataMigrator {
 
@@ -34,25 +40,28 @@ public final class DataMigrator {
 
   /** Applies every migration not yet recorded in {@code data_migrations}. Returns each report. */
   public List<Run> run(ProjectRegistry projects, DataMigration.Prompter prompter) {
-    var applied = appliedNames();
     var runs = new ArrayList<Run>();
     for (var migration : migrations) {
-      if (applied.contains(migration.name())) {
-        runs.add(new Run(migration.name(), true, DataMigration.Report.empty()));
-        continue;
-      }
-      var report = migration.apply(db, projects, prompter);
-      db.execute(
-          "INSERT INTO data_migrations (name, applied_at) VALUES (?, ?)",
-          migration.name(),
-          DateTimeUtils.now().toString());
-      runs.add(new Run(migration.name(), false, report));
+      runs.add(
+          db.immediateTransaction(
+              () -> {
+                if (isApplied(migration.name())) {
+                  return new Run(migration.name(), true, DataMigration.Report.empty());
+                }
+                var report = migration.apply(db, projects, prompter);
+                db.execute(
+                    "INSERT INTO data_migrations (name, applied_at) VALUES (?, ?)",
+                    migration.name(),
+                    DateTimeUtils.now().toString());
+                return new Run(migration.name(), false, report);
+              }));
     }
     return List.copyOf(runs);
   }
 
-  private Set<String> appliedNames() {
-    return new HashSet<>(db.query("SELECT name FROM data_migrations", row -> row.text(0)));
+  private boolean isApplied(String name) {
+    return !db.query("SELECT name FROM data_migrations WHERE name = ?", row -> row.text(0), name)
+        .isEmpty();
   }
 
   /**

--- a/sail-core/src/main/java/ai/singlr/sail/store/LegacyDataMigration.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/LegacyDataMigration.java
@@ -35,7 +35,7 @@ public final class LegacyDataMigration implements DataMigration {
   @Override
   public Report apply(Sqlite db, ProjectRegistry projects, Prompter prompter) {
     var attributed = attributeSpecs(db, projects);
-    var unresolved = nullProjectIds(db);
+    var unresolved = legacyProjectIds(db);
     if (!unresolved.isEmpty()) {
       throw new IllegalStateException(
           "Cannot complete the 0.14.0 migration until these specs have projects: "
@@ -93,16 +93,13 @@ public final class LegacyDataMigration implements DataMigration {
 
   private static int attributeSpecs(Sqlite db, ProjectRegistry projects) {
     var applied = 0;
-    for (var id : nullProjectIds(db)) {
+    var specs = new SpecStore(db);
+    for (var id : legacyProjectIds(db)) {
       var candidates = projectCandidates(db, id, projects);
       if (candidates.size() != 1) {
         continue;
       }
-      db.execute(
-          "UPDATE specs SET project = ? WHERE id = ? AND project IS NULL",
-          candidates.getFirst(),
-          id);
-      applied += db.changes();
+      applied += specs.assignMigrationProject(id, candidates.getFirst()) ? 1 : 0;
     }
     return applied;
   }
@@ -125,8 +122,10 @@ public final class LegacyDataMigration implements DataMigration {
     return List.copyOf(matches);
   }
 
-  private static List<String> nullProjectIds(Sqlite db) {
-    return db.query("SELECT id FROM specs WHERE project IS NULL ORDER BY id", row -> row.text(0));
+  private static List<String> legacyProjectIds(Sqlite db) {
+    return db.query(
+        "SELECT id FROM specs WHERE project IS NULL OR project = 'unassigned' ORDER BY id",
+        row -> row.text(0));
   }
 
   private static String basename(String path) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/LegacyDataMigration.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/LegacyDataMigration.java
@@ -8,7 +8,6 @@ package ai.singlr.sail.store;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.ProjectRegistry;
 import ai.singlr.sail.engine.NodeIdentity;
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.function.Supplier;
@@ -35,8 +34,13 @@ public final class LegacyDataMigration implements DataMigration {
 
   @Override
   public Report apply(Sqlite db, ProjectRegistry projects, Prompter prompter) {
-    var notes = new ArrayList<String>();
-    var attributed = attributeSpecs(db, projects, notes);
+    var attributed = attributeSpecs(db, projects);
+    var unresolved = nullProjectIds(db);
+    if (!unresolved.isEmpty()) {
+      throw new IllegalStateException(
+          "Cannot complete the 0.14.0 migration until these specs have projects: "
+              + String.join(", ", unresolved));
+    }
     var runs = new RunStore(db);
     var stamped = stampRuns(db, runs);
     var terminalized = terminalizeLegacyBuilds(db, runs);
@@ -45,9 +49,7 @@ public final class LegacyDataMigration implements DataMigration {
             + new SpecStore(db).backfillRevisions()
             + new ProjectStore(db).backfillRevisions()
             + new ReviewStore(db).backfillRevisions();
-    var ambiguous = nullProjectIds(db).size();
-    return new Report(
-        attributed + stamped + terminalized + journaled, ambiguous, 0, List.copyOf(notes));
+    return new Report(attributed + stamped + terminalized + journaled, 0, 0, List.of());
   }
 
   private int stampRuns(Sqlite db, RunStore runs) {
@@ -76,6 +78,7 @@ public final class LegacyDataMigration implements DataMigration {
             """
             SELECT id, status FROM runs
             WHERE role = 'build' AND COALESCE(unit, '') = ''
+                AND repos IS NULL
                 AND status IN ('running', 'stopping')
             ORDER BY id""",
             row -> new LegacyRun(row.text(0), row.text(1)));
@@ -88,7 +91,7 @@ public final class LegacyDataMigration implements DataMigration {
     return changed;
   }
 
-  private static int attributeSpecs(Sqlite db, ProjectRegistry projects, List<String> notes) {
+  private static int attributeSpecs(Sqlite db, ProjectRegistry projects) {
     var applied = 0;
     for (var id : nullProjectIds(db)) {
       var candidates = projectCandidates(db, id, projects);
@@ -100,15 +103,6 @@ public final class LegacyDataMigration implements DataMigration {
           candidates.getFirst(),
           id);
       applied += db.changes();
-    }
-    var unresolved = nullProjectIds(db);
-    if (!unresolved.isEmpty()) {
-      notes.add(
-          "  ! "
-              + unresolved.size()
-              + " spec(s) still have no project: "
-              + String.join(", ", unresolved)
-              + ". Assign each explicitly with 'sail spec edit <id> --project <name>'.");
     }
     return applied;
   }

--- a/sail-core/src/main/java/ai/singlr/sail/store/LegacyDataMigration.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/LegacyDataMigration.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.ProjectRegistry;
+import ai.singlr.sail.engine.NodeIdentity;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.function.Supplier;
+
+/** Carries every pre-0.14 row to the v1 data floor exactly once. */
+public final class LegacyDataMigration implements DataMigration {
+
+  public static final String NAME = "legacy-data-floor-0.14.0";
+
+  private final Supplier<String> nodeHandle;
+
+  public LegacyDataMigration() {
+    this(NodeIdentity::handle);
+  }
+
+  LegacyDataMigration(Supplier<String> nodeHandle) {
+    this.nodeHandle = nodeHandle;
+  }
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public Report apply(Sqlite db, ProjectRegistry projects, Prompter prompter) {
+    var notes = new ArrayList<String>();
+    var attributed = attributeSpecs(db, projects, notes);
+    var runs = new RunStore(db);
+    var stamped = stampRuns(db, runs);
+    var terminalized = terminalizeLegacyBuilds(db, runs);
+    var journaled =
+        runs.backfillRevisions()
+            + new SpecStore(db).backfillRevisions()
+            + new ProjectStore(db).backfillRevisions()
+            + new ReviewStore(db).backfillRevisions();
+    var ambiguous = nullProjectIds(db).size();
+    return new Report(
+        attributed + stamped + terminalized + journaled, ambiguous, 0, List.copyOf(notes));
+  }
+
+  private int stampRuns(Sqlite db, RunStore runs) {
+    var ids =
+        db.query(
+            "SELECT id FROM runs WHERE node IS NULL OR node = '' ORDER BY id", row -> row.text(0));
+    if (ids.isEmpty()) {
+      return 0;
+    }
+    var handle = nodeHandle.get();
+    if (Strings.isBlank(handle)) {
+      throw new IllegalStateException(
+          "The 0.14.0 migration cannot attribute "
+              + ids.size()
+              + " legacy run(s) without this box's FDE handle: "
+              + String.join(", ", ids)
+              + ". Set it with 'sail host config set sync-handle <handle>', then rerun"
+              + " 'sail migrate'.");
+    }
+    return runs.backfillNode(handle);
+  }
+
+  private static int terminalizeLegacyBuilds(Sqlite db, RunStore runs) {
+    var active =
+        db.query(
+            """
+            SELECT id, status FROM runs
+            WHERE role = 'build' AND COALESCE(unit, '') = ''
+                AND status IN ('running', 'stopping')
+            ORDER BY id""",
+            row -> new LegacyRun(row.text(0), row.text(1)));
+    var changed = 0;
+    for (var run : active) {
+      if (runs.transition(run.id(), run.status(), "stopped")) {
+        changed++;
+      }
+    }
+    return changed;
+  }
+
+  private static int attributeSpecs(Sqlite db, ProjectRegistry projects, List<String> notes) {
+    var applied = 0;
+    for (var id : nullProjectIds(db)) {
+      var candidates = projectCandidates(db, id, projects);
+      if (candidates.size() != 1) {
+        continue;
+      }
+      db.execute(
+          "UPDATE specs SET project = ? WHERE id = ? AND project IS NULL",
+          candidates.getFirst(),
+          id);
+      applied += db.changes();
+    }
+    var unresolved = nullProjectIds(db);
+    if (!unresolved.isEmpty()) {
+      notes.add(
+          "  ! "
+              + unresolved.size()
+              + " spec(s) still have no project: "
+              + String.join(", ", unresolved)
+              + ". Assign each explicitly with 'sail spec edit <id> --project <name>'.");
+    }
+    return applied;
+  }
+
+  private static List<String> projectCandidates(
+      Sqlite db, String specId, ProjectRegistry projects) {
+    if (projects.names().size() == 1) {
+      return projects.names();
+    }
+    var matches = new LinkedHashSet<String>();
+    var repos =
+        db.query(
+            "SELECT repo FROM spec_repos WHERE spec_id = ? ORDER BY repo",
+            row -> row.text(0),
+            specId);
+    for (var repo : repos) {
+      matches.addAll(projects.projectsContainingRepo(repo));
+      matches.addAll(projects.projectsContainingRepo(basename(repo)));
+    }
+    return List.copyOf(matches);
+  }
+
+  private static List<String> nullProjectIds(Sqlite db) {
+    return db.query("SELECT id FROM specs WHERE project IS NULL ORDER BY id", row -> row.text(0));
+  }
+
+  private static String basename(String path) {
+    var separator = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+    return separator < 0 ? path : path.substring(separator + 1);
+  }
+
+  private record LegacyRun(String id, String status) {}
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -461,7 +461,65 @@ public final class SchemaManager {
           "DROP TABLE runs",
           "ALTER TABLE runs_v2 RENAME TO runs",
           "CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project)",
-          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)");
+          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)",
+          "UPDATE runs SET role = 'build' WHERE role IS NULL",
+          """
+          CREATE TABLE runs_v3 (
+              id TEXT PRIMARY KEY,
+              project TEXT NOT NULL,
+              spec_id TEXT,
+              agent TEXT NOT NULL,
+              branch TEXT,
+              task TEXT,
+              pid INTEGER,
+              status TEXT NOT NULL DEFAULT 'running'
+                  CHECK (status IN ('running', 'stopping', 'completed', 'stopped', 'failed')),
+              started_at TEXT NOT NULL,
+              completed_at TEXT,
+              exit_code INTEGER,
+              watcher_pid INTEGER,
+              node TEXT,
+              role TEXT NOT NULL DEFAULT 'build'
+                  CHECK (role IN ('build', 'review')),
+              log_path TEXT,
+              rev TEXT,
+              base_rev TEXT,
+              unit TEXT,
+              repos TEXT
+          )""",
+          """
+          INSERT INTO runs_v3 (id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos)
+              SELECT id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos FROM runs""",
+          "DROP TABLE runs",
+          "ALTER TABLE runs_v3 RENAME TO runs",
+          "CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project)",
+          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)",
+          """
+          UPDATE api_tokens SET fde_id = NULL
+          WHERE fde_id IS NOT NULL
+              AND NOT EXISTS (SELECT 1 FROM fdes WHERE fdes.id = api_tokens.fde_id)""",
+          """
+          CREATE TABLE api_tokens_v2 (
+              token_hash TEXT PRIMARY KEY,
+              name TEXT NOT NULL UNIQUE,
+              role TEXT NOT NULL DEFAULT 'member'
+                  CHECK (role IN ('admin', 'member', 'viewer')),
+              fde_id TEXT REFERENCES fdes(id) ON DELETE CASCADE,
+              created_at TEXT NOT NULL,
+              last_used_at TEXT,
+              expires_at TEXT
+          )""",
+          """
+          INSERT INTO api_tokens_v2
+                  (token_hash, name, role, fde_id, created_at, last_used_at, expires_at)
+              SELECT token_hash, name, role, fde_id, created_at, last_used_at, expires_at
+              FROM api_tokens""",
+          "DROP TABLE api_tokens",
+          "ALTER TABLE api_tokens_v2 RENAME TO api_tokens");
 
   /**
    * The last schema version whose {@code specs.status} CHECK predates {@code awaiting_merge}. The
@@ -471,6 +529,8 @@ public final class SchemaManager {
    * children's {@code ON DELETE CASCADE} and wipe spec content, repos, and dependencies.
    */
   static final int LAST_VERSION_WITH_NARROW_STATUS_CHECK = versionBefore("CREATE TABLE specs_v2");
+
+  static final int LAST_VERSION_BEFORE_V1_FLOOR = versionBefore("UPDATE runs SET role");
 
   private static int versionBefore(String statementPrefix) {
     for (var i = 0; i < MIGRATIONS.size(); i++) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -499,7 +499,7 @@ public final class SchemaManager {
           "CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project)",
           "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)",
           """
-          UPDATE api_tokens SET fde_id = NULL
+          DELETE FROM api_tokens
           WHERE fde_id IS NOT NULL
               AND NOT EXISTS (SELECT 1 FROM fdes WHERE fdes.id = api_tokens.fde_id)""",
           """

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -462,6 +462,40 @@ public final class SchemaManager {
           "ALTER TABLE runs_v2 RENAME TO runs",
           "CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project)",
           "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)",
+          "UPDATE specs SET project = 'unassigned' WHERE project IS NULL",
+          """
+          CREATE TABLE specs_v4 (
+              id TEXT PRIMARY KEY,
+              title TEXT NOT NULL,
+              status TEXT NOT NULL DEFAULT 'draft'
+                  CHECK (status IN ('draft', 'pending', 'in_progress', 'review', 'awaiting_merge',
+                      'done', 'cancelled', 'archived')),
+              assignee TEXT,
+              agent TEXT,
+              model TEXT,
+              reasoning_effort TEXT
+                  CHECK (reasoning_effort IS NULL OR reasoning_effort IN
+                      ('none', 'low', 'medium', 'high', 'xhigh')),
+              branch TEXT,
+              priority INTEGER NOT NULL DEFAULT 0,
+              created_by TEXT,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              project TEXT NOT NULL DEFAULT 'unassigned',
+              updated_by TEXT,
+              rev TEXT,
+              base_rev TEXT
+          )""",
+          """
+          INSERT INTO specs_v4 (id, title, status, assignee, agent, model, reasoning_effort,
+                  branch, priority, created_by, created_at, updated_at, project, updated_by,
+                  rev, base_rev)
+              SELECT id, title, status, assignee, agent, model, reasoning_effort,
+                  branch, priority, created_by, created_at, updated_at, project, updated_by,
+                  rev, base_rev FROM specs""",
+          "DROP TABLE specs",
+          "ALTER TABLE specs_v4 RENAME TO specs",
+          "CREATE INDEX IF NOT EXISTS idx_specs_project ON specs(project)",
           "UPDATE runs SET role = 'build' WHERE role IS NULL",
           """
           CREATE TABLE runs_v3 (
@@ -530,7 +564,8 @@ public final class SchemaManager {
    */
   static final int LAST_VERSION_WITH_NARROW_STATUS_CHECK = versionBefore("CREATE TABLE specs_v2");
 
-  static final int LAST_VERSION_BEFORE_V1_FLOOR = versionBefore("UPDATE runs SET role");
+  static final int LAST_VERSION_BEFORE_V1_FLOOR =
+      versionBefore("UPDATE specs SET project = 'unassigned'");
 
   private static int versionBefore(String statementPrefix) {
     for (var i = 0; i < MIGRATIONS.size(); i++) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -611,6 +611,24 @@ public final class SpecStore implements ConflictResolver {
             ENTITY));
   }
 
+  /** Attributes a legacy spec and journals its new snapshot in the same transaction. */
+  public boolean assignMigrationProject(String id, String project) {
+    return db.transaction(
+        () -> {
+          db.execute(
+              """
+              UPDATE specs SET project = ?
+              WHERE id = ? AND (project IS NULL OR project = 'unassigned')""",
+              project,
+              id);
+          if (db.changes() == 0) {
+            return false;
+          }
+          recordRevision(id, "migration", false);
+          return true;
+        });
+  }
+
   /**
    * Records a baseline revision for every spec that has none yet. A spec written before this store
    * journaled its mutations has a row in {@code specs} but no change-log entry, so it is invisible

--- a/sail-core/src/main/java/ai/singlr/sail/sync/RemoteMainReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/RemoteMainReplica.java
@@ -89,6 +89,12 @@ public final class RemoteMainReplica implements MainReplica {
       if (!(response instanceof SyncWire.Fetched f)) {
         throw new SyncTransportException("Expected a fetch response, got: " + response);
       }
+      if (!SyncWire.V1_UPGRADE_FLOOR.equals(f.upgradeFloor())) {
+        throw new SyncTransportException(
+            "Sync requires Sail "
+                + SyncWire.V1_UPGRADE_FLOOR
+                + " or newer on every box. Run 'sail upgrade' on main, then sync again.");
+      }
       fetched = f;
       maxSeq = f.maxSeq();
     }

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncDatabase.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncDatabase.java
@@ -5,9 +5,12 @@
 
 package ai.singlr.sail.sync;
 
-import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.DataMigration;
+import ai.singlr.sail.store.LegacyDataMigration;
+import ai.singlr.sail.store.MigrationRunner;
 import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * The only database handle a sync path may run on: constructing one converges the schema, so a sync
@@ -34,7 +37,8 @@ public final class SyncDatabase implements AutoCloseable {
   public static SyncDatabase converge(Path dbPath, String box) {
     var db = Sqlite.open(dbPath);
     try {
-      new SchemaManager(db).migrate();
+      MigrationRunner.applyAll(
+          db, List.of(new LegacyDataMigration()), DataMigration.Prompter.NON_INTERACTIVE);
     } catch (RuntimeException e) {
       db.close();
       throw new IllegalStateException(

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
@@ -75,7 +75,7 @@ public final class SyncRpcServer {
   private SyncWire.Response respondTo(SyncWire.Request request) {
     try {
       return switch (request) {
-        case SyncWire.Fetch fetch -> fetched(fetch.entityType());
+        case SyncWire.Fetch fetch -> fetched(fetch.entityType(), fetch.upgradeFloor());
         case SyncWire.FetchFdes ignored -> new SyncWire.Fdes(fdeRoster.entries());
         case SyncWire.Commit commit -> onCommit(commit);
         case SyncWire.Bye ignored -> throw new IllegalStateException("Bye ends the session loop");
@@ -102,7 +102,13 @@ public final class SyncRpcServer {
     out.flush();
   }
 
-  private SyncWire.Response fetched(String entityType) {
+  private SyncWire.Response fetched(String entityType, String upgradeFloor) {
+    if (!SyncWire.V1_UPGRADE_FLOOR.equals(upgradeFloor)) {
+      return new SyncWire.Failed(
+          "Sync requires Sail "
+              + SyncWire.V1_UPGRADE_FLOOR
+              + " or newer on every box. Run 'sail upgrade' on this node, then sync again.");
+    }
     var main = replicas.get(entityType);
     if (main == null) {
       return new SyncWire.Failed("Unknown entity type: " + entityType);

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncRpcServer.java
@@ -14,14 +14,15 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Main's side of one sync session: a stateless request loop over the SSH channel's stdio. It routes
- * each {@link SyncWire.Fetch}/{@link SyncWire.Commit} to the authoritative {@link MainReplica} for
- * its entity type (specs, files), serves the node's roster pull, and returns at {@link
- * SyncWire.Bye} or end of stream. The {@link SyncPrincipal} carries the push half of Door-2
- * authorization: a {@code viewer} opens a session and pulls every type, but its commits are refused
- * so only {@code member}+ work propagates. The principal's handle additionally binds run commits to
- * execution provenance — a session may create, update, or delete only runs stamped with its own
- * node, so no member can forge run metadata another box would treat as its own execution.
+ * Main's side of one sync session: a request loop over the SSH channel's stdio. It verifies the
+ * peer's upgrade floor before serving data, routes each {@link SyncWire.Fetch}/{@link
+ * SyncWire.Commit} to the authoritative {@link MainReplica} for its entity type (specs, files),
+ * serves the node's roster pull, and returns at {@link SyncWire.Bye} or end of stream. The {@link
+ * SyncPrincipal} carries the push half of Door-2 authorization: a {@code viewer} opens a session
+ * and pulls every type, but its commits are refused so only {@code member}+ work propagates. The
+ * principal's handle additionally binds run commits to execution provenance — a session may create,
+ * update, or delete only runs stamped with its own node, so no member can forge run metadata
+ * another box would treat as its own execution.
  */
 public final class SyncRpcServer {
 
@@ -31,6 +32,7 @@ public final class SyncRpcServer {
   private final SyncPrincipal principal;
   private final FdeRoster fdeRoster;
   private final SyncTransitionSink transitionSink;
+  private boolean upgradeFloorVerified;
 
   public SyncRpcServer(MainReplica main, boolean writable) {
     this(Map.of("spec", main), new SyncPrincipal(null, writable), FdeRoster.EMPTY);
@@ -57,6 +59,7 @@ public final class SyncRpcServer {
   }
 
   public void serve(Reader in, Writer out) throws IOException {
+    upgradeFloorVerified = false;
     for (var line = SyncWire.readFramed(in); line != null; line = SyncWire.readFramed(in)) {
       var request = SyncWire.decodeRequest(line);
       if (request instanceof SyncWire.Bye) {
@@ -75,9 +78,16 @@ public final class SyncRpcServer {
   private SyncWire.Response respondTo(SyncWire.Request request) {
     try {
       return switch (request) {
-        case SyncWire.Fetch fetch -> fetched(fetch.entityType(), fetch.upgradeFloor());
-        case SyncWire.FetchFdes ignored -> new SyncWire.Fdes(fdeRoster.entries());
-        case SyncWire.Commit commit -> onCommit(commit);
+        case SyncWire.Fetch fetch -> {
+          if (!SyncWire.V1_UPGRADE_FLOOR.equals(fetch.upgradeFloor())) {
+            yield incompatiblePeer();
+          }
+          upgradeFloorVerified = true;
+          yield fetched(fetch.entityType());
+        }
+        case SyncWire.FetchFdes ignored ->
+            upgradeFloorVerified ? new SyncWire.Fdes(fdeRoster.entries()) : incompatiblePeer();
+        case SyncWire.Commit commit -> upgradeFloorVerified ? onCommit(commit) : incompatiblePeer();
         case SyncWire.Bye ignored -> throw new IllegalStateException("Bye ends the session loop");
       };
     } catch (RuntimeException e) {
@@ -102,13 +112,14 @@ public final class SyncRpcServer {
     out.flush();
   }
 
-  private SyncWire.Response fetched(String entityType, String upgradeFloor) {
-    if (!SyncWire.V1_UPGRADE_FLOOR.equals(upgradeFloor)) {
-      return new SyncWire.Failed(
-          "Sync requires Sail "
-              + SyncWire.V1_UPGRADE_FLOOR
-              + " or newer on every box. Run 'sail upgrade' on this node, then sync again.");
-    }
+  private static SyncWire.Failed incompatiblePeer() {
+    return new SyncWire.Failed(
+        "Sync requires Sail "
+            + SyncWire.V1_UPGRADE_FLOOR
+            + " or newer on every box. Run 'sail upgrade' on this node, then sync again.");
+  }
+
+  private SyncWire.Response fetched(String entityType) {
     var main = replicas.get(entityType);
     if (main == null) {
       return new SyncWire.Failed("Unknown entity type: " + entityType);

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncWire.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncWire.java
@@ -35,12 +35,15 @@ public final class SyncWire {
   private static final String EXPECTED = "expectedRev";
   private static final String STALE = "stale";
   private static final String ENTITY_TYPE = "entityType";
+  private static final String UPGRADE_FLOOR = "upgradeFloor";
 
   private static final String OP_FETCH = "fetch";
   private static final String OP_COMMIT = "commit";
   private static final String OP_BYE = "bye";
   private static final String OP_FETCH_FDES = "fetch-fdes";
   private static final String FDES = "fdes";
+
+  public static final String V1_UPGRADE_FLOOR = "0.14.0";
 
   /**
    * Hard ceiling on one framed message, bounding the memory a single read can claim. A sync message
@@ -79,7 +82,11 @@ public final class SyncWire {
   /**
    * Ask main for its whole shared state of one entity type — specs, files — to reconcile against.
    */
-  public record Fetch(String entityType) implements Request {}
+  public record Fetch(String entityType, String upgradeFloor) implements Request {
+    public Fetch(String entityType) {
+      this(entityType, V1_UPGRADE_FLOOR);
+    }
+  }
 
   /** Ask main for its FDE roster, which the node mirrors (main-authoritative, one-way). */
   public record FetchFdes() implements Request {}
@@ -104,8 +111,13 @@ public final class SyncWire {
   public record Snapshot(String rev, Map<String, Object> snapshot) {}
 
   /** Main's answer to {@link Fetch}: its identity, high-water sequence, and every shared entity. */
-  public record Fetched(String mainId, long maxSeq, Map<String, Snapshot> entities)
-      implements Response {}
+  public record Fetched(
+      String mainId, long maxSeq, Map<String, Snapshot> entities, String upgradeFloor)
+      implements Response {
+    public Fetched(String mainId, long maxSeq, Map<String, Snapshot> entities) {
+      this(mainId, maxSeq, entities, V1_UPGRADE_FLOOR);
+    }
+  }
 
   /** Main accepted a {@link Commit}: the minted rev and main's new high-water sequence. */
   public record Committed(String rev, long maxSeq) implements Response {}
@@ -123,6 +135,7 @@ public final class SyncWire {
       case Fetch fetch -> {
         map.put(OP, OP_FETCH);
         map.put(ENTITY_TYPE, fetch.entityType());
+        map.put(UPGRADE_FLOOR, fetch.upgradeFloor());
       }
       case Commit commit -> {
         map.put(OP, OP_COMMIT);
@@ -143,6 +156,7 @@ public final class SyncWire {
       case Fetched fetched -> {
         map.put(ID, fetched.mainId());
         map.put(MAX_SEQ, fetched.maxSeq());
+        map.put(UPGRADE_FLOOR, fetched.upgradeFloor());
         var entities = new LinkedHashMap<String, Object>();
         fetched
             .entities()
@@ -174,7 +188,7 @@ public final class SyncWire {
     var map = YamlUtil.parseMap(line);
     var op = string(map, OP);
     return switch (op) {
-      case OP_FETCH -> new Fetch(string(map, ENTITY_TYPE));
+      case OP_FETCH -> new Fetch(string(map, ENTITY_TYPE), string(map, UPGRADE_FLOOR));
       case OP_COMMIT ->
           new Commit(
               string(map, ENTITY_TYPE),
@@ -199,7 +213,8 @@ public final class SyncWire {
       return new Fdes(fdeList(map));
     }
     if (map.containsKey(ENTITIES)) {
-      return new Fetched(string(map, ID), longValue(map, MAX_SEQ), entities(map));
+      return new Fetched(
+          string(map, ID), longValue(map, MAX_SEQ), entities(map), string(map, UPGRADE_FLOOR));
     }
     if (map.containsKey(REV)) {
       return new Committed(string(map, REV), longValue(map, MAX_SEQ));

--- a/sail-core/src/test/java/ai/singlr/sail/store/DataMigratorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/DataMigratorTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ai.singlr.sail.config.ProjectRegistry;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DataMigratorTest {
+
+  @TempDir Path tempDir;
+  private Path dbPath;
+  private Sqlite db;
+  private ProjectRegistry projects;
+
+  @BeforeEach
+  void setUp() {
+    dbPath = tempDir.resolve("migrator.db");
+    db = Sqlite.open(dbPath);
+    new SchemaManager(db).migrate();
+    db.execute("CREATE TABLE probe (id TEXT PRIMARY KEY)");
+    projects = ProjectRegistry.loadFromDisk(tempDir.resolve("projects"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) {
+      db.close();
+    }
+  }
+
+  @Test
+  void failingMigrationRollsBackEveryEffectIncludingNestedTransactions() {
+    var migrator = new DataMigrator(db, List.of(probeMigration("half-done", true)));
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> migrator.run(projects, DataMigration.Prompter.NON_INTERACTIVE));
+
+    assertEquals(0, probeCount(db));
+    assertEquals(List.of(), appliedNames(db));
+  }
+
+  @Test
+  void concurrentFirstRunsFromTwoConnectionsApplyExactlyOnce() throws Exception {
+    var start = new CountDownLatch(1);
+    try (var other = Sqlite.open(dbPath);
+        var pool = Executors.newFixedThreadPool(2)) {
+      var first = pool.submit(() -> racingRun(db, start));
+      var second = pool.submit(() -> racingRun(other, start));
+      start.countDown();
+      var outcomes = List.of(first.get(), second.get());
+
+      assertEquals(1, outcomes.stream().filter(run -> !run.alreadyApplied()).count());
+      assertEquals(1, outcomes.stream().filter(DataMigrator.Run::alreadyApplied).count());
+    }
+    assertEquals(1, probeCount(db));
+    assertEquals(List.of("racy"), appliedNames(db));
+  }
+
+  private DataMigrator.Run racingRun(Sqlite connection, CountDownLatch start) {
+    try {
+      start.await();
+      return new DataMigrator(connection, List.of(probeMigration("racy", false)))
+          .run(projects, DataMigration.Prompter.NON_INTERACTIVE)
+          .getFirst();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted while racing the migrator", e);
+    }
+  }
+
+  private static DataMigration probeMigration(String name, boolean fail) {
+    return new DataMigration() {
+      @Override
+      public String name() {
+        return name;
+      }
+
+      @Override
+      public Report apply(Sqlite target, ProjectRegistry registry, Prompter prompter) {
+        target.transaction(
+            () -> target.execute("INSERT INTO probe (id) VALUES (?)", "effect-" + name));
+        if (fail) {
+          throw new IllegalStateException("Migration failed after writing");
+        }
+        return new Report(1, 0, 0, List.of());
+      }
+    };
+  }
+
+  private static int probeCount(Sqlite connection) {
+    return connection.query("SELECT id FROM probe", row -> row.text(0)).size();
+  }
+
+  private static List<String> appliedNames(Sqlite connection) {
+    return connection.query("SELECT name FROM data_migrations ORDER BY name", row -> row.text(0));
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/LegacyDataMigrationTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/LegacyDataMigrationTest.java
@@ -78,7 +78,7 @@ class LegacyDataMigrationTest {
                 row -> row.integer(0))
             .orElseThrow());
     assertEquals(
-        1L,
+        0L,
         db.queryOne(
                 """
                 SELECT COUNT(*) FROM api_tokens
@@ -96,23 +96,60 @@ class LegacyDataMigrationTest {
   }
 
   @Test
-  void ambiguousProjectlessSpecsAreNamedAndLeftUntouched() throws Exception {
+  void currentForegroundBuildRetainsItsRepositoryReservation() throws Exception {
+    db.execute(
+        """
+        INSERT INTO runs
+            (id, project, agent, status, started_at, node, role, unit, repos)
+        VALUES
+            ('foreground', 'acme', 'codex', 'running', '2026-01-01',
+                'node-a', 'build', '', '["repo"]')""");
+
+    migrate(projectRegistry("acme"));
+
+    var foreground = new RunStore(db).findById("foreground").orElseThrow();
+    assertEquals("running", foreground.status());
+    assertEquals(List.of("repo"), foreground.repos());
+  }
+
+  @Test
+  void unresolvedProjectlessSpecsAbortBeforeJournalingAndCanBeRetried() throws Exception {
     db.execute(
         """
         INSERT INTO specs (id, title, status, created_at, updated_at, project)
         VALUES ('orphan', 'Orphan', 'pending', '2026-01-01', '2026-01-01', NULL)""");
     var projects = projectRegistry("acme", "beta");
 
-    var run = migrate(projects).getFirst();
+    var failure = assertThrows(IllegalStateException.class, () -> migrate(projects));
 
-    assertEquals(1, run.report().ambiguous());
-    assertTrue(run.report().notes().getFirst().contains("1 spec(s)"));
-    assertTrue(run.report().notes().getFirst().contains("orphan"));
+    assertTrue(failure.getMessage().contains("orphan"));
+    assertEquals(0L, changeLogCount());
+    assertEquals(
+        0L,
+        db.queryOne(
+                "SELECT COUNT(*) FROM data_migrations WHERE name = ?",
+                row -> row.integer(0),
+                LegacyDataMigration.NAME)
+            .orElseThrow());
     assertEquals(
         1L,
         db.queryOne(
                 "SELECT COUNT(*) FROM specs WHERE id = 'orphan' AND project IS NULL",
                 row -> row.integer(0))
+            .orElseThrow());
+
+    db.execute("UPDATE specs SET project = 'acme' WHERE id = 'orphan'");
+
+    var retry = migrate(projects).getFirst();
+
+    assertEquals(1, retry.report().applied());
+    assertEquals(List.of("orphan"), new SpecStore(db).syncEntityIds().stream().sorted().toList());
+    assertEquals(
+        1L,
+        db.queryOne(
+                "SELECT COUNT(*) FROM data_migrations WHERE name = ?",
+                row -> row.integer(0),
+                LegacyDataMigration.NAME)
             .orElseThrow());
   }
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/LegacyDataMigrationTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/LegacyDataMigrationTest.java
@@ -6,7 +6,9 @@
 package ai.singlr.sail.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -70,6 +72,7 @@ class LegacyDataMigrationTest {
             row -> row.text(0)));
 
     assertRoleConstraint();
+    assertProjectConstraint();
     db.execute("DELETE FROM fdes WHERE id = 'fde-1'");
     assertEquals(
         0L,
@@ -134,7 +137,9 @@ class LegacyDataMigrationTest {
     assertEquals(
         1L,
         db.queryOne(
-                "SELECT COUNT(*) FROM specs WHERE id = 'orphan' AND project IS NULL",
+                """
+                SELECT COUNT(*) FROM specs
+                WHERE id = 'orphan' AND project = 'unassigned'""",
                 row -> row.integer(0))
             .orElseThrow());
 
@@ -151,6 +156,29 @@ class LegacyDataMigrationTest {
                 row -> row.integer(0),
                 LegacyDataMigration.NAME)
             .orElseThrow());
+  }
+
+  @Test
+  void attributingAnAlreadyJournaledSpecMintsARevisionForTheNewSnapshot() throws Exception {
+    db.execute(
+        """
+        INSERT INTO specs (id, title, status, created_at, updated_at, project)
+        VALUES ('shared', 'Shared', 'pending', '2026-01-01', '2026-01-01', NULL)""");
+    var legacyStore = new SpecStore(db);
+    assertEquals(1, legacyStore.backfillRevisions());
+    var legacyRev = legacyStore.latestRev("shared");
+    assertNull(legacyStore.comparableAtRev("shared", legacyRev).get("project"));
+
+    migrate(projectRegistry("acme"));
+
+    var migratedStore = new SpecStore(db);
+    var migratedRev = migratedStore.latestRev("shared");
+    assertNotEquals(legacyRev, migratedRev);
+    assertEquals("acme", migratedStore.comparableAtRev("shared", migratedRev).get("project"));
+    assertNull(migratedStore.comparableAtRev("shared", legacyRev).get("project"));
+    assertEquals(
+        List.of("local", "migration"),
+        new ChangeLog(db).history("spec", "shared").stream().map(ChangeLog.Entry::origin).toList());
   }
 
   @Test
@@ -232,6 +260,18 @@ class LegacyDataMigrationTest {
                 """
                 INSERT INTO runs (id, project, agent, status, started_at, role)
                 VALUES ('bad-role', 'acme', 'codex', 'running', '2026-01-01', 'other')"""));
+  }
+
+  private void assertProjectConstraint() {
+    var notNull =
+        db.queryOne(
+                "SELECT \"notnull\" FROM pragma_table_info('specs') WHERE name = 'project'",
+                row -> row.integer(0))
+            .orElseThrow();
+    assertEquals(1L, notNull);
+    assertThrows(
+        SqliteException.class,
+        () -> db.execute("UPDATE specs SET project = NULL WHERE id = 'legacy-spec'"));
   }
 
   private long changeLogCount() {

--- a/sail-core/src/test/java/ai/singlr/sail/store/LegacyDataMigrationTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/LegacyDataMigrationTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.ProjectRegistry;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LegacyDataMigrationTest {
+
+  @TempDir Path tempDir;
+  private Path dbPath;
+  private Sqlite db;
+
+  @BeforeEach
+  void setUp() {
+    dbPath = tempDir.resolve("legacy.db");
+    db = Sqlite.open(dbPath);
+    stageLegacySchema();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) {
+      db.close();
+    }
+  }
+
+  @Test
+  void migrationCarriesEveryLegacyShapeForwardOnce() throws Exception {
+    seedLegacyRows();
+    var projects = projectRegistry("acme");
+
+    var first = migrate(projects);
+
+    var build = new RunStore(db).findById("legacy-build").orElseThrow();
+    assertEquals("build", build.role());
+    assertEquals("stopped", build.status());
+    assertNotNull(build.completedAt());
+    assertEquals("node-a", build.node());
+    assertTrue(new RunStore(db).runningForProjectOnNode("acme", "node-a").isEmpty());
+
+    var review = new RunStore(db).findById("review-run").orElseThrow();
+    assertEquals("review", review.role());
+    assertEquals("running", review.status());
+    assertEquals("", review.unit());
+
+    assertEquals(
+        "acme",
+        db.queryOne("SELECT project FROM specs WHERE id = 'legacy-spec'", row -> row.text(0))
+            .orElseThrow());
+    assertEquals(0, first.getFirst().report().ambiguous());
+    assertEquals(
+        List.of("project", "review", "run", "spec"),
+        db.query(
+            "SELECT DISTINCT entity_type FROM change_log ORDER BY entity_type",
+            row -> row.text(0)));
+
+    assertRoleConstraint();
+    db.execute("DELETE FROM fdes WHERE id = 'fde-1'");
+    assertEquals(
+        0L,
+        db.queryOne(
+                "SELECT COUNT(*) FROM api_tokens WHERE token_hash = 'token-1'",
+                row -> row.integer(0))
+            .orElseThrow());
+    assertEquals(
+        1L,
+        db.queryOne(
+                """
+                SELECT COUNT(*) FROM api_tokens
+                WHERE token_hash = 'orphan-token' AND fde_id IS NULL""",
+                row -> row.integer(0))
+            .orElseThrow());
+
+    var revisions = changeLogCount();
+    var second =
+        new DataMigrator(db, List.of(new LegacyDataMigration(() -> "node-a")))
+            .run(projects, DataMigration.Prompter.NON_INTERACTIVE);
+
+    assertTrue(second.getFirst().alreadyApplied());
+    assertEquals(revisions, changeLogCount());
+  }
+
+  @Test
+  void ambiguousProjectlessSpecsAreNamedAndLeftUntouched() throws Exception {
+    db.execute(
+        """
+        INSERT INTO specs (id, title, status, created_at, updated_at, project)
+        VALUES ('orphan', 'Orphan', 'pending', '2026-01-01', '2026-01-01', NULL)""");
+    var projects = projectRegistry("acme", "beta");
+
+    var run = migrate(projects).getFirst();
+
+    assertEquals(1, run.report().ambiguous());
+    assertTrue(run.report().notes().getFirst().contains("1 spec(s)"));
+    assertTrue(run.report().notes().getFirst().contains("orphan"));
+    assertEquals(
+        1L,
+        db.queryOne(
+                "SELECT COUNT(*) FROM specs WHERE id = 'orphan' AND project IS NULL",
+                row -> row.integer(0))
+            .orElseThrow());
+  }
+
+  @Test
+  void twoBoxesBackfillTheSameContentAddressedSpecRevision() throws Exception {
+    db.execute(
+        """
+        INSERT INTO specs (id, title, status, created_at, updated_at, project)
+        VALUES ('shared', 'Shared', 'pending', '2026-01-01', '2026-01-01', NULL)""");
+    var projects = projectRegistry("acme");
+    migrate(projects);
+    var firstRev = new SpecStore(db).latestRev("shared");
+
+    var otherPath = tempDir.resolve("other.db");
+    stageLegacySchema(Sqlite.open(otherPath));
+    try (var other = Sqlite.open(otherPath)) {
+      other.execute(
+          """
+          INSERT INTO specs (id, title, status, created_at, updated_at, project)
+          VALUES ('shared', 'Shared', 'pending', '2026-01-01', '2026-01-01', NULL)""");
+      new SchemaManager(other).migrate();
+      new DataMigrator(other, List.of(new LegacyDataMigration(() -> "node-b")))
+          .run(projects, DataMigration.Prompter.NON_INTERACTIVE);
+
+      assertEquals(firstRev, new SpecStore(other).latestRev("shared"));
+    }
+  }
+
+  private List<DataMigrator.Run> migrate(ProjectRegistry projects) {
+    new SchemaManager(db).migrate();
+    return new DataMigrator(db, List.of(new LegacyDataMigration(() -> "node-a")))
+        .run(projects, DataMigration.Prompter.NON_INTERACTIVE);
+  }
+
+  private void seedLegacyRows() {
+    db.execute(
+        """
+        INSERT INTO specs (id, title, status, created_at, updated_at, project)
+        VALUES ('legacy-spec', 'Legacy', 'in_progress', '2026-01-01', '2026-01-01', NULL)""");
+    db.execute(
+        """
+        INSERT INTO projects (name, definition, created_at, updated_at)
+        VALUES ('acme', 'name: acme', '2026-01-01', '2026-01-01')""");
+    db.execute(
+        """
+        INSERT INTO reviews (id, spec_id, status, created_at)
+        VALUES ('legacy-review', 'legacy-spec', 'running', '2026-01-01')""");
+    db.execute(
+        """
+        INSERT INTO runs
+            (id, project, spec_id, agent, status, started_at, node, role, unit)
+        VALUES
+            ('legacy-build', 'acme', 'legacy-spec', 'codex', 'running', '2026-01-01',
+                NULL, NULL, ''),
+            ('review-run', 'acme', 'legacy-spec', 'codex', 'running', '2026-01-01',
+                NULL, 'review', '')""");
+    db.execute(
+        """
+        INSERT INTO fdes (id, handle, status, created_at)
+        VALUES ('fde-1', 'ada', 'active', '2026-01-01')""");
+    db.execute(
+        """
+        INSERT INTO api_tokens (token_hash, name, role, fde_id, created_at)
+        VALUES
+            ('token-1', 'legacy', 'member', 'fde-1', '2026-01-01'),
+            ('orphan-token', 'orphan', 'member', 'missing', '2026-01-01')""");
+  }
+
+  private void assertRoleConstraint() {
+    var notNull =
+        db.queryOne(
+                "SELECT \"notnull\" FROM pragma_table_info('runs') WHERE name = 'role'",
+                row -> row.integer(0))
+            .orElseThrow();
+    assertEquals(1L, notNull);
+    assertThrows(
+        SqliteException.class,
+        () ->
+            db.execute(
+                """
+                INSERT INTO runs (id, project, agent, status, started_at, role)
+                VALUES ('bad-role', 'acme', 'codex', 'running', '2026-01-01', 'other')"""));
+  }
+
+  private long changeLogCount() {
+    return db.queryOne("SELECT COUNT(*) FROM change_log", row -> row.integer(0)).orElseThrow();
+  }
+
+  private ProjectRegistry projectRegistry(String... names) throws Exception {
+    var projectsDir = tempDir.resolve("projects-" + String.join("-", names));
+    for (var name : names) {
+      var projectDir = projectsDir.resolve(name);
+      Files.createDirectories(projectDir);
+      Files.writeString(
+          projectDir.resolve("sail.yaml"),
+          "name: "
+              + name
+              + "\nimage: ubuntu/24.04\nresources: { cpu: 2, memory: 4GB, disk: 20GB }\n");
+    }
+    return ProjectRegistry.loadFromDisk(projectsDir);
+  }
+
+  private void stageLegacySchema() {
+    stageLegacySchema(db);
+    db = Sqlite.open(dbPath);
+  }
+
+  private static void stageLegacySchema(Sqlite legacy) {
+    new SchemaManager(legacy).migrateTo(SchemaManager.LAST_VERSION_BEFORE_V1_FLOOR);
+    legacy.execute("PRAGMA writable_schema = ON");
+    legacy.execute(
+        """
+        UPDATE sqlite_schema
+        SET sql = replace(sql,
+            'role TEXT NOT NULL DEFAULT ''build''',
+            'role TEXT DEFAULT ''build''')
+        WHERE type = 'table' AND name = 'runs'""");
+    legacy.execute(
+        """
+        UPDATE sqlite_schema
+        SET sql = replace(sql,
+            'project TEXT NOT NULL DEFAULT ''unassigned''',
+            'project TEXT DEFAULT ''unassigned''')
+        WHERE type = 'table' AND name = 'specs'""");
+    legacy.execute("PRAGMA writable_schema = OFF");
+    legacy.close();
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/SyncSchemaConvergenceTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SyncSchemaConvergenceTest.java
@@ -134,4 +134,34 @@ class SyncSchemaConvergenceTest {
       assertEquals(versionAfterFirst, new SchemaManager(second.db()).currentVersion());
     }
   }
+
+  @Test
+  void aPreFloorLegacyBuildIsTerminalBeforeSyncCanUseTheHandle() {
+    var path = tempDir.resolve("pre-floor.db");
+    try (var legacy = Sqlite.open(path)) {
+      new SchemaManager(legacy).migrateTo(SchemaManager.LAST_VERSION_BEFORE_V1_FLOOR);
+      legacy.execute(
+          """
+          INSERT INTO runs
+              (id, project, spec_id, node, role, agent, status, started_at, unit)
+          VALUES
+              ('legacy', 'acme', 'auth', 'node-a', 'build', 'codex', 'running',
+                  '2026-01-01', '')""");
+    }
+
+    try (var converged = SyncDatabase.converge(path, "node-a")) {
+      var run = new RunStore(converged.db()).findById("legacy").orElseThrow();
+      assertEquals("stopped", run.status());
+      assertTrue(run.completedAt() != null);
+      assertEquals(
+          1L,
+          converged
+              .db()
+              .queryOne(
+                  "SELECT COUNT(*) FROM data_migrations WHERE name = ?",
+                  row -> row.integer(0),
+                  LegacyDataMigration.NAME)
+              .orElseThrow());
+    }
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/sync/RemoteMainReplicaTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/RemoteMainReplicaTest.java
@@ -52,6 +52,17 @@ class RemoteMainReplicaTest {
   }
 
   @Test
+  void aPreFloorMainIsRefusedBeforeItsDataIsRead() {
+    var legacy = new SyncWire.Fetched("old-main", 1, Map.of(), null);
+    var replica = replica(SyncWire.encode(legacy));
+
+    var failure = assertThrows(SyncTransportException.class, replica::entityIds);
+
+    assertTrue(failure.getMessage().contains("0.14.0"));
+    assertTrue(failure.getMessage().contains("sail upgrade"));
+  }
+
+  @Test
   void aRefusedCommitSurfacesItsReason() {
     var replica = replica(SyncWire.encode(new SyncWire.Failed("read-only")));
     var ex = assertThrows(SyncTransportException.class, () -> replica.commit("x", Map.of(), null));

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
@@ -57,9 +57,20 @@ class SyncRpcServerTest {
   private static SyncWire.Response serve(boolean writable, SyncWire.Request request)
       throws Exception {
     var out = new StringWriter();
-    new SyncRpcServer(new FakeMain(), writable)
-        .serve(new StringReader(SyncWire.encode(request) + "\n"), out);
-    return SyncWire.decodeResponse(out.toString().strip());
+    var input =
+        request instanceof SyncWire.Fetch
+            ? SyncWire.encode(request) + "\n"
+            : verifiedRequest("spec", request);
+    new SyncRpcServer(new FakeMain(), writable).serve(new StringReader(input), out);
+    return lastResponse(out);
+  }
+
+  private static String verifiedRequest(String entityType, SyncWire.Request request) {
+    return SyncWire.encode(new SyncWire.Fetch(entityType)) + "\n" + SyncWire.encode(request) + "\n";
+  }
+
+  private static SyncWire.Response lastResponse(StringWriter out) {
+    return SyncWire.decodeResponse(out.toString().lines().toList().getLast());
   }
 
   @Test
@@ -88,6 +99,20 @@ class SyncRpcServerTest {
   }
 
   @Test
+  void aCommitBeforeTheUpgradeFloorHandshakeIsRefused() throws Exception {
+    var response = new StringWriter();
+
+    new SyncRpcServer(new FakeMain(), true)
+        .serve(
+            new StringReader(
+                SyncWire.encode(new SyncWire.Commit("spec", "a", Map.of(), null)) + "\n"),
+            response);
+
+    var failure = assertInstanceOf(SyncWire.Failed.class, lastResponse(response));
+    assertTrue(failure.message().contains("0.14.0"));
+  }
+
+  @Test
   void theCommitBindsThePushingHandleAsSyncProvenance() throws Exception {
     var seenPeer = new java.util.concurrent.atomic.AtomicReference<String>("unset");
     MainReplica capturing =
@@ -102,7 +127,7 @@ class SyncRpcServerTest {
     new SyncRpcServer(Map.of("spec", capturing), new SyncPrincipal("sumesh", true), FdeRoster.EMPTY)
         .serve(
             new StringReader(
-                SyncWire.encode(new SyncWire.Commit("spec", "a", Map.of(), null)) + "\n"),
+                verifiedRequest("spec", new SyncWire.Commit("spec", "a", Map.of(), null))),
             out);
 
     assertEquals(
@@ -137,8 +162,8 @@ class SyncRpcServerTest {
         };
     var out = new StringWriter();
     new SyncRpcServer(Map.of("run", main), new SyncPrincipal(handle, true), FdeRoster.EMPTY)
-        .serve(new StringReader(SyncWire.encode(commit) + "\n"), out);
-    return SyncWire.decodeResponse(out.toString().strip());
+        .serve(new StringReader(verifiedRequest("run", commit)), out);
+    return lastResponse(out);
   }
 
   @Test
@@ -230,9 +255,9 @@ class SyncRpcServerTest {
 
     new SyncRpcServer(
             Map.of("spec", main), new SyncPrincipal(null, true), FdeRoster.EMPTY, seen::add)
-        .serve(new StringReader(SyncWire.encode(commit) + "\n"), out);
+        .serve(new StringReader(verifiedRequest("spec", commit)), out);
 
-    assertInstanceOf(SyncWire.Committed.class, SyncWire.decodeResponse(out.toString().strip()));
+    assertInstanceOf(SyncWire.Committed.class, lastResponse(out));
     assertEquals(1, seen.size());
     assertEquals("in_progress", seen.getFirst().to());
   }
@@ -253,9 +278,9 @@ class SyncRpcServerTest {
 
     new SyncRpcServer(
             Map.of("spec", main), new SyncPrincipal(null, true), FdeRoster.EMPTY, seen::add)
-        .serve(new StringReader(SyncWire.encode(commit) + "\n"), out);
+        .serve(new StringReader(verifiedRequest("spec", commit)), out);
 
-    assertInstanceOf(SyncWire.Rejected.class, SyncWire.decodeResponse(out.toString().strip()));
+    assertInstanceOf(SyncWire.Rejected.class, lastResponse(out));
     assertTrue(seen.isEmpty());
   }
 
@@ -290,12 +315,12 @@ class SyncRpcServerTest {
               transition -> {
                 throw new IllegalStateException("slack is down");
               })
-          .serve(new StringReader(SyncWire.encode(commit) + "\n"), out);
+          .serve(new StringReader(verifiedRequest("spec", commit)), out);
     } finally {
       System.setErr(originalErr);
     }
 
-    assertInstanceOf(SyncWire.Committed.class, SyncWire.decodeResponse(out.toString().strip()));
+    assertInstanceOf(SyncWire.Committed.class, lastResponse(out));
     assertTrue(captured.toString(StandardCharsets.UTF_8).contains("slack is down"));
   }
 
@@ -304,15 +329,25 @@ class SyncRpcServerTest {
     var roster = List.<Map<String, Object>>of(Map.of("handle", "ada", "role", "admin"));
     var out = new StringWriter();
     new SyncRpcServer(new FakeMain(), false, () -> roster)
-        .serve(new StringReader(SyncWire.encode(new SyncWire.FetchFdes()) + "\n"), out);
+        .serve(new StringReader(verifiedRequest("spec", new SyncWire.FetchFdes())), out);
 
-    var response = (SyncWire.Fdes) SyncWire.decodeResponse(out.toString().strip());
+    var response = (SyncWire.Fdes) lastResponse(out);
     assertEquals("ada", response.fdes().getFirst().get("handle"));
   }
 
   @Test
   void fetchFdesDefaultsToAnEmptyRoster() throws Exception {
     assertInstanceOf(SyncWire.Fdes.class, serve(true, new SyncWire.FetchFdes()));
+  }
+
+  @Test
+  void fetchFdesBeforeTheUpgradeFloorHandshakeIsRefused() throws Exception {
+    var out = new StringWriter();
+
+    new SyncRpcServer(new FakeMain(), true)
+        .serve(new StringReader(SyncWire.encode(new SyncWire.FetchFdes()) + "\n"), out);
+
+    assertInstanceOf(SyncWire.Failed.class, lastResponse(out));
   }
 
   @Test
@@ -339,9 +374,10 @@ class SyncRpcServerTest {
     var out = new StringWriter();
     var request = new SyncWire.Commit("spec", "a", Map.of(), null);
 
-    new SyncRpcServer(throwing, true).serve(new StringReader(SyncWire.encode(request) + "\n"), out);
+    new SyncRpcServer(throwing, true)
+        .serve(new StringReader(verifiedRequest("spec", request)), out);
 
-    assertInstanceOf(SyncWire.Failed.class, SyncWire.decodeResponse(out.toString().strip()));
+    assertInstanceOf(SyncWire.Failed.class, lastResponse(out));
   }
 
   @Test
@@ -375,10 +411,10 @@ class SyncRpcServerTest {
     var out = new StringWriter();
     var request = new SyncWire.Commit("spec", "a", Map.of(), null);
 
-    new SyncRpcServer(throwing, true).serve(new StringReader(SyncWire.encode(request) + "\n"), out);
+    new SyncRpcServer(throwing, true)
+        .serve(new StringReader(verifiedRequest("spec", request)), out);
 
-    var failed =
-        assertInstanceOf(SyncWire.Failed.class, SyncWire.decodeResponse(out.toString().strip()));
+    var failed = assertInstanceOf(SyncWire.Failed.class, lastResponse(out));
     assertTrue(
         failed.message().contains("database is locked"),
         "the actionable root cause must surface, not the wrapper: " + failed.message());
@@ -400,7 +436,7 @@ class SyncRpcServerTest {
     System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
     try {
       new SyncRpcServer(throwing, true)
-          .serve(new StringReader(SyncWire.encode(request) + "\n"), new StringWriter());
+          .serve(new StringReader(verifiedRequest("spec", request)), new StringWriter());
     } finally {
       System.setErr(originalErr);
     }

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
@@ -73,6 +73,15 @@ class SyncRpcServerTest {
   }
 
   @Test
+  void aPreFloorNodeIsRefusedBeforeMainServesData() throws Exception {
+    var failure =
+        assertInstanceOf(SyncWire.Failed.class, serve(true, new SyncWire.Fetch("spec", null)));
+
+    assertTrue(failure.message().contains("0.14.0"));
+    assertTrue(failure.message().contains("sail upgrade"));
+  }
+
+  @Test
   void aWritableServerAcceptsACommit() throws Exception {
     var response = serve(true, new SyncWire.Commit("spec", "a", Map.of(), null));
     assertEquals("1-x", assertInstanceOf(SyncWire.Committed.class, response).rev());

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -21,6 +21,7 @@ import ai.singlr.sail.engine.SshIdentityProvisioner;
 import ai.singlr.sail.store.DataMigration;
 import ai.singlr.sail.store.DataMigrator;
 import ai.singlr.sail.store.FileStore;
+import ai.singlr.sail.store.LegacyDataMigration;
 import ai.singlr.sail.store.MigrationRunner;
 import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.RunStore;
@@ -54,11 +55,8 @@ import picocli.CommandLine.Spec;
     mixinStandardHelpOptions = true)
 public final class MigrateCommand implements Runnable {
 
-  /**
-   * Every one-shot data migration tracked in {@code data_migrations}. Empty today — the early
-   * backfills have all been applied — but the framework stays so future migrations have a home.
-   */
-  public static final List<DataMigration> REGISTRY = List.of();
+  /** Every one-shot data migration tracked in {@code data_migrations}. Add new ones at the end. */
+  public static final List<DataMigration> REGISTRY = List.of(new LegacyDataMigration());
 
   @Option(
       names = "--non-interactive",

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.DataMigration;
+import ai.singlr.sail.store.LegacyDataMigration;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
@@ -53,6 +54,20 @@ class MigrateCommandTest {
         db, "test.db", DataMigration.Prompter.NON_INTERACTIVE, false, true);
 
     assertDoesNotThrow(() -> new SpecStore(db).findById("none"));
+  }
+
+  @Test
+  void migrateRegistersTheV1DataFloorOnce() {
+    MigrateCommand.applyMigrations(
+        db, "test.db", DataMigration.Prompter.NON_INTERACTIVE, false, true);
+
+    assertEquals(
+        1L,
+        db.queryOne(
+                "SELECT COUNT(*) FROM data_migrations WHERE name = ?",
+                row -> row.integer(0),
+                LegacyDataMigration.NAME)
+            .orElseThrow());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- establish the 0.14.0 v1 data floor with total, validated run roles and real API-token ownership cascades
- run the node/revision/project attribution backfills once, terminalizing legacy blank-unit build runs while preserving review runs
- converge the complete floor before sync and refuse pre-0.14 peers before exchanging data
- document the fleet upgrade floor in the README and 0.14.0 release notes

## Verification

- `mvn clean verify`
- `mvn -Pintegration -Dsail.it.requireIncus=false verify`
