### PR TITLE
One identity model: every agent session is a run

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -370,9 +370,11 @@ their repo sets overlap. The overlap gate is an atomic reservation: one `BEGIN I
 SQLite transaction checks every running local run and inserts the new run with its reserved
 repos, so concurrent dispatches — even a CLI and the server in separate processes — can never
 both claim the same repo, and a reservation failure aborts the dispatch before any spec is
-claimed or branch checked out. An ad-hoc `sail agent start` session mints no run row, so
-dispatch probes the fixed `sail-agent` identity and refuses while one is live: a row-less
-agent may touch any repo, and whole-container is the only safe reading. Coverage is probed rather than bookkept, per run, and the periodic
+claimed or branch checked out. An ad-hoc `sail agent run --task` session is a run like any
+other: it mints a `role='adhoc'` row with no spec and an empty repo set — the
+whole-container reservation — through the same transaction, so ad-hoc and dispatched agents
+exclude each other atomically and are stopped, listed, and reconciled by the same run-scoped
+machinery. Coverage is probed rather than bookkept, per run, and the periodic
 re-armer — whose coverage probe is process-level, seeing units in
 any user's systemd scope and plain fallback processes alike — relaunches unit-or-nothing for
 any running agent nothing covers, resuming the original deadline rather than granting a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,21 @@ One identity model: every agent session is a run.
   `agent logs`, and `agent report` resolve ad-hoc sessions through their run rows like any
   dispatch. The `run_not_active` stop reason no longer occurs: run-scoped identities made
   the pid-identity-theft guards obsolete.
-- Foreground sessions write their pid to the run's pid file, so they are probeable and
-  stoppable through the same identity as background ones.
+- Foreground sessions write their pid to the run's pid file, record the same run-scoped
+  unit name on their run row, and persist their process identity, so they are probeable,
+  stoppable, and reconcilable through the same identity as background ones — a crashed
+  foreground launcher no longer strands its whole-container reservation, and a launch
+  failure never frees the reservation while the agent still probes live.
+- Runs persist the agent process's `/proc` start-time fingerprint at launch; a stop refuses
+  to signal a pid whose fingerprint no longer matches, so an in-container PID reused after
+  the agent exits can never be killed by a stale run.
+- The watcher re-armer walks live session runs (build and ad-hoc alike) instead of
+  in-progress specs, so a crashed watcher over an ad-hoc background session is replaced
+  within a pass; its probe is systemd-strict, so a foreground session is never armed with
+  guardrails it was not launched with.
+- `sail agent run` regenerates the shared home-level agent context only after the
+  whole-container reservation is won, so a refused launch leaves the running agent's
+  instructions and skills untouched.
 - Review runs record their real execution identity (`sail-review-<id>`) instead of a blank
   unit.
 - The missed-stop sweep releases a spec-less run only on probed evidence of death and never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## Unreleased
+
+One identity model: every agent session is a run.
+
+- `sail agent run --task` and `sail agent sweep` now mint a first-class run
+  (`role='adhoc'`, no spec) with a run-scoped unit, log, and pid file, and reserve the whole
+  container through the same atomic transaction as dispatch — an ad-hoc session and a
+  dispatched agent can no longer run beside each other, in either order.
+- The fixed `sail-agent` unit and `~/.sail/agent.*` files are gone. Stop any running agent
+  session before upgrading: a fixed-unit ad-hoc session launched by an older binary is
+  invisible to this version's run-scoped stop, status, and log commands and must be stopped
+  by that older binary (or by hand) first.
+- `sail agent stop` on an ad-hoc session now reports its run id; `sail agent status`,
+  `agent logs`, and `agent report` resolve ad-hoc sessions through their run rows like any
+  dispatch. The `run_not_active` stop reason no longer occurs: run-scoped identities made
+  the pid-identity-theft guards obsolete.
+- Foreground sessions write their pid to the run's pid file, so they are probeable and
+  stoppable through the same identity as background ones.
+- Review runs record their real execution identity (`sail-review-<id>`) instead of a blank
+  unit.
+- The missed-stop sweep releases a spec-less run only on probed evidence of death and never
+  releases any reservation while its agent's identity still probes live.
+
 ## 0.14.0
 
 Version 0.14.0 is the v1 upgrade floor. Upgrade every box in a fleet to 0.14.0 before

--- a/sail-core/src/main/java/ai/singlr/sail/store/DispatchGate.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/DispatchGate.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.store;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -49,11 +50,20 @@ public final class DispatchGate {
     return running.stream()
         .map(
             run ->
-                run.specId().equals(targetSpecId)
+                sameSpec(run.specId(), targetSpecId)
                     ? Optional.of(new Conflict(run, List.of()))
                     : conflictWith(targetRepos, run))
         .flatMap(Optional::stream)
         .findFirst();
+  }
+
+  /**
+   * Whether the running run works the very spec being dispatched. A blank id names no spec — an
+   * ad-hoc session or a legacy row — so two blank ids are never "the same spec"; their conflict is
+   * decided by the repo overlap rule alone (which an empty repo set makes total anyway).
+   */
+  private static boolean sameSpec(String runSpecId, String targetSpecId) {
+    return runSpecId != null && !runSpecId.isBlank() && Objects.equals(runSpecId, targetSpecId);
   }
 
   private static Optional<Conflict> conflictWith(List<String> targetRepos, RunningRun run) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -71,7 +71,8 @@ public final class RunStore implements ConflictResolver {
       String unit,
       String startedAt,
       String completedAt,
-      List<String> repos) {
+      List<String> repos,
+      Long pidTicks) {
 
     /** Whether this row is a build attempt of a spec. */
     public boolean buildRole() {
@@ -97,7 +98,7 @@ public final class RunStore implements ConflictResolver {
 
   private static final String COLUMNS =
       "id, project, spec_id, node, role, agent, branch, task, pid, watcher_pid, status,"
-          + " exit_code, log_path, unit, started_at, completed_at, repos";
+          + " exit_code, log_path, unit, started_at, completed_at, repos, pid_ticks";
 
   /**
    * Records a new run in the {@code running} state, journaling a baseline revision so it
@@ -455,16 +456,20 @@ public final class RunStore implements ConflictResolver {
   }
 
   /**
-   * Stamps the agent and watcher pids on a run once launch has produced them. The run row is
-   * created before launch (so terminal hook events can find it), then updated here with the pids
-   * the launch resolved. Journals a revision so the pids replicate.
+   * Stamps the agent process identity and watcher pid on a run once launch has produced them. The
+   * run row is created before launch (so terminal hook events can find it), then updated here with
+   * what the launch resolved. {@code pidTicks} is the agent process's {@code /proc} start-time
+   * fingerprint — pids are reused by the kernel, so the pid alone can later name an unrelated
+   * process, and the stop lane refuses to signal a pid whose fingerprint no longer matches.
+   * Journals a revision so the identity replicates.
    */
-  public void updateProcess(String id, Integer pid, Integer watcherPid) {
+  public void updateProcess(String id, Integer pid, Long pidTicks, Integer watcherPid) {
     db.transaction(
         () -> {
           db.execute(
-              "UPDATE runs SET pid = ?, watcher_pid = ? WHERE id = ?",
+              "UPDATE runs SET pid = ?, pid_ticks = ?, watcher_pid = ? WHERE id = ?",
               pid != null ? pid.longValue() : null,
+              pidTicks,
               watcherPid != null ? watcherPid.longValue() : null,
               id);
           recordRevision(id, "local", false);
@@ -649,15 +654,15 @@ public final class RunStore implements ConflictResolver {
     db.execute(
         """
         INSERT INTO runs (id, project, spec_id, node, role, agent, branch, task, pid, watcher_pid,
-            status, exit_code, log_path, unit, started_at, completed_at, repos)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            status, exit_code, log_path, unit, started_at, completed_at, repos, pid_ticks)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET project = excluded.project, spec_id = excluded.spec_id,
             node = excluded.node, role = excluded.role, agent = excluded.agent,
             branch = excluded.branch, task = excluded.task, pid = excluded.pid,
             watcher_pid = excluded.watcher_pid, status = excluded.status,
             exit_code = excluded.exit_code, log_path = excluded.log_path, unit = excluded.unit,
             started_at = excluded.started_at, completed_at = excluded.completed_at,
-            repos = excluded.repos""",
+            repos = excluded.repos, pid_ticks = excluded.pid_ticks""",
         row.id(),
         row.project(),
         row.specId(),
@@ -674,7 +679,8 @@ public final class RunStore implements ConflictResolver {
         row.unit(),
         Objects.requireNonNullElse(row.startedAt(), DateTimeUtils.now().toString()),
         row.completedAt(),
-        YamlUtil.dumpJson(Objects.requireNonNullElse(row.repos(), List.of())));
+        YamlUtil.dumpJson(Objects.requireNonNullElse(row.repos(), List.of())),
+        row.pidTicks());
   }
 
   private static Map<String, Object> snapshotMap(RunRow run) {
@@ -696,6 +702,7 @@ public final class RunStore implements ConflictResolver {
     map.put("started_at", run.startedAt());
     map.put("completed_at", run.completedAt());
     map.put("repos", Objects.requireNonNullElse(run.repos(), List.of()));
+    map.put("pid_ticks", run.pidTicks());
     return map;
   }
 
@@ -753,7 +760,8 @@ public final class RunStore implements ConflictResolver {
         text(snapshot, "unit"),
         text(snapshot, "started_at"),
         text(snapshot, "completed_at"),
-        stringList(snapshot, "repos"));
+        stringList(snapshot, "repos"),
+        longValue(snapshot, "pid_ticks"));
   }
 
   private static String text(Map<String, Object> map, String key) {
@@ -769,6 +777,10 @@ public final class RunStore implements ConflictResolver {
 
   private static Integer integer(Map<String, Object> map, String key) {
     return map.get(key) instanceof Number n ? n.intValue() : null;
+  }
+
+  private static Long longValue(Map<String, Object> map, String key) {
+    return map.get(key) instanceof Number n ? n.longValue() : null;
   }
 
   private String rawBaseRev(String id) {
@@ -801,6 +813,7 @@ public final class RunStore implements ConflictResolver {
         row.text(13),
         row.text(14),
         row.text(15),
-        YamlUtil.parseStringList(row.text(16)));
+        YamlUtil.parseStringList(row.text(16)),
+        row.isNull(17) ? null : row.integer(17));
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -462,17 +462,28 @@ public final class RunStore implements ConflictResolver {
    * fingerprint — pids are reused by the kernel, so the pid alone can later name an unrelated
    * process, and the stop lane refuses to signal a pid whose fingerprint no longer matches.
    * Journals a revision so the identity replicates.
+   *
+   * <p>Commits only while the run is still {@code running} and returns whether it did. A stop that
+   * lands during launch preparation records its terminal intent on the row; the launcher discovers
+   * that loss here and must tear down whatever it just started instead of letting an unrecorded
+   * agent escape the reservation. {@code BEGIN IMMEDIATE} closes the read-then-write window against
+   * the stop's own claim transaction.
    */
-  public void updateProcess(String id, Integer pid, Long pidTicks, Integer watcherPid) {
-    db.transaction(
+  public boolean updateProcess(String id, Integer pid, Long pidTicks, Integer watcherPid) {
+    return db.immediateTransaction(
         () -> {
           db.execute(
-              "UPDATE runs SET pid = ?, pid_ticks = ?, watcher_pid = ? WHERE id = ?",
+              "UPDATE runs SET pid = ?, pid_ticks = ?, watcher_pid = ? WHERE id = ?"
+                  + " AND status = 'running'",
               pid != null ? pid.longValue() : null,
               pidTicks,
               watcherPid != null ? watcherPid.longValue() : null,
               id);
+          if (db.changes() == 0) {
+            return false;
+          }
           recordRevision(id, "local", false);
+          return true;
         });
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -73,11 +73,27 @@ public final class RunStore implements ConflictResolver {
       String completedAt,
       List<String> repos) {
 
-    /** Whether this row is a build attempt. */
+    /** Whether this row is a build attempt of a spec. */
     public boolean buildRole() {
       return "build".equals(role);
     }
+
+    /** Whether this row is an ad-hoc session — an engineer-initiated run that works no spec. */
+    public boolean adhocRole() {
+      return "adhoc".equals(role);
+    }
+
+    /**
+     * Whether this row is an agent session an operator owns — a build attempt or an ad-hoc run — as
+     * opposed to a pipeline-driven review execution. Session rows are the ones the stop, status,
+     * and log lanes address.
+     */
+    public boolean sessionRole() {
+      return buildRole() || adhocRole();
+    }
   }
+
+  private static final String SESSION_ROLES = "role IN ('build', 'adhoc')";
 
   private static final String COLUMNS =
       "id, project, spec_id, node, role, agent, branch, task, pid, watcher_pid, status,"
@@ -130,7 +146,9 @@ public final class RunStore implements ConflictResolver {
   /**
    * Records a review negotiation under the review UUID that owns its prompt, session, and log
    * files. Reviewer and fix invocations deliberately share that identity, so one run row remains
-   * addressable as {@code ~/.sail/runs/<reviewId>/review.log} throughout the negotiation.
+   * addressable as {@code ~/.sail/runs/<reviewId>/review.log} throughout the negotiation. {@code
+   * unit} is the review's real execution identity ({@code sail-review-<id>}), recorded so a probe
+   * of any run row is honest even though reviews execute as blocking foreground work.
    */
   public String createReview(
       String reviewId,
@@ -140,9 +158,10 @@ public final class RunStore implements ConflictResolver {
       String agent,
       String branch,
       String task,
-      String logPath) {
+      String logPath,
+      String unit) {
     return create(
-        reviewId, project, specId, node, "review", agent, branch, task, null, null, logPath, "");
+        reviewId, project, specId, node, "review", agent, branch, task, null, null, logPath, unit);
   }
 
   /**
@@ -162,6 +181,7 @@ public final class RunStore implements ConflictResolver {
       String project,
       String specId,
       String node,
+      String role,
       List<String> repos,
       String agent,
       String branch,
@@ -194,11 +214,12 @@ public final class RunStore implements ConflictResolver {
               """
               INSERT INTO runs (id, project, spec_id, node, role, agent, branch, task, status,
                   started_at, log_path, unit, repos)
-              VALUES (?, ?, ?, ?, 'build', ?, ?, ?, 'running', ?, ?, ?, ?)""",
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'running', ?, ?, ?, ?)""",
               id,
               project,
               specId,
               node,
+              role,
               agent,
               branch,
               task,
@@ -216,18 +237,20 @@ public final class RunStore implements ConflictResolver {
   }
 
   /**
-   * The latest build run of {@code project} that executed on this box, or empty. Review runs remain
-   * in the aggregate but do not replace the build session used by agent status, log, and report
-   * commands. Ownership is by node: a box with a handle owns exactly the runs stamped with it; a
-   * box with no handle owns exactly its own blank-node runs and never a run adopted from another
-   * box via sync.
+   * The latest agent session (build or ad-hoc) of {@code project} that executed on this box, or
+   * empty. Review runs remain in the aggregate but do not replace the session used by agent status,
+   * log, and report commands. Ownership is by node: a box with a handle owns exactly the runs
+   * stamped with it; a box with no handle owns exactly its own blank-node runs and never a run
+   * adopted from another box via sync.
    */
   public Optional<RunRow> latestForProjectOnNode(String project, String localHandle) {
     return db.queryOne(
         "SELECT "
             + COLUMNS
             + " FROM runs WHERE project = ? AND IFNULL(node, '') = ?"
-            + " AND role = 'build' ORDER BY started_at DESC"
+            + " AND "
+            + SESSION_ROLES
+            + " ORDER BY started_at DESC"
             + " LIMIT 1",
         this::mapRow,
         project,
@@ -235,17 +258,17 @@ public final class RunStore implements ConflictResolver {
   }
 
   /**
-   * The active build run of {@code project} that executed on this box, or empty. {@code stopping}
-   * counts as active: an interrupted stop's claim must stay addressable so a project-targeted stop
-   * retry resumes it instead of falling through to the ad-hoc identity. Node-scoped like {@link
-   * #latestForProjectOnNode}.
+   * The active agent session (build or ad-hoc) of {@code project} that executed on this box, or
+   * empty. {@code stopping} counts as active: an interrupted stop's claim must stay addressable so
+   * a project-targeted stop retry resumes it. Node-scoped like {@link #latestForProjectOnNode}.
    */
   public Optional<RunRow> runningForProjectOnNode(String project, String localHandle) {
     return db.queryOne(
         "SELECT "
             + COLUMNS
             + " FROM runs WHERE project = ? AND status IN ('running', 'stopping')"
-            + " AND IFNULL(node, '') = ? AND role = 'build'"
+            + " AND IFNULL(node, '') = ? AND "
+            + SESSION_ROLES
             + " ORDER BY started_at DESC LIMIT 1",
         this::mapRow,
         project,
@@ -253,24 +276,24 @@ public final class RunStore implements ConflictResolver {
   }
 
   /**
-   * Every build run holding an unfinished stop claim ({@code stopping}) — a stop that recorded its
-   * terminal intent but was interrupted before the halt was verified. The reconciler's
-   * interrupted-stop pass finalizes these once their unit is gone.
+   * Every agent session (build or ad-hoc) holding an unfinished stop claim ({@code stopping}) — a
+   * stop that recorded its terminal intent but was interrupted before the halt was verified. The
+   * reconciler's interrupted-stop pass finalizes these once their unit is gone.
    */
   public List<RunRow> stopping() {
     return db.query(
-        "SELECT " + COLUMNS + " FROM runs WHERE status = 'stopping' AND role = 'build'",
+        "SELECT " + COLUMNS + " FROM runs WHERE status = 'stopping' AND " + SESSION_ROLES,
         this::mapRow);
   }
 
   /**
-   * Every build run still in the {@code running} state, across all projects and nodes — the
-   * build-session reaper's full input. Review executions are foreground work owned and completed by
-   * the review controller, so the systemd reaper must not probe them as build units.
+   * Every agent session (build or ad-hoc) still in the {@code running} state, across all projects
+   * and nodes — the session reaper's full input. Review executions are foreground work owned and
+   * completed by the review controller, so the systemd reaper must not probe them as build units.
    */
   public List<RunRow> running() {
     return db.query(
-        "SELECT " + COLUMNS + " FROM runs WHERE status = 'running' AND role = 'build'",
+        "SELECT " + COLUMNS + " FROM runs WHERE status = 'running' AND " + SESSION_ROLES,
         this::mapRow);
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -588,7 +588,8 @@ public final class SchemaManager {
           "DROP TABLE runs",
           "ALTER TABLE runs_v4 RENAME TO runs",
           "CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project)",
-          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)");
+          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)",
+          "ALTER TABLE runs ADD COLUMN pid_ticks INTEGER");
 
   /**
    * The last schema version whose {@code specs.status} CHECK predates {@code awaiting_merge}. The

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -553,7 +553,42 @@ public final class SchemaManager {
               SELECT token_hash, name, role, fde_id, created_at, last_used_at, expires_at
               FROM api_tokens""",
           "DROP TABLE api_tokens",
-          "ALTER TABLE api_tokens_v2 RENAME TO api_tokens");
+          "ALTER TABLE api_tokens_v2 RENAME TO api_tokens",
+          """
+          CREATE TABLE runs_v4 (
+              id TEXT PRIMARY KEY,
+              project TEXT NOT NULL,
+              spec_id TEXT,
+              agent TEXT NOT NULL,
+              branch TEXT,
+              task TEXT,
+              pid INTEGER,
+              status TEXT NOT NULL DEFAULT 'running'
+                  CHECK (status IN ('running', 'stopping', 'completed', 'stopped', 'failed')),
+              started_at TEXT NOT NULL,
+              completed_at TEXT,
+              exit_code INTEGER,
+              watcher_pid INTEGER,
+              node TEXT,
+              role TEXT NOT NULL DEFAULT 'build'
+                  CHECK (role IN ('build', 'adhoc', 'review')),
+              log_path TEXT,
+              rev TEXT,
+              base_rev TEXT,
+              unit TEXT,
+              repos TEXT
+          )""",
+          """
+          INSERT INTO runs_v4 (id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos)
+              SELECT id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos FROM runs""",
+          "DROP TABLE runs",
+          "ALTER TABLE runs_v4 RENAME TO runs",
+          "CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project)",
+          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)");
 
   /**
    * The last schema version whose {@code specs.status} CHECK predates {@code awaiting_merge}. The

--- a/sail-core/src/test/java/ai/singlr/sail/store/MissedStopsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/MissedStopsTest.java
@@ -36,7 +36,8 @@ class MissedStopsTest {
         "sail-agent-run",
         startedAt,
         null,
-        java.util.List.of());
+        java.util.List.of(),
+        null);
   }
 
   private static MissedStops.Outcome assess(RunStore.RunRow session, boolean observed) {

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -172,7 +172,8 @@ class RunStoreTest {
         "claude-code",
         "feat/x",
         "review",
-        "/home/dev/.sail/runs/r/agent.log");
+        "/home/dev/.sail/runs/r/agent.log",
+        "sail-review-r");
     var ran = new AtomicBoolean();
 
     assertTrue(
@@ -230,7 +231,8 @@ class RunStoreTest {
             "codex",
             "feat/x",
             "review",
-            "/home/dev/.sail/runs/rev/review.log");
+            "/home/dev/.sail/runs/rev/review.log",
+            "sail-review-rev");
     db.execute("UPDATE runs SET status = 'stopping' WHERE id = ?", review);
 
     var claims = store.stopping();
@@ -254,7 +256,16 @@ class RunStoreTest {
     var id = DateTimeUtils.newId().toString();
     var logPath = "/home/dev/.sail/runs/" + id + "/review.log";
 
-    store.createReview(id, "backend", "auth", "node-a", "codex", "feat/auth", "review it", logPath);
+    store.createReview(
+        id,
+        "backend",
+        "auth",
+        "node-a",
+        "codex",
+        "feat/auth",
+        "review it",
+        logPath,
+        "sail-review-" + id);
 
     var running = store.findById(id).orElseThrow();
     assertEquals("review", running.role());
@@ -264,7 +275,7 @@ class RunStoreTest {
     assertEquals("feat/auth", running.branch());
     assertEquals("review it", running.task());
     assertEquals(logPath, running.logPath());
-    assertTrue(running.unit().isBlank());
+    assertEquals("sail-review-" + id, running.unit());
     assertEquals("review", store.comparableSnapshot(id).get("role"));
 
     store.complete(id, "completed", 0);
@@ -428,7 +439,8 @@ class RunStoreTest {
         "codex",
         "feat/x",
         "review it",
-        "/home/dev/.sail/runs/" + reviewId + "/review.log");
+        "/home/dev/.sail/runs/" + reviewId + "/review.log",
+        "sail-review-" + reviewId);
 
     assertEquals(buildId, store.latestForProjectOnNode("backend", "node-a").orElseThrow().id());
     assertEquals(buildId, store.runningForProjectOnNode("backend", "node-a").orElseThrow().id());
@@ -440,8 +452,18 @@ class RunStoreTest {
   void startupFailsOnlyLocalRunningReviewRows() {
     var local = DateTimeUtils.newId().toString();
     var foreign = DateTimeUtils.newId().toString();
-    store.createReview(local, "backend", "auth", "node-a", "codex", "b", "t", "/runs/" + local);
-    store.createReview(foreign, "backend", "auth", "node-b", "codex", "b", "t", "/runs/" + foreign);
+    store.createReview(
+        local, "backend", "auth", "node-a", "codex", "b", "t", "/runs/" + local, "sail-review-l");
+    store.createReview(
+        foreign,
+        "backend",
+        "auth",
+        "node-b",
+        "codex",
+        "b",
+        "t",
+        "/runs/" + foreign,
+        "sail-review-f");
 
     assertEquals(1, store.failRunningReviewsOnNode("node-a"));
     assertEquals("failed", store.findById(local).orElseThrow().status());
@@ -650,12 +672,168 @@ class RunStoreTest {
         "backend",
         specId,
         node,
+        "build",
         repos,
         "claude-code",
         "feat/x",
         "do it",
         "/home/dev/.sail/runs/" + id + "/agent.log",
         "sail-agent-" + id);
+  }
+
+  private java.util.Optional<DispatchGate.Conflict> reserveAdhoc(String id, String node) {
+    return store.reserveDispatch(
+        id,
+        "backend",
+        "",
+        node,
+        "adhoc",
+        java.util.List.of(),
+        "claude-code",
+        null,
+        "do it",
+        "/home/dev/.sail/runs/" + id + "/agent.log",
+        "sail-agent-" + id);
+  }
+
+  @Test
+  void anAdhocReservationRecordsItsRoleAndEmptyRepoSet() {
+    var id = DateTimeUtils.newId().toString();
+
+    var conflict = reserveAdhoc(id, "node-a");
+
+    assertTrue(conflict.isEmpty());
+    var run = store.findById(id).orElseThrow();
+    assertEquals("adhoc", run.role());
+    assertEquals("", run.specId());
+    assertEquals(java.util.List.of(), run.repos());
+    assertEquals("running", run.status());
+    assertEquals("sail-agent-" + id, run.unit());
+  }
+
+  @Test
+  void anAdhocReservationBlocksAnyDispatch() {
+    reserveAdhoc(DateTimeUtils.newId().toString(), "node-a");
+
+    var conflict =
+        reserve(
+            store, DateTimeUtils.newId().toString(), "auth", "node-a", java.util.List.of("app"));
+
+    assertTrue(conflict.isPresent(), "an ad-hoc session reserves the whole container");
+  }
+
+  @Test
+  void aRunningDispatchBlocksAnAdhocReservation() {
+    reserve(store, DateTimeUtils.newId().toString(), "auth", "node-a", java.util.List.of("app"));
+
+    var conflict = reserveAdhoc(DateTimeUtils.newId().toString(), "node-a");
+
+    assertTrue(conflict.isPresent(), "an ad-hoc target overlaps every reserved repo set");
+  }
+
+  @Test
+  void anAdhocReservationBlocksASecondAdhocReservation() {
+    reserveAdhoc(DateTimeUtils.newId().toString(), "node-a");
+
+    var conflict = reserveAdhoc(DateTimeUtils.newId().toString(), "node-a");
+
+    assertTrue(conflict.isPresent());
+  }
+
+  @Test
+  void aFinishedAdhocRunFreesTheContainerForTheNextReservation() {
+    var first = DateTimeUtils.newId().toString();
+    reserveAdhoc(first, "node-a");
+    store.complete(first, "stopped", 0);
+
+    assertTrue(reserveAdhoc(DateTimeUtils.newId().toString(), "node-a").isEmpty());
+  }
+
+  @Test
+  void aLegacyNullSpecRunningRunStillGatesReservationsWithoutBlowingUp() {
+    var id = DateTimeUtils.newId().toString();
+    store.create(
+        id,
+        "backend",
+        null,
+        "node-a",
+        "build",
+        "codex",
+        null,
+        null,
+        null,
+        null,
+        null,
+        "sail-agent-" + id);
+
+    var conflict = reserveAdhoc(DateTimeUtils.newId().toString(), "node-a");
+
+    assertTrue(conflict.isPresent());
+  }
+
+  @Test
+  void sessionQueriesIncludeAdhocRuns() {
+    var id = DateTimeUtils.newId().toString();
+    reserveAdhoc(id, "node-a");
+
+    assertEquals(id, store.runningForProjectOnNode("backend", "node-a").orElseThrow().id());
+    assertEquals(id, store.latestForProjectOnNode("backend", "node-a").orElseThrow().id());
+    assertEquals(java.util.List.of(id), store.running().stream().map(RunStore.RunRow::id).toList());
+    assertTrue(store.transition(id, "running", "stopping"));
+    assertEquals(
+        java.util.List.of(id), store.stopping().stream().map(RunStore.RunRow::id).toList());
+  }
+
+  @Test
+  void sessionRoleCoversBuildAndAdhocButNeverReview() {
+    var adhoc = DateTimeUtils.newId().toString();
+    reserveAdhoc(adhoc, "node-a");
+    var build = newRun("backend", "auth");
+    var review =
+        store.createReview(
+            DateTimeUtils.newId().toString(),
+            "backend",
+            "auth",
+            "node-a",
+            "codex",
+            "feat/x",
+            "review",
+            "/home/dev/.sail/runs/rev/review.log",
+            "sail-review-rev");
+
+    assertTrue(store.findById(adhoc).orElseThrow().sessionRole());
+    assertTrue(store.findById(build).orElseThrow().sessionRole());
+    assertFalse(store.findById(build).orElseThrow().adhocRole());
+    assertTrue(store.findById(adhoc).orElseThrow().adhocRole());
+    assertFalse(store.findById(review).orElseThrow().sessionRole());
+    assertFalse(store.findById(adhoc).orElseThrow().buildRole());
+  }
+
+  @Test
+  void adhocRunsNeverSurfaceAsSpecAttempts() {
+    var adhoc = DateTimeUtils.newId().toString();
+    reserveAdhoc(adhoc, "node-a");
+
+    assertTrue(store.listForSpec("").stream().noneMatch(RunStore.RunRow::buildRole));
+    assertFalse(store.runIfLatestAttempt(adhoc, "", () -> {}));
+  }
+
+  @Test
+  void createReviewRecordsItsUnit() {
+    var id = DateTimeUtils.newId().toString();
+
+    store.createReview(
+        id,
+        "backend",
+        "auth",
+        "node-a",
+        "codex",
+        "feat/auth",
+        "review it",
+        "/home/dev/.sail/runs/" + id + "/review.log",
+        "sail-review-" + id);
+
+    assertEquals("sail-review-" + id, store.findById(id).orElseThrow().unit());
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -79,6 +79,23 @@ class RunStoreTest {
   }
 
   @Test
+  void updateProcessPersistsThePidFingerprintAndItReplicates() {
+    var id = newRun("backend", "auth");
+
+    store.updateProcess(id, 4321, 987654321L, 8765);
+
+    var run = store.findById(id).orElseThrow();
+    assertEquals(4321, run.pid());
+    assertEquals(987654321L, run.pidTicks());
+    assertEquals(8765, run.watcherPid());
+    var snapshot = store.comparableSnapshot(id);
+    assertEquals(987654321L, snapshot.get("pid_ticks"), "the fingerprint replicates with the run");
+    var adopted = DateTimeUtils.newId().toString();
+    store.applyRevision(adopted, snapshot, "1-remote");
+    assertEquals(987654321L, store.findById(adopted).orElseThrow().pidTicks());
+  }
+
+  @Test
   void transitionCommitsOnlyFromTheExpectedStatus() {
     var id = newRun("backend", "auth");
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -79,10 +79,22 @@ class RunStoreTest {
   }
 
   @Test
+  void updateProcessRefusesToStampARunTheStopAlreadyClaimed() {
+    var id = newRun("backend", "auth");
+    assertTrue(store.transition(id, "running", "stopped"));
+
+    assertFalse(store.updateProcess(id, 4321, 987654321L, 8765));
+
+    var run = store.findById(id).orElseThrow();
+    assertEquals("stopped", run.status());
+    assertNotEquals(4321, run.pid(), "a refused stamp must leave the row's identity untouched");
+  }
+
+  @Test
   void updateProcessPersistsThePidFingerprintAndItReplicates() {
     var id = newRun("backend", "auth");
 
-    store.updateProcess(id, 4321, 987654321L, 8765);
+    assertTrue(store.updateProcess(id, 4321, 987654321L, 8765));
 
     var run = store.findById(id).orElseThrow();
     assertEquals(4321, run.pid());

--- a/sail-core/src/test/java/ai/singlr/sail/sync/RunSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/RunSyncTest.java
@@ -116,7 +116,8 @@ class RunSyncTest {
         "codex",
         "feat/auth",
         "review it",
-        "/home/dev/.sail/runs/" + id + "/review.log");
+        "/home/dev/.sail/runs/" + id + "/review.log",
+        "sail-review-" + id);
 
     sync(node);
     sync(other);

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/AgentReporter.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/AgentReporter.java
@@ -126,17 +126,11 @@ public final class AgentReporter {
   }
 
   /**
-   * The identity to probe for live session state: a run's recorded unit, or the ad-hoc identity.
+   * The identity to probe for live session state: the run's recorded unit, with a foreground run's
+   * blank unit still probing through the run-scoped pid file.
    */
   private static AgentUnit unitOf(RunStore.RunRow session) {
-    if (session == null) {
-      return AgentUnit.BUILD;
-    }
-    if (session.unit() == null || session.unit().isBlank()) {
-      throw new IllegalStateException(
-          "Build run " + session.id() + " has no unit; run 'sail migrate' to repair its data.");
-    }
-    return AgentUnit.recorded(session.id(), session.unit());
+    return AgentUnit.recorded(session.id(), Objects.toString(session.unit(), ""));
   }
 
   /**
@@ -154,7 +148,7 @@ public final class AgentReporter {
       throws IOException, InterruptedException, TimeoutException {
 
     var agentSession = new AgentSession(shell);
-    var info = agentSession.queryStatus(containerName, unitOf(session));
+    var info = session == null ? null : agentSession.queryStatus(containerName, unitOf(session));
     var running = info != null && info.running();
     var startedAt =
         session != null && session.startedAt() != null

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
@@ -167,6 +167,53 @@ public final class AgentSession {
   }
 
   /**
+   * Reads a container process's non-reusable start fingerprint: the {@code starttime} field of
+   * {@code /proc/<pid>/stat}, in clock ticks since boot. The kernel reuses numeric pids, so a pid
+   * alone can later name an unrelated process; two processes assigned the same pid can never share
+   * a start time, so a fingerprint persisted at launch distinguishes the process a run launched
+   * from any later occupant of its pid. Returns null when the process is gone or unreadable.
+   */
+  public Long readProcessStartTicks(String containerName, int pid)
+      throws IOException, InterruptedException, TimeoutException {
+    var cmd = ContainerExec.asDevUser(containerName, List.of("cat", "/proc/" + pid + "/stat"));
+    var result = shell.exec(cmd);
+    return result.ok() ? parseStartTicks(result.stdout()) : null;
+  }
+
+  /**
+   * Field 22 of the stat line, located after the last {@code ')'} because the comm field may itself
+   * contain spaces or parentheses.
+   */
+  static Long parseStartTicks(String stat) {
+    var close = stat.lastIndexOf(')');
+    if (close < 0) {
+      return null;
+    }
+    var fields = stat.substring(close + 1).trim().split("\\s+");
+    if (fields.length < 20) {
+      return null;
+    }
+    try {
+      return Long.parseLong(fields[19]);
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Whether the unit is active in the container's user systemd manager. Unlike {@link #queryStatus}
+   * this never falls back to the run's pid file, so it distinguishes launch modes: a background
+   * session runs as its recorded unit, a foreground session only writes the pid file.
+   */
+  public boolean unitActive(String containerName, AgentUnit unit)
+      throws IOException, InterruptedException, TimeoutException {
+    var cmd =
+        ContainerExec.asDevUser(
+            containerName, List.of("systemctl", "--user", "--quiet", "is-active", unit.service()));
+    return shell.exec(cmd).ok();
+  }
+
+  /**
    * Kills the given role's running agent inside the container. SIGTERM first, then SIGKILL. A
    * SIGKILL that fails against a still-live process throws instead of returning normally, so a
    * caller can never record a successful stop for an agent that survived the signal.

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
@@ -23,8 +23,6 @@ import java.util.concurrent.TimeoutException;
 public final class AgentSession {
 
   private static final String SAIL_DIR = "/home/dev/.sail";
-  private static final String LOG_FILE = AgentUnit.BUILD.logPath();
-  private static final String TASK_FILE = AgentUnit.BUILD.taskPath();
 
   private final ShellExec shell;
 
@@ -63,18 +61,11 @@ public final class AgentSession {
   }
 
   /**
-   * Writes the task text to a file inside the container. Uses printf with a positional argument to
-   * avoid heredoc injection (content containing the delimiter could escape the heredoc).
-   */
-  public void writeTaskFile(String containerName, String task)
-      throws IOException, InterruptedException, TimeoutException {
-    writeTaskFile(containerName, task, AgentUnit.BUILD);
-  }
-
-  /**
-   * Writes the task/prompt file for the given role's unit (build task or review prompt). Creates
-   * the file's parent directory first: a run-scoped unit lives under {@code ~/.sail/runs/<runId>/},
-   * which does not exist yet when dispatch stages the task before launch.
+   * Writes the task/prompt file for the given role's unit (build task or review prompt). Uses
+   * printf with a positional argument to avoid heredoc injection (content containing the delimiter
+   * could escape the heredoc). Creates the file's parent directory first: a run-scoped unit lives
+   * under {@code ~/.sail/runs/<runId>/}, which does not exist yet when the launcher stages the task
+   * before launch.
    */
   public void writeTaskFile(String containerName, String task, AgentUnit unit)
       throws IOException, InterruptedException, TimeoutException {
@@ -94,59 +85,16 @@ public final class AgentSession {
     }
   }
 
-  /** Writes session metadata JSON inside the container for an ad-hoc (non-spec) launch. */
-  public void writeSession(String containerName, String task, String branch)
-      throws IOException, InterruptedException, TimeoutException {
-    writeSession(containerName, task, branch, "", "");
-  }
-
   /**
-   * Writes session metadata JSON inside the container. The {@code specId} and {@code agentType} are
-   * the durable record of which spec this dispatch is for: the systemd unit's environment carries
-   * them too, but a successfully-exited transient unit is garbage-collected within seconds, taking
-   * its environment with it. The watcher therefore recovers them from this file when the unit is
-   * already gone, so a clean agent exit still produces a spec-attributed stop signal.
+   * Writes session metadata JSON for the given role's unit (its own session file and log path). The
+   * {@code specId}, {@code agentType}, and {@code runId} are the durable record of what this launch
+   * executes: the systemd unit's environment carries them too, but a successfully-exited transient
+   * unit is garbage-collected within seconds, taking its environment with it. The watcher therefore
+   * recovers them from this file when the unit is already gone, so a clean agent exit still
+   * produces a run-addressed stop signal. {@code repos} is the spec's resolved repo set (empty for
+   * an ad-hoc session), so the stop gate can scope its readiness checks to exactly the repos a
+   * dispatch works in rather than every repo in the shared container.
    */
-  public void writeSession(
-      String containerName, String task, String branch, String specId, String agentType)
-      throws IOException, InterruptedException, TimeoutException {
-    writeSession(containerName, task, branch, specId, agentType, "", List.of(), AgentUnit.BUILD);
-  }
-
-  /**
-   * Writes session metadata carrying the run id, so the watcher can recover it from the durable
-   * file when the transient unit's environment is already gone and address its synthesized stop at
-   * the exact run.
-   */
-  public void writeSession(
-      String containerName,
-      String task,
-      String branch,
-      String specId,
-      String agentType,
-      String runId)
-      throws IOException, InterruptedException, TimeoutException {
-    writeSession(containerName, task, branch, specId, agentType, runId, List.of(), AgentUnit.BUILD);
-  }
-
-  /**
-   * Writes session metadata carrying the run id and the spec's resolved repos, so the stop gate can
-   * scope its readiness checks to exactly the repos this dispatch works in rather than every repo
-   * in the shared container.
-   */
-  public void writeSession(
-      String containerName,
-      String task,
-      String branch,
-      String specId,
-      String agentType,
-      String runId,
-      List<String> repos)
-      throws IOException, InterruptedException, TimeoutException {
-    writeSession(containerName, task, branch, specId, agentType, runId, repos, AgentUnit.BUILD);
-  }
-
-  /** Writes session metadata for the given role's unit (its own session file and log path). */
   public void writeSession(
       String containerName,
       String task,
@@ -183,12 +131,6 @@ public final class AgentSession {
     }
   }
 
-  /** Queries the current agent session status. Returns null if no session exists. */
-  public SessionInfo queryStatus(String containerName)
-      throws IOException, InterruptedException, TimeoutException {
-    return queryStatus(containerName, AgentUnit.BUILD);
-  }
-
   /** Queries the given role's session status. Returns null if no session exists for it. */
   @SuppressWarnings("unchecked")
   public SessionInfo queryStatus(String containerName, AgentUnit unit)
@@ -222,12 +164,6 @@ public final class AgentSession {
     }
 
     return new SessionInfo(alive, pid, task, startedAt, branch, unit.logPath());
-  }
-
-  /** Kills a running agent process inside the container. SIGTERM first, then SIGKILL. */
-  public void killAgent(String containerName)
-      throws IOException, InterruptedException, TimeoutException {
-    killAgent(containerName, AgentUnit.BUILD);
   }
 
   /**
@@ -272,22 +208,6 @@ public final class AgentSession {
     shell.exec(ContainerExec.asDevUser(containerName, List.of("rm", "-f", unit.pidPath())));
   }
 
-  /**
-   * Builds an {@code incus exec} command for launching an agent in detached/background mode. The
-   * task is read from a file inside the container to avoid shell escaping issues.
-   *
-   * @param agentCli the agent CLI enum (determines headless command syntax)
-   */
-  public static List<String> buildBackgroundLaunchCommand(
-      String containerName,
-      String sshUser,
-      String workDir,
-      boolean fullPermissions,
-      AgentCli agentCli) {
-    return buildBackgroundLaunchCommand(
-        containerName, sshUser, workDir, fullPermissions, agentCli, null, null, null, null);
-  }
-
   public static String launchWorkDir(String sshUser, List<SailYaml.Repo> targetRepos) {
     var workspace = "/home/" + sshUser + "/workspace";
     if (targetRepos.size() == 1) {
@@ -296,70 +216,18 @@ public final class AgentSession {
     return workspace;
   }
 
-  public static List<String> buildBackgroundLaunchCommand(
-      String containerName,
-      String sshUser,
-      String workDir,
-      boolean fullPermissions,
-      AgentCli agentCli,
-      String model,
-      String reasoningEffort) {
-    return buildBackgroundLaunchCommand(
-        containerName,
-        sshUser,
-        workDir,
-        fullPermissions,
-        agentCli,
-        model,
-        reasoningEffort,
-        null,
-        null);
-  }
-
   /**
-   * Same as the simpler overload, with two extra inputs used to correlate hook events back to a
-   * specific spec dispatch:
-   *
-   * <ul>
-   *   <li>{@code specId} — flows into the spawned agent's environment as {@code SAIL_SPEC_ID}; an
-   *       empty or {@code null} value signals a non-spec ad-hoc launch, in which case the in-
-   *       container hook script no-ops instead of publishing events.
-   *   <li>{@code agentType} — flows in as {@code SAIL_AGENT}; defaults to the CLI's yaml name when
-   *       blank.
-   * </ul>
-   */
-  public static List<String> buildBackgroundLaunchCommand(
-      String containerName,
-      String sshUser,
-      String workDir,
-      boolean fullPermissions,
-      AgentCli agentCli,
-      String model,
-      String reasoningEffort,
-      String specId,
-      String agentType) {
-    return buildBackgroundLaunchCommand(
-        containerName,
-        sshUser,
-        workDir,
-        fullPermissions,
-        agentCli,
-        model,
-        reasoningEffort,
-        specId,
-        agentType,
-        AgentUnit.BUILD.logPath(),
-        "");
-  }
-
-  /**
-   * As the other overload, launching under the run's own identity: unit {@code sail-agent-<runId>},
-   * stdout/stderr redirected to {@code logPath} ({@code ~/.sail/runs/<runId>/agent.log}), and
-   * pid/task files under the run directory — so concurrent dispatches never collide on a unit name
-   * or clobber a shared file, and a log address names exactly one execution. The log's parent
-   * directory is created before the redirect. {@code runId} flows in as {@code SAIL_RUN_ID} so the
-   * agent's hooks and the watcher can address terminal events at the exact run; blank means an
-   * ad-hoc launch on the fixed {@link AgentUnit#BUILD} identity.
+   * Builds the {@code incus exec} command launching a headless agent in detached/background mode
+   * under the run's own identity: unit {@code sail-agent-<runId>}, stdout/stderr redirected to
+   * {@code logPath} ({@code ~/.sail/runs/<runId>/agent.log}), and pid/task files under the run
+   * directory — so concurrent executions never collide on a unit name or clobber a shared file, and
+   * a log address names exactly one execution. The task is read from a file inside the container to
+   * avoid shell escaping issues, and the log's parent directory is created before the redirect.
+   * {@code specId} flows into the spawned agent's environment as {@code SAIL_SPEC_ID} (blank for an
+   * ad-hoc session, which makes the in-container hook script no-op); {@code agentType} flows in as
+   * {@code SAIL_AGENT}, defaulting to the CLI's yaml name when blank; {@code runId} flows in as
+   * {@code SAIL_RUN_ID} so the agent's hooks and the watcher can address terminal events at the
+   * exact run.
    */
   public static List<String> buildBackgroundLaunchCommand(
       String containerName,
@@ -375,8 +243,7 @@ public final class AgentSession {
       String runId) {
     var cli = Objects.requireNonNullElse(agentCli, AgentCli.CLAUDE_CODE);
     warnIfReasoningEffortDropped(cli, specId, reasoningEffort);
-    var effectiveRunId = Objects.requireNonNullElse(runId, "");
-    var unit = effectiveRunId.isBlank() ? AgentUnit.BUILD : AgentUnit.forRun(effectiveRunId);
+    var unit = AgentUnit.forRun(runId);
     var settingsPath = cli == AgentCli.CLAUDE_CODE ? ClaudeCodeHookConfig.SETTINGS_PATH : null;
     var agentCmd =
         cli.headlessCommand(
@@ -419,79 +286,17 @@ public final class AgentSession {
             unit.pidPath(),
             effectiveSpec,
             effectiveAgent,
-            effectiveRunId));
+            runId));
   }
 
   /**
-   * Builds an {@code incus exec} command for launching an agent in interactive headless mode
-   * (foreground, with task). The task is read from a file to avoid escaping issues.
-   *
-   * @param agentCli the agent CLI enum (determines headless command syntax)
-   */
-  public static List<String> buildForegroundTaskCommand(
-      String containerName,
-      String sshUser,
-      String workDir,
-      boolean fullPermissions,
-      AgentCli agentCli) {
-    return buildForegroundTaskCommand(
-        containerName, sshUser, workDir, fullPermissions, agentCli, null, null, null, null);
-  }
-
-  public static List<String> buildForegroundTaskCommand(
-      String containerName,
-      String sshUser,
-      String workDir,
-      boolean fullPermissions,
-      AgentCli agentCli,
-      String model,
-      String reasoningEffort) {
-    return buildForegroundTaskCommand(
-        containerName,
-        sshUser,
-        workDir,
-        fullPermissions,
-        agentCli,
-        model,
-        reasoningEffort,
-        null,
-        null);
-  }
-
-  /**
-   * Same as the simpler overload, plus {@code specId} and {@code agentType} for hook attribution.
-   * See {@link #buildBackgroundLaunchCommand(String, String, String, boolean, AgentCli, String,
-   * String, String, String)}.
-   */
-  public static List<String> buildForegroundTaskCommand(
-      String containerName,
-      String sshUser,
-      String workDir,
-      boolean fullPermissions,
-      AgentCli agentCli,
-      String model,
-      String reasoningEffort,
-      String specId,
-      String agentType) {
-    var cli = Objects.requireNonNullElse(agentCli, AgentCli.CLAUDE_CODE);
-    warnIfReasoningEffortDropped(cli, specId, reasoningEffort);
-    var settingsPath = cli == AgentCli.CLAUDE_CODE ? ClaudeCodeHookConfig.SETTINGS_PATH : null;
-    var agentCmd =
-        cli.headlessCommand(TASK_FILE, fullPermissions, model, reasoningEffort, settingsPath);
-    var effectiveSpec = Objects.requireNonNullElse(specId, "");
-    var effectiveAgent = agentType == null || agentType.isBlank() ? cli.yamlName() : agentType;
-    var script = "cd \"$1\" && SAIL_SPEC_ID=\"$3\" SAIL_AGENT=\"$4\" bash -l -c \"$2\"";
-    return ContainerExec.asDevUser(
-        containerName,
-        List.of(
-            "bash", "-l", "-c", script, "bash", workDir, agentCmd, effectiveSpec, effectiveAgent));
-  }
-
-  /**
-   * The dispatch foreground launcher: like the simpler overload but with {@code runId} carried in
-   * as {@code SAIL_RUN_ID} and the agent's stdout/stderr redirected to the run-scoped {@code
-   * logPath}, so a foreground dispatch's recorded log address names a file that actually holds its
-   * output and its terminal hook events can address the exact run.
+   * The foreground launcher: like {@link #buildBackgroundLaunchCommand} but blocking, with {@code
+   * runId} carried in as {@code SAIL_RUN_ID} and the agent's stdout/stderr redirected to the
+   * run-scoped {@code logPath}, so a foreground session's recorded log address names a file that
+   * actually holds its output and its terminal hook events can address the exact run. The wrapper
+   * writes its own pid to the run's pid file and {@code exec}s into the agent, so a foreground
+   * session — which owns no systemd unit — is still probeable and stoppable through the same
+   * run-scoped identity as a background one.
    */
   public static List<String> buildForegroundTaskCommand(
       String containerName,
@@ -507,16 +312,16 @@ public final class AgentSession {
       String runId) {
     var cli = Objects.requireNonNullElse(agentCli, AgentCli.CLAUDE_CODE);
     warnIfReasoningEffortDropped(cli, specId, reasoningEffort);
-    var effectiveRunId = Objects.requireNonNullElse(runId, "");
-    var unit = effectiveRunId.isBlank() ? AgentUnit.BUILD : AgentUnit.forRun(effectiveRunId);
+    var unit = AgentUnit.forRun(runId);
     var settingsPath = cli == AgentCli.CLAUDE_CODE ? ClaudeCodeHookConfig.SETTINGS_PATH : null;
     var agentCmd =
         cli.headlessCommand(unit.taskPath(), fullPermissions, model, reasoningEffort, settingsPath);
     var effectiveSpec = Objects.requireNonNullElse(specId, "");
     var effectiveAgent = agentType == null || agentType.isBlank() ? cli.yamlName() : agentType;
     var script =
-        "mkdir -p \"$(dirname \"$5\")\"; cd \"$1\" && "
-            + "SAIL_SPEC_ID=\"$3\" SAIL_AGENT=\"$4\" SAIL_RUN_ID=\"$6\" bash -l -c \"$2\" > \"$5\" 2>&1";
+        "mkdir -p \"$(dirname \"$5\")\"; printf '%s\\n' \"$$\" > \"$7\"; cd \"$1\" && "
+            + "SAIL_SPEC_ID=\"$3\" SAIL_AGENT=\"$4\" SAIL_RUN_ID=\"$6\""
+            + " exec bash -l -c \"$2\" > \"$5\" 2>&1";
     return ContainerExec.asDevUser(
         containerName,
         List.of(
@@ -530,7 +335,8 @@ public final class AgentSession {
             effectiveSpec,
             effectiveAgent,
             logPath,
-            effectiveRunId));
+            runId,
+            unit.pidPath()));
   }
 
   private static void warnIfReasoningEffortDropped(
@@ -547,23 +353,12 @@ public final class AgentSession {
             + ". Only Codex honors reasoning_effort.");
   }
 
-  /** Returns the path to the agent log file inside the container. */
-  public static String logPath() {
-    return LOG_FILE;
-  }
-
   /**
-   * Reads the agent unit's terminal state from systemd in a single call: liveness, exit code, and
-   * the spec/agent it was launched for (parsed from the unit's recorded environment). Lets the
+   * Reads the given role's unit terminal state from systemd in a single call: liveness, exit code,
+   * and the spec/agent it was launched for (parsed from the unit's recorded environment). Lets the
    * watcher detect an exit and synthesize a reliable stop signal even when the agent's own hook
    * never fired.
    */
-  public ExitState queryExitStatus(String containerName)
-      throws IOException, InterruptedException, TimeoutException {
-    return queryExitStatus(containerName, AgentUnit.BUILD);
-  }
-
-  /** Reads the given role's unit terminal state from systemd (liveness, exit code, spec/agent). */
   public ExitState queryExitStatus(String containerName, AgentUnit unit)
       throws IOException, InterruptedException, TimeoutException {
     var cmd =

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/AgentUnit.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/AgentUnit.java
@@ -11,20 +11,19 @@ import ai.singlr.sail.common.Ids;
  * The identity of a headless agent run inside a container: the systemd unit that owns it and the
  * files carrying its pid, streamed log, session metadata, and task/prompt.
  *
- * <p>A dispatched build run gets a <em>per-run</em> identity via {@link #forRun}: unit {@code
- * sail-agent-<runId>} with every file under {@code ~/.sail/runs/<runId>/}, so concurrent dispatches
- * in one container never collide on a unit name or clobber each other's session state. The run
- * records the unit it was launched with as part of its aggregate; later consumers (stop, probe,
- * reconciler, watcher) rebuild the identity from that record via {@link #recorded} instead of
- * re-deriving the name, so the derivation rule can change without stranding a run that is already
- * executing.
+ * <p>Every agent session — dispatched or ad-hoc — gets a <em>per-run</em> identity via {@link
+ * #forRun}: unit {@code sail-agent-<runId>} with every file under {@code ~/.sail/runs/<runId>/}, so
+ * concurrent executions in one container never collide on a unit name or clobber each other's
+ * session state. The run records the unit it was launched with as part of its aggregate; later
+ * consumers (stop, probe, reconciler, watcher) rebuild the identity from that record via {@link
+ * #recorded} instead of re-deriving the name, so the derivation rule can change without stranding a
+ * run that is already executing.
  *
- * <p>{@link #BUILD} remains the fixed identity of the ad-hoc lane — {@code sail agent start} and
- * other engineer-initiated sessions that mint no run. A review gets a <em>per-review</em> identity
- * via {@link #forReview}: the pipeline executes each spec's review on its own virtual thread, so
- * concurrently completed specs review concurrently, and a shared prompt or log would
- * cross-contaminate them. The reviewer and its fix agent share the review's own {@code review.log},
- * so one attempt's whole review↔fix negotiation still lands in one live-followable file.
+ * <p>A review gets a <em>per-review</em> identity via {@link #forReview}: the pipeline executes
+ * each spec's review on its own virtual thread, so concurrently completed specs review
+ * concurrently, and a shared prompt or log would cross-contaminate them. The reviewer and its fix
+ * agent share the review's own {@code review.log}, so one attempt's whole review↔fix negotiation
+ * still lands in one live-followable file.
  *
  * <p>The paths are the single source of truth for where an agent run lives on disk; {@link
  * AgentSession} and the watcher read them from here rather than hardcoding their own copies.
@@ -40,20 +39,11 @@ public record AgentUnit(
   /** Prefix of every run-scoped build unit: {@code sail-agent-<runId>}. */
   public static final String RUN_UNIT_PREFIX = "sail-agent-";
 
-  /** The ad-hoc (non-dispatch) build agent: one fixed unit and file set per container. */
-  public static final AgentUnit BUILD =
-      new AgentUnit(
-          "sail-agent",
-          DIR + "/agent.log",
-          DIR + "/agent.pid",
-          DIR + "/agent-session.json",
-          DIR + "/agent-task.txt");
-
   /**
-   * The review role's template identity: {@link #fromRole} and the log endpoints use its file names
-   * to derive run-scoped review paths, and {@code sail agent log --review} falls back to its fixed
-   * log when no review exists yet. Live reviews never run here — each executes under its own {@link
-   * #forReview} identity.
+   * The review role's template identity: {@link #logPathForRole} and the log endpoints use its file
+   * names to derive run-scoped review paths, and {@code sail agent log --review} falls back to its
+   * fixed log when no review exists yet. Live reviews never run here — each executes under its own
+   * {@link #forReview} identity.
    */
   public static final AgentUnit REVIEW =
       new AgentUnit(
@@ -125,17 +115,20 @@ public record AgentUnit(
   }
 
   /**
-   * Resolves the log-selecting role name — {@code build} or {@code review}, the API/CLI equivalent
-   * of {@code --review} — to its unit, so the log endpoints share one mapping instead of hardcoding
-   * a second path. Throws {@link IllegalArgumentException} for any other value.
+   * Resolves a run row's recorded role to its run-scoped log path — {@code agent.log} for the build
+   * and ad-hoc session roles, {@code review.log} for reviews — so the log endpoints share one
+   * mapping instead of hardcoding a second path. The path derives from the canonical run id, never
+   * a persisted path: run rows replicate over sync, so a stored path is untrusted input that must
+   * never select a file. Throws {@link IllegalArgumentException} for any other role.
    */
-  public static AgentUnit fromRole(String role) {
+  public static String logPathForRole(String role, String runId) {
+    var id = Ids.requireUuid(runId);
     return switch (role) {
-      case "build" -> BUILD;
-      case "review" -> REVIEW;
+      case "build", "adhoc" -> runDir(id) + "/agent.log";
+      case "review" -> REVIEW.runLogPath(id);
       default ->
           throw new IllegalArgumentException(
-              "Unknown role: " + role + " (expected build or review)");
+              "Unknown role: " + role + " (expected build, adhoc, or review)");
     };
   }
 }

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentReporterTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentReporterTest.java
@@ -45,7 +45,8 @@ class AgentReporterTest {
         unit,
         startedAt,
         completedAt,
-        List.of());
+        List.of(),
+        null);
   }
 
   @Test

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentReporterTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentReporterTest.java
@@ -23,6 +23,30 @@ import org.junit.jupiter.api.io.TempDir;
 class AgentReporterTest {
 
   private static final String CONTAINER = "acme-health";
+  private static final String RUN_ID = "019bd3a8-94b0-7f3d-a0f5-77d2b4cfda01";
+  private static final AgentUnit RUN_UNIT = AgentUnit.forRun(RUN_ID);
+
+  private static RunStore.RunRow sessionRow(
+      String unit, String status, Integer exitCode, String startedAt, String completedAt) {
+    return new RunStore.RunRow(
+        RUN_ID,
+        CONTAINER,
+        "auth",
+        "node-a",
+        "build",
+        "claude-code",
+        "feat/auth",
+        "do it",
+        123,
+        null,
+        status,
+        exitCode,
+        null,
+        unit,
+        startedAt,
+        completedAt,
+        List.of());
+  }
 
   @Test
   void completedSessionWithSpecs(@TempDir java.nio.file.Path stateDir) throws Exception {
@@ -32,22 +56,25 @@ class AgentReporterTest {
         List.of(
             new Spec("auth", "test", "Build auth module", SpecStatus.DONE, null, List.of(), null),
             new Spec("tests", "test", "Write tests", SpecStatus.DONE, null, List.of(), null));
+    var session = sessionRow(RUN_UNIT.unitName(), "completed", 0, startedAt, null);
     var shell =
         new ScriptedShellExecutor()
-            .onOk("cat /home/dev/.sail/agent.pid", "12345\n")
+            .onOk("cat " + RUN_UNIT.pidPath(), "12345\n")
             .onFail("kill -0 12345", "No such process")
             .onOk(
-                "cat /home/dev/.sail/agent-session.json",
+                "cat " + RUN_UNIT.sessionPath(),
                 "{\"task\":\"build auth\",\"started_at\":\""
                     + startedAt
-                    + "\",\"branch\":\"sail/snap-20260302\",\"log_path\":\"/home/dev/.sail/agent.log\"}")
+                    + "\",\"branch\":\"sail/snap-20260302\",\"log_path\":\""
+                    + RUN_UNIT.logPath()
+                    + "\"}")
             .onOk("git -C /home/dev/workspace log -1 --format=%ct", lastCommit + "\n")
             .onOk("git -C /home/dev/workspace rev-list --count", "18\n")
             .onFail("cat /home/dev/guardrail-triggered.yaml", "No such file");
 
     var config = buildConfig();
     var reporter = new AgentReporter(shell);
-    var report = reporter.generate(CONTAINER, config, specs, null, stateDir);
+    var report = reporter.generate(CONTAINER, config, specs, session, stateDir);
 
     assertEquals(CONTAINER, report.name());
     assertEquals("Completed", report.sessionStatus());
@@ -66,22 +93,25 @@ class AgentReporterTest {
   void runningSessionReportsRunning(@TempDir java.nio.file.Path stateDir) throws Exception {
     var startedAt = Instant.now().minusSeconds(1800).toString();
     var lastCommit = String.valueOf(Instant.now().minusSeconds(60).getEpochSecond());
+    var session = sessionRow(RUN_UNIT.unitName(), "running", null, startedAt, null);
     var shell =
         new ScriptedShellExecutor()
-            .onOk("cat /home/dev/.sail/agent.pid", "9999\n")
+            .onOk("cat " + RUN_UNIT.pidPath(), "9999\n")
             .onOk("kill -0 9999", "")
             .onOk(
-                "cat /home/dev/.sail/agent-session.json",
+                "cat " + RUN_UNIT.sessionPath(),
                 "{\"task\":\"fix bug\",\"started_at\":\""
                     + startedAt
-                    + "\",\"branch\":\"\",\"log_path\":\"/home/dev/.sail/agent.log\"}")
+                    + "\",\"branch\":\"\",\"log_path\":\""
+                    + RUN_UNIT.logPath()
+                    + "\"}")
             .onOk("git -C /home/dev/workspace log -1 --format=%ct", lastCommit + "\n")
             .onOk("git -C /home/dev/workspace rev-list --count", "5\n")
             .onFail("cat /home/dev/guardrail-triggered.yaml", "No such file");
 
     var config = buildConfig();
     var reporter = new AgentReporter(shell);
-    var report = reporter.generate(CONTAINER, config, List.of(), null, stateDir);
+    var report = reporter.generate(CONTAINER, config, List.of(), session, stateDir);
 
     assertEquals("Running", report.sessionStatus());
     assertEquals(5, report.commitCount());
@@ -89,17 +119,49 @@ class AgentReporterTest {
   }
 
   @Test
-  void guardrailTriggeredSession(@TempDir java.nio.file.Path stateDir) throws Exception {
-    var startedAt = Instant.now().minusSeconds(3600 * 5).toString();
+  void aForegroundSessionWithABlankUnitStillProbesItsRunScopedPidFile(
+      @TempDir java.nio.file.Path stateDir) throws Exception {
+    var startedAt = Instant.now().minusSeconds(600).toString();
+    var session = sessionRow("", "running", null, startedAt, null);
     var shell =
         new ScriptedShellExecutor()
-            .onOk("cat /home/dev/.sail/agent.pid", "12345\n")
+            .onOk("cat " + RUN_UNIT.pidPath(), "4242\n")
+            .onOk("kill -0 4242", "")
+            .onOk(
+                "cat " + RUN_UNIT.sessionPath(),
+                "{\"task\":\"ad-hoc fix\",\"started_at\":\""
+                    + startedAt
+                    + "\",\"branch\":\"\",\"log_path\":\""
+                    + RUN_UNIT.logPath()
+                    + "\"}")
+            .onOk("git -C /home/dev/workspace log -1 --format=%ct", "\n")
+            .onOk("git -C /home/dev/workspace rev-list --count", "0\n")
+            .onFail("cat /home/dev/guardrail-triggered.yaml", "No such file");
+
+    var report =
+        new AgentReporter(shell).generate(CONTAINER, buildConfig(), List.of(), session, stateDir);
+
+    assertEquals("Running", report.sessionStatus());
+    assertTrue(
+        shell.invocations().stream().anyMatch(c -> c.contains("cat " + RUN_UNIT.pidPath())),
+        "a foreground run's blank unit still probes through the run-scoped pid file");
+  }
+
+  @Test
+  void guardrailTriggeredSession(@TempDir java.nio.file.Path stateDir) throws Exception {
+    var startedAt = Instant.now().minusSeconds(3600 * 5).toString();
+    var session = sessionRow(RUN_UNIT.unitName(), "stopped", null, startedAt, null);
+    var shell =
+        new ScriptedShellExecutor()
+            .onOk("cat " + RUN_UNIT.pidPath(), "12345\n")
             .onFail("kill -0 12345", "No such process")
             .onOk(
-                "cat /home/dev/.sail/agent-session.json",
+                "cat " + RUN_UNIT.sessionPath(),
                 "{\"task\":\"implement API\",\"started_at\":\""
                     + startedAt
-                    + "\",\"branch\":\"sail/api\",\"log_path\":\"/home/dev/.sail/agent.log\"}")
+                    + "\",\"branch\":\"sail/api\",\"log_path\":\""
+                    + RUN_UNIT.logPath()
+                    + "\"}")
             .onOk(
                 "cat /home/dev/guardrail-triggered.yaml",
                 "reason: max_duration\naction: snapshot-and-stop\n")
@@ -108,7 +170,7 @@ class AgentReporterTest {
 
     var config = buildConfig();
     var reporter = new AgentReporter(shell);
-    var report = reporter.generate(CONTAINER, config, List.of(), null, stateDir);
+    var report = reporter.generate(CONTAINER, config, List.of(), session, stateDir);
 
     assertEquals("Killed by guardrail", report.sessionStatus());
     assertTrue(report.guardrailTriggered());
@@ -121,7 +183,6 @@ class AgentReporterTest {
   void noSessionReturnsMinimalReport(@TempDir java.nio.file.Path stateDir) throws Exception {
     var shell =
         new ScriptedShellExecutor()
-            .onFail("cat /home/dev/.sail/agent.pid", "No such file")
             .onFail("cat /home/dev/guardrail-triggered.yaml", "No such file")
             .onOk("git -C /home/dev/workspace log -1 --format=%ct", "\n")
             .onOk("git -C /home/dev/workspace rev-list --count", "0\n");
@@ -134,6 +195,9 @@ class AgentReporterTest {
     assertFalse(report.guardrailTriggered());
     assertFalse(report.rolledBack());
     assertTrue(report.specs().isEmpty());
+    assertTrue(
+        shell.invocations().stream().noneMatch(c -> c.contains("agent.pid")),
+        "a null session row probes no pid file at all");
   }
 
   @Test
@@ -146,22 +210,25 @@ class AgentReporterTest {
             + "\"\nexit_code: 1\nsnapshot_restored: pre-agent-20260302\ntask: implement auth\n";
     Files.writeString(stateDir.resolve("last-rollback.yaml"), rollbackYaml);
 
+    var session = sessionRow(RUN_UNIT.unitName(), "stopped", null, startedAt, null);
     var shell =
         new ScriptedShellExecutor()
-            .onOk("cat /home/dev/.sail/agent.pid", "12345\n")
+            .onOk("cat " + RUN_UNIT.pidPath(), "12345\n")
             .onFail("kill -0 12345", "No such process")
             .onOk(
-                "cat /home/dev/.sail/agent-session.json",
+                "cat " + RUN_UNIT.sessionPath(),
                 "{\"task\":\"implement auth\",\"started_at\":\""
                     + startedAt
-                    + "\",\"branch\":\"sail/snap\",\"log_path\":\"/home/dev/.sail/agent.log\"}")
+                    + "\",\"branch\":\"sail/snap\",\"log_path\":\""
+                    + RUN_UNIT.logPath()
+                    + "\"}")
             .onFail("cat /home/dev/guardrail-triggered.yaml", "No such file")
             .onOk("git -C /home/dev/workspace log -1 --format=%ct", "\n")
             .onOk("git -C /home/dev/workspace rev-list --count", "10\n");
 
     var config = buildConfig();
     var reporter = new AgentReporter(shell);
-    var report = reporter.generate(CONTAINER, config, List.of(), null, stateDir);
+    var report = reporter.generate(CONTAINER, config, List.of(), session, stateDir);
 
     assertEquals("Rolled back", report.sessionStatus());
     assertTrue(report.rolledBack());
@@ -177,22 +244,25 @@ class AgentReporterTest {
             new Spec("auth", "test", "Build auth", SpecStatus.DONE, null, List.of(), null),
             new Spec(
                 "docs", "test", "Update docs", SpecStatus.PENDING, null, List.of("auth"), null));
+    var session = sessionRow(RUN_UNIT.unitName(), "completed", 0, startedAt, null);
     var shell =
         new ScriptedShellExecutor()
-            .onOk("cat /home/dev/.sail/agent.pid", "12345\n")
+            .onOk("cat " + RUN_UNIT.pidPath(), "12345\n")
             .onFail("kill -0 12345", "No such process")
             .onOk(
-                "cat /home/dev/.sail/agent-session.json",
+                "cat " + RUN_UNIT.sessionPath(),
                 "{\"task\":\"build auth\",\"started_at\":\""
                     + startedAt
-                    + "\",\"branch\":\"\",\"log_path\":\"/home/dev/.sail/agent.log\"}")
+                    + "\",\"branch\":\"\",\"log_path\":\""
+                    + RUN_UNIT.logPath()
+                    + "\"}")
             .onOk("git -C /home/dev/workspace log -1 --format=%ct", "\n")
             .onOk("git -C /home/dev/workspace rev-list --count", "8\n")
             .onFail("cat /home/dev/guardrail-triggered.yaml", "No such file");
 
     var config = buildConfig();
     var reporter = new AgentReporter(shell);
-    var report = reporter.generate(CONTAINER, config, specs, null, stateDir);
+    var report = reporter.generate(CONTAINER, config, specs, session, stateDir);
 
     assertEquals(2, report.specs().size());
     assertEquals("Build auth", report.specs().getFirst().title());
@@ -205,28 +275,10 @@ class AgentReporterTest {
       throws Exception {
     var start = Instant.now().minusSeconds(7200);
     var end = Instant.now().minusSeconds(3600);
-    var session =
-        new RunStore.RunRow(
-            "019bd3a8-94b0-7f3d-a0f5-77d2b4cfda01",
-            CONTAINER,
-            "auth",
-            "node-a",
-            "build",
-            "claude-code",
-            "feat/auth",
-            "do it",
-            123,
-            null,
-            "completed",
-            0,
-            null,
-            "sail-agent-build-s1",
-            start.toString(),
-            end.toString(),
-            List.of());
+    var session = sessionRow(RUN_UNIT.unitName(), "completed", 0, start.toString(), end.toString());
     var shell =
         new ScriptedShellExecutor()
-            .onFail("cat /home/dev/.sail/agent.pid", "No such file")
+            .onFail("cat " + RUN_UNIT.pidPath(), "No such file")
             .onFail("cat /home/dev/guardrail-triggered.yaml", "No such file")
             .onOk("git -C /home/dev/workspace log -1 --format=%ct", "\n")
             .onOk("git -C /home/dev/workspace rev-list --count", "0\n");
@@ -243,27 +295,10 @@ class AgentReporterTest {
   void aNonZeroExitIsReportedAsFailed(@TempDir java.nio.file.Path stateDir) throws Exception {
     var start = Instant.now().minusSeconds(120);
     var session =
-        new RunStore.RunRow(
-            "019bd3a8-94b0-7f3d-a0f5-77d2b4cfda02",
-            CONTAINER,
-            "auth",
-            "node-a",
-            "build",
-            "claude-code",
-            "feat/auth",
-            "do it",
-            123,
-            null,
-            "stopped",
-            137,
-            null,
-            "sail-agent-build-s1",
-            start.toString(),
-            Instant.now().toString(),
-            List.of());
+        sessionRow(RUN_UNIT.unitName(), "stopped", 137, start.toString(), Instant.now().toString());
     var shell =
         new ScriptedShellExecutor()
-            .onFail("cat /home/dev/.sail/agent.pid", "No such file")
+            .onFail("cat " + RUN_UNIT.pidPath(), "No such file")
             .onFail("cat /home/dev/guardrail-triggered.yaml", "No such file")
             .onOk("git -C /home/dev/workspace log -1 --format=%ct", "\n")
             .onOk("git -C /home/dev/workspace rev-list --count", "0\n");

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
@@ -19,6 +19,51 @@ import org.junit.jupiter.api.Test;
 
 class AgentSessionTest {
 
+  private static final String RUN_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  private static final AgentUnit RUN_UNIT = AgentUnit.forRun(RUN_ID);
+
+  private static List<String> background(
+      boolean fullPermissions,
+      AgentCli cli,
+      String model,
+      String reasoningEffort,
+      String specId,
+      String agentType) {
+    return AgentSession.buildBackgroundLaunchCommand(
+        "acme",
+        "dev",
+        "/home/dev/workspace",
+        fullPermissions,
+        cli,
+        model,
+        reasoningEffort,
+        specId,
+        agentType,
+        RUN_UNIT.logPath(),
+        RUN_ID);
+  }
+
+  private static List<String> foreground(
+      boolean fullPermissions,
+      AgentCli cli,
+      String model,
+      String reasoningEffort,
+      String specId,
+      String agentType) {
+    return AgentSession.buildForegroundTaskCommand(
+        "acme",
+        "dev",
+        "/home/dev/workspace",
+        fullPermissions,
+        cli,
+        model,
+        reasoningEffort,
+        specId,
+        agentType,
+        RUN_UNIT.logPath(),
+        RUN_ID);
+  }
+
   @Test
   void ensureDirectoryRunsCorrectCommand() throws Exception {
     var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
@@ -36,16 +81,17 @@ class AgentSessionTest {
   void queryStatusWhenRunning() throws Exception {
     var shell =
         new ScriptedShellExecutor()
-            .onOk("cat /home/dev/.sail/agent.pid", "12345\n")
+            .onOk("cat " + RUN_UNIT.pidPath(), "12345\n")
             .onOk("kill -0 12345", "")
             .onOk(
-                "cat /home/dev/.sail/agent-session.json",
-                """
-                {"task":"implement auth","started_at":"2026-02-21T03:00:00Z","branch":"sail/snap-20260221","log_path":"/home/dev/.sail/agent.log"}
-                """);
+                "cat " + RUN_UNIT.sessionPath(),
+                "{\"task\":\"implement auth\",\"started_at\":\"2026-02-21T03:00:00Z\","
+                    + "\"branch\":\"sail/snap-20260221\",\"log_path\":\""
+                    + RUN_UNIT.logPath()
+                    + "\"}");
     var session = new AgentSession(shell);
 
-    var info = session.queryStatus("acme-health");
+    var info = session.queryStatus("acme-health", RUN_UNIT);
 
     assertNotNull(info);
     assertTrue(info.running());
@@ -53,23 +99,24 @@ class AgentSessionTest {
     assertEquals("implement auth", info.task());
     assertEquals("2026-02-21T03:00:00Z", info.startedAt());
     assertEquals("sail/snap-20260221", info.branch());
-    assertEquals("/home/dev/.sail/agent.log", info.logPath());
+    assertEquals(RUN_UNIT.logPath(), info.logPath());
   }
 
   @Test
   void queryStatusWhenStopped() throws Exception {
     var shell =
         new ScriptedShellExecutor()
-            .onOk("cat /home/dev/.sail/agent.pid", "12345\n")
+            .onOk("cat " + RUN_UNIT.pidPath(), "12345\n")
             .onFail("kill -0 12345", "No such process")
             .onOk(
-                "cat /home/dev/.sail/agent-session.json",
-                """
-                {"task":"implement auth","started_at":"2026-02-21T03:00:00Z","branch":"","log_path":"/home/dev/.sail/agent.log"}
-                """);
+                "cat " + RUN_UNIT.sessionPath(),
+                "{\"task\":\"implement auth\",\"started_at\":\"2026-02-21T03:00:00Z\","
+                    + "\"branch\":\"\",\"log_path\":\""
+                    + RUN_UNIT.logPath()
+                    + "\"}");
     var session = new AgentSession(shell);
 
-    var info = session.queryStatus("acme-health");
+    var info = session.queryStatus("acme-health", RUN_UNIT);
 
     assertNotNull(info);
     assertFalse(info.running());
@@ -80,11 +127,13 @@ class AgentSessionTest {
   void queryStatusWhenNoPidFile() throws Exception {
     var shell =
         new ScriptedShellExecutor()
-            .onFail("cat /home/dev/.sail/agent.pid", "No such file")
-            .onOk("systemctl --user show sail-agent.service --property=MainPID --value", "0\n");
+            .onFail("cat " + RUN_UNIT.pidPath(), "No such file")
+            .onOk(
+                "systemctl --user show " + RUN_UNIT.service() + " --property=MainPID --value",
+                "0\n");
     var session = new AgentSession(shell);
 
-    var info = session.queryStatus("acme-health");
+    var info = session.queryStatus("acme-health", RUN_UNIT);
 
     assertNull(info);
   }
@@ -93,17 +142,20 @@ class AgentSessionTest {
   void queryStatusFallsBackToSystemdMainPid() throws Exception {
     var shell =
         new ScriptedShellExecutor()
-            .onFail("cat /home/dev/.sail/agent.pid", "No such file")
-            .onOk("systemctl --user show sail-agent.service --property=MainPID --value", "54321\n")
+            .onFail("cat " + RUN_UNIT.pidPath(), "No such file")
+            .onOk(
+                "systemctl --user show " + RUN_UNIT.service() + " --property=MainPID --value",
+                "54321\n")
             .onOk("kill -0 54321", "")
             .onOk(
-                "cat /home/dev/.sail/agent-session.json",
-                """
-                {"task":"polish ui","started_at":"2026-05-07T03:00:00Z","branch":"feat/ui","log_path":"/home/dev/.sail/agent.log"}
-                """);
+                "cat " + RUN_UNIT.sessionPath(),
+                "{\"task\":\"polish ui\",\"started_at\":\"2026-05-07T03:00:00Z\","
+                    + "\"branch\":\"feat/ui\",\"log_path\":\""
+                    + RUN_UNIT.logPath()
+                    + "\"}");
     var session = new AgentSession(shell);
 
-    var info = session.queryStatus("acme-health");
+    var info = session.queryStatus("acme-health", RUN_UNIT);
 
     assertNotNull(info);
     assertTrue(info.running());
@@ -113,20 +165,20 @@ class AgentSessionTest {
 
   @Test
   void queryStatusWhenPidFileEmpty() throws Exception {
-    var shell = new ScriptedShellExecutor().onOk("cat /home/dev/.sail/agent.pid", "");
+    var shell = new ScriptedShellExecutor().onOk("cat " + RUN_UNIT.pidPath(), "");
     var session = new AgentSession(shell);
 
-    var info = session.queryStatus("acme-health");
+    var info = session.queryStatus("acme-health", RUN_UNIT);
 
     assertNull(info);
   }
 
   @Test
   void queryStatusWhenPidNotANumber() throws Exception {
-    var shell = new ScriptedShellExecutor().onOk("cat /home/dev/.sail/agent.pid", "not-a-number\n");
+    var shell = new ScriptedShellExecutor().onOk("cat " + RUN_UNIT.pidPath(), "not-a-number\n");
     var session = new AgentSession(shell);
 
-    var info = session.queryStatus("acme-health");
+    var info = session.queryStatus("acme-health", RUN_UNIT);
 
     assertNull(info);
   }
@@ -135,27 +187,27 @@ class AgentSessionTest {
   void killAgentSendsTermThenKill() throws Exception {
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
-            .onOk("cat /home/dev/.sail/agent.pid", "9999\n");
+            .onOk("cat " + RUN_UNIT.pidPath(), "9999\n");
     var session = new AgentSession(shell);
 
-    session.killAgent("acme-health");
+    session.killAgent("acme-health", RUN_UNIT);
 
     var cmds = shell.invocations();
     assertTrue(cmds.stream().anyMatch(c -> c.contains("kill 9999")));
     assertTrue(cmds.stream().anyMatch(c -> c.contains("sleep 3")));
     assertTrue(cmds.stream().anyMatch(c -> c.contains("kill -9 9999")));
-    assertTrue(cmds.stream().anyMatch(c -> c.contains("rm -f")));
+    assertTrue(cmds.stream().anyMatch(c -> c.contains("rm -f " + RUN_UNIT.pidPath())));
   }
 
   @Test
   void killAgentCleanTermination() throws Exception {
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
-            .onOk("cat /home/dev/.sail/agent.pid", "9999\n")
+            .onOk("cat " + RUN_UNIT.pidPath(), "9999\n")
             .onFail("kill -0 9999", "No such process");
     var session = new AgentSession(shell);
 
-    session.killAgent("acme-health");
+    session.killAgent("acme-health", RUN_UNIT);
 
     var cmds = shell.invocations();
     assertFalse(cmds.stream().anyMatch(c -> c.contains("kill -9 9999")));
@@ -166,11 +218,11 @@ class AgentSessionTest {
   void killAgentThrowsWhenSigkillFailsOnALiveProcess() {
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
-            .onOk("cat /home/dev/.sail/agent.pid", "9999\n")
+            .onOk("cat " + RUN_UNIT.pidPath(), "9999\n")
             .onFail("kill -9 9999", "Operation not permitted");
     var session = new AgentSession(shell);
 
-    var failure = assertThrows(IOException.class, () -> session.killAgent("acme-health"));
+    var failure = assertThrows(IOException.class, () -> session.killAgent("acme-health", RUN_UNIT));
 
     assertTrue(failure.getMessage().contains("SIGKILL"));
     assertTrue(failure.getMessage().contains("9999"));
@@ -181,7 +233,7 @@ class AgentSessionTest {
   void killAgentTreatsSigkillOfAnAlreadyDeadProcessAsSuccess() throws Exception {
     var shell =
         new ScriptedShellExecutor()
-            .onOk("cat /home/dev/.sail/agent.pid", "9999\n")
+            .onOk("cat " + RUN_UNIT.pidPath(), "9999\n")
             .onOk("kill 9999")
             .onOk("sleep 3")
             .onceOnOk("kill -0 9999")
@@ -189,7 +241,7 @@ class AgentSessionTest {
             .onOk("rm -f");
     var session = new AgentSession(shell);
 
-    session.killAgent("acme-health");
+    session.killAgent("acme-health", RUN_UNIT);
 
     assertTrue(shell.invocations().stream().anyMatch(c -> c.contains("rm -f")));
   }
@@ -198,10 +250,10 @@ class AgentSessionTest {
   void killAgentIgnoresNonNumericPid() throws Exception {
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
-            .onOk("cat /home/dev/.sail/agent.pid", "; rm -rf /\n");
+            .onOk("cat " + RUN_UNIT.pidPath(), "; rm -rf /\n");
     var session = new AgentSession(shell);
 
-    session.killAgent("acme-health");
+    session.killAgent("acme-health", RUN_UNIT);
 
     var cmds = shell.invocations();
     assertEquals(1, cmds.size());
@@ -210,19 +262,17 @@ class AgentSessionTest {
 
   @Test
   void killAgentNoPidFileIsNoOp() throws Exception {
-    var shell = new ScriptedShellExecutor().onFail("cat /home/dev/.sail/agent.pid", "No such file");
+    var shell = new ScriptedShellExecutor().onFail("cat " + RUN_UNIT.pidPath(), "No such file");
     var session = new AgentSession(shell);
 
-    session.killAgent("acme-health");
+    session.killAgent("acme-health", RUN_UNIT);
 
     assertEquals(1, shell.invocations().size());
   }
 
   @Test
   void buildBackgroundLaunchCommandStructure() {
-    var cmd =
-        AgentSession.buildBackgroundLaunchCommand(
-            "acme", "dev", "/home/dev/workspace", false, AgentCli.CLAUDE_CODE);
+    var cmd = background(false, AgentCli.CLAUDE_CODE, null, null, null, null);
 
     assertEquals("incus", cmd.getFirst());
     assertTrue(cmd.contains("acme"));
@@ -231,36 +281,25 @@ class AgentSessionTest {
     assertTrue(
         joined.contains(
             "systemd-run --user --setenv \"SAIL_SPEC_ID=$6\" --setenv \"SAIL_AGENT=$7\""
-                + " --setenv \"SAIL_RUN_ID=$8\" --unit sail-agent"));
+                + " --setenv \"SAIL_RUN_ID=$8\" --unit "
+                + RUN_UNIT.unitName()));
     assertTrue(joined.contains("claude --print"));
     assertTrue(joined.contains("--settings " + ClaudeCodeHookConfig.SETTINGS_PATH));
-    assertTrue(joined.contains("agent.log"));
-    assertTrue(joined.contains("agent.pid"));
-    assertTrue(joined.contains("agent-task.txt"));
+    assertTrue(cmd.contains(RUN_UNIT.logPath()));
+    assertTrue(cmd.contains(RUN_UNIT.pidPath()));
+    assertTrue(joined.contains(RUN_UNIT.taskPath()));
     assertFalse(joined.contains("--dangerously-skip-permissions"));
   }
 
   @Test
   void buildBackgroundLaunchCommandRedirectsToARunScopedLog() {
-    var runId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
-    var runLog = AgentUnit.forRun(runId).logPath();
-    var cmd =
-        AgentSession.buildBackgroundLaunchCommand(
-            "acme",
-            "dev",
-            "/home/dev/workspace",
-            true,
-            AgentCli.CLAUDE_CODE,
-            null,
-            null,
-            "spec-1",
-            "claude-code",
-            runLog,
-            runId);
+    var cmd = background(true, AgentCli.CLAUDE_CODE, null, null, "spec-1", "claude-code");
 
     var joined = String.join(" ", cmd);
-    assertTrue(joined.contains(runLog), "the agent's output is redirected to the run-scoped log");
-    assertTrue(cmd.contains(runId), "the run id is carried in as SAIL_RUN_ID");
+    assertTrue(
+        joined.contains(RUN_UNIT.logPath()),
+        "the agent's output is redirected to the run-scoped log");
+    assertTrue(cmd.contains(RUN_ID), "the run id is carried in as SAIL_RUN_ID");
     assertTrue(
         joined.contains("mkdir -p \"$(dirname \"$4\")\""), "the run's log directory is created");
     assertFalse(
@@ -286,10 +325,6 @@ class AgentSessionTest {
     assertFalse(joinedA.contains(unitB.unitName()), "run A never touches run B's unit");
     assertFalse(joinedB.contains(unitA.unitName()), "run B never touches run A's unit");
     assertFalse(
-        joinedA.contains(AgentUnit.BUILD.pidPath() + " ")
-            || joinedA.contains(AgentUnit.BUILD.taskPath()),
-        "a dispatched launch writes nothing at the fixed per-container paths");
-    assertFalse(
         AgentUnit.forRun(runA).sessionPath().equals(AgentUnit.forRun(runB).sessionPath()),
         "two runs never share a session file");
   }
@@ -311,28 +346,62 @@ class AgentSessionTest {
 
   @Test
   void buildForegroundTaskCommandRedirectsToARunScopedLog() {
-    var runId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
-    var runLog = AgentUnit.forRun(runId).logPath();
-    var cmd =
-        AgentSession.buildForegroundTaskCommand(
-            "acme",
-            "dev",
-            "/home/dev/workspace",
-            true,
-            AgentCli.CLAUDE_CODE,
-            null,
-            null,
-            "spec-1",
-            "claude-code",
-            runLog,
-            runId);
+    var cmd = foreground(true, AgentCli.CLAUDE_CODE, null, null, "spec-1", "claude-code");
 
     var joined = String.join(" ", cmd);
     assertTrue(
-        joined.contains(runLog), "the foreground agent's output is redirected to its run log");
-    assertTrue(cmd.contains(runId), "the run id is carried in as SAIL_RUN_ID");
+        joined.contains(RUN_UNIT.logPath()),
+        "the foreground agent's output is redirected to its run log");
+    assertTrue(cmd.contains(RUN_ID), "the run id is carried in as SAIL_RUN_ID");
     assertTrue(
         joined.contains("SAIL_RUN_ID=\"$6\""), "the run id is exported into the launched process");
+  }
+
+  @Test
+  void buildForegroundTaskCommandWritesTheRunScopedPidFile() {
+    var cmd = foreground(true, AgentCli.CLAUDE_CODE, null, null, "spec-1", "claude-code");
+
+    assertEquals(
+        RUN_UNIT.pidPath(),
+        cmd.getLast(),
+        "the wrapper's pid lands in the run's pid file so a foreground session stays probeable"
+            + " and stoppable");
+    var script = cmd.get(cmd.indexOf("-c") + 1);
+    assertTrue(script.contains("printf '%s\\n' \"$$\" > \"$7\""));
+  }
+
+  @Test
+  void runScopedLaunchCommandsRejectABlankOrInvalidRunId() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            AgentSession.buildBackgroundLaunchCommand(
+                "acme",
+                "dev",
+                "/home/dev/workspace",
+                false,
+                AgentCli.CLAUDE_CODE,
+                null,
+                null,
+                null,
+                null,
+                RUN_UNIT.logPath(),
+                ""));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            AgentSession.buildForegroundTaskCommand(
+                "acme",
+                "dev",
+                "/home/dev/workspace",
+                false,
+                AgentCli.CLAUDE_CODE,
+                null,
+                null,
+                null,
+                null,
+                RUN_UNIT.logPath(),
+                "../escape"));
   }
 
   @Test
@@ -365,9 +434,7 @@ class AgentSessionTest {
 
   @Test
   void buildBackgroundLaunchCommandStreamsClaudeOutput() {
-    var cmd =
-        AgentSession.buildBackgroundLaunchCommand(
-            "acme", "dev", "/home/dev/workspace", false, AgentCli.CLAUDE_CODE);
+    var cmd = background(false, AgentCli.CLAUDE_CODE, null, null, null, null);
 
     var joined = String.join(" ", cmd);
     assertTrue(
@@ -377,9 +444,7 @@ class AgentSessionTest {
 
   @Test
   void buildForegroundTaskCommandDoesNotStream() {
-    var cmd =
-        AgentSession.buildForegroundTaskCommand(
-            "acme", "dev", "/home/dev/workspace", false, AgentCli.CLAUDE_CODE);
+    var cmd = foreground(false, AgentCli.CLAUDE_CODE, null, null, null, null);
 
     var joined = String.join(" ", cmd);
     assertFalse(
@@ -389,9 +454,7 @@ class AgentSessionTest {
 
   @Test
   void buildBackgroundLaunchCommandCodexDoesNotGetStreamFlag() {
-    var cmd =
-        AgentSession.buildBackgroundLaunchCommand(
-            "acme", "dev", "/home/dev/workspace", false, AgentCli.CODEX);
+    var cmd = background(false, AgentCli.CODEX, null, null, null, null);
 
     var joined = String.join(" ", cmd);
     assertFalse(
@@ -400,44 +463,31 @@ class AgentSessionTest {
 
   @Test
   void buildBackgroundLaunchCommandPassesEmptySpecForAdHocLaunches() {
-    var cmd =
-        AgentSession.buildBackgroundLaunchCommand(
-            "acme", "dev", "/home/dev/workspace", false, AgentCli.CLAUDE_CODE);
+    var cmd = background(false, AgentCli.CLAUDE_CODE, null, null, null, null);
 
     var specId = cmd.get(cmd.size() - 3);
     var agent = cmd.get(cmd.size() - 2);
     var runId = cmd.getLast();
     assertEquals("", specId, "ad-hoc launches pass empty specId so the in-container hook no-ops");
     assertEquals("claude-code", agent, "agent type defaults to CLI yamlName when blank");
-    assertEquals("", runId, "ad-hoc launches mint no run, so SAIL_RUN_ID is empty");
+    assertEquals(RUN_ID, runId, "an ad-hoc launch is still a run, so SAIL_RUN_ID carries its id");
   }
 
   @Test
   void buildBackgroundLaunchCommandPassesSpecIdAndAgent() {
-    var cmd =
-        AgentSession.buildBackgroundLaunchCommand(
-            "acme",
-            "dev",
-            "/home/dev/workspace",
-            true,
-            AgentCli.CLAUDE_CODE,
-            null,
-            null,
-            "oauth-flow",
-            "claude-code");
+    var cmd = background(true, AgentCli.CLAUDE_CODE, null, null, "oauth-flow", "claude-code");
 
     assertTrue(cmd.contains("oauth-flow"), "specId must be present as positional arg");
     assertTrue(cmd.contains("claude-code"), "agent type must be present as positional arg");
     var joined = String.join(" ", cmd);
     assertTrue(joined.contains("--setenv \"SAIL_SPEC_ID=$6\""));
     assertTrue(joined.contains("--setenv \"SAIL_AGENT=$7\""));
+    assertTrue(joined.contains("--setenv \"SAIL_RUN_ID=$8\""));
   }
 
   @Test
   void buildBackgroundLaunchCommandNonClaudeOmitsSettingsFlag() {
-    var cmd =
-        AgentSession.buildBackgroundLaunchCommand(
-            "acme", "dev", "/home/dev/workspace", true, AgentCli.CODEX);
+    var cmd = background(true, AgentCli.CODEX, null, null, null, null);
 
     var joined = String.join(" ", cmd);
     assertFalse(joined.contains("--settings"), "only Claude Code gets the sail settings file");
@@ -445,9 +495,7 @@ class AgentSessionTest {
 
   @Test
   void buildBackgroundLaunchCommandWithPermissions() {
-    var cmd =
-        AgentSession.buildBackgroundLaunchCommand(
-            "acme", "dev", "/home/dev/workspace", true, AgentCli.CLAUDE_CODE);
+    var cmd = background(true, AgentCli.CLAUDE_CODE, null, null, null, null);
 
     var joined = String.join(" ", cmd);
     assertTrue(
@@ -459,9 +507,7 @@ class AgentSessionTest {
 
   @Test
   void buildBackgroundLaunchCommandCodexUsesExec() {
-    var cmd =
-        AgentSession.buildBackgroundLaunchCommand(
-            "acme", "dev", "/home/dev/workspace", false, AgentCli.CODEX);
+    var cmd = background(false, AgentCli.CODEX, null, null, null, null);
 
     var joined = String.join(" ", cmd);
     assertTrue(joined.contains("codex exec"));
@@ -471,9 +517,7 @@ class AgentSessionTest {
 
   @Test
   void buildBackgroundLaunchCommandCodexFullAuto() {
-    var cmd =
-        AgentSession.buildBackgroundLaunchCommand(
-            "acme", "dev", "/home/dev/workspace", true, AgentCli.CODEX);
+    var cmd = background(true, AgentCli.CODEX, null, null, null, null);
 
     var joined = String.join(" ", cmd);
     assertTrue(joined.contains("codex exec --dangerously-bypass-approvals-and-sandbox"));
@@ -481,9 +525,7 @@ class AgentSessionTest {
 
   @Test
   void buildBackgroundLaunchCommandCodexModelOptions() {
-    var cmd =
-        AgentSession.buildBackgroundLaunchCommand(
-            "acme", "dev", "/home/dev/workspace", true, AgentCli.CODEX, "gpt-5.5", "high");
+    var cmd = background(true, AgentCli.CODEX, "gpt-5.5", "high", null, null);
 
     var joined = String.join(" ", cmd);
     assertTrue(
@@ -502,16 +544,8 @@ class AgentSessionTest {
     List<String> cmd;
     try {
       cmd =
-          AgentSession.buildBackgroundLaunchCommand(
-              "acme",
-              "dev",
-              "/home/dev/workspace",
-              true,
-              AgentCli.CLAUDE_CODE,
-              "claude-opus-4",
-              "high",
-              "auth-flow",
-              "claude-code");
+          background(
+              true, AgentCli.CLAUDE_CODE, "claude-opus-4", "high", "auth-flow", "claude-code");
     } finally {
       System.setErr(originalErr);
     }
@@ -533,16 +567,7 @@ class AgentSessionTest {
     var captured = new java.io.ByteArrayOutputStream();
     System.setErr(new java.io.PrintStream(captured, true, java.nio.charset.StandardCharsets.UTF_8));
     try {
-      AgentSession.buildBackgroundLaunchCommand(
-          "acme",
-          "dev",
-          "/home/dev/workspace",
-          true,
-          AgentCli.CLAUDE_CODE,
-          null,
-          "none",
-          "auth-flow",
-          "claude-code");
+      background(true, AgentCli.CLAUDE_CODE, null, "none", "auth-flow", "claude-code");
     } finally {
       System.setErr(originalErr);
     }
@@ -558,8 +583,7 @@ class AgentSessionTest {
     var captured = new java.io.ByteArrayOutputStream();
     System.setErr(new java.io.PrintStream(captured, true, java.nio.charset.StandardCharsets.UTF_8));
     try {
-      AgentSession.buildBackgroundLaunchCommand(
-          "acme", "dev", "/home/dev/workspace", true, AgentCli.CLAUDE_CODE, "claude-opus-4", null);
+      background(true, AgentCli.CLAUDE_CODE, "claude-opus-4", null, null, null);
     } finally {
       System.setErr(originalErr);
     }
@@ -574,17 +598,7 @@ class AgentSessionTest {
     System.setErr(new java.io.PrintStream(captured, true, java.nio.charset.StandardCharsets.UTF_8));
     List<String> cmd;
     try {
-      cmd =
-          AgentSession.buildForegroundTaskCommand(
-              "acme",
-              "dev",
-              "/home/dev/workspace",
-              true,
-              AgentCli.CLAUDE_CODE,
-              null,
-              "high",
-              "auth-flow",
-              "claude-code");
+      cmd = foreground(true, AgentCli.CLAUDE_CODE, null, "high", "auth-flow", "claude-code");
     } finally {
       System.setErr(originalErr);
     }
@@ -595,9 +609,7 @@ class AgentSessionTest {
 
   @Test
   void buildBackgroundLaunchCommandDefaultsToClaudeCode() {
-    var cmd =
-        AgentSession.buildBackgroundLaunchCommand(
-            "acme", "dev", "/home/dev/workspace", false, null);
+    var cmd = background(false, null, null, null, null, null);
 
     var joined = String.join(" ", cmd);
     assertTrue(joined.contains("claude --print"));
@@ -608,12 +620,22 @@ class AgentSessionTest {
     var workDir = "/home/dev/workspace; touch /tmp/pwned";
     var cmd =
         AgentSession.buildBackgroundLaunchCommand(
-            "acme", "dev", workDir, false, AgentCli.CLAUDE_CODE);
+            "acme",
+            "dev",
+            workDir,
+            false,
+            AgentCli.CLAUDE_CODE,
+            null,
+            null,
+            null,
+            null,
+            RUN_UNIT.logPath(),
+            RUN_ID);
 
     var script = cmd.get(cmd.indexOf("-lc") + 1);
     assertTrue(script.contains("systemd-run"));
-    assertTrue(script.contains("--unit sail-agent"));
-    assertTrue(script.contains("systemctl --user show sail-agent.service"));
+    assertTrue(script.contains("--unit " + RUN_UNIT.unitName()));
+    assertTrue(script.contains("systemctl --user show " + RUN_UNIT.service()));
     assertTrue(script.contains("cd \"$1\""));
     assertFalse(script.contains(workDir));
     assertTrue(cmd.contains(workDir));
@@ -624,7 +646,17 @@ class AgentSessionTest {
     var workDir = "/home/dev/workspace; touch /tmp/pwned";
     var cmd =
         AgentSession.buildForegroundTaskCommand(
-            "acme", "dev", workDir, false, AgentCli.CLAUDE_CODE);
+            "acme",
+            "dev",
+            workDir,
+            false,
+            AgentCli.CLAUDE_CODE,
+            null,
+            null,
+            null,
+            null,
+            RUN_UNIT.logPath(),
+            RUN_ID);
 
     var script = cmd.get(cmd.indexOf("-c") + 1);
     assertTrue(script.contains("cd \"$1\""));
@@ -634,9 +666,7 @@ class AgentSessionTest {
 
   @Test
   void buildForegroundTaskCommandStructure() {
-    var cmd =
-        AgentSession.buildForegroundTaskCommand(
-            "acme", "dev", "/home/dev/workspace", false, AgentCli.CLAUDE_CODE);
+    var cmd = foreground(false, AgentCli.CLAUDE_CODE, null, null, null, null);
 
     assertEquals("incus", cmd.getFirst());
     assertTrue(cmd.contains("acme"));
@@ -644,22 +674,18 @@ class AgentSessionTest {
     assertTrue(joined.contains("claude --print"));
     assertTrue(joined.contains("--settings " + ClaudeCodeHookConfig.SETTINGS_PATH));
     assertTrue(joined.contains("agent-task.txt"));
-    assertTrue(joined.contains("SAIL_SPEC_ID=\"$3\" SAIL_AGENT=\"$4\""));
+    var script = cmd.get(cmd.indexOf("-c") + 1);
+    assertEquals(
+        "mkdir -p \"$(dirname \"$5\")\"; printf '%s\\n' \"$$\" > \"$7\"; cd \"$1\" && "
+            + "SAIL_SPEC_ID=\"$3\" SAIL_AGENT=\"$4\" SAIL_RUN_ID=\"$6\""
+            + " exec bash -l -c \"$2\" > \"$5\" 2>&1",
+        script);
+    assertEquals(RUN_UNIT.pidPath(), cmd.getLast());
   }
 
   @Test
   void buildForegroundTaskCommandPassesSpecIdAndAgent() {
-    var cmd =
-        AgentSession.buildForegroundTaskCommand(
-            "acme",
-            "dev",
-            "/home/dev/workspace",
-            true,
-            AgentCli.CLAUDE_CODE,
-            null,
-            null,
-            "oauth-flow",
-            "claude-code");
+    var cmd = foreground(true, AgentCli.CLAUDE_CODE, null, null, "oauth-flow", "claude-code");
 
     assertTrue(cmd.contains("oauth-flow"));
     assertTrue(cmd.contains("claude-code"));
@@ -667,9 +693,7 @@ class AgentSessionTest {
 
   @Test
   void buildForegroundTaskCommandCodexExec() {
-    var cmd =
-        AgentSession.buildForegroundTaskCommand(
-            "acme", "dev", "/home/dev/workspace", true, AgentCli.CODEX);
+    var cmd = foreground(true, AgentCli.CODEX, null, null, null, null);
 
     var joined = String.join(" ", cmd);
     assertTrue(joined.contains("codex exec --dangerously-bypass-approvals-and-sandbox"));
@@ -693,35 +717,10 @@ class AgentSessionTest {
 
   @Test
   void buildForegroundTaskCommandDefaultsToClaudeCode() {
-    var cmd =
-        AgentSession.buildForegroundTaskCommand("acme", "dev", "/home/dev/workspace", false, null);
+    var cmd = foreground(false, null, null, null, null, null);
 
     var joined = String.join(" ", cmd);
     assertTrue(joined.contains("claude --print"));
-  }
-
-  @Test
-  void writeSessionExecutesCommand() throws Exception {
-    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
-    var session = new AgentSession(shell);
-
-    session.writeSession("acme", "implement auth", "sail/snap-20260221");
-
-    var cmds = shell.invocations();
-    assertEquals(1, cmds.size());
-    assertTrue(cmds.getFirst().contains("agent-session.json"));
-  }
-
-  @Test
-  void writeTaskFileExecutesCommand() throws Exception {
-    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
-    var session = new AgentSession(shell);
-
-    session.writeTaskFile("acme", "implement the payment webhook");
-
-    var cmds = shell.invocations();
-    assertEquals(1, cmds.size());
-    assertTrue(cmds.getFirst().contains("agent-task.txt"));
   }
 
   @Test
@@ -802,28 +801,30 @@ class AgentSessionTest {
     var shell =
         new ScriptedShellExecutor()
             .onOk(
-                "systemctl --user show sail-agent.service",
+                "systemctl --user show " + RUN_UNIT.service(),
                 """
                 ActiveState=failed
                 ExecMainStatus=1
-                Environment=SAIL_SPEC_ID=auth SAIL_AGENT=claude-code
-                """);
+                Environment=SAIL_SPEC_ID=auth SAIL_AGENT=claude-code SAIL_RUN_ID=%s
+                """
+                    .formatted(RUN_ID));
     var session = new AgentSession(shell);
 
-    var state = session.queryExitStatus("acme");
+    var state = session.queryExitStatus("acme", RUN_UNIT);
 
     assertFalse(state.active());
     assertEquals(1, state.exitCode());
     assertEquals("auth", state.specId());
+    assertEquals(RUN_ID, state.runId());
   }
 
   @Test
   void queryExitStatusTreatsAShellFailureAsStillActive() throws Exception {
     var shell =
-        new ScriptedShellExecutor().onFail("systemctl --user show sail-agent.service", "boom");
+        new ScriptedShellExecutor().onFail("systemctl --user show " + RUN_UNIT.service(), "boom");
     var session = new AgentSession(shell);
 
-    var state = session.queryExitStatus("acme");
+    var state = session.queryExitStatus("acme", RUN_UNIT);
 
     assertTrue(state.active());
   }
@@ -833,20 +834,23 @@ class AgentSessionTest {
     var shell =
         new ScriptedShellExecutor()
             .onOk(
-                "systemctl --user show sail-agent.service",
+                "systemctl --user show " + RUN_UNIT.service(),
                 """
                 ActiveState=inactive
                 ExecMainStatus=0
                 Environment=
                 """)
             .onOk(
-                "cat /home/dev/.sail/agent-session.json",
-                """
-                {"task":"t","branch":"b","spec_id":"v1-sync-commit-integrity","agent_type":"claude-code","started_at":"2026-06-30T16:55:14Z","log_path":"/home/dev/.sail/agent.log"}
-                """);
+                "cat " + RUN_UNIT.sessionPath(),
+                "{\"task\":\"t\",\"branch\":\"b\",\"spec_id\":\"v1-sync-commit-integrity\","
+                    + "\"agent_type\":\"claude-code\",\"run_id\":\""
+                    + RUN_ID
+                    + "\",\"started_at\":\"2026-06-30T16:55:14Z\",\"log_path\":\""
+                    + RUN_UNIT.logPath()
+                    + "\"}");
     var session = new AgentSession(shell);
 
-    var state = session.queryExitStatus("sail-mast");
+    var state = session.queryExitStatus("sail-mast", RUN_UNIT);
 
     assertFalse(state.active(), "a successfully-exited unit is collected and reads as inactive");
     assertEquals(0, state.exitCode());
@@ -855,6 +859,7 @@ class AgentSessionTest {
         state.specId(),
         "spec id must survive unit garbage collection via the durable session file");
     assertEquals("claude-code", state.agentType());
+    assertEquals(RUN_ID, state.runId(), "run id must survive unit garbage collection too");
   }
 
   @Test
@@ -862,15 +867,16 @@ class AgentSessionTest {
     var shell =
         new ScriptedShellExecutor()
             .onOk(
-                "systemctl --user show sail-agent.service",
+                "systemctl --user show " + RUN_UNIT.service(),
                 """
                 ActiveState=active
                 ExecMainStatus=0
-                Environment=SAIL_SPEC_ID=scrum-12 SAIL_AGENT=codex
-                """);
+                Environment=SAIL_SPEC_ID=scrum-12 SAIL_AGENT=codex SAIL_RUN_ID=%s
+                """
+                    .formatted(RUN_ID));
     var session = new AgentSession(shell);
 
-    var state = session.queryExitStatus("acme");
+    var state = session.queryExitStatus("acme", RUN_UNIT);
 
     assertTrue(state.active());
     assertEquals("scrum-12", state.specId());
@@ -878,18 +884,27 @@ class AgentSessionTest {
   }
 
   @Test
-  void writeSessionPersistsSpecIdAndAgentTypeForDurableRecovery() throws Exception {
+  void writeSessionPersistsSpecIdAgentTypeAndRunIdForDurableRecovery() throws Exception {
     var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
     var session = new AgentSession(shell);
 
     session.writeSession(
-        "acme", "implement auth", "branch", "v1-sync-commit-integrity", "claude-code");
+        "acme",
+        "implement auth",
+        "branch",
+        "v1-sync-commit-integrity",
+        "claude-code",
+        RUN_ID,
+        List.of(),
+        RUN_UNIT);
 
     var cmd = shell.invocations().getFirst();
-    assertTrue(cmd.contains("agent-session.json"));
+    assertTrue(cmd.contains(RUN_UNIT.sessionPath()));
     assertTrue(cmd.contains("spec_id"), "session must persist spec_id for watcher recovery");
     assertTrue(cmd.contains("v1-sync-commit-integrity"));
     assertTrue(cmd.contains("claude-code"));
+    assertTrue(cmd.contains("run_id"), "session must persist run_id for watcher recovery");
+    assertTrue(cmd.contains(RUN_ID));
   }
 
   @Test
@@ -898,7 +913,14 @@ class AgentSessionTest {
     var session = new AgentSession(shell);
 
     session.writeSession(
-        "acme", "task", "branch", "spec-1", "claude-code", "run-1", List.of("manatee-nexus"));
+        "acme",
+        "task",
+        "branch",
+        "spec-1",
+        "claude-code",
+        RUN_ID,
+        List.of("manatee-nexus"),
+        RUN_UNIT);
 
     var cmd = shell.invocations().getFirst();
     assertTrue(cmd.contains("repos"), "session must persist repos for stop-gate scoping");

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
@@ -103,6 +103,41 @@ class AgentSessionTest {
   }
 
   @Test
+  void parseStartTicksReadsField22AfterTheCommField() {
+    assertEquals(
+        12345L,
+        AgentSession.parseStartTicks(
+            "77 (my (weird) app) S 1 2 3 4 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 12345 100 5"));
+    assertNull(AgentSession.parseStartTicks("no stat line"));
+    assertNull(AgentSession.parseStartTicks("77 (short) S 1 2"));
+  }
+
+  @Test
+  void readProcessStartTicksReadsProcStatInTheContainer() throws Exception {
+    var shell =
+        new ScriptedShellExecutor()
+            .onOk(
+                "cat /proc/123/stat",
+                "123 (bash) S 1 123 123 0 -1 4194560 0 0 0 0 0 0 0 0 20 0 1 0 555 0 0");
+    var session = new AgentSession(shell);
+
+    assertEquals(555L, session.readProcessStartTicks("acme-health", 123));
+    assertNull(session.readProcessStartTicks("acme-health", 999));
+  }
+
+  @Test
+  void unitActiveAsksSystemdAndNeverTheFile() throws Exception {
+    var shell = new ScriptedShellExecutor().onOk("is-active " + RUN_UNIT.service());
+    var session = new AgentSession(shell);
+
+    assertTrue(session.unitActive("acme-health", RUN_UNIT));
+    assertTrue(
+        shell.invocations().getFirst().contains("systemctl --user --quiet is-active"),
+        shell.invocations().getFirst());
+    assertFalse(new AgentSession(new ScriptedShellExecutor()).unitActive("acme-health", RUN_UNIT));
+  }
+
+  @Test
   void queryStatusWhenStopped() throws Exception {
     var shell =
         new ScriptedShellExecutor()

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentUnitTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentUnitTest.java
@@ -7,63 +7,31 @@ package ai.singlr.sail.engine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 class AgentUnitTest {
 
-  @Test
-  void buildRoleMatchesTheLegacyDispatchPathsExactly() {
-    assertEquals("sail-agent", AgentUnit.BUILD.unitName());
-    assertEquals("sail-agent.service", AgentUnit.BUILD.service());
-    assertEquals("/home/dev/.sail/agent.log", AgentUnit.BUILD.logPath());
-    assertEquals("/home/dev/.sail/agent.pid", AgentUnit.BUILD.pidPath());
-    assertEquals("/home/dev/.sail/agent-session.json", AgentUnit.BUILD.sessionPath());
-    assertEquals("/home/dev/.sail/agent-task.txt", AgentUnit.BUILD.taskPath());
-  }
-
-  @Test
-  void reviewRoleIsFullyIsolatedFromBuildSoNeitherClobbersTheOther() {
-    assertNotEquals(AgentUnit.BUILD.unitName(), AgentUnit.REVIEW.unitName());
-    assertNotEquals(AgentUnit.BUILD.logPath(), AgentUnit.REVIEW.logPath());
-    assertNotEquals(AgentUnit.BUILD.pidPath(), AgentUnit.REVIEW.pidPath());
-    assertNotEquals(AgentUnit.BUILD.sessionPath(), AgentUnit.REVIEW.sessionPath());
-    assertNotEquals(AgentUnit.BUILD.taskPath(), AgentUnit.REVIEW.taskPath());
-    assertEquals("sail-review", AgentUnit.REVIEW.unitName());
-    assertEquals("/home/dev/.sail/review.log", AgentUnit.REVIEW.logPath());
-  }
-
-  @Test
-  void fromRoleResolvesTheLogSelectingRoleNames() {
-    assertSame(AgentUnit.BUILD, AgentUnit.fromRole("build"));
-    assertSame(AgentUnit.REVIEW, AgentUnit.fromRole("review"));
-  }
-
-  @Test
-  void fromRoleRejectsUnknownRole() {
-    assertThrows(IllegalArgumentException.class, () -> AgentUnit.fromRole("bogus"));
-  }
+  private static final String RUN_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  private static final String RUN_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 
   @Test
   void forRunDerivesTheWholeIdentityUnderTheRunDir() {
-    var runId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    var unit = AgentUnit.forRun(RUN_A);
 
-    var unit = AgentUnit.forRun(runId);
-
-    assertEquals("sail-agent-" + runId, unit.unitName());
-    assertEquals("sail-agent-" + runId + ".service", unit.service());
-    assertEquals("/home/dev/.sail/runs/" + runId + "/agent.log", unit.logPath());
-    assertEquals("/home/dev/.sail/runs/" + runId + "/agent.pid", unit.pidPath());
-    assertEquals("/home/dev/.sail/runs/" + runId + "/agent-session.json", unit.sessionPath());
-    assertEquals("/home/dev/.sail/runs/" + runId + "/agent-task.txt", unit.taskPath());
+    assertEquals("sail-agent-" + RUN_A, unit.unitName());
+    assertEquals("sail-agent-" + RUN_A + ".service", unit.service());
+    assertEquals("/home/dev/.sail/runs/" + RUN_A + "/agent.log", unit.logPath());
+    assertEquals("/home/dev/.sail/runs/" + RUN_A + "/agent.pid", unit.pidPath());
+    assertEquals("/home/dev/.sail/runs/" + RUN_A + "/agent-session.json", unit.sessionPath());
+    assertEquals("/home/dev/.sail/runs/" + RUN_A + "/agent-task.txt", unit.taskPath());
   }
 
   @Test
   void twoRunsGetFullyDisjointIdentities() {
-    var a = AgentUnit.forRun("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
-    var b = AgentUnit.forRun("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+    var a = AgentUnit.forRun(RUN_A);
+    var b = AgentUnit.forRun(RUN_B);
 
     assertNotEquals(a.unitName(), b.unitName());
     assertNotEquals(a.logPath(), b.logPath());
@@ -74,12 +42,10 @@ class AgentUnitTest {
 
   @Test
   void recordedAddressesSystemdByTheRecordedNameAndFilesByTheCanonicalRunId() {
-    var runId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
-
-    var unit = AgentUnit.recorded(runId, "sail-agent-legacy-shape");
+    var unit = AgentUnit.recorded(RUN_A, "sail-agent-legacy-shape");
 
     assertEquals("sail-agent-legacy-shape", unit.unitName());
-    assertEquals("/home/dev/.sail/runs/" + runId + "/agent-session.json", unit.sessionPath());
+    assertEquals("/home/dev/.sail/runs/" + RUN_A + "/agent-session.json", unit.sessionPath());
   }
 
   @Test
@@ -87,6 +53,13 @@ class AgentUnitTest {
     assertThrows(IllegalArgumentException.class, () -> AgentUnit.forRun("../escape"));
     assertThrows(IllegalArgumentException.class, () -> AgentUnit.recorded("$(rm -rf)", "unit"));
     assertThrows(IllegalArgumentException.class, () -> AgentUnit.forReview("../escape"));
+  }
+
+  @Test
+  void reviewTemplateKeepsItsFixedFallbackPaths() {
+    assertEquals("sail-review", AgentUnit.REVIEW.unitName());
+    assertEquals("sail-review.service", AgentUnit.REVIEW.service());
+    assertEquals("/home/dev/.sail/review.log", AgentUnit.REVIEW.logPath());
   }
 
   @Test
@@ -114,13 +87,48 @@ class AgentUnitTest {
   }
 
   @Test
+  void aRunAndAReviewOfTheSameIdNeverShareFiles() {
+    var run = AgentUnit.forRun(RUN_A);
+    var review = AgentUnit.forReview(RUN_A);
+
+    assertNotEquals(run.unitName(), review.unitName());
+    assertNotEquals(run.logPath(), review.logPath());
+    assertNotEquals(run.pidPath(), review.pidPath());
+    assertNotEquals(run.sessionPath(), review.sessionPath());
+    assertNotEquals(run.taskPath(), review.taskPath());
+  }
+
+  @Test
+  void logPathForRoleResolvesBuildAndAdhocToTheRunsAgentLog() {
+    assertEquals(
+        "/home/dev/.sail/runs/" + RUN_A + "/agent.log", AgentUnit.logPathForRole("build", RUN_A));
+    assertEquals(
+        "/home/dev/.sail/runs/" + RUN_A + "/agent.log", AgentUnit.logPathForRole("adhoc", RUN_A));
+  }
+
+  @Test
+  void logPathForRoleResolvesReviewToTheRunsReviewLog() {
+    assertEquals(
+        "/home/dev/.sail/runs/" + RUN_A + "/review.log", AgentUnit.logPathForRole("review", RUN_A));
+  }
+
+  @Test
+  void logPathForRoleRejectsUnknownRole() {
+    assertThrows(IllegalArgumentException.class, () -> AgentUnit.logPathForRole("bogus", RUN_A));
+  }
+
+  @Test
+  void logPathForRoleRejectsANonCanonicalRunId() {
+    assertThrows(
+        IllegalArgumentException.class, () -> AgentUnit.logPathForRole("build", "../escape"));
+  }
+
+  @Test
   void runScopedLogPathsNameExactlyOneExecutionUnderTheRunDir() {
-    assertEquals("/home/dev/.sail/runs/run-1", AgentUnit.runDir("run-1"));
-    assertEquals("/home/dev/.sail/runs/run-1/agent.log", AgentUnit.BUILD.runLogPath("run-1"));
-    assertEquals("/home/dev/.sail/runs/run-1/review.log", AgentUnit.REVIEW.runLogPath("run-1"));
+    assertEquals("/home/dev/.sail/runs/" + RUN_A, AgentUnit.runDir(RUN_A));
     assertNotEquals(
-        AgentUnit.BUILD.runLogPath("run-1"),
-        AgentUnit.BUILD.runLogPath("run-2"),
+        AgentUnit.logPathForRole("build", RUN_A),
+        AgentUnit.logPathForRole("build", RUN_B),
         "two runs get isolated logs");
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/AgentLogStreamer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/AgentLogStreamer.java
@@ -5,7 +5,6 @@
 
 package ai.singlr.sail.api;
 
-import ai.singlr.sail.common.Ids;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.engine.AgentUnit;
 import ai.singlr.sail.engine.ContainerExec;
@@ -127,8 +126,10 @@ public final class AgentLogStreamer implements HttpHandler {
       if (RunPolicy.access(
               ApiRouter.actorOf(exchange),
               run.id(),
-              run.specId(),
-              specAssignee.apply(run.specId()).orElse(null))
+              StopOperations.specIdOf(run),
+              Strings.isBlank(run.specId())
+                  ? run.node()
+                  : specAssignee.apply(run.specId()).orElse(null))
           instanceof AccessDecision.Refused refused) {
         var fix =
             Strings.isBlank(refused.fix())
@@ -239,7 +240,7 @@ public final class AgentLogStreamer implements HttpHandler {
    * interpolated into the script, so it can never be interpreted as shell syntax.
    */
   static String[] buildTailCommand(String project, String runId, String role, int since) {
-    var logPath = AgentUnit.fromRole(role).runLogPath(Ids.requireUuid(runId));
+    var logPath = AgentUnit.logPathForRole(role, runId);
     var script =
         since > 0
             ? "touch -- \"$1\" 2>/dev/null; exec tail -n \"+$2\" -f -- \"$1\""

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -308,8 +308,7 @@ public final class DispatchOperations {
         agentType,
         branch,
         task,
-        unit,
-        background);
+        unit);
     try {
       var prepared =
           claimAndPrepare(
@@ -334,9 +333,8 @@ public final class DispatchOperations {
               unit,
               runId);
       var status = querySession(new AgentSession(shell), project, unit);
-      if (background) {
-        updateRunProcess(runId, status, launch.watcher());
-      } else {
+      updateRunProcess(runId, project, status, launch.watcher());
+      if (!background) {
         completeForegroundRun(runId, launch.exitCode());
       }
       if (status != null && status.running()) {
@@ -356,7 +354,7 @@ public final class DispatchOperations {
           background ? null : launch.exitCode(),
           launch.watcher());
     } catch (RuntimeException e) {
-      releaseIfAbsent(runId, project, unit, background);
+      releaseIfAbsent(runId, project, unit);
       throw e;
     }
   }
@@ -405,8 +403,7 @@ public final class DispatchOperations {
               runId));
       return new AdhocSession(runId, null, null, Optional.empty());
     }
-    reserveAdhocRun(
-        runId, project, localHandle, agentType, request.branch(), request.task(), unit, background);
+    reserveAdhocRun(runId, project, localHandle, agentType, request.branch(), request.task(), unit);
     try {
       prepare(preparer);
       var launch =
@@ -426,9 +423,8 @@ public final class DispatchOperations {
               unit,
               runId);
       var status = querySession(new AgentSession(shell), project, unit);
-      if (background) {
-        updateRunProcess(runId, status, launch.watcher());
-      } else {
+      updateRunProcess(runId, project, status, launch.watcher());
+      if (!background) {
         completeForegroundRun(runId, launch.exitCode());
       }
       if (status != null && status.running()) {
@@ -437,7 +433,7 @@ public final class DispatchOperations {
       return new AdhocSession(
           runId, status, background ? null : launch.exitCode(), launch.watcher());
     } catch (RuntimeException e) {
-      releaseIfAbsent(runId, project, unit, background);
+      releaseIfAbsent(runId, project, unit);
       throw e;
     }
   }
@@ -966,9 +962,10 @@ public final class DispatchOperations {
    * prunes the container's oldest run-log directories (best-effort). A run store is absent only on
    * boxes that keep no run aggregate, which have nothing to reserve against.
    *
-   * <p>A foreground dispatch records a blank unit: it runs as a plain child process and creates no
-   * systemd unit, so the missed-stop reconciler must skip it rather than falsely stop the
-   * still-running agent. The foreground run completes when its blocking launcher returns.
+   * <p>A foreground dispatch records the same run-scoped unit name even though it launches no
+   * systemd service: the run's pid file carries the same identity, so stop, probe, and the
+   * missed-stop reconciler address a foreground session exactly like a background one. The
+   * foreground run completes when its blocking launcher returns.
    */
   private void reserveRun(
       String runId,
@@ -979,13 +976,11 @@ public final class DispatchOperations {
       String agentType,
       String branch,
       String task,
-      AgentUnit unit,
-      boolean background) {
+      AgentUnit unit) {
     if (runStore == null) {
       return;
     }
-    reserve(
-        runId, project, specId, node, "build", repos, agentType, branch, task, unit, background);
+    reserve(runId, project, specId, node, "build", repos, agentType, branch, task, unit);
   }
 
   /**
@@ -1002,15 +997,13 @@ public final class DispatchOperations {
       String agentType,
       String branch,
       String task,
-      AgentUnit unit,
-      boolean background) {
+      AgentUnit unit) {
     if (runStore == null) {
       throw new ApiException(
           ErrorCode.COMMAND_FAILED,
           "This box keeps no run aggregate, so an agent session cannot be reserved or tracked.");
     }
-    reserve(
-        runId, project, "", node, "adhoc", List.of(), agentType, branch, task, unit, background);
+    reserve(runId, project, "", node, "adhoc", List.of(), agentType, branch, task, unit);
   }
 
   private void reserve(
@@ -1023,9 +1016,7 @@ public final class DispatchOperations {
       String agentType,
       String branch,
       String task,
-      AgentUnit unit,
-      boolean background) {
-    var recordedUnit = background ? unit.unitName() : "";
+      AgentUnit unit) {
     Optional<DispatchGate.Conflict> conflict;
     try {
       conflict =
@@ -1040,7 +1031,7 @@ public final class DispatchOperations {
               branch,
               task,
               unit.logPath(),
-              recordedUnit);
+              unit.unitName());
     } catch (RuntimeException e) {
       throw new ApiException(ErrorCode.COMMAND_FAILED, "Failed to record the dispatch run.", e);
     }
@@ -1076,16 +1067,35 @@ public final class DispatchOperations {
     return "running".equals(run.status()) || StopOperations.STOPPING.equals(run.status());
   }
 
-  /** Stamps the agent + watcher pids on a background run once launch has resolved them. */
+  /**
+   * Stamps the run's process identity once launch has resolved it: the agent pid, its {@code /proc}
+   * start-time fingerprint (live processes only — the fingerprint exists to prove a pid still names
+   * the process this run launched, so a foreground session that already exited records its pid
+   * without one), and the fallback watcher pid.
+   */
   private void updateRunProcess(
-      String runId, AgentSession.SessionInfo status, Optional<WatcherSpawner.Spawned> watcher) {
+      String runId,
+      String project,
+      AgentSession.SessionInfo status,
+      Optional<WatcherSpawner.Spawned> watcher) {
     Integer watcherPid =
         watcher.orElse(null) instanceof WatcherSpawner.Fallback fallback
             ? (int) fallback.pid()
             : null;
+    Integer pid = status != null ? status.pid() : null;
+    var pidTicks =
+        status != null && status.running() ? readStartTicks(project, status.pid()) : null;
     runBookkeeping(
         "update run process " + runId,
-        () -> runStore.updateProcess(runId, status != null ? status.pid() : null, watcherPid));
+        () -> runStore.updateProcess(runId, pid, pidTicks, watcherPid));
+  }
+
+  private Long readStartTicks(String project, int pid) {
+    try {
+      return new AgentSession(shell).readProcessStartTicks(project, pid);
+    } catch (Exception e) {
+      return null;
+    }
   }
 
   /**
@@ -1118,22 +1128,23 @@ public final class DispatchOperations {
   }
 
   /**
-   * Releases the run's repo reservation on a launch failure only when the agent is proven absent. A
-   * failure before or during launch leaves no live unit, so the run is failed and its repo freed.
-   * But once a background systemd unit has started, a later failure (watcher spawn, status probe)
-   * leaves a live agent on its run-scoped unit; failing the run would free the repo under it and
-   * admit an overlapping dispatch. An unprobeable unit is treated as live for the same reason — the
-   * missed-stop reconciler releases a genuinely dead unit on its next pass. A foreground run
-   * creates no unit, so a foreground launch failure always frees the reservation.
+   * Releases the run's repo reservation on a launch failure only when the agent is proven absent —
+   * probed on the run's own identity (systemd unit and run-scoped pid file), so the check covers
+   * background and foreground launches alike. A failure before or during launch leaves no live
+   * process, so the run is failed and its repo freed. But once the agent process exists — a
+   * background unit that started, a foreground child whose blocking wait threw — a later failure
+   * leaves a live agent, and failing the run would free the repo under it and admit an overlapping
+   * session. An unprobeable identity is treated as live for the same reason — the missed-stop
+   * reconciler releases a genuinely dead run on its next pass.
    */
-  private void releaseIfAbsent(String runId, String project, AgentUnit unit, boolean background) {
-    if (background && backgroundAgentLive(project, unit)) {
+  private void releaseIfAbsent(String runId, String project, AgentUnit unit) {
+    if (agentLive(project, unit)) {
       return;
     }
     failRun(runId);
   }
 
-  private boolean backgroundAgentLive(String project, AgentUnit unit) {
+  private boolean agentLive(String project, AgentUnit unit) {
     try {
       var status = new AgentSession(shell).queryStatus(project, unit);
       return status != null && status.running();

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -333,7 +333,9 @@ public final class DispatchOperations {
               unit,
               runId);
       var status = querySession(new AgentSession(shell), project, unit);
-      updateRunProcess(runId, project, status, launch.watcher());
+      if (!updateRunProcess(runId, project, status, launch.watcher())) {
+        throw launchLostToCancel(runId, project, unit);
+      }
       if (!background) {
         completeForegroundRun(runId, launch.exitCode());
       }
@@ -423,7 +425,9 @@ public final class DispatchOperations {
               unit,
               runId);
       var status = querySession(new AgentSession(shell), project, unit);
-      updateRunProcess(runId, project, status, launch.watcher());
+      if (!updateRunProcess(runId, project, status, launch.watcher())) {
+        throw launchLostToCancel(runId, project, unit);
+      }
       if (!background) {
         completeForegroundRun(runId, launch.exitCode());
       }
@@ -1072,12 +1076,20 @@ public final class DispatchOperations {
    * start-time fingerprint (live processes only — the fingerprint exists to prove a pid still names
    * the process this run launched, so a foreground session that already exited records its pid
    * without one), and the fallback watcher pid.
+   *
+   * <p>Returns whether the run still owned its launch: the stamp commits only on a {@code running}
+   * row, so a {@code false} means an operator's cancel claimed the run during preparation and the
+   * caller must tear down whatever it started. A store error stays best-effort bookkeeping (the
+   * launch proceeds); only the definitive lost-race answer aborts it.
    */
-  private void updateRunProcess(
+  private boolean updateRunProcess(
       String runId,
       String project,
       AgentSession.SessionInfo status,
       Optional<WatcherSpawner.Spawned> watcher) {
+    if (runStore == null) {
+      return true;
+    }
     Integer watcherPid =
         watcher.orElse(null) instanceof WatcherSpawner.Fallback fallback
             ? (int) fallback.pid()
@@ -1085,9 +1097,32 @@ public final class DispatchOperations {
     Integer pid = status != null ? status.pid() : null;
     var pidTicks =
         status != null && status.running() ? readStartTicks(project, status.pid()) : null;
-    runBookkeeping(
-        "update run process " + runId,
-        () -> runStore.updateProcess(runId, pid, pidTicks, watcherPid));
+    try {
+      return runStore.updateProcess(runId, pid, pidTicks, watcherPid);
+    } catch (RuntimeException e) {
+      System.err.println(
+          "  [api] Warning: could not update run process " + runId + ": " + e.getMessage());
+      return true;
+    }
+  }
+
+  /**
+   * Tears down a launch whose run was cancelled during preparation: the operator's stop already
+   * recorded the terminal outcome, so the just-started agent must die rather than run unrecorded
+   * against a released claim. Halting is best-effort — the unit is transient and run-scoped, so a
+   * halt that races the process's own exit is a no-op — and the conflict names what happened.
+   */
+  private ApiException launchLostToCancel(String runId, String project, AgentUnit unit) {
+    try {
+      StopOperations.sessionHalter(shell).halt(project, unit);
+    } catch (Exception e) {
+      System.err.println(
+          "  [api] Warning: could not halt cancelled launch " + runId + ": " + e.getMessage());
+    }
+    return new ApiException(
+        ErrorCode.CONFLICT,
+        "Run " + runId + " was cancelled while its launch was preparing; the agent was torn down.",
+        "The cancel already recorded the run's outcome; no retry is needed.");
   }
 
   private Long readStartTicks(String project, int pid) {
@@ -1123,8 +1158,15 @@ public final class DispatchOperations {
   /**
    * Marks a run failed when its launch throws, so a created-but-never-launched row is not orphaned.
    */
+  /**
+   * Fails a run on a launch error, but only if the run is still {@code running}: a stop that
+   * cancelled the run mid-launch, or a watcher that already recorded the real exit, owns the
+   * terminal record and must not be overwritten by the launch's cleanup.
+   */
   private void failRun(String runId) {
-    runBookkeeping("mark run failed " + runId, () -> runStore.complete(runId, "failed", null));
+    runBookkeeping(
+        "mark run failed " + runId,
+        () -> runStore.transition(runId, "running", "failed", (Integer) null));
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -78,6 +78,19 @@ public final class DispatchOperations {
       Integer exitCode,
       Optional<WatcherSpawner.Spawned> watcher) {}
 
+  /**
+   * Container preparation that must not run until the whole-container reservation is won — the
+   * pre-launch snapshot and the work-branch checkout. A refused reservation means another agent
+   * owns the container, so no workspace mutation may precede it; a preparation failure is a launch
+   * failure and releases the reservation through the same path.
+   */
+  @FunctionalInterface
+  public interface AdhocPreparer {
+    AdhocPreparer NONE = () -> {};
+
+    void prepare() throws Exception;
+  }
+
   /** What a dispatch produced. */
   public sealed interface Outcome permits NoSpecs, Dispatched {}
 
@@ -356,10 +369,16 @@ public final class DispatchOperations {
    * atomic mechanism. Background launches get the same run-addressed guardrail watcher as
    * dispatches. No spec means no policy: unlike dispatch, a blank node handle is allowed — the
    * reservation is stamped with whatever identity the box has, exactly like the run rows it gates
-   * against. A dry run mints the id and announces the launch command but writes and executes
-   * nothing.
+   * against. The {@code preparer} runs strictly after the reservation is won and before anything is
+   * staged or launched, so a refused launch leaves the workspace untouched. A dry run mints the id
+   * and announces the launch command but reserves, prepares, writes, and executes nothing.
    */
   public AdhocSession startAdhoc(String project, AdhocRequest request, String localHandle) {
+    return startAdhoc(project, request, localHandle, AdhocPreparer.NONE);
+  }
+
+  public AdhocSession startAdhoc(
+      String project, AdhocRequest request, String localHandle, AdhocPreparer preparer) {
     var loaded = projects.loadRunning(project);
     var config = loaded.config();
     var agentType =
@@ -389,6 +408,7 @@ public final class DispatchOperations {
     reserveAdhocRun(
         runId, project, localHandle, agentType, request.branch(), request.task(), unit, background);
     try {
+      prepare(preparer);
       var launch =
           launchSession(
               project,
@@ -419,6 +439,15 @@ public final class DispatchOperations {
     } catch (RuntimeException e) {
       releaseIfAbsent(runId, project, unit, background);
       throw e;
+    }
+  }
+
+  private static void prepare(AdhocPreparer preparer) {
+    try {
+      preparer.prepare();
+    } catch (Exception e) {
+      throw new ApiException(
+          ErrorCode.AGENT_LAUNCH_FAILED, "Failed to prepare the agent session.", e);
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -59,6 +59,25 @@ public final class DispatchOperations {
   public record Request(
       String specId, String mode, boolean dryRun, List<String> repos, boolean restart) {}
 
+  /**
+   * One ad-hoc session launch — {@code sail agent run --task}. No spec, no policy: the operator
+   * supplies the task directly, and the session reserves the whole container. {@code branch} is the
+   * already-checked-out work branch (or null), {@code path} an optional workspace subdirectory.
+   */
+  public record AdhocRequest(
+      String task, String branch, String path, boolean background, boolean dryRun) {}
+
+  /**
+   * A launched ad-hoc session: its minted run id and, live launches only, the probed session,
+   * foreground exit code, and watcher. A dry run carries the run id it would have used and nothing
+   * else.
+   */
+  public record AdhocSession(
+      String runId,
+      AgentSession.SessionInfo session,
+      Integer exitCode,
+      Optional<WatcherSpawner.Spawned> watcher) {}
+
   /** What a dispatch produced. */
   public sealed interface Outcome permits NoSpecs, Dispatched {}
 
@@ -327,6 +346,91 @@ public final class DispatchOperations {
       releaseIfAbsent(runId, project, unit, background);
       throw e;
     }
+  }
+
+  /**
+   * Launches one ad-hoc agent session — the {@code sail agent run --task} lane — as a first-class
+   * run: a minted run id, {@code role='adhoc'} with no spec, a run-scoped unit and file set, and a
+   * whole-container reservation through the same {@link RunStore#reserveDispatch} transaction that
+   * gates dispatches, so an ad-hoc session and a dispatched agent are mutually exclusive by the one
+   * atomic mechanism. Background launches get the same run-addressed guardrail watcher as
+   * dispatches. No spec means no policy: unlike dispatch, a blank node handle is allowed — the
+   * reservation is stamped with whatever identity the box has, exactly like the run rows it gates
+   * against. A dry run mints the id and announces the launch command but writes and executes
+   * nothing.
+   */
+  public AdhocSession startAdhoc(String project, AdhocRequest request, String localHandle) {
+    var loaded = projects.loadRunning(project);
+    var config = loaded.config();
+    var agentType =
+        config.agent() != null ? config.agent().type() : AgentCli.CLAUDE_CODE.yamlName();
+    var runId = DateTimeUtils.newId().toString();
+    var unit = AgentUnit.forRun(runId);
+    var background = request.background();
+    var workDir = adhocWorkDir(config, request.path());
+    var fullPermissions = adhocFullPermissions(config);
+    if (request.dryRun()) {
+      listener.launching(
+          background,
+          launchCommand(
+              project,
+              config,
+              workDir,
+              fullPermissions,
+              null,
+              null,
+              "",
+              agentType,
+              background,
+              unit,
+              runId));
+      return new AdhocSession(runId, null, null, Optional.empty());
+    }
+    reserveAdhocRun(
+        runId, project, localHandle, agentType, request.branch(), request.task(), unit, background);
+    try {
+      var launch =
+          launchSession(
+              project,
+              config,
+              workDir,
+              fullPermissions,
+              null,
+              null,
+              "",
+              agentType,
+              request.task(),
+              request.branch(),
+              List.of(),
+              background,
+              unit,
+              runId);
+      var status = querySession(new AgentSession(shell), project, unit);
+      if (background) {
+        updateRunProcess(runId, status, launch.watcher());
+      } else {
+        completeForegroundRun(runId, launch.exitCode());
+      }
+      if (status != null && status.running()) {
+        publishAgentSessionStarted(project, null, agentType, status.pid(), runId, launch.watcher());
+      }
+      return new AdhocSession(
+          runId, status, background ? null : launch.exitCode(), launch.watcher());
+    } catch (RuntimeException e) {
+      releaseIfAbsent(runId, project, unit, background);
+      throw e;
+    }
+  }
+
+  private static String adhocWorkDir(SailYaml config, String path) {
+    var workDir = "/home/" + config.sshUser() + "/workspace";
+    return Strings.isBlank(path) ? workDir : workDir + "/" + path;
+  }
+
+  private static boolean adhocFullPermissions(SailYaml config) {
+    return config.agent() != null
+        && config.agent().config() != null
+        && "full".equals(config.agent().config().get("permissions"));
   }
 
   /** What the claim/branch phase produced: the snapshot label and whether a branch was set up. */
@@ -614,6 +718,44 @@ public final class DispatchOperations {
       String agentType,
       AgentUnit unit,
       String runId) {
+    return launchSession(
+        project,
+        config,
+        AgentSession.launchWorkDir(config.sshUser(), targetRepos),
+        true,
+        spec.model(),
+        spec.reasoningEffort(),
+        spec.id(),
+        agentType,
+        task,
+        branch,
+        targetRepos.stream().map(SailYaml.Repo::path).toList(),
+        background,
+        unit,
+        runId);
+  }
+
+  /**
+   * The one launch sequence both the dispatch and ad-hoc lanes execute: stage the run-scoped task
+   * and session files, build the launch command for the run's own unit, run it, and — background
+   * only — verify the launch and arm the run-addressed watcher. The lanes differ only in what they
+   * pass: a dispatch carries its spec's identity and model, an ad-hoc session a blank spec id.
+   */
+  private LaunchOutcome launchSession(
+      String project,
+      SailYaml config,
+      String workDir,
+      boolean fullPermissions,
+      String model,
+      String reasoningEffort,
+      String specId,
+      String agentType,
+      String task,
+      String branch,
+      List<String> repoPaths,
+      boolean background,
+      AgentUnit unit,
+      String runId) {
     try {
       ensureSailSetup(project);
       var session = new AgentSession(shell);
@@ -623,39 +765,24 @@ public final class DispatchOperations {
           project,
           task,
           Objects.requireNonNullElse(branch, ""),
-          spec.id(),
+          specId,
           agentType,
           runId,
-          targetRepos.stream().map(SailYaml.Repo::path).toList(),
+          repoPaths,
           unit);
-      var agentCli = AgentCli.fromYamlName(agentType);
-      var workDir = AgentSession.launchWorkDir(config.sshUser(), targetRepos);
       var command =
-          background
-              ? AgentSession.buildBackgroundLaunchCommand(
-                  project,
-                  config.sshUser(),
-                  workDir,
-                  true,
-                  agentCli,
-                  spec.model(),
-                  spec.reasoningEffort(),
-                  spec.id(),
-                  agentType,
-                  unit.logPath(),
-                  runId)
-              : AgentSession.buildForegroundTaskCommand(
-                  project,
-                  config.sshUser(),
-                  workDir,
-                  true,
-                  agentCli,
-                  spec.model(),
-                  spec.reasoningEffort(),
-                  spec.id(),
-                  agentType,
-                  unit.logPath(),
-                  runId);
+          launchCommand(
+              project,
+              config,
+              workDir,
+              fullPermissions,
+              model,
+              reasoningEffort,
+              specId,
+              agentType,
+              background,
+              unit,
+              runId);
       listener.launching(background, command);
       var exitCode = launcher.launch(command);
       if (background) {
@@ -670,6 +797,46 @@ public final class DispatchOperations {
     } catch (Exception e) {
       throw new ApiException(ErrorCode.AGENT_LAUNCH_FAILED, "Failed to launch agent.", e);
     }
+  }
+
+  private static List<String> launchCommand(
+      String project,
+      SailYaml config,
+      String workDir,
+      boolean fullPermissions,
+      String model,
+      String reasoningEffort,
+      String specId,
+      String agentType,
+      boolean background,
+      AgentUnit unit,
+      String runId) {
+    var agentCli = AgentCli.fromYamlName(agentType);
+    return background
+        ? AgentSession.buildBackgroundLaunchCommand(
+            project,
+            config.sshUser(),
+            workDir,
+            fullPermissions,
+            agentCli,
+            model,
+            reasoningEffort,
+            specId,
+            agentType,
+            unit.logPath(),
+            runId)
+        : AgentSession.buildForegroundTaskCommand(
+            project,
+            config.sshUser(),
+            workDir,
+            fullPermissions,
+            agentCli,
+            model,
+            reasoningEffort,
+            specId,
+            agentType,
+            unit.logPath(),
+            runId);
   }
 
   /**
@@ -709,15 +876,21 @@ public final class DispatchOperations {
   }
 
   private static ApiException overlapRefusal(DispatchGate.Conflict conflict) {
+    var run = conflict.run();
+    var occupied =
+        Strings.isBlank(run.specId())
+            ? "Ad-hoc agent run " + run.runId() + " is occupying this container"
+            : "Agent run "
+                + run.runId()
+                + " is already working spec '"
+                + run.specId()
+                + "' in "
+                + (conflict.overlap().isEmpty()
+                    ? "this container"
+                    : "repo(s) " + conflict.overlap());
     return new ApiException(
         ErrorCode.AGENT_ALREADY_RUNNING,
-        "Agent run "
-            + conflict.run().runId()
-            + " is already working spec '"
-            + conflict.run().specId()
-            + "' in "
-            + (conflict.overlap().isEmpty() ? "this container" : "repo(s) " + conflict.overlap())
-            + ".",
+        occupied + ".",
         "Wait for it to finish or stop it, or dispatch a spec targeting disjoint repos.");
   }
 
@@ -782,6 +955,47 @@ public final class DispatchOperations {
     if (runStore == null) {
       return;
     }
+    reserve(
+        runId, project, specId, node, "build", repos, agentType, branch, task, unit, background);
+  }
+
+  /**
+   * Reserves an ad-hoc session through the identical transaction: {@code role='adhoc'}, no spec,
+   * and an empty repo set — which the gate reads as the whole project, so the session excludes and
+   * is excluded by every dispatch atomically. Unlike dispatch, an absent run store is a refusal,
+   * not a skip: the reservation is the only thing standing between two agents in one container, and
+   * an ad-hoc session without a row would also be invisible to stop, status, and retention.
+   */
+  private void reserveAdhocRun(
+      String runId,
+      String project,
+      String node,
+      String agentType,
+      String branch,
+      String task,
+      AgentUnit unit,
+      boolean background) {
+    if (runStore == null) {
+      throw new ApiException(
+          ErrorCode.COMMAND_FAILED,
+          "This box keeps no run aggregate, so an agent session cannot be reserved or tracked.");
+    }
+    reserve(
+        runId, project, "", node, "adhoc", List.of(), agentType, branch, task, unit, background);
+  }
+
+  private void reserve(
+      String runId,
+      String project,
+      String specId,
+      String node,
+      String role,
+      List<String> repos,
+      String agentType,
+      String branch,
+      String task,
+      AgentUnit unit,
+      boolean background) {
     var recordedUnit = background ? unit.unitName() : "";
     Optional<DispatchGate.Conflict> conflict;
     try {
@@ -791,6 +1005,7 @@ public final class DispatchOperations {
               project,
               specId,
               node,
+              role,
               repos,
               agentType,
               branch,

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
@@ -209,15 +210,20 @@ public final class MissedStopReconciler implements AutoCloseable {
   }
 
   /**
-   * Releases a repo reservation orphaned by a crash between reserving a dispatch run and claiming
-   * its spec: the run committed {@code running} but the spec never left {@code pending}, so the
-   * in-progress reconcile pass never reaches it and its repo would block every future overlapping
-   * dispatch. Only a run older than {@link #LAUNCH_GRACE} is touched, so a run still inside the
-   * microsecond reserve-then-claim window of a healthy dispatch is never disturbed. The spec was
-   * never claimed, so it stays {@code pending} and dispatchable; only the dead reservation is
-   * cleared. Foreign runs are left to their executing box. A run whose spec was already handled
-   * earlier in this same sweep is skipped, so an async status flip caused by the sweep's own
-   * replayed stop can never make one pass both reconcile and release the one run.
+   * Releases a reservation orphaned by a crash: a run committed {@code running} whose agent is
+   * provably not coming — a dispatch whose spec never left {@code pending} (a crash between reserve
+   * and claim), or a spec-less ad-hoc session whose recorded process is dead (its watcher died with
+   * it, so no stop was ever synthesized). Only a run older than {@link #LAUNCH_GRACE} is touched,
+   * so a run still inside a healthy launch window is never disturbed, and a run whose recorded
+   * identity still probes <em>live</em> is always left alone — a reservation must never be freed
+   * under a working agent. A spec-less run with no recorded pid is also left alone: it is either
+   * still launching or a foreground session whose blocking launcher owns its completion, and an
+   * operator {@code sail agent stop} heals the crashed remainder. The release is the same {@code
+   * running → stopped} compare-and-set every finisher uses, so racing the watcher's own completion
+   * can never overwrite a recorded exit. Foreign runs are left to their executing box. A run whose
+   * spec was already handled earlier in this same sweep is skipped, so an async status flip caused
+   * by the sweep's own replayed stop can never make one pass both reconcile and release the one
+   * run.
    */
   int releaseStrandedReservations(Set<String> handledThisSweep) {
     var node = localHandle.get();
@@ -226,20 +232,47 @@ public final class MissedStopReconciler implements AutoCloseable {
     for (var run : sessionStore.running()) {
       if (handledThisSweep.contains(run.specId())
           || !SailOperations.ownsRun(run.node(), node)
-          || !MissedStops.parseOr(run.startedAt(), Instant.MAX).isBefore(deadline)
-          || specBeingWorked(run.specId())) {
+          || !MissedStops.parseOr(run.startedAt(), Instant.MAX).isBefore(deadline)) {
         continue;
+      }
+      if (Strings.isBlank(run.specId())) {
+        if (run.pid() == null || agentProbablyAlive(run)) {
+          continue;
+        }
+      } else {
+        if (specBeingWorked(run.specId()) || agentProbablyAlive(run)) {
+          continue;
+        }
       }
       System.err.println(
           "  [reconcile] releasing stranded reservation "
               + run.id()
-              + " for spec "
-              + run.specId()
-              + " (running with no agent working it; spec is not in_progress or review)");
-      sessionStore.complete(run.id(), "stopped", null);
-      released++;
+              + (Strings.isBlank(run.specId())
+                  ? " (ad-hoc session whose recorded process is gone)"
+                  : " for spec "
+                      + run.specId()
+                      + " (running with no agent working it; spec is not in_progress or"
+                      + " review)"));
+      if (sessionStore.transition(run.id(), "running", "stopped")) {
+        released++;
+      }
     }
     return released;
+  }
+
+  /**
+   * Whether the run's recorded identity still probes live — or cannot be probed at all: a probe
+   * failure reads as alive, because the sweep must prefer leaving a reservation in place over
+   * freeing one under an agent it could not observe. A foreground run's blank unit still probes
+   * through its run-scoped pid file.
+   */
+  private boolean agentProbablyAlive(RunStore.RunRow run) {
+    try {
+      return unitProbe.active(run.project(), run.id(), Objects.toString(run.unit(), ""));
+    } catch (Exception e) {
+      System.err.println("  [reconcile] could not probe run " + run.id() + ": " + e.getMessage());
+      return true;
+    }
   }
 
   /**
@@ -259,9 +292,8 @@ public final class MissedStopReconciler implements AutoCloseable {
       if (!SailOperations.ownsRun(run.node(), node)) {
         continue;
       }
-      var unit = StopOperations.runUnit(run).unitName();
       try {
-        if (unitProbe.active(run.project(), run.id(), unit)) {
+        if (unitProbe.active(run.project(), run.id(), StopOperations.runUnit(run).unitName())) {
           continue;
         }
         if (sessionStore.transition(run.id(), "stopping", "stopped")) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -45,13 +45,14 @@ import java.util.function.Supplier;
  * session replays the stop with its recorded exit code — after probing its recorded unit, because
  * the row may be a hook-backstop claim for an agent that is still running (an active unit vetoes
  * the replay). A running session past the launch grace period whose recorded run identity is
- * inactive or absent gets a synthesized stop. A running session with no recorded unit is skipped
- * because foreground launchers own their blocking process's completion. The synthesized stop
- * carries <em>no exit code</em>: the transient unit is garbage-collected on exit, so the real code
- * is unrecoverable, and the replay path makes the same choice for a terminal session that never
- * recorded one — the pipeline treats the absent code as not-a-failure and lets review judge the
- * work. Every replayed stop carries {@code source=reconcile} so the event log shows it was
- * reconstructed, not observed.
+ * inactive or absent gets a synthesized stop. Every session — background or foreground — records
+ * its run-scoped identity, and the probe reads the pid file before the systemd unit, so foreground
+ * sessions reconcile the same way; only a legacy row with no recorded unit is skipped, because its
+ * blocking launcher owned its completion. The synthesized stop carries <em>no exit code</em>: the
+ * transient unit is garbage-collected on exit, so the real code is unrecoverable, and the replay
+ * path makes the same choice for a terminal session that never recorded one — the pipeline treats
+ * the absent code as not-a-failure and lets review judge the work. Every replayed stop carries
+ * {@code source=reconcile} so the event log shows it was reconstructed, not observed.
  *
  * <p>Best-effort by design: a failing spec is logged and skipped, a failing pass is logged and
  * retried on the next tick, and passes never overlap. Run after the bus subscribers are wired.
@@ -212,18 +213,18 @@ public final class MissedStopReconciler implements AutoCloseable {
   /**
    * Releases a reservation orphaned by a crash: a run committed {@code running} whose agent is
    * provably not coming — a dispatch whose spec never left {@code pending} (a crash between reserve
-   * and claim), or a spec-less ad-hoc session whose recorded process is dead (its watcher died with
-   * it, so no stop was ever synthesized). Only a run older than {@link #LAUNCH_GRACE} is touched,
-   * so a run still inside a healthy launch window is never disturbed, and a run whose recorded
-   * identity still probes <em>live</em> is always left alone — a reservation must never be freed
-   * under a working agent. A spec-less run with no recorded pid is also left alone: it is either
-   * still launching or a foreground session whose blocking launcher owns its completion, and an
-   * operator {@code sail agent stop} heals the crashed remainder. The release is the same {@code
-   * running → stopped} compare-and-set every finisher uses, so racing the watcher's own completion
-   * can never overwrite a recorded exit. Foreign runs are left to their executing box. A run whose
-   * spec was already handled earlier in this same sweep is skipped, so an async status flip caused
-   * by the sweep's own replayed stop can never make one pass both reconcile and release the one
-   * run.
+   * and claim), or a spec-less ad-hoc session whose recorded identity probes dead (its watcher died
+   * with it, or its foreground launcher crashed, so no stop was ever recorded). Only a run older
+   * than {@link #LAUNCH_GRACE} is touched, so a run still inside a healthy launch window is never
+   * disturbed, and a run whose recorded identity still probes <em>live</em> is always left alone —
+   * a reservation must never be freed under a working agent. The probe reads the run-scoped pid
+   * file before the systemd unit, so it covers foreground sessions (which launch no service) and
+   * background sessions that crashed before their pid was persisted alike; an unprobeable run reads
+   * as alive. The release is the same {@code running → stopped} compare-and-set every finisher
+   * uses, so racing the watcher's own completion can never overwrite a recorded exit. Foreign runs
+   * are left to their executing box. A run whose spec was already handled earlier in this same
+   * sweep is skipped, so an async status flip caused by the sweep's own replayed stop can never
+   * make one pass both reconcile and release the one run.
    */
   int releaseStrandedReservations(Set<String> handledThisSweep) {
     var node = localHandle.get();
@@ -232,17 +233,10 @@ public final class MissedStopReconciler implements AutoCloseable {
     for (var run : sessionStore.running()) {
       if (handledThisSweep.contains(run.specId())
           || !SailOperations.ownsRun(run.node(), node)
-          || !MissedStops.parseOr(run.startedAt(), Instant.MAX).isBefore(deadline)) {
+          || !MissedStops.parseOr(run.startedAt(), Instant.MAX).isBefore(deadline)
+          || specBeingWorked(run.specId())
+          || agentProbablyAlive(run)) {
         continue;
-      }
-      if (Strings.isBlank(run.specId())) {
-        if (run.pid() == null || agentProbablyAlive(run)) {
-          continue;
-        }
-      } else {
-        if (specBeingWorked(run.specId()) || agentProbablyAlive(run)) {
-          continue;
-        }
       }
       System.err.println(
           "  [reconcile] releasing stranded reservation "

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -569,7 +569,15 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     }
     var unit = AgentUnit.forReview(reviewId);
     runStore.createReview(
-        reviewId, project, specId, localHandle.get(), agent, branch, task, unit.logPath());
+        reviewId,
+        project,
+        specId,
+        localHandle.get(),
+        agent,
+        branch,
+        task,
+        unit.logPath(),
+        unit.unitName());
     syncTrigger.run();
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RunPolicy.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RunPolicy.java
@@ -11,40 +11,51 @@ import ai.singlr.sail.common.Strings;
  * Resource-scoped authorization for the run aggregate: reading a run's log (buffered tail or SSE
  * stream) and stopping it. Pure and I/O-free so REST and SSE evaluate the identical verdict for the
  * identical caller from one place. A run's owner is its spec's assignee — an FDE must not read the
- * logs of a spec that is not assigned to them — with the admin retaining override.
+ * logs of a spec that is not assigned to them — or, for an ad-hoc session that works no spec, the
+ * handle of the box that launched it; the admin retains override either way.
  *
- * <p>Fails closed: a spec with no assignee (or a deleted spec) yields no owner, so only an admin
- * may reach it; a machine token's null handle matches no assignee.
+ * <p>Fails closed: no owner (an unassigned or deleted spec, an ad-hoc run from a handle-less box)
+ * means only an admin may reach it; a machine token's null handle matches no owner.
  */
 public final class RunPolicy {
 
   private RunPolicy() {}
 
   /**
-   * Decides whether {@code actor} may access run {@code runId}, whose spec {@code specId} is
-   * assigned to {@code specAssignee}. The provenance guard (does this run belong to this box) is a
+   * Decides whether {@code actor} may access run {@code runId}: {@code specId} names its spec (null
+   * for an ad-hoc session) and {@code owner} the identity that owns it — the spec's assignee or the
+   * ad-hoc session's launching handle. The provenance guard (does this run belong to this box) is a
    * separate, earlier check; this governs identity.
    */
-  public static AccessDecision access(
-      Actor actor, String runId, String specId, String specAssignee) {
+  public static AccessDecision access(Actor actor, String runId, String specId, String owner) {
     if (actor.isAdmin()) {
       return AccessDecision.allowed();
     }
-    if (Strings.isNotBlank(specAssignee) && specAssignee.equals(actor.handle())) {
+    if (Strings.isNotBlank(owner) && owner.equals(actor.handle())) {
       return AccessDecision.allowed();
     }
     return AccessDecision.refused(
         ErrorCode.FORBIDDEN_NOT_ASSIGNEE,
-        "Run "
-            + runId
-            + " belongs to spec '"
-            + specId
-            + "'"
-            + (Strings.isNotBlank(specAssignee)
-                ? ", assigned to '" + specAssignee + "', not you."
-                : ", which is unassigned."),
+        describeRun(runId, specId, owner),
         "Only "
-            + (Strings.isNotBlank(specAssignee) ? specAssignee : "the spec's assignee")
+            + (Strings.isNotBlank(owner) ? owner : "its owner")
             + " or an admin may access this run.");
+  }
+
+  private static String describeRun(String runId, String specId, String owner) {
+    if (Strings.isBlank(specId)) {
+      return "Run "
+          + runId
+          + " is an ad-hoc session"
+          + (Strings.isNotBlank(owner) ? " launched by '" + owner + "', not you." : ".");
+    }
+    return "Run "
+        + runId
+        + " belongs to spec '"
+        + specId
+        + "'"
+        + (Strings.isNotBlank(owner)
+            ? ", assigned to '" + owner + "', not you."
+            : ", which is unassigned.");
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -5,7 +5,6 @@
 
 package ai.singlr.sail.api;
 
-import ai.singlr.sail.common.Ids;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
@@ -444,9 +443,6 @@ public final class SailOperations implements Operations {
               notRunning.runId(), false, notRunning.reason(), null, notRunning.specCancelled());
       case StopOperations.AlreadyTerminal terminal ->
           new StopRunResponse(terminal.runId(), false, terminal.reason(), null, false);
-      case StopOperations.NotActive notActive ->
-          new StopRunResponse(
-              notActive.runId(), false, notActive.reason(), notActive.livePid(), false);
     };
   }
 
@@ -475,11 +471,16 @@ public final class SailOperations implements Operations {
     if (isForeign(run, localHandle)) {
       return foreignRun(run);
     }
-    if (RunPolicy.access(actor, run.id(), run.specId(), specAssignee(run.specId()))
+    if (RunPolicy.access(actor, run.id(), StopOperations.specIdOf(run), runOwner(run))
         instanceof AccessDecision.Refused refused) {
       return Result.failure(refused.code(), refused.message(), refused.fix());
     }
     return served.apply(run);
+  }
+
+  /** The identity that owns a run: its spec's assignee, or the launching node for ad-hoc runs. */
+  private String runOwner(RunStore.RunRow run) {
+    return Strings.isBlank(run.specId()) ? run.node() : specAssignee(run.specId());
   }
 
   /**
@@ -661,11 +662,10 @@ public final class SailOperations implements Operations {
   }
 
   /**
-   * The agent status of a project that may now host several concurrent runs: every local {@code
-   * running} run is probed on its own recorded unit and listed, with the newest one filling the
-   * single-session fields so the common one-run case reads exactly as before. A project with no
-   * running run rows falls back to the fixed ad-hoc session probe, which also covers {@code sail
-   * agent start} sessions that mint no run.
+   * The agent status of a project that may host several concurrent runs: every local {@code
+   * running} session run — dispatched or ad-hoc — is probed on its own recorded identity and
+   * listed, with the newest one filling the single-session fields so the common one-run case reads
+   * exactly as before. No run rows means no session: every agent session is a run.
    */
   private AgentStatusResponse agentStatusValue(String project, String localHandle) {
     projects.requireExists(project);
@@ -675,12 +675,11 @@ public final class SailOperations implements Operations {
             ? List.<RunStore.RunRow>of()
             : runStore.listForProject(project).stream()
                 .filter(DispatchOperations::ownsLiveAgent)
-                .filter(RunStore.RunRow::buildRole)
+                .filter(RunStore.RunRow::sessionRole)
                 .filter(run -> ownsRun(run.node(), localHandle))
                 .toList();
     if (running.isEmpty()) {
-      var info = querySession(agentSession, project, AgentUnit.BUILD);
-      return agentStatusResponse(project, info, List.of());
+      return agentStatusResponse(project, null, List.of());
     }
     var runs =
         running.stream()
@@ -730,7 +729,7 @@ public final class SailOperations implements Operations {
     if (Strings.isBlank(run.logPath())) {
       return new RunLogResponse(run.id(), List.of(), "This run has no log file.");
     }
-    var logPath = AgentUnit.fromRole(run.role()).runLogPath(Ids.requireUuid(run.id()));
+    var logPath = AgentUnit.logPathForRole(run.role(), run.id());
     var cmd =
         ContainerExec.asDevUser(
             run.project(), List.of("tail", "-n", String.valueOf(tail), "--", logPath));

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SlackReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SlackReactor.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.engine.SlackClient;
 import ai.singlr.sail.engine.SlackPoster;
 import ai.singlr.sail.store.SlackThreadStore;
@@ -95,7 +96,7 @@ public final class SlackReactor implements EventSubscriber {
 
   @Override
   public Predicate<Event> filter() {
-    return e -> NOTIFIABLE_TYPES.contains(e.type());
+    return e -> NOTIFIABLE_TYPES.contains(e.type()) && Strings.isNotBlank(e.spec());
   }
 
   @Override

--- a/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
@@ -44,12 +44,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * whose agent already died still gets its intent recorded atomically (spec cancelled, a
  * still-{@code running} run released as {@code stopped}, in one transaction). Every run — build or
  * ad-hoc, background or foreground — owns its run-scoped unit and pid file, so a stop can only ever
- * signal the process the addressed run launched (the residual risk is in-container pid reuse
- * against a stale pid file, not cross-run identity theft, and the verified halt re-probes before
- * anything is finalized). A run that is no longer its spec's latest attempt is never a lever to
- * cancel newer work (a terminal one is {@link AlreadyTerminal}; a live or dead one is halted or
- * released without touching the spec), and a second stop of the same run is idempotent by
- * construction, returning {@link AlreadyTerminal} without signalling anything.
+ * signal the process the addressed run launched: the run-scoped file rules out cross-run identity
+ * theft, and a run that persisted its agent pid is additionally guarded against in-container pid
+ * reuse — a stale file naming a live replacement pid refuses with a conflict instead of authorizing
+ * a kill, and the verified halt re-probes before anything is finalized. A run that is no longer its
+ * spec's latest attempt is never a lever to cancel newer work (a terminal one is {@link
+ * AlreadyTerminal}; a live or dead one is halted or released without touching the spec), and a
+ * second stop of the same run is idempotent by construction, returning {@link AlreadyTerminal}
+ * without signalling anything.
  */
 public final class StopOperations {
 
@@ -264,6 +266,7 @@ public final class StopOperations {
       }
       return new NotRunning(run.id(), specIdOf(run), recordIntent(run, spec, actor), true);
     }
+    requirePidOwnership(run, info.pid());
     listener.halting(run.project(), unit.unitName(), info.pid());
     if (dryRun) {
       return new Stopped(run.id(), run.specId(), info.pid(), previewCancel(run, spec));
@@ -313,6 +316,7 @@ public final class StopOperations {
       }
       return new NotRunning(run.id(), specIdOf(run), false, true);
     }
+    requirePidOwnership(run, info.pid());
     listener.halting(run.project(), unit.unitName(), info.pid());
     if (dryRun) {
       return new Stopped(run.id(), specIdOf(run), info.pid(), false);
@@ -391,6 +395,28 @@ public final class StopOperations {
             specStore.compareAndSetStatus(spec.id(), SpecStatus.CANCELLED, spec.status());
           }
         });
+  }
+
+  /**
+   * A run that persisted its agent pid only ever signals that pid. The run-scoped pid file rules
+   * out cross-run confusion, but not in-container pid reuse after the original process exits — a
+   * stale file naming a live replacement pid must never authorize a kill. A run with no persisted
+   * pid (a session whose launch never resolved one) has no fingerprint to compare, so the file's
+   * run-scoped identity is the only — and sufficient — authority.
+   */
+  private static void requirePidOwnership(RunStore.RunRow run, int livePid) {
+    if (run.pid() != null && run.pid() != livePid) {
+      throw new ApiException(
+          ErrorCode.CONFLICT,
+          "Run "
+              + run.id()
+              + " recorded PID "
+              + run.pid()
+              + " but its pid file names live PID "
+              + livePid
+              + "; refusing to signal a process the run does not own.",
+          "Reconcile the stale run before retrying the stop.");
+    }
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
@@ -238,9 +238,10 @@ public final class StopOperations {
    * halt, and finalize the claim once the kill is verified. A run already holding a claim is an
    * interrupted stop and resumes instead. Every no-op branch is structured and write-free except
    * the stranded rescues, which record intent without a kill. A dead probe over a run that never
-   * persisted a pid and never completed is the pre-launch preparation window, not a stranded run —
-   * releasing its reservation there would let the imminent launch escape the container-isolation
-   * invariant, so the stop conflicts instead of rescuing.
+   * persisted a pid covers both a launch still preparing and a launch that died before stamping;
+   * recording terminal intent is safe in both, because the launcher's process stamp commits only
+   * while the run is still {@code running} — a launch that loses to this cancel discovers the loss
+   * at the stamp and tears its agent down rather than escaping the reservation.
    */
   private Outcome stopResolved(RunStore.RunRow run, Actor actor, boolean dryRun) {
     var spec = specOf(run);
@@ -265,12 +266,6 @@ public final class StopOperations {
     var unit = runUnit(run);
     var info = probe(run.project(), unit);
     if (info == null || !info.running()) {
-      if (run.pid() == null && run.completedAt() == null) {
-        throw new ApiException(
-            ErrorCode.CONFLICT,
-            "Run " + run.id() + " is still preparing to launch.",
-            "Retry the stop after launch preparation resolves.");
-      }
       if (dryRun) {
         return new NotRunning(run.id(), specIdOf(run), previewCancel(run, spec), true);
       }
@@ -279,7 +274,7 @@ public final class StopOperations {
     requirePidOwnership(run, info.pid());
     listener.halting(run.project(), unit.unitName(), info.pid());
     if (dryRun) {
-      return new Stopped(run.id(), run.specId(), info.pid(), previewCancel(run, spec));
+      return new Stopped(run.id(), specIdOf(run), info.pid(), previewCancel(run, spec));
     }
     return killVerified(run, spec, actor, unit, info.pid());
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
@@ -237,7 +237,10 @@ public final class StopOperations {
    * own recorded unit, claim the stop (spec cancelled, run {@code stopping}, one transaction),
    * halt, and finalize the claim once the kill is verified. A run already holding a claim is an
    * interrupted stop and resumes instead. Every no-op branch is structured and write-free except
-   * the stranded rescues, which record intent without a kill.
+   * the stranded rescues, which record intent without a kill. A dead probe over a run that never
+   * persisted a pid and never completed is the pre-launch preparation window, not a stranded run —
+   * releasing its reservation there would let the imminent launch escape the container-isolation
+   * invariant, so the stop conflicts instead of rescuing.
    */
   private Outcome stopResolved(RunStore.RunRow run, Actor actor, boolean dryRun) {
     var spec = specOf(run);
@@ -262,6 +265,12 @@ public final class StopOperations {
     var unit = runUnit(run);
     var info = probe(run.project(), unit);
     if (info == null || !info.running()) {
+      if (run.pid() == null && run.completedAt() == null) {
+        throw new ApiException(
+            ErrorCode.CONFLICT,
+            "Run " + run.id() + " is still preparing to launch.",
+            "Retry the stop after launch preparation resolves.");
+      }
       if (dryRun) {
         return new NotRunning(run.id(), specIdOf(run), previewCancel(run, spec), true);
       }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
@@ -46,12 +46,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * ad-hoc, background or foreground — owns its run-scoped unit and pid file, so a stop can only ever
  * signal the process the addressed run launched: the run-scoped file rules out cross-run identity
  * theft, and a run that persisted its agent pid is additionally guarded against in-container pid
- * reuse — a stale file naming a live replacement pid refuses with a conflict instead of authorizing
- * a kill, and the verified halt re-probes before anything is finalized. A run that is no longer its
- * spec's latest attempt is never a lever to cancel newer work (a terminal one is {@link
- * AlreadyTerminal}; a live or dead one is halted or released without touching the spec), and a
- * second stop of the same run is idempotent by construction, returning {@link AlreadyTerminal}
- * without signalling anything.
+ * reuse — a stale file naming a different live pid, or the recorded pid itself reoccupied by a
+ * process whose {@code /proc} start-time fingerprint no longer matches the one persisted at launch,
+ * refuses with a conflict instead of authorizing a kill, and the verified halt re-probes before
+ * anything is finalized. A run that is no longer its spec's latest attempt is never a lever to
+ * cancel newer work (a terminal one is {@link AlreadyTerminal}; a live or dead one is halted or
+ * released without touching the spec), and a second stop of the same run is idempotent by
+ * construction, returning {@link AlreadyTerminal} without signalling anything.
  */
 public final class StopOperations {
 
@@ -398,14 +399,22 @@ public final class StopOperations {
   }
 
   /**
-   * A run that persisted its agent pid only ever signals that pid. The run-scoped pid file rules
-   * out cross-run confusion, but not in-container pid reuse after the original process exits — a
-   * stale file naming a live replacement pid must never authorize a kill. A run with no persisted
-   * pid (a session whose launch never resolved one) has no fingerprint to compare, so the file's
-   * run-scoped identity is the only — and sufficient — authority.
+   * A run that persisted its agent pid only ever signals that pid — and only while the pid still
+   * names the process the run launched. The run-scoped pid file rules out cross-run confusion, but
+   * not in-container pid reuse after the original process exits: a replacement process assigned the
+   * same numeric pid makes the stored pid, the stale file, and the live pid all agree, so equality
+   * alone proves nothing. The persisted {@code /proc} start-time fingerprint does: no two processes
+   * ever share a pid <em>and</em> a start time, so a live process whose fingerprint differs — or
+   * cannot be read — is a replacement and must never be signalled. A run with no persisted pid (a
+   * session whose launch never resolved one) has no identity to compare, so the file's run-scoped
+   * identity is the only — and sufficient — authority; a run persisted before fingerprints existed
+   * keeps the pid-equality guard alone.
    */
-  private static void requirePidOwnership(RunStore.RunRow run, int livePid) {
-    if (run.pid() != null && run.pid() != livePid) {
+  private void requirePidOwnership(RunStore.RunRow run, int livePid) {
+    if (run.pid() == null) {
+      return;
+    }
+    if (run.pid() != livePid) {
       throw new ApiException(
           ErrorCode.CONFLICT,
           "Run "
@@ -416,6 +425,34 @@ public final class StopOperations {
               + livePid
               + "; refusing to signal a process the run does not own.",
           "Reconcile the stale run before retrying the stop.");
+    }
+    if (pidReused(run, livePid)) {
+      throw new ApiException(
+          ErrorCode.CONFLICT,
+          "Run "
+              + run.id()
+              + "'s recorded PID "
+              + livePid
+              + " now names a different process (the PID was reused after the agent exited);"
+              + " refusing to signal a process the run does not own.",
+          "Reconcile the stale run before retrying the stop.");
+    }
+  }
+
+  /**
+   * Whether the live process at the run's pid is a later occupant rather than the process the run
+   * launched. No fingerprint on the run means nothing to compare; an unreadable live fingerprint
+   * reads as reused, because a kill must never proceed on an identity that cannot be verified.
+   */
+  private boolean pidReused(RunStore.RunRow run, int livePid) {
+    if (run.pidTicks() == null) {
+      return false;
+    }
+    try {
+      return !run.pidTicks()
+          .equals(new AgentSession(shell).readProcessStartTicks(run.project(), livePid));
+    } catch (Exception e) {
+      return true;
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
@@ -42,12 +42,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * <p>The lane is also the clean way out of a stranded spec, not only a process kill: a resolved run
  * whose agent already died still gets its intent recorded atomically (spec cancelled, a
- * still-{@code running} run released as {@code stopped}, in one transaction). A pid mismatch is a
- * structured no-op — stopping a stale run id can never kill a different, newer run — a run that is
- * no longer its spec's latest attempt is never a lever to cancel newer work (a terminal one is
- * {@link AlreadyTerminal}; a live or dead one is halted or released without touching the spec), and
- * a second stop of the same run is idempotent by construction, returning {@link AlreadyTerminal}
- * without signalling anything.
+ * still-{@code running} run released as {@code stopped}, in one transaction). Every run — build or
+ * ad-hoc, background or foreground — owns its run-scoped unit and pid file, so a stop can only ever
+ * signal the process the addressed run launched (the residual risk is in-container pid reuse
+ * against a stale pid file, not cross-run identity theft, and the verified halt re-probes before
+ * anything is finalized). A run that is no longer its spec's latest attempt is never a lever to
+ * cancel newer work (a terminal one is {@link AlreadyTerminal}; a live or dead one is halted or
+ * released without touching the spec), and a second stop of the same run is idempotent by
+ * construction, returning {@link AlreadyTerminal} without signalling anything.
  */
 public final class StopOperations {
 
@@ -64,14 +66,13 @@ public final class StopOperations {
   public record ProjectTarget(String project) implements Target {}
 
   /** What a stop produced; each lane renders it without duplicating any decision. */
-  public sealed interface Outcome permits Stopped, NotRunning, AlreadyTerminal, NotActive {
+  public sealed interface Outcome permits Stopped, NotRunning, AlreadyTerminal {
     /** Whether this stop wrote anything — a halted agent, a cancelled spec, a released run. */
     default boolean mutated() {
       return switch (this) {
         case Stopped ignored -> true;
         case NotRunning notRunning -> notRunning.specCancelled() || notRunning.runReleased();
         case AlreadyTerminal ignored -> false;
-        case NotActive ignored -> false;
       };
     }
 
@@ -85,15 +86,15 @@ public final class StopOperations {
         case NotRunning notRunning ->
             notRunning.runReleased() ? "no_agent_running" : "run_not_running";
         case AlreadyTerminal ignored -> "run_not_running";
-        case NotActive ignored -> "run_not_active";
       };
     }
   }
 
   /**
-   * The live agent was halted after its terminal intent was recorded. {@code runId} and {@code
-   * specId} are null for an ad-hoc session that minted no run; {@code specCancelled} reports
-   * whether the spec moved to {@link SpecStatus#CANCELLED}.
+   * The live agent was halted after its terminal intent was recorded. {@code runId} always names
+   * the stopped run — an ad-hoc session is a run like any other; {@code specId} is null for a run
+   * that works no spec; {@code specCancelled} reports whether the spec moved to {@link
+   * SpecStatus#CANCELLED}.
    */
   public record Stopped(String runId, String specId, Integer pid, boolean specCancelled)
       implements Outcome {}
@@ -110,12 +111,6 @@ public final class StopOperations {
   /** The run and its spec are already terminal — a repeated stop, a pure no-op. */
   public record AlreadyTerminal(String runId, String specId, String runStatus) implements Outcome {}
 
-  /**
-   * The live agent on the run's unit is not this run's process ({@code livePid} differs from the
-   * run's recorded pid), so nothing was killed and nothing was written.
-   */
-  public record NotActive(String runId, String specId, Integer livePid) implements Outcome {}
-
   /** How the kill runs — the only side effect that differs from a store write. */
   @FunctionalInterface
   public interface AgentHalter {
@@ -129,22 +124,16 @@ public final class StopOperations {
   }
 
   /**
-   * Resolves the session shown by CLI status/config views: the active build run's own unit first,
-   * then the independent ad-hoc unit.
+   * Resolves the session shown by CLI status/config views: the active session run's (build or
+   * ad-hoc) own recorded identity, or null when the project has no active run on this box.
    */
   public static AgentSession.SessionInfo resolveSession(
       ShellExec shell, RunStore runs, String project, String localHandle) throws Exception {
-    var session = new AgentSession(shell);
-    AgentSession.SessionInfo runInfo = null;
     var run = runs.runningForProjectOnNode(project, localHandle).orElse(null);
-    if (run != null) {
-      runInfo = session.queryStatus(project, runUnit(run));
-      if (runInfo != null && runInfo.running()) {
-        return runInfo;
-      }
+    if (run == null) {
+      return null;
     }
-    var adHoc = session.queryStatus(project, AgentUnit.BUILD);
-    return adHoc != null || runInfo == null ? adHoc : runInfo;
+    return new AgentSession(shell).queryStatus(project, runUnit(run));
   }
 
   /**
@@ -209,7 +198,7 @@ public final class StopOperations {
           "Run " + run.id() + " executed on " + node + "; only its executing box can stop it.",
           "Stop it from " + node + "'s box.");
     }
-    if (!run.buildRole()) {
+    if (!run.sessionRole()) {
       throw new ApiException(
           ErrorCode.INVALID_ROLE,
           "Run "
@@ -226,27 +215,18 @@ public final class StopOperations {
   }
 
   /**
-   * A project-targeted stop resolves the active run row first, but a stale row must not mask the
-   * separate fixed ad-hoc session: a dispatched agent that died without completing its row leaves a
-   * {@code running} row behind while a later {@code sail agent start} session is the live process
-   * the operator means to stop. When the resolved run turns out dead ({@link NotRunning}), the
-   * stranded rescue still happens and the ad-hoc identity is probed and stopped as well.
+   * A project-targeted stop resolves the newest active session run — build or ad-hoc, the two are
+   * mutually exclusive by reservation — and applies the one resolved-run procedure. A project with
+   * no active run on this box has nothing to stop.
    */
   private Outcome stopProject(String project, Actor actor, String localHandle, boolean dryRun) {
     projects.requireExists(project);
     var run = runStore.runningForProjectOnNode(project, localHandle).orElse(null);
     if (run == null) {
-      return stopAdHoc(project, dryRun);
+      return new NotRunning(null, null, false, false);
     }
     authorize(actor, run);
-    var resolved = stopResolved(run, actor, dryRun);
-    if (!(resolved instanceof NotRunning stranded)) {
-      return resolved;
-    }
-    if (stopAdHoc(project, dryRun) instanceof Stopped stopped) {
-      return new Stopped(null, stranded.specId(), stopped.pid(), stranded.specCancelled());
-    }
-    return stranded;
+    return stopResolved(run, actor, dryRun);
   }
 
   /**
@@ -263,7 +243,7 @@ public final class StopOperations {
     }
     if (!"running".equals(run.status())) {
       if (!cancelable(spec)) {
-        return new AlreadyTerminal(run.id(), run.specId(), run.status());
+        return new AlreadyTerminal(run.id(), specIdOf(run), run.status());
       }
       if (dryRun) {
         return isCurrentAttempt(run)
@@ -280,12 +260,9 @@ public final class StopOperations {
     var info = probe(run.project(), unit);
     if (info == null || !info.running()) {
       if (dryRun) {
-        return new NotRunning(run.id(), run.specId(), previewCancel(run, spec), true);
+        return new NotRunning(run.id(), specIdOf(run), previewCancel(run, spec), true);
       }
-      return new NotRunning(run.id(), run.specId(), recordIntent(run, spec, actor), true);
-    }
-    if (run.pid() == null || info.pid() != run.pid()) {
-      return new NotActive(run.id(), run.specId(), info.pid());
+      return new NotRunning(run.id(), specIdOf(run), recordIntent(run, spec, actor), true);
     }
     listener.halting(run.project(), unit.unitName(), info.pid());
     if (dryRun) {
@@ -315,7 +292,7 @@ public final class StopOperations {
       throw failure;
     }
     finishStop(run, actor);
-    return new Stopped(run.id(), run.specId(), pid, cancelled);
+    return new Stopped(run.id(), specIdOf(run), pid, cancelled);
   }
 
   /**
@@ -334,19 +311,16 @@ public final class StopOperations {
       if (!dryRun) {
         finishStop(run, actor);
       }
-      return new NotRunning(run.id(), run.specId(), false, true);
-    }
-    if (run.pid() == null || info.pid() != run.pid()) {
-      return new NotActive(run.id(), run.specId(), info.pid());
+      return new NotRunning(run.id(), specIdOf(run), false, true);
     }
     listener.halting(run.project(), unit.unitName(), info.pid());
     if (dryRun) {
-      return new Stopped(run.id(), run.specId(), info.pid(), false);
+      return new Stopped(run.id(), specIdOf(run), info.pid(), false);
     }
     halt(run.project(), unit);
     verifyHalted(run.project(), unit);
     finishStop(run, actor);
-    return new Stopped(run.id(), run.specId(), info.pid(), false);
+    return new Stopped(run.id(), specIdOf(run), info.pid(), false);
   }
 
   /**
@@ -471,26 +445,6 @@ public final class StopOperations {
   }
 
   /**
-   * The ad-hoc fallback for a project with no active run row: a {@code sail agent start} session
-   * owns no run and no spec, so there is no intent to record — the verified kill is the whole stop,
-   * and nothing exists for the reaper or the pipeline to resume. Verified matters here too: the
-   * halter is a no-op when the pid file is missing while the probe can still see the live process
-   * through systemd, and only a re-probe keeps that state from being reported stopped.
-   */
-  private Outcome stopAdHoc(String project, boolean dryRun) {
-    var info = probe(project, AgentUnit.BUILD);
-    if (info == null || !info.running()) {
-      return new NotRunning(null, null, false, false);
-    }
-    listener.halting(project, AgentUnit.BUILD.unitName(), info.pid());
-    if (!dryRun) {
-      halt(project, AgentUnit.BUILD);
-      verifyHalted(project, AgentUnit.BUILD);
-    }
-    return new Stopped(null, null, info.pid(), false);
-  }
-
-  /**
    * Records the operator's terminal intent for a run with no live process to kill: the spec (when
    * still {@code in_progress}/{@code review}) moves to {@link SpecStatus#CANCELLED} and the run is
    * released as {@code stopped} with no exit code — in one transaction when both apply, so a
@@ -526,11 +480,16 @@ public final class StopOperations {
     data.put(Event.WellKnownData.RUN_ID, run.id());
     return Event.of(
         run.project(),
-        run.specId(),
+        specIdOf(run),
         Event.WellKnownTypes.AGENT_CANCELLED,
         agent,
         HostInfo.hostname(),
         data);
+  }
+
+  /** The run's spec id with the blank ad-hoc form normalized to null: no spec means no spec. */
+  static String specIdOf(RunStore.RunRow run) {
+    return Strings.isBlank(run.specId()) ? null : run.specId();
   }
 
   private SpecStore.SpecRow specOf(RunStore.RunRow run) {
@@ -546,23 +505,24 @@ public final class StopOperations {
   }
 
   private void authorize(Actor actor, RunStore.RunRow run) {
-    var assignee =
+    var owner =
         Strings.isBlank(run.specId())
-            ? null
+            ? run.node()
             : specStore.findById(run.specId()).map(SpecStore.SpecRow::assignee).orElse(null);
-    if (RunPolicy.access(actor, run.id(), run.specId(), assignee)
+    if (RunPolicy.access(actor, run.id(), specIdOf(run), owner)
         instanceof AccessDecision.Refused refused) {
       throw new ApiException(refused.code(), refused.message(), refused.fix());
     }
   }
 
-  /** The systemd/file identity of a build run, rebuilt from the unit name recorded at launch. */
+  /**
+   * The systemd/file identity of a session run, rebuilt from the unit name recorded at launch. A
+   * foreground run records no unit — it is a blocking child process, not a service — but its
+   * run-scoped pid file carries the same identity, so probing and killing work through the file
+   * side while the systemd side simply reports nothing.
+   */
   static AgentUnit runUnit(RunStore.RunRow run) {
-    if (Strings.isBlank(run.unit())) {
-      throw new IllegalStateException(
-          "Build run " + run.id() + " has no unit; run 'sail migrate' to repair its data.");
-    }
-    return AgentUnit.recorded(run.id(), run.unit());
+    return AgentUnit.recorded(run.id(), Objects.toString(run.unit(), ""));
   }
 
   private AgentSession.SessionInfo probe(String project, AgentUnit unit) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/WatcherRearmer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/WatcherRearmer.java
@@ -5,9 +5,12 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.engine.AgentSession;
+import ai.singlr.sail.engine.AgentUnit;
+import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.store.RunStore;
-import ai.singlr.sail.store.SpecStore;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.function.LongPredicate;
@@ -15,32 +18,34 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
- * Keeps every running agent guarded: for each {@code in_progress} spec whose latest session is
- * still {@code running} and whose recorded agent unit is still active, but which no live watcher
- * covers, this relaunches the watcher — at daemon start and then periodically, so a watcher that
- * dies mid-run (crash, OOM kill) leaves the agent unguarded for at most one pass interval. The
- * relaunched {@code sail agent watch} recomputes its wall-clock deadline from the session's
- * original {@code started_at}, so an agent three hours into a four-hour budget gets the remaining
- * hour, not a fresh four. Only sessions this node executed are considered — a synced foreign run is
- * its executing node's to guard, and arming a local watcher against it would eventually enforce a
- * foreign deadline on this box's container.
+ * Keeps every running agent guarded: for each local {@code running} session run — build or ad-hoc,
+ * the run table is the one session model — whose recorded agent unit is still active but which no
+ * live watcher covers, this relaunches the watcher — at daemon start and then periodically, so a
+ * watcher that dies mid-run (crash, OOM kill) leaves the agent unguarded for at most one pass
+ * interval. The relaunched {@code sail agent watch} recomputes its wall-clock deadline from the
+ * session's original {@code started_at}, so an agent three hours into a four-hour budget gets the
+ * remaining hour, not a fresh four. Only sessions this node executed are considered — a synced
+ * foreign run is its executing node's to guard, and arming a local watcher against it would
+ * eventually enforce a foreign deadline on this box's container.
  *
  * <p>Coverage is probed, not bookkept — and probed at the process level: a recorded watcher pid
  * that is still alive (free, in-process check) or any {@code sail agent watch} process for the run
  * ({@link WatcherSpawner#watcherProcessRunningForRun}, which sees every systemd scope, every user's
  * manager, and plain fallback processes alike) means covered. Unit-name probes alone would be blind
  * to a watcher armed in another user's manager and re-arm a double whose guardrail actions fire
- * twice. Relaunching is unit-or-nothing ({@link WatcherSpawner#spawnUnitForRun}); where systemd is
- * unavailable the relaunch is empty and the missed-stop sweep still replays the stop when the agent
- * ends. A session whose agent unit is already dead is that sweep's job, not this one's.
+ * twice. The agent probe is deliberately systemd-strict ({@link #systemdUnitActiveProbe}): a
+ * watcher supervises a unit, and only background sessions run as one — a foreground session writes
+ * the same run-scoped pid file but its blocking launcher owns its lifecycle, so a pid-file-based
+ * probe would arm guardrails over a session that was never meant to have them. Relaunching is
+ * unit-or-nothing ({@link WatcherSpawner#spawnUnitForRun}); where systemd is unavailable the
+ * relaunch is empty and the missed-stop sweep still replays the stop when the agent ends. A session
+ * whose agent unit is already dead is that sweep's job, not this one's, and a legacy row with no
+ * recorded unit has nothing to supervise.
  */
 public final class WatcherRearmer implements AutoCloseable {
 
   /** Re-arm cadence, matching the missed-stop sweep: unguarded time is bounded by one interval. */
   public static final Duration DEFAULT_INTERVAL = MissedStopReconciler.DEFAULT_INTERVAL;
-
-  private static final SpecStore.SpecFilter IN_PROGRESS =
-      new SpecStore.SpecFilter(null, "in_progress", null, null, null);
 
   /** Relaunches a run's watcher as a unit; empty when neither systemd scope accepts it. */
   @FunctionalInterface
@@ -48,9 +53,8 @@ public final class WatcherRearmer implements AutoCloseable {
     Optional<WatcherSpawner.Unit> relaunch(RunStore.RunRow run) throws Exception;
   }
 
-  private final SpecStore specStore;
   private final RunStore sessionStore;
-  private final MissedStopReconciler.UnitProbe agentUnitProbe;
+  private final MissedStopReconciler.UnitProbe agentUnitActive;
   private final Predicate<String> watcherRunning;
   private final LongPredicate watcherAlive;
   private final Supplier<String> localHandle;
@@ -58,16 +62,14 @@ public final class WatcherRearmer implements AutoCloseable {
   private final PeriodicPass pass;
 
   public WatcherRearmer(
-      SpecStore specStore,
       RunStore sessionStore,
-      MissedStopReconciler.UnitProbe agentUnitProbe,
+      MissedStopReconciler.UnitProbe agentUnitActive,
       Predicate<String> watcherRunning,
       LongPredicate watcherAlive,
       Supplier<String> localHandle,
       WatcherRelauncher relauncher) {
-    this.specStore = specStore;
     this.sessionStore = sessionStore;
-    this.agentUnitProbe = agentUnitProbe;
+    this.agentUnitActive = agentUnitActive;
     this.watcherRunning = watcherRunning;
     this.watcherAlive = watcherAlive;
     this.localHandle = localHandle;
@@ -78,6 +80,16 @@ public final class WatcherRearmer implements AutoCloseable {
   /** Liveness of a host process by pid — how recorded watcher pids are checked in production. */
   public static LongPredicate livingProcess() {
     return pid -> ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false);
+  }
+
+  /**
+   * The production agent probe: active only when the run's recorded unit is live in the container's
+   * user systemd manager, never through the pid file — the discriminator that keeps a live
+   * foreground session from being armed with a watcher it was never launched with.
+   */
+  public static MissedStopReconciler.UnitProbe systemdUnitActiveProbe(ShellExec shell) {
+    var session = new AgentSession(shell);
+    return (project, runId, unit) -> session.unitActive(project, AgentUnit.recorded(runId, unit));
   }
 
   /** Starts the periodic re-arm at the default cadence. */
@@ -95,19 +107,28 @@ public final class WatcherRearmer implements AutoCloseable {
   }
 
   /**
-   * Runs one re-arm pass and returns how many watchers were relaunched. Best-effort: a failing spec
-   * is logged and skipped so one broken project cannot leave the rest unwatched, and a store error
+   * Runs one re-arm pass and returns how many watchers were relaunched. Best-effort: a failing run
+   * is logged and skipped so one broken session cannot leave the rest unwatched, and a store error
    * is logged and swallowed so re-arming can never block server startup.
    */
   public int rearm() {
     var rearmed = 0;
     try {
-      for (var spec : specStore.list(IN_PROGRESS)) {
+      var node = localHandle.get();
+      for (var run : sessionStore.running()) {
+        if (!SailOperations.ownsRun(run.node(), node) || Strings.isBlank(run.unit())) {
+          continue;
+        }
         try {
-          rearmed += rearm(spec) ? 1 : 0;
+          rearmed += rearm(run) ? 1 : 0;
         } catch (Exception e) {
           System.err.println(
-              "  [rearm] failed for " + spec.project() + "/" + spec.id() + ": " + e.getMessage());
+              "  [rearm] failed for "
+                  + run.project()
+                  + " session "
+                  + run.id()
+                  + ": "
+                  + e.getMessage());
         }
       }
     } catch (Exception e) {
@@ -116,48 +137,30 @@ public final class WatcherRearmer implements AutoCloseable {
     return rearmed;
   }
 
-  private boolean rearm(SpecStore.SpecRow spec) throws Exception {
-    var node = localHandle.get();
-    var latest =
-        sessionStore.listForSpec(spec.id()).stream()
-            .filter(RunStore.RunRow::buildRole)
-            .filter(run -> SailOperations.ownsRun(run.node(), node))
-            .findFirst();
-    if (latest.isEmpty() || !"running".equals(latest.get().status())) {
-      return false;
-    }
-    var session = latest.get();
+  private boolean rearm(RunStore.RunRow session) throws Exception {
     if (session.watcherPid() != null && watcherAlive.test(session.watcherPid())) {
       return false;
     }
     if (watcherRunning.test(session.id())) {
       return false;
     }
-    if (!agentUnitProbe.active(spec.project(), session.id(), session.unit())) {
+    if (!agentUnitActive.active(session.project(), session.id(), session.unit())) {
       return false;
     }
     var unit = relauncher.relaunch(session);
     if (unit.isEmpty()) {
       System.err.println(
           "  [rearm] "
-              + spec.project()
-              + "/"
-              + spec.id()
-              + " (session "
-              + session.id()
-              + "): agent is running unwatched but no watcher unit could be launched (no agent"
+              + describe(session)
+              + ": agent is running unwatched but no watcher unit could be launched (no agent"
               + " block or no systemd scope); the missed-stop sweep still replays its stop when"
               + " the agent ends");
       return false;
     }
     System.err.println(
         "  [rearm] re-armed watcher for "
-            + spec.project()
-            + "/"
-            + spec.id()
-            + " (session "
-            + session.id()
-            + "): "
+            + describe(session)
+            + ": "
             + (unit.get().adopted()
                 ? "adopted already-active unit " + unit.get().name()
                 : "launched unit "
@@ -166,6 +169,11 @@ public final class WatcherRearmer implements AutoCloseable {
                     + unit.get().scope()
                     + " scope), resuming the original deadline from the session's started_at"));
     return true;
+  }
+
+  private static String describe(RunStore.RunRow session) {
+    var work = Strings.isBlank(session.specId()) ? "ad-hoc" : "spec " + session.specId();
+    return session.project() + " session " + session.id() + " (" + work + ")";
   }
 
   @Override

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLogCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentLogCommand.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
@@ -80,6 +81,10 @@ public final class AgentLogCommand implements Runnable {
     ContainerStateGuard.requireRunning(state, name);
 
     var logPath = resolveLogPath(name, review);
+    if (logPath == null) {
+      printNoLog();
+      return;
+    }
 
     if (follow) {
       var tailCmd = ContainerExec.asDevUser(name, List.of("tail", "-f", logPath));
@@ -105,19 +110,7 @@ public final class AgentLogCommand implements Runnable {
       var result = shell.exec(cmd);
       if (!result.ok()) {
         if (result.stderr().contains("No such file")) {
-          if (json) {
-            var map = new LinkedHashMap<String, Object>();
-            map.put("name", name);
-            map.put("lines", List.of());
-            map.put("error", "No agent log found");
-            System.out.println(YamlUtil.dumpJson(map));
-            return;
-          }
-          System.out.println(
-              Ansi.AUTO.string(
-                  "  @|faint No agent log found. Launch an agent with: sail agent start "
-                      + name
-                      + " --task \"...\" --background|@"));
+          printNoLog();
           return;
         }
         throw new IOException("Failed to read agent log: " + result.stderr());
@@ -137,53 +130,66 @@ public final class AgentLogCommand implements Runnable {
   }
 
   /**
-   * The log file to tail. With {@code --review}, the latest review's own negotiation log ({@code
-   * ~/.sail/runs/<reviewId>/review.log}) — each review owns its files so concurrent pipelines never
-   * interleave, which means there is no live shared review log to follow. Otherwise the latest
-   * build run's own run-scoped log ({@code ~/.sail/runs/<id>/agent.log}) — since dispatch moved off
-   * the shared {@code agent.log}, tailing the shared file would show nothing for a dispatched run.
-   * Falls back to the fixed shared path when no run or review row exists (a manual {@code sail
-   * agent start}, or a pre-upgrade review) or the control-plane database cannot be read.
+   * The log file to tail, or null when the project has no session to show. With {@code --review},
+   * the latest review's own negotiation log ({@code ~/.sail/runs/<reviewId>/review.log}) — each
+   * review owns its files so concurrent pipelines never interleave — resolved through the latest
+   * <em>build</em> run, since only a spec's dispatch has reviews. Otherwise the latest session
+   * run's own run-scoped log ({@code ~/.sail/runs/<id>/agent.log}), dispatched and ad-hoc alike:
+   * every agent session is a run, so no run row means no log.
    */
   private String resolveLogPath(String project, boolean review) {
     try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
-      var latestRun = new RunStore(db).latestForProjectOnNode(project, NodeIdentity.handle());
+      var runs = new RunStore(db);
       if (review) {
-        return reviewLogPathFrom(latestRun, new ReviewStore(db));
+        return reviewLogPathFrom(latestBuildRun(runs, project), new ReviewStore(db));
       }
-      return logPathFrom(latestRun);
+      return logPathFrom(runs.latestForProjectOnNode(project, NodeIdentity.handle()));
     } catch (RuntimeException e) {
-      return logPathFor(review);
+      return null;
     }
   }
 
-  /** The latest local run's run-scoped log path, or the shared build log when there is none. */
+  private static Optional<RunStore.RunRow> latestBuildRun(RunStore runs, String project) {
+    return runs.listForProject(project).stream()
+        .filter(RunStore.RunRow::buildRole)
+        .filter(
+            run ->
+                Objects.toString(run.node(), "")
+                    .equals(Objects.toString(NodeIdentity.handle(), "")))
+        .findFirst();
+  }
+
+  /** The latest local session run's run-scoped log path, or null when there is none. */
   static String logPathFrom(Optional<RunStore.RunRow> latestRun) {
-    return latestRun
-        .map(RunStore.RunRow::logPath)
-        .filter(Strings::isNotBlank)
-        .orElseGet(() -> logPathFor(false));
+    return latestRun.map(RunStore.RunRow::logPath).filter(Strings::isNotBlank).orElse(null);
   }
 
   /**
-   * The latest run's spec's latest review log, per-review under the review's own directory, or the
-   * fixed foreground-review log when the current dispatch attempt has no review yet. Foreground
-   * review identity intentionally remains shared until the ad-hoc run-scoping work lands.
+   * The latest build run's spec's latest review log, per-review under the review's own directory,
+   * or the fixed foreground-review log when the current dispatch attempt has no review yet.
    */
   static String reviewLogPathFrom(Optional<RunStore.RunRow> latestRun, ReviewStore reviews) {
     return latestRun
         .map(RunStore.RunRow::specId)
         .flatMap(reviews::latestReviewForSpec)
         .map(review -> AgentUnit.forReview(review.id()).logPath())
-        .orElseGet(() -> logPathFor(true));
+        .orElseGet(AgentUnit.REVIEW::logPath);
   }
 
-  /**
-   * The static log path for a unit: the reviewer/fix negotiation ({@code review.log}) with {@code
-   * --review}, else the coder's shared build log ({@code agent.log}).
-   */
-  static String logPathFor(boolean review) {
-    return (review ? AgentUnit.REVIEW : AgentUnit.BUILD).logPath();
+  private void printNoLog() {
+    if (json) {
+      var map = new LinkedHashMap<String, Object>();
+      map.put("name", name);
+      map.put("lines", List.of());
+      map.put("error", "No agent log found");
+      System.out.println(YamlUtil.dumpJson(map));
+      return;
+    }
+    System.out.println(
+        Ansi.AUTO.string(
+            "  @|faint No agent log found. Launch an agent with: sail agent run "
+                + name
+                + " --task \"...\" --background|@"));
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStopCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentStopCommand.java
@@ -164,15 +164,6 @@ public final class AgentStopCommand implements Runnable {
                       + " is already "
                       + terminal.runStatus()
                       + "; nothing to stop.|@"));
-      case StopOperations.NotActive notActive ->
-          System.err.println(
-              Banner.errorLine(
-                  "The live agent (PID "
-                      + notActive.livePid()
-                      + ") does not belong to run "
-                      + notActive.runId()
-                      + "; nothing was stopped. Check 'sail agent status' and retry.",
-                  Ansi.AUTO));
     }
   }
 
@@ -206,12 +197,6 @@ public final class AgentStopCommand implements Runnable {
         map.put("reason", terminal.reason());
         map.put("run_status", terminal.runStatus());
         putRunAndSpec(map, terminal.runId(), terminal.specId(), false);
-      }
-      case StopOperations.NotActive notActive -> {
-        map.put("stopped", false);
-        map.put("reason", notActive.reason());
-        map.put("live_pid", notActive.livePid());
-        putRunAndSpec(map, notActive.runId(), notActive.specId(), false);
       }
     }
     return map;

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentSweepCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentSweepCommand.java
@@ -5,18 +5,26 @@
 
 package ai.singlr.sail.commands;
 
-import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.api.ApiException;
+import ai.singlr.sail.api.DispatchOperations;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
-import ai.singlr.sail.engine.AgentCli;
-import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerStateGuard;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
-import java.nio.file.Files;
+import ai.singlr.sail.engine.WatcherSpawner;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -24,6 +32,11 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Spec;
 
+/**
+ * Runs the entropy-sweep prompt as a foreground ad-hoc session through the shared {@link
+ * DispatchOperations} launch machinery, so a sweep is a first-class run — reserved, recorded, and
+ * mutually exclusive with any dispatched agent in the container.
+ */
 @Command(
     name = "sweep",
     description = "Run an entropy sweep to clean up codebase drift and inconsistencies.",
@@ -86,64 +99,78 @@ public final class AgentSweepCommand implements Runnable {
 
     ContainerStateGuard.requireRunning(state, name);
 
-    var singYamlPath = SailPaths.resolveSailYaml(name, file);
-    SailYaml config = null;
-    if (Files.exists(singYamlPath)) {
-      config = SailYaml.fromMap(YamlUtil.parseFile(singYamlPath));
+    var handle = Objects.toString(HostSync.handle(), "");
+    var describeOnly = json || dryRun;
+    var launchCommand = new AtomicReference<List<String>>();
+    try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+      var operations = operations(shell, launchCommand, db);
+      var request =
+          new DispatchOperations.AdhocRequest(SWEEP_PROMPT, null, null, false, describeOnly);
+      DispatchOperations.AdhocSession session;
+      try {
+        session = operations.startAdhoc(name, request, handle);
+      } catch (ApiException e) {
+        var action = e.failure().action();
+        throw new IllegalStateException(
+            Strings.isBlank(action) ? e.getMessage() : e.getMessage() + " " + action, e);
+      }
+      render(session, launchCommand.get());
     }
+  }
 
-    var sshUser = config != null ? config.sshUser() : "dev";
-    var workDir = "/home/" + sshUser + "/workspace";
-    var agentType =
-        config != null && config.agent() != null ? config.agent().type() : "claude-code";
-    var agentCli = AgentCli.fromYamlName(agentType);
-    var fullPermissions =
-        config != null
-            && config.agent() != null
-            && config.agent().config() != null
-            && "full".equals(config.agent().config().get("permissions"));
+  private DispatchOperations operations(
+      ShellExecutor shell, AtomicReference<List<String>> launchCommand, Sqlite db) {
+    var listener =
+        new DispatchOperations.Listener() {
+          @Override
+          public void launching(boolean bg, List<String> command) {
+            launchCommand.set(command);
+            if (json) {
+              return;
+            }
+            if (!dryRun) {
+              Banner.printBranding(System.out, Ansi.AUTO);
+            }
+            System.out.println();
+            System.out.println(Ansi.AUTO.string("  @|bold Launching entropy sweep...|@"));
+            System.out.println(Ansi.AUTO.string("  @|faint " + String.join(" ", command) + "|@"));
+            System.out.println();
+          }
+        };
+    return new DispatchOperations(
+        shell,
+        file,
+        new SpecStore(db),
+        new ReviewStore(db),
+        new RunStore(db),
+        new FdeStore(db),
+        event -> {},
+        new WatcherSpawner(shell, WatcherSpawner::spawnProcess),
+        (project, config) -> "",
+        DispatchOperations.terminalLauncher(),
+        listener);
+  }
 
-    var agentSession = new AgentSession(shell);
-    agentSession.ensureDirectory(name);
-    agentSession.writeTaskFile(name, SWEEP_PROMPT);
-
-    var sshCmd =
-        AgentSession.buildForegroundTaskCommand(name, sshUser, workDir, fullPermissions, agentCli);
-
+  private void render(DispatchOperations.AdhocSession session, List<String> command) {
     if (json) {
       var map = new LinkedHashMap<String, Object>();
       map.put("name", name);
       map.put("action", "sweep");
-      map.put("agent", agentType);
-      map.put("ssh_command", String.join(" ", sshCmd));
+      map.put("run_id", session.runId());
+      map.put("ssh_command", command == null ? "" : String.join(" ", command));
       System.out.println(YamlUtil.dumpJson(map));
       return;
     }
-
-    if (!dryRun) {
-      Banner.printBranding(System.out, Ansi.AUTO);
-    }
-    System.out.println();
-    System.out.println(
-        Ansi.AUTO.string("  @|bold Launching entropy sweep with " + agentType + "...|@"));
-    System.out.println(Ansi.AUTO.string("  @|faint " + String.join(" ", sshCmd) + "|@"));
-    System.out.println();
-
     if (dryRun) {
-      System.out.println("[dry-run] " + String.join(" ", sshCmd));
-    } else {
-      var pb = new ProcessBuilder(sshCmd);
-      pb.inheritIO();
-      var process = pb.start();
-      var exitCode = process.waitFor();
-      if (exitCode != 0) {
-        System.err.println(
-            Banner.errorLine("Sweep session exited with code " + exitCode, Ansi.AUTO));
-      } else {
-        System.out.println(Ansi.AUTO.string("  @|bold,green \u2713 Entropy sweep complete.|@"));
-        System.out.println(
-            Ansi.AUTO.string("  @|faint Report at:|@ /home/" + sshUser + "/sweep-report.md"));
-      }
+      System.out.println("[dry-run] " + (command == null ? "" : String.join(" ", command)));
+      return;
     }
+    if (session.exitCode() != null && session.exitCode() != 0) {
+      System.err.println(
+          Banner.errorLine("Sweep session exited with code " + session.exitCode(), Ansi.AUTO));
+      return;
+    }
+    System.out.println(Ansi.AUTO.string("  @|bold,green ✓ Entropy sweep complete.|@"));
+    System.out.println(Ansi.AUTO.string("  @|faint Report at:|@ ~/sweep-report.md"));
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
@@ -56,12 +56,10 @@ import picocli.CommandLine.Spec;
  * only its remaining budget. Supervision is on by default (see {@code Guardrails.defaults()});
  * sail.yaml overrides every threshold and the action.
  *
- * <p>A dispatched run's watcher is run-addressed: {@code --run} names the run whose agent it
- * supervises and {@code --unit} the systemd unit that run was launched as (recorded on the run,
- * never re-derived here). Progress events then reset the stall timer only when they carry this
- * run's id, so a concurrent run's tool calls in the same container never keep a hung agent alive.
- * Without {@code --run} the watcher supervises the fixed ad-hoc identity, the {@code sail agent
- * start} lane.
+ * <p>Every watcher is run-addressed: {@code --run} names the run whose agent it supervises and
+ * {@code --unit} the systemd unit that run was launched as (recorded on the run, never re-derived
+ * here). Progress events reset the stall timer only when they carry this run's id, so a concurrent
+ * run's tool calls in the same container never keep a hung agent alive.
  */
 @Command(
     name = "watch",
@@ -84,7 +82,8 @@ public final class AgentWatchCommand implements Runnable {
 
   @Option(
       names = "--run",
-      description = "Run id of the dispatched agent to supervise (default: the ad-hoc session).")
+      required = true,
+      description = "Run id of the agent session to supervise.")
   private String runId;
 
   @Option(
@@ -122,13 +121,10 @@ public final class AgentWatchCommand implements Runnable {
   }
 
   /**
-   * The identity this watcher supervises: the recorded unit of {@code --run} (derived only when a
-   * caller omitted {@code --unit}), or the fixed ad-hoc identity when no run was named.
+   * The identity this watcher supervises: the recorded unit of {@code --run}, derived only when a
+   * caller omitted {@code --unit}.
    */
   private AgentUnit resolveUnit() {
-    if (Strings.isBlank(runId)) {
-      return AgentUnit.BUILD;
-    }
     return Strings.isBlank(unitName)
         ? AgentUnit.forRun(runId)
         : AgentUnit.recorded(runId, unitName);
@@ -337,15 +333,11 @@ public final class AgentWatchCommand implements Runnable {
   }
 
   /**
-   * Whether an event belongs to the watched run. A run-addressed watcher accepts only events
-   * stamped with its run id — the in-container hooks send {@code SAIL_RUN_ID} on every heartbeat —
-   * so a concurrent run's tool calls never reset this run's stall timer. A project-scoped (ad-hoc)
-   * watcher accepts everything, the prior behavior.
+   * Whether an event belongs to the watched run. The watcher accepts only events stamped with its
+   * run id — the in-container hooks send {@code SAIL_RUN_ID} on every heartbeat — so a concurrent
+   * run's tool calls never reset this run's stall timer.
    */
   static boolean matchesRun(Event event, String watchedRunId) {
-    if (Strings.isBlank(watchedRunId)) {
-      return true;
-    }
     return watchedRunId.equals(
         Objects.toString(event.data().get(Event.WellKnownData.RUN_ID), null));
   }
@@ -435,20 +427,22 @@ public final class AgentWatchCommand implements Runnable {
     if (publisher == null) {
       return;
     }
-    if (Strings.isBlank(exit.specId())) {
+    if (Strings.isBlank(exit.specId()) && Strings.isBlank(exit.runId())) {
       System.out.println(
           Ansi.AUTO.string(
-              "  @|faint [watch] no spec id for "
+              "  @|faint [watch] no spec or run id recovered for "
                   + project
-                  + "; ad-hoc session, no stop published|@"));
+                  + "; no stop published|@"));
       return;
     }
     try {
       publisher.publish(syntheticStop(project, exit));
       System.out.println(
           Ansi.AUTO.string(
-              "  @|faint [watch] published stop for spec "
-                  + exit.specId()
+              "  @|faint [watch] published stop for "
+                  + (Strings.isBlank(exit.specId())
+                      ? "run " + exit.runId()
+                      : "spec " + exit.specId())
                   + " (exit "
                   + exit.exitCode()
                   + ")|@"));
@@ -473,7 +467,7 @@ public final class AgentWatchCommand implements Runnable {
     }
     return Event.of(
         project,
-        exit.specId(),
+        Strings.isBlank(exit.specId()) ? null : exit.specId(),
         Event.WellKnownTypes.AGENT_SESSION_STOPPED,
         agent,
         HostInfo.hostname(),

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.ApiException;
 import ai.singlr.sail.api.DispatchOperations;
+import ai.singlr.sail.api.ErrorCode;
 import ai.singlr.sail.api.Event;
 import ai.singlr.sail.api.SailEventPublisher;
 import ai.singlr.sail.common.DateTimeUtils;
@@ -215,27 +216,10 @@ public final class RunCommand implements Runnable {
 
     var label = SnapshotManager.defaultLabel();
     var snapshotTaken = !dryRun && SnapshotDecision.shouldSnapshot(snapshot, config, json);
+    var branchName = branchName(config, label);
 
-    if (snapshotTaken) {
-      var snapMgr = new SnapshotManager(shell);
-      SnapshotDecision.create(System.out, snapMgr, name, label, json);
-    }
-
-    String branchName = null;
-    if (config.agent() != null && config.agent().autoBranch()) {
-      var prefix = config.agent().branchPrefix() != null ? config.agent().branchPrefix() : "sail/";
-      validateSafePath(prefix, "branch_prefix");
-      branchName = prefix + label;
-      System.out.println(Ansi.AUTO.string("  @|bold Creating branch:|@ " + branchName + "..."));
-      var branchCmd =
-          ContainerExec.asDevUser(
-              name, List.of("git", "-C", workDir, "checkout", "-b", branchName));
-      var result = shell.exec(branchCmd);
-      if (!result.ok()) {
-        throw new IOException("Failed to create branch '" + branchName + "': " + result.stderr());
-      }
-      System.out.println(Ansi.AUTO.string("  @|green \u2713|@ Branch " + branchName));
-      System.out.println();
+    if (task == null) {
+      prepareContainer(shell, workDir, snapshotTaken, label, branchName);
     }
 
     if (!json && agentCli == AgentCli.CLAUDE_CODE) {
@@ -251,24 +235,60 @@ public final class RunCommand implements Runnable {
       System.out.println();
     }
 
-    var snapshotLabel = snapshotTaken ? label : null;
-
     if (task != null) {
-      launchTaskSession(shell, branchName, snapshotLabel);
+      launchTaskSession(shell, workDir, branchName, snapshotTaken, label);
     } else {
       launchInteractive(sshUser, workDir, fullPermissions, agentCli);
     }
+  }
+
+  private String branchName(SailYaml config, String label) {
+    if (config.agent() == null || !config.agent().autoBranch()) {
+      return null;
+    }
+    var prefix = Objects.requireNonNullElse(config.agent().branchPrefix(), "sail/");
+    validateSafePath(prefix, "branch_prefix");
+    return prefix + label;
+  }
+
+  /**
+   * The pre-launch container mutations — the snapshot and the work-branch checkout. The task lane
+   * runs this only through {@link DispatchOperations.AdhocPreparer}, strictly after the
+   * whole-container reservation is won, so a refused launch never disturbs the workspace of the
+   * agent that owns it; the interactive lane, which reserves nothing, prepares inline.
+   */
+  private void prepareContainer(
+      ShellExecutor shell, String workDir, boolean snapshotTaken, String label, String branchName)
+      throws Exception {
+    if (snapshotTaken) {
+      SnapshotDecision.create(System.out, new SnapshotManager(shell), name, label, json);
+    }
+    if (branchName == null) {
+      return;
+    }
+    System.out.println(Ansi.AUTO.string("  @|bold Creating branch:|@ " + branchName + "..."));
+    var branchCmd =
+        ContainerExec.asDevUser(name, List.of("git", "-C", workDir, "checkout", "-b", branchName));
+    var result = shell.exec(branchCmd);
+    if (!result.ok()) {
+      throw new IOException("Failed to create branch '" + branchName + "': " + result.stderr());
+    }
+    System.out.println(Ansi.AUTO.string("  @|green ✓|@ Branch " + branchName));
+    System.out.println();
   }
 
   /**
    * Launches the headless task session as a first-class ad-hoc run through the shared {@link
    * DispatchOperations} launch machinery: a minted run id, a whole-container reservation, a
    * run-scoped unit and log, and — in the background mode — the same run-addressed guardrail
-   * watcher a dispatch gets. {@code --json} describes the launch (the command and run-scoped paths)
-   * without executing it, exactly as before.
+   * watcher a dispatch gets. The snapshot and branch checkout ride the preparer, so they happen
+   * only once the reservation is won. {@code --json} and {@code --dry-run} describe the launch (the
+   * command and run-scoped paths) without reserving, preparing, or executing anything.
    */
-  private void launchTaskSession(ShellExecutor shell, String branchName, String snapshotLabel)
+  private void launchTaskSession(
+      ShellExecutor shell, String workDir, String branchName, boolean snapshotTaken, String label)
       throws Exception {
+    var snapshotLabel = snapshotTaken ? label : null;
     var handle = Objects.toString(HostSync.handle(), "");
     var describeOnly = json || dryRun;
     var launchCommand = new AtomicReference<List<String>>();
@@ -278,9 +298,17 @@ public final class RunCommand implements Runnable {
           new DispatchOperations.AdhocRequest(task, branchName, path, background, describeOnly);
       DispatchOperations.AdhocSession session;
       try {
-        session = operations.startAdhoc(name, request, handle);
+        session =
+            operations.startAdhoc(
+                name,
+                request,
+                handle,
+                () -> prepareContainer(shell, workDir, snapshotTaken, label, branchName));
       } catch (ApiException e) {
-        if (background && snapshotLabel != null) {
+        if (background
+            && snapshotLabel != null
+            && rollbackSafe(
+                e, new RunStore(db).runningForProjectOnNode(name, handle).isPresent())) {
           System.err.println(Banner.errorLine(e.getMessage(), Ansi.AUTO));
           autoRollback(shell, snapshotLabel, 1);
         }
@@ -290,6 +318,16 @@ public final class RunCommand implements Runnable {
       }
       render(session, launchCommand.get(), branchName);
     }
+  }
+
+  /**
+   * A snapshot restore is only safe when the refused launch left nothing behind: an actual launch
+   * failure with no run still active on this box. A reservation refusal means another agent owns
+   * the container — restoring would yank the workspace out from under it — and a post-launch
+   * supervision failure deliberately keeps the run reserved with a live agent underneath.
+   */
+  static boolean rollbackSafe(ApiException e, boolean activeSession) {
+    return e.failure().errorCode() == ErrorCode.AGENT_LAUNCH_FAILED && !activeSession;
   }
 
   private DispatchOperations operations(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
@@ -141,10 +141,6 @@ public final class RunCommand implements Runnable {
       validateSafePath(path, "--path");
     }
 
-    if (!noRegen) {
-      regenContext(shell, config);
-    }
-
     launchAgent(shell, config);
   }
 
@@ -219,6 +215,9 @@ public final class RunCommand implements Runnable {
     var branchName = branchName(config, label);
 
     if (task == null) {
+      if (!noRegen) {
+        regenContext(shell, config);
+      }
       prepareContainer(shell, workDir, snapshotTaken, label, branchName);
     }
 
@@ -236,7 +235,7 @@ public final class RunCommand implements Runnable {
     }
 
     if (task != null) {
-      launchTaskSession(shell, workDir, branchName, snapshotTaken, label);
+      launchTaskSession(shell, config, workDir, branchName, snapshotTaken, label);
     } else {
       launchInteractive(sshUser, workDir, fullPermissions, agentCli);
     }
@@ -253,9 +252,11 @@ public final class RunCommand implements Runnable {
 
   /**
    * The pre-launch container mutations — the snapshot and the work-branch checkout. The task lane
-   * runs this only through {@link DispatchOperations.AdhocPreparer}, strictly after the
-   * whole-container reservation is won, so a refused launch never disturbs the workspace of the
-   * agent that owns it; the interactive lane, which reserves nothing, prepares inline.
+   * runs this (and the context regeneration, which overwrites the shared home-level agent context)
+   * only through {@link DispatchOperations.AdhocPreparer}, strictly after the whole-container
+   * reservation is won, so a refused launch never disturbs the workspace — or the lazily loaded
+   * instructions and skills — of the agent that owns it; the interactive lane, which reserves
+   * nothing, prepares inline.
    */
   private void prepareContainer(
       ShellExecutor shell, String workDir, boolean snapshotTaken, String label, String branchName)
@@ -281,12 +282,18 @@ public final class RunCommand implements Runnable {
    * Launches the headless task session as a first-class ad-hoc run through the shared {@link
    * DispatchOperations} launch machinery: a minted run id, a whole-container reservation, a
    * run-scoped unit and log, and — in the background mode — the same run-addressed guardrail
-   * watcher a dispatch gets. The snapshot and branch checkout ride the preparer, so they happen
-   * only once the reservation is won. {@code --json} and {@code --dry-run} describe the launch (the
-   * command and run-scoped paths) without reserving, preparing, or executing anything.
+   * watcher a dispatch gets. The context regeneration, snapshot, and branch checkout ride the
+   * preparer, so they happen only once the reservation is won. {@code --json} and {@code --dry-run}
+   * describe the launch (the command and run-scoped paths) without reserving, preparing, or
+   * executing anything.
    */
   private void launchTaskSession(
-      ShellExecutor shell, String workDir, String branchName, boolean snapshotTaken, String label)
+      ShellExecutor shell,
+      SailYaml config,
+      String workDir,
+      String branchName,
+      boolean snapshotTaken,
+      String label)
       throws Exception {
     var snapshotLabel = snapshotTaken ? label : null;
     var handle = Objects.toString(HostSync.handle(), "");
@@ -303,7 +310,12 @@ public final class RunCommand implements Runnable {
                 name,
                 request,
                 handle,
-                () -> prepareContainer(shell, workDir, snapshotTaken, label, branchName));
+                () -> {
+                  if (!noRegen) {
+                    regenContext(shell, config);
+                  }
+                  prepareContainer(shell, workDir, snapshotTaken, label, branchName);
+                });
       } catch (ApiException e) {
         if (background
             && snapshotLabel != null

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
@@ -5,14 +5,19 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.api.ApiException;
+import ai.singlr.sail.api.DispatchOperations;
+import ai.singlr.sail.api.Event;
+import ai.singlr.sail.api.SailEventPublisher;
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecDirectory;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.AgentCli;
 import ai.singlr.sail.engine.AgentContextInstaller;
-import ai.singlr.sail.engine.AgentSession;
+import ai.singlr.sail.engine.AgentUnit;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
@@ -22,7 +27,11 @@ import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SnapshotManager;
+import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.gen.AgentContextGenerator;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import java.io.IOException;
@@ -30,6 +39,7 @@ import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
@@ -95,6 +105,8 @@ public final class RunCommand implements Runnable {
   private String file;
 
   @picocli.CommandLine.Spec private CommandSpec spec;
+
+  private SailEventPublisher eventPublisher;
 
   @Override
   public void run() {
@@ -241,13 +253,159 @@ public final class RunCommand implements Runnable {
 
     var snapshotLabel = snapshotTaken ? label : null;
 
-    if (task != null && background) {
-      launchBackground(
-          shell, config, sshUser, workDir, fullPermissions, branchName, agentCli, snapshotLabel);
-    } else if (task != null) {
-      launchForegroundTask(shell, sshUser, workDir, fullPermissions, agentCli);
+    if (task != null) {
+      launchTaskSession(shell, branchName, snapshotLabel);
     } else {
       launchInteractive(sshUser, workDir, fullPermissions, agentCli);
+    }
+  }
+
+  /**
+   * Launches the headless task session as a first-class ad-hoc run through the shared {@link
+   * DispatchOperations} launch machinery: a minted run id, a whole-container reservation, a
+   * run-scoped unit and log, and — in the background mode — the same run-addressed guardrail
+   * watcher a dispatch gets. {@code --json} describes the launch (the command and run-scoped paths)
+   * without executing it, exactly as before.
+   */
+  private void launchTaskSession(ShellExecutor shell, String branchName, String snapshotLabel)
+      throws Exception {
+    var handle = Objects.toString(HostSync.handle(), "");
+    var describeOnly = json || dryRun;
+    var launchCommand = new AtomicReference<List<String>>();
+    try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
+      var operations = operations(shell, db, launchCommand);
+      var request =
+          new DispatchOperations.AdhocRequest(task, branchName, path, background, describeOnly);
+      DispatchOperations.AdhocSession session;
+      try {
+        session = operations.startAdhoc(name, request, handle);
+      } catch (ApiException e) {
+        if (background && snapshotLabel != null) {
+          System.err.println(Banner.errorLine(e.getMessage(), Ansi.AUTO));
+          autoRollback(shell, snapshotLabel, 1);
+        }
+        var action = e.failure().action();
+        throw new IllegalStateException(
+            Strings.isBlank(action) ? e.getMessage() : e.getMessage() + " " + action, e);
+      }
+      render(session, launchCommand.get(), branchName);
+    }
+  }
+
+  private DispatchOperations operations(
+      ShellExecutor shell, Sqlite db, AtomicReference<List<String>> launchCommand) {
+    var listener =
+        new DispatchOperations.Listener() {
+          @Override
+          public void launching(boolean bg, List<String> command) {
+            launchCommand.set(command);
+            if (json) {
+              return;
+            }
+            System.out.println(
+                Ansi.AUTO.string(
+                    bg
+                        ? "  @|bold Launching agent in background...|@"
+                        : "  @|bold Launching agent with task...|@"));
+            System.out.println(Ansi.AUTO.string("  @|faint " + String.join(" ", command) + "|@"));
+            System.out.println();
+          }
+
+          @Override
+          public void runsPruned(int count) {
+            if (count > 0 && !json) {
+              System.out.println(
+                  Ansi.AUTO.string(
+                      "  @|faint Pruned " + count + " old run log(s) in " + name + ".|@"));
+            }
+          }
+
+          @Override
+          public void sailSetupUpdated(boolean updated) {
+            if (updated && !json) {
+              System.out.println(
+                  Ansi.AUTO.string(
+                      "  @|faint Updated sail event helpers in "
+                          + name
+                          + " (installed files were stale or incomplete).|@"));
+            }
+          }
+        };
+    return new DispatchOperations(
+        shell,
+        file,
+        new SpecStore(db),
+        new ReviewStore(db),
+        new RunStore(db),
+        new FdeStore(db),
+        this::publishLifecycle,
+        new WatcherSpawner(shell, WatcherSpawner::spawnProcess),
+        (project, config) -> "",
+        DispatchOperations.terminalLauncher(),
+        listener);
+  }
+
+  private void render(
+      DispatchOperations.AdhocSession session, List<String> command, String branchName) {
+    if (json) {
+      var map = new LinkedHashMap<String, Object>();
+      map.put("name", name);
+      map.put("mode", background ? "background" : "foreground");
+      map.put("task", task);
+      map.put("branch", branchName);
+      map.put("run_id", session.runId());
+      map.put("log_path", AgentUnit.forRun(session.runId()).logPath());
+      map.put("ssh_command", command == null ? "" : String.join(" ", command));
+      System.out.println(YamlUtil.dumpJson(map));
+      return;
+    }
+    if (dryRun) {
+      System.out.println("[dry-run] " + (command == null ? "" : String.join(" ", command)));
+      return;
+    }
+    if (background) {
+      Banner.printAgentLaunched(name, task, branchName, System.out, Ansi.AUTO);
+      session
+          .watcher()
+          .ifPresent(
+              spawned ->
+                  System.out.println(
+                      Ansi.AUTO.string(
+                          "  @|green ✓|@ "
+                              + GuardrailWatcher.describe(
+                                  spawned, WatcherSpawner.watchLogForRun(name, session.runId())))));
+      return;
+    }
+    if (session.exitCode() != null && session.exitCode() != 0) {
+      System.err.println(
+          Banner.errorLine("Agent session exited with code " + session.exitCode(), Ansi.AUTO));
+    }
+  }
+
+  /**
+   * Publishes a lifecycle {@link Event} to the running sail-api best-effort, so SSE subscribers see
+   * the session start regardless of surface; the control-plane database already holds the run, so
+   * an unreachable sail-api never fails the launch.
+   */
+  private void publishLifecycle(Event event) {
+    try {
+      if (eventPublisher == null) {
+        eventPublisher = SailEventPublisher.localDefault();
+      }
+      eventPublisher.publish(event);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    } catch (Exception e) {
+      if (!json) {
+        System.err.println(
+            Banner.errorLine(
+                "Could not publish "
+                    + event.type()
+                    + " event ("
+                    + e.getMessage()
+                    + "). sail-api may be unreachable; the launch itself is unaffected.",
+                Ansi.AUTO));
+      }
     }
   }
 
@@ -270,66 +428,6 @@ public final class RunCommand implements Runnable {
         + " done`. Then pick up the next pending spec and continue working.";
   }
 
-  private void launchBackground(
-      ShellExecutor shell,
-      SailYaml config,
-      String sshUser,
-      String workDir,
-      boolean fullPermissions,
-      String branchName,
-      AgentCli agentCli,
-      String snapshotLabel)
-      throws Exception {
-    var agentSession = new AgentSession(shell);
-    agentSession.ensureDirectory(name);
-    agentSession.writeTaskFile(name, task);
-    agentSession.writeSession(name, task, Objects.requireNonNullElse(branchName, ""));
-
-    var sshCmd =
-        AgentSession.buildBackgroundLaunchCommand(
-            name, sshUser, workDir, fullPermissions, agentCli);
-
-    if (json) {
-      var map = new LinkedHashMap<String, Object>();
-      map.put("name", name);
-      map.put("mode", "background");
-      map.put("task", task);
-      map.put("branch", branchName);
-      map.put("log_path", AgentSession.logPath());
-      map.put("ssh_command", String.join(" ", sshCmd));
-      System.out.println(YamlUtil.dumpJson(map));
-      return;
-    }
-
-    System.out.println(Ansi.AUTO.string("  @|bold Launching agent in background...|@"));
-    if (dryRun) {
-      System.out.println(Ansi.AUTO.string("  @|faint " + String.join(" ", sshCmd) + "|@"));
-    }
-    System.out.println();
-
-    if (dryRun) {
-      System.out.println("[dry-run] " + String.join(" ", sshCmd));
-    } else {
-      var pb = new ProcessBuilder(sshCmd);
-      pb.inheritIO();
-      var process = pb.start();
-      var exitCode = process.waitFor();
-      if (exitCode != 0) {
-        System.err.println(
-            Banner.errorLine("Background launch exited with code " + exitCode, Ansi.AUTO));
-        if (snapshotLabel != null) {
-          autoRollback(shell, snapshotLabel, exitCode);
-        }
-      }
-    }
-
-    Banner.printAgentLaunched(name, task, branchName, System.out, Ansi.AUTO);
-
-    if (!dryRun) {
-      GuardrailWatcher.launch(name, file, config, shell);
-    }
-  }
-
   private void autoRollback(ShellExecutor shell, String snapshotLabel, int exitCode) {
     try {
       var rollbackMap = new LinkedHashMap<String, Object>();
@@ -347,48 +445,6 @@ public final class RunCommand implements Runnable {
     } catch (Exception rollbackEx) {
       System.err.println(
           Banner.errorLine("Auto-rollback failed: " + rollbackEx.getMessage(), Ansi.AUTO));
-    }
-  }
-
-  private void launchForegroundTask(
-      ShellExecutor shell,
-      String sshUser,
-      String workDir,
-      boolean fullPermissions,
-      AgentCli agentCli)
-      throws Exception {
-    var agentSession = new AgentSession(shell);
-    agentSession.ensureDirectory(name);
-    agentSession.writeTaskFile(name, task);
-
-    var sshCmd =
-        AgentSession.buildForegroundTaskCommand(name, sshUser, workDir, fullPermissions, agentCli);
-
-    if (json) {
-      var map = new LinkedHashMap<String, Object>();
-      map.put("name", name);
-      map.put("mode", "foreground");
-      map.put("task", task);
-      map.put("ssh_command", String.join(" ", sshCmd));
-      System.out.println(YamlUtil.dumpJson(map));
-      return;
-    }
-
-    System.out.println(Ansi.AUTO.string("  @|bold Launching agent with task...|@"));
-    System.out.println(Ansi.AUTO.string("  @|faint " + String.join(" ", sshCmd) + "|@"));
-    System.out.println();
-
-    if (dryRun) {
-      System.out.println("[dry-run] " + String.join(" ", sshCmd));
-    } else {
-      var pb = new ProcessBuilder(sshCmd);
-      pb.inheritIO();
-      var process = pb.start();
-      var exitCode = process.waitFor();
-      if (exitCode != 0) {
-        System.err.println(
-            Banner.errorLine("Agent session exited with code " + exitCode, Ansi.AUTO));
-      }
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -261,9 +261,8 @@ public final class ServerStartCommand implements Runnable {
     var watcherSpawner = new WatcherSpawner(reconcileShell, null);
     var rearmer =
         new WatcherRearmer(
-            specStore,
             runStore,
-            unitProbe,
+            WatcherRearmer.systemdUnitActiveProbe(reconcileShell),
             watcherSpawner::watcherProcessRunningForRun,
             WatcherRearmer.livingProcess(),
             NodeIdentity::handle,

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/GuardrailWatcher.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/GuardrailWatcher.java
@@ -5,46 +5,15 @@
 
 package ai.singlr.sail.engine;
 
-import ai.singlr.sail.config.SailYaml;
 import java.nio.file.Path;
-import picocli.CommandLine.Help.Ansi;
 
 /**
- * Starts the background guardrail watcher ({@code sail agent watch}) for a project. Supervision is
- * on by default: the watcher is spawned for every dispatched agent and applies {@link
- * ai.singlr.sail.config.Guardrails#defaults()} when sail.yaml declares no guardrails of its own.
- * Shared by the CLI dispatch/run/launch commands, which all spawn it the same way through {@link
- * WatcherSpawner} — detached from this process, so it survives Ctrl-C on the dispatch stream and
- * the SSH session ending. Failures are reported but never fatal to the launch.
+ * Renders how a guardrail watcher ({@code sail agent watch}) ended up running, for the launch lanes
+ * that spawn one through {@link WatcherSpawner} and narrate the result.
  */
 public final class GuardrailWatcher {
 
   private GuardrailWatcher() {}
-
-  /**
-   * Spawns a detached watcher for the project's agent (no-op only when there is no agent block),
-   * through the caller's own shell so wiring matches the rest of the command.
-   */
-  public static void launch(String project, String file, SailYaml config, ShellExec shell) {
-    if (config == null || config.agent() == null) {
-      return;
-    }
-    try {
-      var sailYamlPath = SailPaths.resolveSailYaml(project, file);
-      var watchLog = SailPaths.projectDir(project).resolve("watch.log");
-      var spawner = new WatcherSpawner(shell, WatcherSpawner::spawnProcess);
-      var spawned = spawner.spawn(project, sailYamlPath, watchLog);
-      System.out.println(Ansi.AUTO.string("  @|green ✓|@ " + describe(spawned, watchLog)));
-    } catch (Exception e) {
-      System.err.println(
-          Banner.errorLine(
-              "Failed to start guardrail watcher: "
-                  + e.getMessage()
-                  + ". Run manually: sail agent watch "
-                  + project,
-              Ansi.AUTO));
-    }
-  }
 
   public static String describe(WatcherSpawner.Spawned spawned, Path watchLog) {
     return switch (spawned) {

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/WatcherSpawner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/WatcherSpawner.java
@@ -23,16 +23,14 @@ import java.util.Optional;
  * fallback is supplied — a plain detached process last, loudly marked degraded because no unit name
  * can address it.
  *
- * <p>A dispatched run's watcher is run-addressed: unit {@code sail-watch-<runId>}, watching exactly
- * the agent unit recorded on the run, logging to the run's own host-side file {@code
+ * <p>Every watcher is run-addressed: unit {@code sail-watch-<runId>}, watching exactly the agent
+ * unit recorded on the run, logging to the run's own host-side file {@code
  * <project-dir>/runs/<runId>/watch.log} so concurrent watchers never interleave one file. Per-run
- * unit names cannot collide, so a fresh dispatch never needs to stop a previous watcher — and must
- * not: a project-scoped watcher still active from a pre-upgrade agent owns that agent and is left
- * to drain it. The legacy project-scoped unit {@code sail-watch-<project>} remains only for the
- * ad-hoc lane ({@code sail agent start}), whose agent keeps the fixed per-container identity.
+ * unit names cannot collide, so a fresh launch never needs to stop a previous watcher — and must
+ * not: a watcher still active from another run owns that run's agent and is left to drain it.
  *
- * <p>Two spawn intents with different collision semantics. {@link #spawnForRun} serves dispatch and
- * always launches fresh. {@link #spawnUnitForRun} serves the re-armer: it only runs against a run
+ * <p>Two spawn intents with different collision semantics. {@link #spawnForRun} serves launches and
+ * always spawns fresh. {@link #spawnUnitForRun} serves the re-armer: it only runs against a run
  * already verified uncovered, so an active unit of the same name means a concurrent pass won the
  * race and is adopted, never doubled.
  *
@@ -77,11 +75,6 @@ public final class WatcherSpawner {
     this.fallback = fallback;
   }
 
-  /** The legacy project-scoped unit name, still used by the ad-hoc (non-dispatch) lane. */
-  public static String unitName(String project) {
-    return UNIT_PREFIX + project;
-  }
-
   /** The run-scoped watcher unit name: {@code sail-watch-<runId>}. */
   public static String unitNameForRun(String runId) {
     return UNIT_PREFIX + Ids.requireUuid(runId);
@@ -93,17 +86,6 @@ public final class WatcherSpawner {
         .resolve("runs")
         .resolve(Ids.requireUuid(runId))
         .resolve("watch.log");
-  }
-
-  /** The legacy project-scoped watcher argv, still used by the ad-hoc lane. */
-  public static List<String> watchCommand(String project, Path sailYaml) {
-    return List.of(
-        SailPaths.binaryPath().toString(),
-        "agent",
-        "watch",
-        project,
-        "-f",
-        sailYaml.toAbsolutePath().toString());
   }
 
   /**
@@ -136,21 +118,11 @@ public final class WatcherSpawner {
   }
 
   /**
-   * Spawns the legacy project-scoped watcher for a fresh ad-hoc session: any unit still active from
-   * a previous session is stopped first — never adopted, because its wall-clock deadline anchors to
-   * the old session and would be enforced against the new agent. Falls back to a detached process
-   * when no systemd scope accepts and a fallback was supplied; throws when every rung failed or the
+   * Spawns a fresh run-addressed watcher for a launched run. Per-run unit names cannot collide, so
+   * nothing is stopped first — a still-active watcher from another run (or a pre-upgrade
+   * project-scoped one) owns its own agent and is left alone. Falls back to a detached process when
+   * no systemd scope accepts and a fallback was supplied; throws when every rung failed or the
    * thread was interrupted mid-ladder, which the caller treats as a launch failure.
-   */
-  public Spawned spawn(String project, Path sailYaml, Path watchLog) throws IOException {
-    stopExisting(project);
-    return spawnFresh(unitName(project), watchCommand(project, sailYaml), watchLog);
-  }
-
-  /**
-   * Spawns a fresh run-addressed watcher for a dispatched run. Per-run unit names cannot collide,
-   * so nothing is stopped first — a still-active watcher from another run (or a pre-upgrade
-   * project-scoped one) owns its own agent and is left alone.
    */
   public Spawned spawnForRun(String project, Path sailYaml, String runId, String agentUnit)
       throws IOException {
@@ -227,21 +199,6 @@ public final class WatcherSpawner {
       }
     }
     return Optional.empty();
-  }
-
-  private void stopExisting(String project) {
-    for (var mode : Mode.values()) {
-      if (execOk(
-          SystemdServiceInstaller.systemctl(mode, "--quiet", "is-active", unitName(project)))) {
-        execOk(SystemdServiceInstaller.systemctl(mode, "stop", unitName(project)));
-        System.err.println(
-            "  [watch] stopped stale watcher unit "
-                + unitName(project)
-                + " ("
-                + scopeName(mode)
-                + " scope) from a previous session before arming the new one");
-      }
-    }
   }
 
   private Optional<Mode> activeScope(String unit) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AdhocDispatchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AdhocDispatchTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -275,6 +276,68 @@ class AdhocDispatchTest {
     assertTrue(
         runStore.runningForProjectOnNode("acme", HANDLE).isEmpty(),
         "a launch that never produced an agent frees the container");
+  }
+
+  @Test
+  void thePreparerRunsOnlyOnceTheReservationIsWon() throws Exception {
+    var ops = operations(liveAgentShell());
+    var reservedAtPrepare = new AtomicBoolean();
+
+    ops.startAdhoc(
+        "acme",
+        background("task"),
+        HANDLE,
+        () -> reservedAtPrepare.set(runStore.runningForProjectOnNode("acme", HANDLE).isPresent()));
+
+    assertTrue(reservedAtPrepare.get(), "preparation must see the reservation already held");
+  }
+
+  @Test
+  void aRefusedReservationNeverRunsThePreparer() throws Exception {
+    var ops = operations(liveAgentShell());
+    ops.startAdhoc("acme", background("one"), HANDLE);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.startAdhoc(
+                    "acme",
+                    background("two"),
+                    HANDLE,
+                    () -> {
+                      throw new AssertionError("a refused reservation must not prepare");
+                    }));
+
+    assertEquals(ErrorCode.AGENT_ALREADY_RUNNING, refusal.failure().errorCode());
+  }
+
+  @Test
+  void aFailedPreparationReleasesTheReservationWithoutLaunching() throws Exception {
+    var shell = new StubShell().on("incus list ^acme$", RUNNING_JSON);
+    var ops =
+        operations(
+            shell,
+            command -> {
+              throw new AssertionError("a failed preparation must not launch");
+            },
+            true);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.startAdhoc(
+                    "acme",
+                    background("task"),
+                    HANDLE,
+                    () -> {
+                      throw new IOException("git checkout failed");
+                    }));
+
+    assertEquals(ErrorCode.AGENT_LAUNCH_FAILED, refusal.failure().errorCode());
+    assertEquals("failed", runStore.listForProject("acme").getFirst().status());
+    assertTrue(runStore.runningForProjectOnNode("acme", HANDLE).isEmpty());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AdhocDispatchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AdhocDispatchTest.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.WatcherSpawner;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The ad-hoc launch lane: {@code startAdhoc} mints a run, reserves the whole container through the
+ * same transaction as dispatch, launches on the run-scoped identity, and shares dispatch's watcher
+ * and bookkeeping — so ad-hoc and dispatched agents are mutually exclusive by construction.
+ */
+class AdhocDispatchTest {
+
+  private static final String HANDLE = "me";
+  private static final Actor ADMIN = Actor.cliOperator(HANDLE);
+
+  private static final String RUNNING_JSON =
+      """
+      [{"name": "acme", "status": "Running", "state": {}}]
+      """;
+
+  private static final String YAML =
+      """
+      name: acme
+      ssh:
+        user: dev
+      repos:
+        - url: https://github.com/acme/app.git
+          path: app
+      agent:
+        type: claude-code
+      """;
+
+  @TempDir Path tempDir;
+
+  private SpecStore specStore;
+  private RunStore runStore;
+  private Sqlite db;
+  private final List<Event> events = new ArrayList<>();
+
+  private DispatchOperations operations(ShellExec shell) throws IOException {
+    return operations(shell, command -> 0, true);
+  }
+
+  private DispatchOperations operations(
+      ShellExec shell, DispatchOperations.AgentLauncher launcher, boolean withRunStore)
+      throws IOException {
+    var yaml = tempDir.resolve("sail-" + System.nanoTime() + ".yaml");
+    Files.writeString(yaml, YAML);
+    db = Sqlite.open(tempDir.resolve("adhoc-" + System.nanoTime() + ".db"));
+    new SchemaManager(db).migrate();
+    specStore = new SpecStore(db);
+    runStore = new RunStore(db);
+    new FdeStore(db).add(HANDLE, null, null, "admin");
+    return new DispatchOperations(
+        shell,
+        yaml.toString(),
+        specStore,
+        new ReviewStore(db),
+        withRunStore ? runStore : null,
+        new FdeStore(db),
+        events::add,
+        new WatcherSpawner(shell, (command, logPath) -> 4242L),
+        (project, config) -> "",
+        launcher,
+        DispatchOperations.Listener.NONE);
+  }
+
+  private static StubShell liveAgentShell() {
+    return new StubShell()
+        .on("incus list ^acme$", RUNNING_JSON)
+        .on("mkdir -p /home/dev/.sail", "")
+        .on("printf '%s'", "")
+        .on("agent.pid", "123")
+        .on("kill -0 123", "")
+        .on("agent-session.json", "{\"task\": \"work\"}");
+  }
+
+  private static DispatchOperations.AdhocRequest background(String task) {
+    return new DispatchOperations.AdhocRequest(task, null, null, true, false);
+  }
+
+  @Test
+  void aBackgroundAdhocLaunchMintsAReservedRunWithItsOwnIdentity() throws Exception {
+    var ops = operations(liveAgentShell());
+
+    var session = ops.startAdhoc("acme", background("fix the flaky test"), HANDLE);
+
+    var run = runStore.findById(session.runId()).orElseThrow();
+    assertEquals("adhoc", run.role());
+    assertEquals("", run.specId());
+    assertEquals(HANDLE, run.node());
+    assertEquals("running", run.status());
+    assertEquals(List.of(), run.repos());
+    assertEquals("sail-agent-" + session.runId(), run.unit());
+    assertEquals("/home/dev/.sail/runs/" + session.runId() + "/agent.log", run.logPath());
+    assertEquals(123, run.pid());
+    assertEquals("fix the flaky test", run.task());
+    assertNotNull(session.session());
+    assertTrue(session.watcher().isPresent());
+  }
+
+  @Test
+  void aBackgroundAdhocLaunchPublishesARunAddressedStartWithNoSpec() throws Exception {
+    var ops = operations(liveAgentShell());
+
+    var session = ops.startAdhoc("acme", background("task"), HANDLE);
+
+    assertEquals(1, events.size());
+    var event = events.getFirst();
+    assertEquals(Event.WellKnownTypes.AGENT_SESSION_STARTED, event.type());
+    assertNull(event.spec());
+    assertEquals(session.runId(), event.data().get(Event.WellKnownData.RUN_ID));
+  }
+
+  @Test
+  void aForegroundAdhocLaunchCompletesItsRunWithTheExitCode() throws Exception {
+    var shell =
+        new StubShell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("mkdir -p /home/dev/.sail", "")
+            .on("printf '%s'", "");
+    var ops = operations(shell, command -> 3, true);
+
+    var session =
+        ops.startAdhoc(
+            "acme", new DispatchOperations.AdhocRequest("task", null, null, false, false), HANDLE);
+
+    assertEquals(3, session.exitCode());
+    var run = runStore.findById(session.runId()).orElseThrow();
+    assertEquals("failed", run.status());
+    assertEquals(3, run.exitCode());
+    assertEquals("", run.unit(), "a foreground session owns no systemd unit");
+    assertTrue(session.watcher().isEmpty());
+  }
+
+  @Test
+  void anAdhocSessionBlocksDispatchAndDispatchBlocksAdhoc() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+    ops.startAdhoc("acme", background("task"), HANDLE);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.dispatch(
+                    "acme",
+                    new DispatchOperations.Request("auth", "background", false, null, false),
+                    ADMIN,
+                    HANDLE));
+
+    assertEquals(ErrorCode.AGENT_ALREADY_RUNNING, refusal.failure().errorCode());
+    assertTrue(refusal.getMessage().contains("Ad-hoc agent run"), refusal.getMessage());
+    assertEquals(
+        SpecStatus.PENDING,
+        specStore.findById("auth").orElseThrow().status(),
+        "the refused dispatch never claims the spec");
+  }
+
+  @Test
+  void aRunningDispatchBlocksTheAdhocLaunch() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+    runStore.reserveDispatch(
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "acme",
+        "auth",
+        HANDLE,
+        "build",
+        List.of("app"),
+        "claude-code",
+        "b1",
+        "task",
+        "/log",
+        "sail-agent-x");
+
+    var refusal =
+        assertThrows(ApiException.class, () -> ops.startAdhoc("acme", background("task"), HANDLE));
+
+    assertEquals(ErrorCode.AGENT_ALREADY_RUNNING, refusal.failure().errorCode());
+  }
+
+  @Test
+  void aSecondAdhocSessionIsRefusedWhileTheFirstIsLive() throws Exception {
+    var ops = operations(liveAgentShell());
+    var first = ops.startAdhoc("acme", background("one"), HANDLE);
+
+    var refusal =
+        assertThrows(ApiException.class, () -> ops.startAdhoc("acme", background("two"), HANDLE));
+
+    assertEquals(ErrorCode.AGENT_ALREADY_RUNNING, refusal.failure().errorCode());
+    assertTrue(refusal.getMessage().contains(first.runId()), refusal.getMessage());
+  }
+
+  @Test
+  void aDryRunMintsNothingAndWritesNothing() throws Exception {
+    var launchedCommands = new ArrayList<List<String>>();
+    var yaml = tempDir.resolve("dry.yaml");
+    Files.writeString(yaml, YAML);
+    db = Sqlite.open(tempDir.resolve("dry.db"));
+    new SchemaManager(db).migrate();
+    runStore = new RunStore(db);
+    var ops =
+        new DispatchOperations(
+            new StubShell().on("incus list ^acme$", RUNNING_JSON),
+            yaml.toString(),
+            new SpecStore(db),
+            new ReviewStore(db),
+            runStore,
+            new FdeStore(db),
+            events::add,
+            new WatcherSpawner(new StubShell(), (command, logPath) -> 4242L),
+            (project, config) -> "",
+            command -> {
+              throw new AssertionError("a dry run must not launch");
+            },
+            new DispatchOperations.Listener() {
+              @Override
+              public void launching(boolean background, List<String> command) {
+                launchedCommands.add(command);
+              }
+            });
+
+    var session =
+        ops.startAdhoc(
+            "acme", new DispatchOperations.AdhocRequest("task", null, null, true, true), HANDLE);
+
+    assertNotNull(session.runId());
+    assertEquals(1, launchedCommands.size());
+    assertTrue(runStore.listForProject("acme").isEmpty());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void aFailedBackgroundLaunchReleasesTheReservation() throws Exception {
+    var shell =
+        new StubShell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("mkdir -p /home/dev/.sail", "")
+            .on("printf '%s'", "");
+    var ops = operations(shell, command -> 1, true);
+
+    assertThrows(ApiException.class, () -> ops.startAdhoc("acme", background("task"), HANDLE));
+
+    var run = runStore.listForProject("acme").getFirst();
+    assertEquals("failed", run.status());
+    assertTrue(
+        runStore.runningForProjectOnNode("acme", HANDLE).isEmpty(),
+        "a launch that never produced an agent frees the container");
+  }
+
+  @Test
+  void aBoxWithoutARunAggregateRefusesTheAdhocLaunch() throws Exception {
+    var ops = operations(liveAgentShell(), command -> 0, false);
+
+    var refusal =
+        assertThrows(ApiException.class, () -> ops.startAdhoc("acme", background("task"), HANDLE));
+
+    assertEquals(ErrorCode.COMMAND_FAILED, refusal.failure().errorCode());
+  }
+
+  @Test
+  void theWorkspacePathScopesTheLaunchWorkDir() throws Exception {
+    var commands = new ArrayList<List<String>>();
+    var yaml = tempDir.resolve("path.yaml");
+    Files.writeString(yaml, YAML);
+    db = Sqlite.open(tempDir.resolve("path.db"));
+    new SchemaManager(db).migrate();
+    runStore = new RunStore(db);
+    var ops =
+        new DispatchOperations(
+            liveAgentShell(),
+            yaml.toString(),
+            new SpecStore(db),
+            new ReviewStore(db),
+            runStore,
+            new FdeStore(db),
+            events::add,
+            new WatcherSpawner(liveAgentShell(), (command, logPath) -> 4242L),
+            (project, config) -> "",
+            command -> {
+              commands.add(command);
+              return 0;
+            },
+            DispatchOperations.Listener.NONE);
+
+    ops.startAdhoc(
+        "acme", new DispatchOperations.AdhocRequest("task", null, "app/api", true, false), HANDLE);
+
+    assertTrue(
+        String.join(" ", commands.getFirst()).contains("/home/dev/workspace/app/api"),
+        () -> String.join(" ", commands.getFirst()));
+  }
+
+  private void seedSpec(String id) {
+    specStore.create(
+        new SpecStore.SpecRow(
+            id,
+            "acme",
+            "Spec " + id,
+            SpecStatus.PENDING,
+            HANDLE,
+            null,
+            null,
+            null,
+            null,
+            0,
+            HANDLE,
+            null,
+            null,
+            HANDLE,
+            List.of(),
+            List.of("app")));
+    specStore.setContent(id, "Do " + id, "");
+  }
+
+  private static final class StubShell implements ShellExec {
+    private final Map<String, Result> scripts = new LinkedHashMap<>();
+
+    StubShell on(String pattern, String stdout) {
+      scripts.put(pattern, new Result(0, stdout, ""));
+      return this;
+    }
+
+    @Override
+    public Result exec(List<String> command) {
+      var joined = String.join(" ", command);
+      for (var entry : scripts.entrySet()) {
+        if (joined.contains(entry.getKey())) {
+          return entry.getValue();
+        }
+      }
+      return new Result(1, "", "no script for " + joined);
+    }
+
+    @Override
+    public Result exec(List<String> command, Path workDir, Duration timeout) {
+      return exec(command);
+    }
+
+    @Override
+    public boolean isDryRun() {
+      return false;
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AdhocDispatchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AdhocDispatchTest.java
@@ -158,8 +158,64 @@ class AdhocDispatchTest {
     var run = runStore.findById(session.runId()).orElseThrow();
     assertEquals("failed", run.status());
     assertEquals(3, run.exitCode());
-    assertEquals("", run.unit(), "a foreground session owns no systemd unit");
+    assertEquals(
+        "sail-agent-" + session.runId(),
+        run.unit(),
+        "a foreground session records the same durable run-scoped identity as a background one");
     assertTrue(session.watcher().isEmpty());
+  }
+
+  @Test
+  void aForegroundLaunchFailureWithALiveAgentKeepsTheReservation() throws Exception {
+    var ops =
+        operations(
+            liveAgentShell(),
+            command -> {
+              throw new IOException("terminal wait interrupted");
+            },
+            true);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.startAdhoc(
+                    "acme",
+                    new DispatchOperations.AdhocRequest("task", null, null, false, false),
+                    HANDLE));
+
+    assertEquals(ErrorCode.AGENT_LAUNCH_FAILED, refusal.failure().errorCode());
+    assertEquals("running", runStore.listForProject("acme").getFirst().status());
+    assertTrue(
+        runStore.runningForProjectOnNode("acme", HANDLE).isPresent(),
+        "a surviving foreground agent must keep the whole-container reservation");
+  }
+
+  @Test
+  void aForegroundLaunchFailureWithNoAgentReleasesTheReservation() throws Exception {
+    var shell =
+        new StubShell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("mkdir -p /home/dev/.sail", "")
+            .on("printf '%s'", "");
+    var ops =
+        operations(
+            shell,
+            command -> {
+              throw new IOException("spawn failed");
+            },
+            true);
+
+    assertThrows(
+        ApiException.class,
+        () ->
+            ops.startAdhoc(
+                "acme",
+                new DispatchOperations.AdhocRequest("task", null, null, false, false),
+                HANDLE));
+
+    assertEquals("failed", runStore.listForProject("acme").getFirst().status());
+    assertTrue(runStore.runningForProjectOnNode("acme", HANDLE).isEmpty());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AdhocRunLifecycleIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AdhocRunLifecycleIT.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.AbstractIncusIT;
+import ai.singlr.sail.engine.AgentSession;
+import ai.singlr.sail.engine.AgentUnit;
+import ai.singlr.sail.engine.ContainerFilePush;
+import ai.singlr.sail.engine.WatcherSpawner;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The whole ad-hoc lifecycle against <strong>one real incus container</strong>: {@code startAdhoc}
+ * reserves the container and launches the agent under its own {@code sail-agent-<runId>} unit, a
+ * concurrent dispatch is refused while it is live, and the shared clean-stop procedure halts the
+ * agent, verifies the kill, and releases the reservation — the run id addressing every step. A fake
+ * {@code codex} binary stands in for the agent (sleeps) — no LLM, no API key. Runs only under the
+ * {@code integration} profile against a real incus daemon; skips elsewhere.
+ */
+class AdhocRunLifecycleIT extends AbstractIncusIT {
+
+  private static final String CONTAINER = "sail-it-adhoc-run";
+  private static final String HANDLE = "it-node";
+  private static final Actor OPERATOR = Actor.cliOperator(HANDLE);
+
+  private static final String FAKE_AGENT =
+      """
+      #!/usr/bin/env bash
+      sleep 30
+      """;
+
+  private Path stateDir;
+
+  @BeforeEach
+  void provision() throws Exception {
+    ensureIncusOrSkip();
+    launch(CONTAINER);
+    var setup =
+        exec(
+            CONTAINER,
+            List.of(
+                "bash",
+                "-c",
+                "set -e;"
+                    + " userdel -r ubuntu 2>/dev/null || true;"
+                    + " id -u dev >/dev/null 2>&1 || useradd -m -u 1000 -s /bin/bash dev;"
+                    + " mkdir -p /home/dev/.sail /home/dev/workspace;"
+                    + " chown -R dev:dev /home/dev;"
+                    + " for i in $(seq 1 30); do"
+                    + " loginctl enable-linger dev 2>/dev/null && exit 0; sleep 1; done;"
+                    + " loginctl enable-linger dev"));
+    assertTrue(setup.ok(), "container provisioning failed: " + setup.stderr());
+    awaitUserManager();
+    ContainerFilePush.push(
+        shell, CONTAINER, "/usr/local/bin/codex", FAKE_AGENT, List.of("--mode", "0755"));
+    stateDir = Files.createTempDirectory("adhoc-run-it");
+  }
+
+  @AfterEach
+  void cleanup() {
+    deleteContainerQuietly(CONTAINER);
+    if (stateDir != null) {
+      deleteRecursively(stateDir);
+    }
+  }
+
+  @Test
+  void anAdhocSessionLivesStopsAndReleasesThroughItsRunIdentity() throws Exception {
+    var yaml = stateDir.resolve("sail.yaml");
+    Files.writeString(
+        yaml,
+        """
+        name: %s
+        ssh:
+          user: dev
+        repos:
+          - url: https://example.invalid/app.git
+            path: app
+        agent:
+          type: codex
+        """
+            .formatted(CONTAINER));
+    try (var db = Sqlite.open(stateDir.resolve("it.db"))) {
+      new SchemaManager(db).migrate();
+      var specStore = new SpecStore(db);
+      var runStore = new RunStore(db);
+      new FdeStore(db).add(HANDLE, null, null, "admin");
+      seedSpec(specStore, "spec-app", List.of("app"));
+      var events = new CopyOnWriteArrayList<Event>();
+      var dispatchOps =
+          new DispatchOperations(
+              shell,
+              yaml.toString(),
+              specStore,
+              new ReviewStore(db),
+              runStore,
+              new FdeStore(db),
+              events::add,
+              new WatcherSpawner(refusingShell(), (command, logPath) -> 4242L),
+              (project, config) -> "",
+              DispatchOperations.shellLauncher(shell),
+              DispatchOperations.Listener.NONE);
+
+      var session =
+          dispatchOps.startAdhoc(
+              CONTAINER,
+              new DispatchOperations.AdhocRequest("sleep for a while", null, null, true, false),
+              HANDLE);
+
+      var run = runStore.findById(session.runId()).orElseThrow();
+      assertEquals("adhoc", run.role());
+      assertEquals("", run.specId());
+      assertEquals("sail-agent-" + session.runId(), run.unit());
+      assertNotNull(run.pid(), "the launched agent's pid is stamped on the run");
+      var live =
+          new AgentSession(shell).queryStatus(CONTAINER, AgentUnit.recorded(run.id(), run.unit()));
+      assertTrue(live != null && live.running(), "the ad-hoc agent runs under its own unit");
+
+      var dispatchRefusal =
+          assertThrows(
+              ApiException.class,
+              () ->
+                  dispatchOps.dispatch(
+                      CONTAINER,
+                      new DispatchOperations.Request("spec-app", "background", false, null, false),
+                      OPERATOR,
+                      HANDLE));
+      assertEquals(ErrorCode.AGENT_ALREADY_RUNNING, dispatchRefusal.failure().errorCode());
+      assertEquals(
+          SpecStatus.PENDING,
+          specStore.findById("spec-app").orElseThrow().status(),
+          "the refused dispatch claims nothing");
+
+      var stopOps =
+          new StopOperations(
+              shell,
+              yaml.toString(),
+              specStore,
+              runStore,
+              events::add,
+              StopOperations.sessionHalter(shell),
+              StopOperations.Listener.NONE);
+      var outcome =
+          stopOps.stop(new StopOperations.ProjectTarget(CONTAINER), OPERATOR, HANDLE, false);
+
+      var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+      assertEquals(session.runId(), stopped.runId());
+      assertEquals("stopped", runStore.findById(session.runId()).orElseThrow().status());
+      var afterStop =
+          new AgentSession(shell).queryStatus(CONTAINER, AgentUnit.recorded(run.id(), run.unit()));
+      assertTrue(afterStop == null || !afterStop.running(), "the verified halt left no process");
+      assertInstanceOf(
+          DispatchOperations.Dispatched.class,
+          dispatchOps.dispatch(
+              CONTAINER,
+              new DispatchOperations.Request("spec-app", "background", false, null, false),
+              OPERATOR,
+              HANDLE),
+          "the released reservation admits the next dispatch");
+    }
+  }
+
+  private static void seedSpec(SpecStore store, String id, List<String> repos) {
+    store.create(
+        new SpecStore.SpecRow(
+            id,
+            CONTAINER,
+            "Title " + id,
+            SpecStatus.PENDING,
+            HANDLE,
+            "codex",
+            null,
+            null,
+            null,
+            0,
+            HANDLE,
+            null,
+            null,
+            HANDLE,
+            List.of(),
+            repos));
+    store.setContent(id, "Do " + id, "");
+  }
+
+  private static ai.singlr.sail.engine.ShellExec refusingShell() {
+    return new ai.singlr.sail.engine.ShellExec() {
+      @Override
+      public Result exec(List<String> command) {
+        return new Result(1, "", "refused");
+      }
+
+      @Override
+      public Result exec(List<String> command, Path workDir, Duration timeout) {
+        return new Result(1, "", "refused");
+      }
+
+      @Override
+      public boolean isDryRun() {
+        return false;
+      }
+    };
+  }
+
+  private void awaitUserManager() throws Exception {
+    var deadline = Instant.now().plus(Duration.ofSeconds(60));
+    while (Instant.now().isBefore(deadline)) {
+      var probe = exec(CONTAINER, List.of("test", "-S", "/run/user/1000/bus"));
+      if (probe.ok()) {
+        return;
+      }
+      Thread.sleep(Duration.ofSeconds(1));
+    }
+    throw new AssertionError("dev user's systemd manager (bus) never came up in " + CONTAINER);
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AgentLogStreamerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AgentLogStreamerTest.java
@@ -59,7 +59,8 @@ class AgentLogStreamerTest {
         null,
         "t0",
         null,
-        java.util.List.of());
+        java.util.List.of(),
+        null);
   }
 
   private static AgentLogStreamer streamer(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -926,7 +926,8 @@ class ApiRouterTest {
             null,
             "t0",
             "t1",
-            java.util.List.of());
+            java.util.List.of(),
+            null);
     var view = RunView.from(row);
     assertEquals("s1", view.id());
     assertEquals("node-a", view.node());

--- a/sail-infra/src/test/java/ai/singlr/sail/api/DispatchLaunchCancelRaceTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/DispatchLaunchCancelRaceTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.WatcherSpawner;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The launch-vs-cancel race: an operator stop that claims a run during launch preparation must win.
+ * The launcher discovers the loss when its process stamp refuses to commit on the no-longer-
+ * running row, tears down the agent it just started, and surfaces the conflict — it must never
+ * overwrite the stop's terminal record or report a successful dispatch.
+ */
+class DispatchLaunchCancelRaceTest {
+
+  private static final String HANDLE = "me";
+  private static final Actor ADMIN = Actor.cliOperator(HANDLE);
+
+  private static final String RUNNING_JSON =
+      """
+      [
+        {
+          "name": "acme",
+          "status": "Running",
+          "state": {
+            "network": {
+              "eth0": {
+                "addresses": [
+                  {"family": "inet", "address": "10.0.0.42", "scope": "global"}
+                ]
+              }
+            }
+          }
+        }
+      ]
+      """;
+
+  private static final String YAML =
+      """
+      name: acme
+      ssh:
+        user: dev
+      repos:
+        - url: https://github.com/acme/app.git
+          path: app
+      agent:
+        type: claude-code
+        auto_branch: true
+        branch_prefix: sail/
+      """;
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) {
+      db.close();
+    }
+  }
+
+  @Test
+  void aCancelDuringLaunchPreparationTearsDownTheAgentAndKeepsTheStopRecord() throws Exception {
+    var yaml = tempDir.resolve("sail.yaml");
+    Files.writeString(yaml, YAML);
+    db = Sqlite.open(tempDir.resolve("race.db"));
+    new SchemaManager(db).migrate();
+    var specStore = new SpecStore(db);
+    specStore.create(
+        new SpecStore.SpecRow(
+            "auth",
+            "acme",
+            "Add auth",
+            SpecStatus.PENDING,
+            HANDLE,
+            null,
+            null,
+            null,
+            null,
+            0,
+            "me",
+            null,
+            null,
+            "me",
+            List.of(),
+            List.of()));
+    specStore.setContent("auth", "Do auth", "");
+    new FdeStore(db).add(HANDLE, null, null, "admin");
+    var runStore = new RunStore(db);
+    var events = new CopyOnWriteArrayList<Event>();
+    var cancelled = new AtomicReference<String>();
+    var shell = new CancelDuringLaunchShell(cancelled);
+    var ops =
+        new DispatchOperations(
+            shell,
+            yaml.toString(),
+            specStore,
+            new ReviewStore(db),
+            runStore,
+            new FdeStore(db),
+            events::add,
+            new WatcherSpawner(shell, (command, logPath) -> 4242L),
+            (project, config) -> "",
+            command -> {
+              var run = runStore.running().getFirst();
+              assertTrue(runStore.transition(run.id(), "running", "stopped"));
+              cancelled.set(run.id());
+              return 0;
+            },
+            DispatchOperations.Listener.NONE);
+
+    var conflict =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.dispatch(
+                    "acme",
+                    new DispatchOperations.Request("auth", "background", false, null, false),
+                    ADMIN,
+                    HANDLE));
+
+    assertEquals(ErrorCode.CONFLICT, conflict.failure().errorCode());
+    var run = runStore.findById(cancelled.get()).orElseThrow();
+    assertEquals("stopped", run.status(), "the launcher must not overwrite the stop's record");
+    assertNull(run.pid(), "a lost launch must not stamp its process identity");
+    assertTrue(
+        shell.commandsAfterCancel.stream().anyMatch(c -> c.contains(cancelled.get())),
+        "the launcher must attempt to tear down the agent it started");
+    assertTrue(
+        events.stream().noneMatch(e -> "agent_session_started".equals(e.type())),
+        "a cancelled launch must not announce a started session");
+  }
+
+  /**
+   * Answers the prepare-lane probes exactly as the parity fixture does and records every command
+   * issued after the cancel landed, so the test can prove the launcher attempted to tear down the
+   * agent it started. The cancel itself is injected at the launcher seam, not here.
+   */
+  private static final class CancelDuringLaunchShell implements ShellExec {
+    private final AtomicReference<String> cancelled;
+    private final List<String> commandsAfterCancel = new CopyOnWriteArrayList<>();
+
+    CancelDuringLaunchShell(AtomicReference<String> cancelled) {
+      this.cancelled = cancelled;
+    }
+
+    @Override
+    public Result exec(List<String> command) {
+      var joined = String.join(" ", command);
+      if (cancelled.get() != null) {
+        commandsAfterCancel.add(joined);
+      }
+      if (joined.contains("incus list ^acme$")) {
+        return new Result(0, RUNNING_JSON, "");
+      }
+      if (joined.contains("mkdir -p /home/dev/.sail")
+          || joined.contains("printf '%s'")
+          || joined.contains("test -d /home/dev/workspace/app/.git")
+          || joined.contains("git -C /home/dev/workspace/app checkout -b sail/auth")
+          || joined.contains("claude")) {
+        return new Result(0, "", "");
+      }
+      return new Result(1, "", "no script for " + joined);
+    }
+
+    @Override
+    public Result exec(List<String> command, Path workDir, Duration timeout) {
+      return exec(command);
+    }
+
+    @Override
+    public boolean isDryRun() {
+      return false;
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/DispatchRetentionTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/DispatchRetentionTest.java
@@ -52,6 +52,7 @@ class DispatchRetentionTest {
         "sail-agent-r",
         null,
         null,
-        List.of());
+        List.of(),
+        null);
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -151,7 +151,7 @@ class MissedStopReconcilerTest {
     createPendingSpec("auth");
     runningSession("auth");
 
-    var released = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+    var released = reconciler(new CountingProbe(false), PAST_GRACE).sweep();
 
     assertEquals(1, released);
     assertEquals(
@@ -169,7 +169,7 @@ class MissedStopReconcilerTest {
     createSpec("auth", SpecStatus.DONE);
     runningSession("auth");
 
-    var released = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+    var released = reconciler(new CountingProbe(false), PAST_GRACE).sweep();
 
     assertEquals(1, released);
     assertEquals(
@@ -254,6 +254,137 @@ class MissedStopReconcilerTest {
   }
 
   @Test
+  void aStrandedReservationWithALiveAgentIsNeverReleased() {
+    createSpec("auth", SpecStatus.DONE);
+    runningSession("auth");
+
+    var released = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+
+    assertEquals(0, released);
+    assertEquals(
+        "running",
+        sessionStore.listForSpec("auth").getFirst().status(),
+        "a reservation is never freed under an agent whose identity still probes live");
+  }
+
+  @Test
+  void releasesADeadAdhocRunPastGrace() {
+    var runId = adhocSession(77);
+
+    var released = reconciler(new CountingProbe(false), PAST_GRACE).sweep();
+
+    assertEquals(1, released);
+    assertEquals("stopped", sessionStore.findById(runId).orElseThrow().status());
+  }
+
+  @Test
+  void aLiveAdhocRunKeepsItsReservation() {
+    var runId = adhocSession(77);
+
+    var released = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+
+    assertEquals(0, released);
+    assertEquals("running", sessionStore.findById(runId).orElseThrow().status());
+  }
+
+  @Test
+  void anAdhocRunWithNoRecordedPidIsLeftToItsLauncherOrTheOperatorStop() {
+    var runId = adhocSession(null);
+    var probe = new CountingProbe(false);
+
+    var released = reconciler(probe, PAST_GRACE).sweep();
+
+    assertEquals(0, released);
+    assertEquals(0, probe.calls.get());
+    assertEquals("running", sessionStore.findById(runId).orElseThrow().status());
+  }
+
+  @Test
+  void anUnprobeableAdhocRunIsLeftAlone() {
+    var runId = adhocSession(77);
+    MissedStopReconciler.UnitProbe failing =
+        (project, id, unit) -> {
+          throw new IOException("container unreachable");
+        };
+
+    var released = reconciler(failing, PAST_GRACE).sweep();
+
+    assertEquals(0, released);
+    assertEquals("running", sessionStore.findById(runId).orElseThrow().status());
+  }
+
+  @Test
+  void aFreshAdhocRunInsideTheLaunchGraceIsNeverProbed() {
+    var runId = adhocSession(77);
+    var probe = new CountingProbe(false);
+
+    var released = reconciler(probe, Instant::now).sweep();
+
+    assertEquals(0, released);
+    assertEquals(0, probe.calls.get());
+    assertEquals("running", sessionStore.findById(runId).orElseThrow().status());
+  }
+
+  @Test
+  void aReleaseThatLosesToTheWatcherCompletionNeverOverwritesTheExit() {
+    var runId = adhocSession(77);
+    MissedStopReconciler.UnitProbe completingProbe =
+        (project, id, unit) -> {
+          sessionStore.transition(runId, "running", "completed", 0);
+          return false;
+        };
+
+    var released = reconciler(completingProbe, PAST_GRACE).sweep();
+
+    assertEquals(0, released);
+    var run = sessionStore.findById(runId).orElseThrow();
+    assertEquals("completed", run.status());
+    assertEquals(0, run.exitCode());
+  }
+
+  @Test
+  void anInterruptedAdhocStopIsFinalizedOnceItsUnitIsGone() throws Exception {
+    var runId = adhocSession(77);
+    sessionStore.transition(runId, "running", "stopping");
+    var latch = new CountDownLatch(1);
+    var cancels = captureCancels(latch);
+
+    var finalized = reconciler(new CountingProbe(false), PAST_GRACE).sweep();
+
+    assertEquals(1, finalized);
+    assertEquals("stopped", sessionStore.findById(runId).orElseThrow().status());
+    BusTesting.awaitDelivery(latch);
+    assertEquals(1, cancels.size());
+    assertNull(cancels.peek().spec());
+    assertEquals(runId, cancels.peek().data().get(Event.WellKnownData.RUN_ID));
+  }
+
+  @Test
+  void aBlankUnitStoppingClaimStillProbesThroughItsPidFile() {
+    var runId = DateTimeUtils.newId().toString();
+    sessionStore.reserveDispatch(
+        runId,
+        "test-project",
+        "",
+        "node-a",
+        "adhoc",
+        List.of(),
+        "claude-code",
+        null,
+        "task",
+        "/home/dev/.sail/runs/" + runId + "/agent.log",
+        "");
+    sessionStore.transition(runId, "running", "stopping");
+    var probe = new CountingProbe(false);
+
+    var finalized = reconciler(probe, PAST_GRACE).sweep();
+
+    assertEquals(1, finalized);
+    assertEquals("", probe.lastUnit);
+    assertEquals("stopped", sessionStore.findById(runId).orElseThrow().status());
+  }
+
+  @Test
   void keepsARunningReservationForAnInProgressSpec() {
     createInProgressSpec("auth");
     runningSession("auth");
@@ -284,6 +415,26 @@ class MissedStopReconcilerTest {
   private String finishedSession(String specId, String status, Integer exitCode) {
     var id = runningSession(specId);
     sessionStore.complete(id, status, exitCode);
+    return id;
+  }
+
+  private String adhocSession(Integer pid) {
+    var id = DateTimeUtils.newId().toString();
+    sessionStore.reserveDispatch(
+        id,
+        "test-project",
+        "",
+        "node-a",
+        "adhoc",
+        List.of(),
+        "claude-code",
+        null,
+        "task",
+        "/home/dev/.sail/runs/" + id + "/agent.log",
+        "sail-agent-" + id);
+    if (pid != null) {
+      sessionStore.updateProcess(id, pid, null);
+    }
     return id;
   }
 
@@ -586,7 +737,7 @@ class MissedStopReconcilerTest {
   void aRunReconciledThisSweepIsNotAlsoReleasedAsStranded() {
     createSpec("auth", SpecStatus.AWAITING_MERGE);
     runningSession("auth");
-    var rec = reconciler(new CountingProbe(true), PAST_GRACE);
+    var rec = reconciler(new CountingProbe(false), PAST_GRACE);
 
     assertEquals(
         0,

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -288,14 +288,27 @@ class MissedStopReconcilerTest {
   }
 
   @Test
-  void anAdhocRunWithNoRecordedPidIsLeftToItsLauncherOrTheOperatorStop() {
+  void anAdhocRunWithNoRecordedPidIsStillProbedAndReleasedWhenDead() {
     var runId = adhocSession(null);
     var probe = new CountingProbe(false);
 
     var released = reconciler(probe, PAST_GRACE).sweep();
 
+    assertEquals(1, released);
+    assertEquals(1, probe.calls.get());
+    assertEquals(
+        "stopped",
+        sessionStore.findById(runId).orElseThrow().status(),
+        "a crashed launcher must not retain an empty-container reservation forever");
+  }
+
+  @Test
+  void aLiveAdhocRunWithNoRecordedPidKeepsItsReservation() {
+    var runId = adhocSession(null);
+
+    var released = reconciler(new CountingProbe(true), PAST_GRACE).sweep();
+
     assertEquals(0, released);
-    assertEquals(0, probe.calls.get());
     assertEquals("running", sessionStore.findById(runId).orElseThrow().status());
   }
 
@@ -433,7 +446,7 @@ class MissedStopReconcilerTest {
         "/home/dev/.sail/runs/" + id + "/agent.log",
         "sail-agent-" + id);
     if (pid != null) {
-      sessionStore.updateProcess(id, pid, null);
+      sessionStore.updateProcess(id, pid, null, null);
     }
     return id;
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RunPolicyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RunPolicyTest.java
@@ -66,4 +66,25 @@ class RunPolicyTest {
     var r = refused(RunPolicy.access(actor(null, Role.MEMBER), RUN, SPEC, "raj"));
     assertEquals(ErrorCode.FORBIDDEN_NOT_ASSIGNEE, r.code());
   }
+
+  @Test
+  void adhocLauncherMayAccessTheirOwnRun() {
+    assertAllowed(RunPolicy.access(actor("uday", Role.MEMBER), RUN, null, "uday"));
+  }
+
+  @Test
+  void adhocRunRefusesOtherMembersNamingTheLauncher() {
+    var r = refused(RunPolicy.access(actor("raj", Role.MEMBER), RUN, null, "uday"));
+    assertEquals(ErrorCode.FORBIDDEN_NOT_ASSIGNEE, r.code());
+    assertTrue(r.message().contains("ad-hoc session"), r.message());
+    assertTrue(r.message().contains("uday"), r.message());
+  }
+
+  @Test
+  void adhocRunFromAHandlelessBoxAllowsOnlyAdmin() {
+    var r = refused(RunPolicy.access(actor("uday", Role.MEMBER), RUN, null, ""));
+    assertEquals(ErrorCode.FORBIDDEN_NOT_ASSIGNEE, r.code());
+    assertTrue(r.message().contains("ad-hoc session"), r.message());
+    assertAllowed(RunPolicy.access(actor("ops", Role.ADMIN), RUN, null, ""));
+  }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -541,6 +541,7 @@ class SailOperationsTest {
                     "acme",
                     "auth",
                     LOCAL_HANDLE,
+                    "build",
                     List.of("app"),
                     "claude-code",
                     "b1",
@@ -577,6 +578,7 @@ class SailOperationsTest {
                     "acme",
                     "auth",
                     LOCAL_HANDLE,
+                    "build",
                     List.of("app", "web"),
                     "claude-code",
                     "b1",
@@ -619,6 +621,7 @@ class SailOperationsTest {
                   "acme",
                   "auth",
                   LOCAL_HANDLE,
+                  "build",
                   List.of("app", "web"),
                   "claude-code",
                   "b1",
@@ -886,16 +889,16 @@ class SailOperationsTest {
   @Test
   void agentStatusReturnsRunningSessionDetails() throws Exception {
     var operations =
-        operations(
+        opsWithRun(
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
-                .on("cat /home/dev/.sail/agent.pid", "123")
+                .on("cat /home/dev/.sail/runs/" + R1 + "/agent.pid", "123")
                 .on("kill -0 123", "")
                 .on(
-                    "cat /home/dev/.sail/agent-session.json",
+                    "cat /home/dev/.sail/runs/" + R1 + "/agent-session.json",
                     "{\"task\": \"work\", \"started_at\": \"2026-01-01T00:00:00Z\", \"branch\": \"sail/auth\"}"));
 
-    var result = operations.agentStatus("acme", LOCAL_HANDLE);
+    var result = operations.agentStatus("acme", "node-a");
 
     assertEquals(true, get(result, "agent_running"));
     assertEquals(123, get(result, "pid"));
@@ -905,12 +908,13 @@ class SailOperationsTest {
   @Test
   void agentStatusMapsQueryFailures() throws Exception {
     var operations =
-        operations(
+        opsWithRun(
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
-                .throwOn("cat /home/dev/.sail/agent.pid", new IOException("denied")));
+                .throwOn(
+                    "cat /home/dev/.sail/runs/" + R1 + "/agent.pid", new IOException("denied")));
 
-    var error = operations.agentStatus("acme", LOCAL_HANDLE);
+    var error = operations.agentStatus("acme", "node-a");
 
     assertError(ErrorCode.AGENT_STATUS_FAILED, error);
   }
@@ -1203,21 +1207,20 @@ class SailOperationsTest {
   }
 
   @Test
-  void stopRunDoesNotKillADifferentActiveRunOfTheSameProject() throws Exception {
-    var operations =
-        opsWithRun(
-            shell()
-                .on("incus list ^acme$", RUNNING_JSON)
-                .on("cat /home/dev/.sail/runs/" + R1 + "/agent.pid", "999")
-                .on("kill -0 999", new ShellExec.Result(0, "", ""))
-                .on(
-                    "cat /home/dev/.sail/runs/" + R1 + "/agent-session.json",
-                    "{\"task\": \"other\"}"));
+  void stopRunHaltsWhateverItsOwnRunScopedPidFileRecords() throws Exception {
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("cat /home/dev/.sail/runs/" + R1 + "/agent.pid", "999")
+            .onSequence(
+                "kill -0 999", new ShellExec.Result(0, "", ""), new ShellExec.Result(1, "", ""))
+            .on("cat /home/dev/.sail/runs/" + R1 + "/agent-session.json", "{\"task\": \"other\"}");
+    var operations = opsWithRun(shell);
 
     var result = operations.stopRun(R1, "node-a", ADMIN);
 
-    assertEquals(false, get(result, "stopped"), "the run's pid is 123; the live agent is 999");
-    assertEquals("run_not_active", get(result, "reason"));
+    assertEquals(true, get(result, "stopped"), "the run-scoped pid file is the run's identity");
+    assertEquals(999, get(result, "pid"));
   }
 
   @Test
@@ -1269,7 +1272,8 @@ class SailOperationsTest {
                   "codex",
                   "feat/auth",
                   "review it",
-                  "/home/dev/.sail/runs/" + R3 + "/review.log");
+                  "/home/dev/.sail/runs/" + R3 + "/review.log",
+                  "sail-review-" + R3);
             });
 
     var result = operations.stopRun(R1, "node-a", ADMIN);
@@ -1341,24 +1345,50 @@ class SailOperationsTest {
   }
 
   @Test
-  void agentStatusFallsBackToTheAdHocSessionWhenNoRunIsRunning() throws Exception {
+  void agentStatusReportsNoSessionWhenNoRunIsRunning() throws Exception {
+    var operations =
+        operationsWithStores(
+            baseYaml(), shell().on("incus list ^acme$", RUNNING_JSON), null, s2 -> {}, runs -> {});
+
+    var result = operations.agentStatus("acme", "node-a");
+
+    assertEquals(false, get(result, "agent_running"));
+    assertEquals(0, ((List<?>) get(result, "runs")).size());
+  }
+
+  @Test
+  void agentStatusListsAnAdhocRunLikeAnySession() throws Exception {
     var operations =
         operationsWithStores(
             baseYaml(),
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
-                .on("cat /home/dev/.sail/agent.pid", "123")
+                .on("cat /home/dev/.sail/runs/" + R1 + "/agent.pid", "123")
                 .on("kill -0 123", "")
-                .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"ad hoc\"}"),
+                .on(
+                    "cat /home/dev/.sail/runs/" + R1 + "/agent-session.json",
+                    "{\"task\": \"ad hoc\"}"),
             null,
             s2 -> {},
-            runs -> {});
+            runs ->
+                runs.reserveDispatch(
+                    R1,
+                    "acme",
+                    "",
+                    "node-a",
+                    "adhoc",
+                    List.of(),
+                    "claude-code",
+                    null,
+                    "ad hoc",
+                    RUN_LOG,
+                    "sail-agent-" + R1));
 
     var result = operations.agentStatus("acme", "node-a");
 
     assertEquals(true, get(result, "agent_running"));
     assertEquals("ad hoc", get(result, "task"));
-    assertEquals(0, ((List<?>) get(result, "runs")).size());
+    assertEquals(1, ((List<?>) get(result, "runs")).size());
   }
 
   @Test
@@ -2145,10 +2175,10 @@ class SailOperationsTest {
   @Test
   void agentReportMapsReporterFailure() throws Exception {
     var operations =
-        operations(
+        opsWithRun(
             shell()
                 .on("incus list ^acme$", RUNNING_JSON)
-                .throwOn("cat /home/dev/.sail/agent.pid", new IOException("boom")));
+                .throwOn("cat /home/dev/.sail/runs/" + R1 + "/agent.pid", new IOException("boom")));
 
     var error = operations.agentReport("acme", "node-a");
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -1420,7 +1420,7 @@ class SailOperationsTest {
   }
 
   @Test
-  void aForegroundRunRemainsUnprobeableWhileItsLauncherOwnsCompletion() throws Exception {
+  void aForegroundRunRecordsItsDurableRunScopedIdentity() throws Exception {
     var runs = new java.util.concurrent.atomic.AtomicReference<RunStore>();
     var shell =
         shell()
@@ -1440,7 +1440,11 @@ class SailOperationsTest {
     dispatch(operations, "acme", request("auth", "foreground", false));
 
     var recorded = runs.get().listForProject("acme").getFirst();
-    assertEquals("", recorded.unit());
+    assertEquals(
+        "sail-agent-" + recorded.id(),
+        recorded.unit(),
+        "a foreground session records the same durable run-scoped identity as a background one");
+    assertEquals(123, recorded.pid(), "the session's pid is stamped from its run-scoped pid file");
   }
 
   @Test
@@ -1824,7 +1828,8 @@ class SailOperationsTest {
         unit,
         "t0",
         null,
-        java.util.List.of());
+        java.util.List.of(),
+        null);
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -1207,20 +1207,18 @@ class SailOperationsTest {
   }
 
   @Test
-  void stopRunHaltsWhateverItsOwnRunScopedPidFileRecords() throws Exception {
+  void stopRunRefusesAStalePidFileNamingAPidTheRunDoesNotOwn() throws Exception {
     var shell =
         shell()
             .on("incus list ^acme$", RUNNING_JSON)
             .on("cat /home/dev/.sail/runs/" + R1 + "/agent.pid", "999")
-            .onSequence(
-                "kill -0 999", new ShellExec.Result(0, "", ""), new ShellExec.Result(1, "", ""))
+            .on("kill -0 999", "")
             .on("cat /home/dev/.sail/runs/" + R1 + "/agent-session.json", "{\"task\": \"other\"}");
     var operations = opsWithRun(shell);
 
-    var result = operations.stopRun(R1, "node-a", ADMIN);
+    var error = operations.stopRun(R1, "node-a", ADMIN);
 
-    assertEquals(true, get(result, "stopped"), "the run-scoped pid file is the run's identity");
-    assertEquals(999, get(result, "pid"));
+    assertError(ErrorCode.CONFLICT, error);
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SlackReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SlackReactorTest.java
@@ -101,11 +101,20 @@ class SlackReactorTest {
   }
 
   @Test
-  void filterAcceptsAllNotifiableTypes() {
+  void filterAcceptsAllNotifiableTypesForASpecScopedEvent() {
     var filter = reactor(new RecordingPoster()).filter();
     for (var type : SlackReactor.NOTIFIABLE_TYPES) {
-      assertTrue(filter.test(Event.of("p", null, type, "a", "h")), "should accept " + type);
+      assertTrue(filter.test(Event.of("p", "auth", type, "a", "h")), "should accept " + type);
     }
+  }
+
+  @Test
+  void filterRejectsSpecLessEventsSoAdhocRunsNeverPost() {
+    var filter = reactor(new RecordingPoster()).filter();
+    assertFalse(
+        filter.test(Event.of("p", null, Event.WellKnownTypes.AGENT_SESSION_STOPPED, "a", "h")));
+    assertFalse(
+        filter.test(Event.of("p", "", Event.WellKnownTypes.AGENT_SESSION_STOPPED, "a", "h")));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
@@ -550,6 +550,25 @@ class StopOperationsTest {
   }
 
   @Test
+  void aStopDuringLaunchPreparationConflictsInsteadOfReleasingTheReservation() throws Exception {
+    var ops =
+        stopOps(
+            shell().on("incus list ^acme$", RUNNING_JSON),
+            failingHalter(),
+            StopOperations.Listener.NONE);
+    seedAdhocRun(null, UNIT);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.CONFLICT, refusal.failure().errorCode());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
   void aMemberMayStopTheAdhocRunTheirOwnBoxLaunched() throws Exception {
     var shell = liveAgentShell();
     var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
@@ -183,43 +183,36 @@ class StopOperationsTest {
   }
 
   @Test
-  void aPidMismatchKillsNothingAndWritesNothing() throws Exception {
-    var halts = new ArrayList<String>();
-    var ops =
-        stopOps(
-            liveAgentShell(999),
-            (project, unit) -> halts.add(unit.unitName()),
-            StopOperations.Listener.NONE);
-    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
-    seedRun(123, UNIT);
-
-    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
-
-    var notActive = assertInstanceOf(StopOperations.NotActive.class, outcome);
-    assertEquals(999, notActive.livePid());
-    assertEquals(R1, notActive.runId());
-    assertEquals("auth", notActive.specId());
-    assertFalse(notActive.mutated());
-    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
-    assertEquals("running", runStore.findById(R1).orElseThrow().status());
-    assertTrue(halts.isEmpty());
-    assertTrue(events.isEmpty());
-  }
-
-  @Test
-  void aRunWithNoRecordedPidIsNeverKilled() throws Exception {
-    var ops = stopOps(liveAgentShell(), failingHalter(), StopOperations.Listener.NONE);
+  void aRunWithNoRecordedPidIsStillKilledThroughItsRunScopedPidFile() throws Exception {
+    var shell = liveAgentShell();
+    var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);
     seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
     seedRun(null, UNIT);
 
     var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
 
-    assertInstanceOf(StopOperations.NotActive.class, outcome);
-    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals(123, stopped.pid());
+    assertTrue(stopped.specCancelled());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
   }
 
   @Test
-  void aBuildRunWithABlankUnitIsRefusedLoudly() throws Exception {
+  void aForegroundRunWithABlankUnitIsProbedThroughItsRunScopedPidFile() throws Exception {
+    var shell = liveAgentShell();
+    var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, null);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals(123, stopped.pid());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+  }
+
+  @Test
+  void aDeadForegroundRunWithABlankUnitGetsTheStrandedRescue() throws Exception {
     var ops =
         stopOps(
             shell().on("incus list ^acme$", RUNNING_JSON),
@@ -228,14 +221,12 @@ class StopOperationsTest {
     seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
     seedRun(123, null);
 
-    var refusal =
-        assertThrows(
-            IllegalStateException.class,
-            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
 
-    assertEquals(
-        "Build run " + R1 + " has no unit; run 'sail migrate' to repair its data.",
-        refusal.getMessage());
+    var notRunning = assertInstanceOf(StopOperations.NotRunning.class, outcome);
+    assertTrue(notRunning.specCancelled());
+    assertTrue(notRunning.runReleased());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
   }
 
   @Test
@@ -256,19 +247,26 @@ class StopOperationsTest {
   }
 
   @Test
-  void sessionResolutionFallsBackToTheAdHocUnit() throws Exception {
+  void sessionResolutionIsNullWhenNoRunIsActive() throws Exception {
+    var shell = shell();
+    stopOps(shell, failingHalter(), StopOperations.Listener.NONE);
+
+    assertNull(StopOperations.resolveSession(shell, runStore, "acme", LOCAL_HANDLE));
+  }
+
+  @Test
+  void sessionResolutionSeesAnAdhocRunLikeAnyOtherSession() throws Exception {
     var shell =
         shell()
-            .on("cat /home/dev/.sail/agent.pid", "456")
-            .on("kill -0 456", "")
-            .on("cat /home/dev/.sail/agent-session.json", "{\"task\":\"ad hoc\"}");
+            .on("cat " + RUN_PID_FILE, "88")
+            .on("kill -0 88", "")
+            .on("cat /home/dev/.sail/runs/" + R1 + "/agent-session.json", "{\"task\":\"ad hoc\"}");
     stopOps(shell, failingHalter(), StopOperations.Listener.NONE);
+    seedAdhocRun(88, UNIT);
 
     var info = StopOperations.resolveSession(shell, runStore, "acme", LOCAL_HANDLE);
 
-    assertEquals(
-        new AgentSession.SessionInfo(true, 456, "ad hoc", "", "", "/home/dev/.sail/agent.log"),
-        info);
+    assertEquals(new AgentSession.SessionInfo(true, 88, "ad hoc", "", "", RUN_LOG), info);
   }
 
   @Test
@@ -400,68 +398,98 @@ class StopOperationsTest {
   }
 
   @Test
-  void projectTargetWithoutARunStopsTheAdHocSession() throws Exception {
+  void projectTargetResolvesTheAdhocRunAndStopsIt() throws Exception {
     var haltedUnits = new ArrayList<String>();
-    var shell =
-        shell()
-            .on("incus list ^acme$", RUNNING_JSON)
-            .on("cat /home/dev/.sail/agent.pid", "55")
-            .on("kill -0 55", "")
-            .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"ad hoc\"}");
+    var shell = liveAgentShell();
     var ops =
         stopOps(
             shell,
             (project, unit) -> {
               haltedUnits.add(unit.unitName());
-              adHocAgentDies(shell);
+              agentDies(shell);
             },
             StopOperations.Listener.NONE);
+    seedAdhocRun(123, UNIT);
 
     var outcome = ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false);
 
     var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
-    assertEquals(55, stopped.pid());
-    assertNull(stopped.runId());
+    assertEquals(R1, stopped.runId());
+    assertNull(stopped.specId());
+    assertEquals(123, stopped.pid());
     assertFalse(stopped.specCancelled());
-    assertEquals(List.of(AgentUnit.BUILD.unitName()), haltedUnits);
+    assertEquals(List.of(UNIT), haltedUnits);
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+    assertEquals(1, events.size());
+    assertNull(events.getFirst().spec());
+    assertEquals(R1, events.getFirst().data().get(Event.WellKnownData.RUN_ID));
+  }
+
+  @Test
+  void anInterruptedAdhocStopResumesWithoutAnySpecWrite() throws Exception {
+    var shell = liveAgentShell();
+    var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);
+    seedAdhocRun(123, UNIT);
+    assertTrue(runStore.transition(R1, "running", "stopping"));
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals(R1, stopped.runId());
+    assertNull(stopped.specId());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+  }
+
+  @Test
+  void anAdhocHaltThatLeavesTheAgentAliveFailsInsteadOfReportingStopped() throws Exception {
+    var halts = new ArrayList<String>();
+    var ops =
+        stopOps(
+            liveAgentShell(),
+            (project, unit) -> halts.add(unit.unitName()),
+            StopOperations.Listener.NONE);
+    seedAdhocRun(123, UNIT);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.AGENT_STOP_FAILED, refusal.failure().errorCode());
+    assertEquals(1, halts.size());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
     assertTrue(events.isEmpty());
   }
 
   @Test
-  void aStaleRunningRowDoesNotMaskTheLiveAdHocAgent() throws Exception {
-    var haltedUnits = new ArrayList<String>();
-    var shell =
-        shell()
-            .on("incus list ^acme$", RUNNING_JSON)
-            .on("cat /home/dev/.sail/agent.pid", "55")
-            .on("kill -0 55", "")
-            .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"ad hoc\"}");
-    var ops =
-        stopOps(
-            shell,
-            (project, unit) -> {
-              haltedUnits.add(unit.unitName());
-              adHocAgentDies(shell);
-            },
-            StopOperations.Listener.NONE);
-    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
-    seedRun(123, UNIT);
+  void aMemberMayStopTheAdhocRunTheirOwnBoxLaunched() throws Exception {
+    var shell = liveAgentShell();
+    var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);
+    seedAdhocRun(123, UNIT);
 
-    var outcome = ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false);
+    var owner = new Actor(LOCAL_HANDLE, Role.MEMBER, Actor.Lane.API);
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), owner, LOCAL_HANDLE, false);
 
-    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
-    assertEquals(55, stopped.pid());
-    assertNull(stopped.runId());
-    assertEquals("auth", stopped.specId());
-    assertTrue(stopped.specCancelled());
-    assertEquals(List.of(AgentUnit.BUILD.unitName()), haltedUnits);
-    assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
-    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
-    assertEquals(1, events.size());
+    assertInstanceOf(StopOperations.Stopped.class, outcome);
   }
 
   @Test
-  void aDeadRunWithNoAdHocAgentStillReportsTheStrandedRescue() throws Exception {
+  void aMemberWhoDidNotLaunchTheAdhocRunIsRefused() throws Exception {
+    var ops = stopOps(liveAgentShell(), failingHalter(), StopOperations.Listener.NONE);
+    seedAdhocRun(123, UNIT);
+
+    var other = new Actor("raj", Role.MEMBER, Actor.Lane.API);
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), other, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.FORBIDDEN_NOT_ASSIGNEE, refusal.failure().errorCode());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+  }
+
+  @Test
+  void aDeadRunReportsTheStrandedRescueFromTheProjectTarget() throws Exception {
     var ops =
         stopOps(
             shell().on("incus list ^acme$", RUNNING_JSON),
@@ -626,28 +654,6 @@ class StopOperationsTest {
   }
 
   @Test
-  void anAdHocHaltThatLeavesTheAgentAliveFailsInsteadOfReportingStopped() throws Exception {
-    var halts = new ArrayList<String>();
-    var shell =
-        shell()
-            .on("incus list ^acme$", RUNNING_JSON)
-            .on("cat /home/dev/.sail/agent.pid", "55")
-            .on("kill -0 55", "")
-            .on("cat /home/dev/.sail/agent-session.json", "{\"task\": \"ad hoc\"}");
-    var ops =
-        stopOps(shell, (project, unit) -> halts.add(unit.unitName()), StopOperations.Listener.NONE);
-
-    var refusal =
-        assertThrows(
-            ApiException.class,
-            () -> ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false));
-
-    assertEquals(ErrorCode.AGENT_STOP_FAILED, refusal.failure().errorCode());
-    assertEquals(1, halts.size());
-    assertTrue(events.isEmpty());
-  }
-
-  @Test
   void aRunCompletedBetweenProbeAndClaimRefusesWithAConflict() throws Exception {
     var listener =
         new StopOperations.Listener() {
@@ -733,24 +739,6 @@ class StopOperationsTest {
     assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
     assertEquals(SpecStatus.CANCELLED, specStore.findById("auth").orElseThrow().status());
     assertEquals(1, events.size());
-  }
-
-  @Test
-  void aResumedClaimNeverKillsAReplacementProcess() throws Exception {
-    var ops = stopOps(liveAgentShell(456), failingHalter(), StopOperations.Listener.NONE);
-    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
-    seedRun(123, UNIT);
-    interruptStop();
-
-    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
-
-    var notActive = assertInstanceOf(StopOperations.NotActive.class, outcome);
-    assertEquals(456, notActive.livePid());
-    assertEquals(
-        "stopping",
-        runStore.findById(R1).orElseThrow().status(),
-        "the claim stays for the reconciler; the replacement process is untouched");
-    assertTrue(events.isEmpty());
   }
 
   @Test
@@ -901,7 +889,6 @@ class StopOperationsTest {
         "run_not_running", new StopOperations.NotRunning(R1, "auth", false, false).reason());
     assertEquals(
         "run_not_running", new StopOperations.AlreadyTerminal(R1, "auth", "stopped").reason());
-    assertEquals("run_not_active", new StopOperations.NotActive(R1, "auth", 9).reason());
   }
 
   @Test
@@ -960,13 +947,13 @@ class StopOperationsTest {
   void sessionHalterKillsThroughTheAgentSession() throws Exception {
     var shell =
         shell()
-            .on("cat /home/dev/.sail/agent.pid", "77")
+            .on("cat " + RUN_PID_FILE, "77")
             .on("kill 77", "")
             .on("sleep 3", "")
             .on("kill -0 77", new ShellExec.Result(1, "", ""))
-            .on("rm -f /home/dev/.sail/agent.pid", "");
+            .on("rm -f " + RUN_PID_FILE, "");
 
-    StopOperations.sessionHalter(shell).halt("acme", AgentUnit.BUILD);
+    StopOperations.sessionHalter(shell).halt("acme", AgentUnit.forRun(R1));
 
     assertTrue(shell.invocations().stream().anyMatch(cmd -> cmd.contains("kill 77")));
   }
@@ -977,10 +964,6 @@ class StopOperationsTest {
 
   private static void agentDies(FakeShell shell) {
     shell.on("kill -0 123", new ShellExec.Result(1, "", ""));
-  }
-
-  private static void adHocAgentDies(FakeShell shell) {
-    shell.on("kill -0 55", new ShellExec.Result(1, "", ""));
   }
 
   private void interruptStop() {
@@ -1057,6 +1040,14 @@ class StopOperationsTest {
             List.of()));
   }
 
+  private void seedAdhocRun(Integer pid, String unit) {
+    runStore.reserveDispatch(
+        R1, "acme", "", LOCAL_HANDLE, "adhoc", List.of(), "codex", null, "do it", RUN_LOG, unit);
+    if (pid != null) {
+      runStore.updateProcess(R1, pid, null);
+    }
+  }
+
   private void seedRun(Integer pid, String unit) {
     runStore.create(
         R1,
@@ -1075,7 +1066,15 @@ class StopOperationsTest {
 
   private void seedReviewRun() {
     runStore.createReview(
-        R2, "acme", "auth", LOCAL_HANDLE, "codex", "feat/auth", "review", RUN_LOG);
+        R2,
+        "acme",
+        "auth",
+        LOCAL_HANDLE,
+        "codex",
+        "feat/auth",
+        "review",
+        RUN_LOG,
+        "sail-review-" + R2);
   }
 
   private void seedNewerRun() {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
@@ -200,6 +200,25 @@ class StopOperationsTest {
   }
 
   @Test
+  void anUnreadableFingerprintOnALivePidRefusesWithoutSignalling() throws Exception {
+    var shell =
+        liveAgentShell().throwOn("cat /proc/123/stat", new java.io.IOException("exec timed out"));
+    var ops = stopOps(shell, failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    runStore.updateProcess(R1, 123, 555L, null);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.CONFLICT, refusal.failure().errorCode());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
   void aReusedPidWithAMismatchedFingerprintRefusesWithoutSignalling() throws Exception {
     var shell = liveAgentShell().on("cat /proc/123/stat", statLine(999));
     var ops = stopOps(shell, failingHalter(), StopOperations.Listener.NONE);
@@ -550,7 +569,7 @@ class StopOperationsTest {
   }
 
   @Test
-  void aStopDuringLaunchPreparationConflictsInsteadOfReleasingTheReservation() throws Exception {
+  void aStopDuringLaunchPreparationRecordsTheCancelAndTheLauncherMustYield() throws Exception {
     var ops =
         stopOps(
             shell().on("incus list ^acme$", RUNNING_JSON),
@@ -558,14 +577,17 @@ class StopOperationsTest {
             StopOperations.Listener.NONE);
     seedAdhocRun(null, UNIT);
 
-    var refusal =
-        assertThrows(
-            ApiException.class,
-            () -> ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false));
+    var outcome = ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false);
 
-    assertEquals(ErrorCode.CONFLICT, refusal.failure().errorCode());
-    assertEquals("running", runStore.findById(R1).orElseThrow().status());
-    assertTrue(events.isEmpty());
+    var notRunning = assertInstanceOf(StopOperations.NotRunning.class, outcome);
+    assertTrue(notRunning.runReleased());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+    assertFalse(
+        runStore.updateProcess(R1, 999, 1L, null),
+        "a launch that lost to the cancel must be refused its process stamp");
+
+    var second = ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, false);
+    assertFalse(second.mutated(), "a repeated stop after the prep-window cancel writes nothing");
   }
 
   @Test
@@ -628,6 +650,19 @@ class StopOperationsTest {
     assertFalse(notRunning.specCancelled());
     assertFalse(notRunning.runReleased());
     assertFalse(notRunning.mutated());
+  }
+
+  @Test
+  void aDryRunOverALiveAdhocRunReportsANullSpecLikeTheRealStop() throws Exception {
+    var ops = stopOps(liveAgentShell(), failingHalter(), StopOperations.Listener.NONE);
+    seedAdhocRun(123, UNIT);
+
+    var outcome = ops.stop(new StopOperations.ProjectTarget("acme"), ADMIN, LOCAL_HANDLE, true);
+
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertNull(stopped.specId(), "an ad-hoc dry run must normalize the blank spec id");
+    assertFalse(stopped.specCancelled());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
@@ -183,6 +183,40 @@ class StopOperationsTest {
   }
 
   @Test
+  void aStalePidFileNamingAReusedPidRefusesWithoutSignalling() throws Exception {
+    var ops = stopOps(liveAgentShell(999), failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.CONFLICT, refusal.failure().errorCode());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void aResumedStopAppliesTheSamePidOwnershipGuard() throws Exception {
+    var ops = stopOps(liveAgentShell(999), failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    interruptStop();
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.CONFLICT, refusal.failure().errorCode());
+    assertEquals("stopping", runStore.findById(R1).orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
   void aRunWithNoRecordedPidIsStillKilledThroughItsRunScopedPidFile() throws Exception {
     var shell = liveAgentShell();
     var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
@@ -200,6 +200,60 @@ class StopOperationsTest {
   }
 
   @Test
+  void aReusedPidWithAMismatchedFingerprintRefusesWithoutSignalling() throws Exception {
+    var shell = liveAgentShell().on("cat /proc/123/stat", statLine(999));
+    var ops = stopOps(shell, failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    runStore.updateProcess(R1, 123, 555L, null);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.CONFLICT, refusal.failure().errorCode());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void anUnreadableLiveFingerprintRefusesRatherThanKillOnFaith() throws Exception {
+    var ops = stopOps(liveAgentShell(), failingHalter(), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    runStore.updateProcess(R1, 123, 555L, null);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+
+    assertEquals(ErrorCode.CONFLICT, refusal.failure().errorCode());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+  }
+
+  @Test
+  void aMatchingFingerprintProvesOwnershipAndTheStopProceeds() throws Exception {
+    var shell = liveAgentShell().on("cat /proc/123/stat", statLine(555));
+    var ops = stopOps(shell, killingHalter(shell), StopOperations.Listener.NONE);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+    runStore.updateProcess(R1, 123, 555L, null);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    var stopped = assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals(123, stopped.pid());
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+  }
+
+  private static String statLine(long startTicks) {
+    return "123 (bash) S 1 123 123 0 -1 4194560 0 0 0 0 0 0 0 0 20 0 1 0 " + startTicks + " 0 0";
+  }
+
+  @Test
   void aResumedStopAppliesTheSamePidOwnershipGuard() throws Exception {
     var ops = stopOps(liveAgentShell(999), failingHalter(), StopOperations.Listener.NONE);
     seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
@@ -1078,7 +1132,7 @@ class StopOperationsTest {
     runStore.reserveDispatch(
         R1, "acme", "", LOCAL_HANDLE, "adhoc", List.of(), "codex", null, "do it", RUN_LOG, unit);
     if (pid != null) {
-      runStore.updateProcess(R1, pid, null);
+      runStore.updateProcess(R1, pid, null, null);
     }
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WatcherRearmerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WatcherRearmerTest.java
@@ -346,4 +346,38 @@ class WatcherRearmerTest {
     assertTrue(alive.test(ProcessHandle.current().pid()));
     assertFalse(alive.test(999_999_999L));
   }
+
+  @Test
+  void theProductionUnitProbeAnswersFromTheRunsRecordedUnit() throws Exception {
+    var liveRun = DateTimeUtils.newId().toString();
+    var goneRun = DateTimeUtils.newId().toString();
+    var probed = new java.util.ArrayList<String>();
+    var shell =
+        new ai.singlr.sail.engine.ShellExec() {
+          @Override
+          public Result exec(List<String> command) {
+            var joined = String.join(" ", command);
+            probed.add(joined);
+            var active = joined.contains("is-active") && joined.contains(liveRun);
+            return new Result(active ? 0 : 1, "", "");
+          }
+
+          @Override
+          public Result exec(List<String> command, Path workDir, Duration timeout) {
+            return exec(command);
+          }
+
+          @Override
+          public boolean isDryRun() {
+            return false;
+          }
+        };
+    var probe = WatcherRearmer.systemdUnitActiveProbe(shell);
+
+    assertTrue(probe.active("acme", liveRun, "sail-agent-" + liveRun));
+    assertFalse(probe.active("acme", goneRun, "sail-agent-" + goneRun));
+    assertTrue(
+        probed.stream().allMatch(c -> c.contains("is-active")),
+        "the probe must consult systemd unit liveness, never the pid file");
+  }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/WatcherRearmerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/WatcherRearmerTest.java
@@ -11,16 +11,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.common.DateTimeUtils;
-import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SchemaManager;
-import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
@@ -43,14 +42,12 @@ class WatcherRearmerTest {
 
   @TempDir Path tempDir;
   private Sqlite db;
-  private SpecStore specStore;
   private RunStore sessionStore;
 
   @BeforeEach
   void setUp() {
     db = Sqlite.open(tempDir.resolve("rearm.db"));
     new SchemaManager(db).migrate();
-    specStore = new SpecStore(db);
     sessionStore = new RunStore(db);
   }
 
@@ -59,66 +56,46 @@ class WatcherRearmerTest {
     if (db != null) db.close();
   }
 
-  private void createInProgressSpec(String id) {
-    specStore.create(
-        new SpecStore.SpecRow(
-            id,
-            "test-project",
-            "Test spec",
-            SpecStatus.IN_PROGRESS,
-            null,
-            "claude-code",
-            null,
-            null,
-            "feat/test",
-            0,
-            null,
-            "",
-            "",
-            null,
-            List.of(),
-            List.of()));
+  private String runningSession(String specId, Integer watcherPid) {
+    return session(specId, "build", watcherPid, true);
   }
 
-  private String runningSession(String specId, Integer watcherPid) {
+  private String adhocSession(Integer watcherPid) {
+    return session("", "adhoc", watcherPid, true);
+  }
+
+  private String session(String specId, String role, Integer watcherPid, boolean withUnit) {
     var id = DateTimeUtils.newId().toString();
     return sessionStore.create(
         id,
         "test-project",
         specId,
         "node-a",
-        "build",
+        role,
         "claude-code",
         "feat/test",
         "task",
         1,
         watcherPid,
         "/home/dev/.sail/runs/" + id + "/agent.log",
-        "sail-agent-" + id);
+        withUnit ? "sail-agent-" + id : "");
   }
 
   private WatcherRearmer rearmer(
-      MissedStopReconciler.UnitProbe agentUnitProbe,
+      MissedStopReconciler.UnitProbe agentUnitActive,
       Predicate<String> watcherUnitActive,
       LongPredicate watcherAlive,
       WatcherRearmer.WatcherRelauncher relauncher) {
     return new WatcherRearmer(
-        specStore,
-        sessionStore,
-        agentUnitProbe,
-        watcherUnitActive,
-        watcherAlive,
-        () -> "node-a",
-        relauncher);
+        sessionStore, agentUnitActive, watcherUnitActive, watcherAlive, () -> "node-a", relauncher);
   }
 
   @Test
   void theProbeCoverageCheckAndRelaunchAllAddressTheRunItself() {
-    createInProgressSpec("auth");
     var runId = runningSession("auth", null);
-    var probes = new java.util.concurrent.ConcurrentLinkedQueue<String>();
-    var covered = new java.util.concurrent.ConcurrentLinkedQueue<String>();
-    var relaunched = new java.util.concurrent.ConcurrentLinkedQueue<String>();
+    var probes = new ConcurrentLinkedQueue<String>();
+    var covered = new ConcurrentLinkedQueue<String>();
+    var relaunched = new ConcurrentLinkedQueue<String>();
 
     var rearmed =
         rearmer(
@@ -145,12 +122,10 @@ class WatcherRearmerTest {
 
   @Test
   void aForeignNodesRunIsNeverRearmedHere() {
-    createInProgressSpec("auth");
     runningSession("auth", 5678);
     var relaunches = new AtomicInteger();
     var rearmer =
         new WatcherRearmer(
-            specStore,
             sessionStore,
             (project, runId, unit) -> true,
             NO_UNIT,
@@ -167,7 +142,6 @@ class WatcherRearmerTest {
 
   @Test
   void rearmsAnUncoveredRunningAgentAsAUnit() {
-    createInProgressSpec("auth");
     runningSession("auth", 5678);
     var relaunches = new AtomicInteger();
 
@@ -187,8 +161,68 @@ class WatcherRearmerTest {
   }
 
   @Test
-  void anActiveWatcherUnitCoversTheProjectWithoutConsultingPidOrAgentUnit() {
-    createInProgressSpec("auth");
+  void anUncoveredAdhocBackgroundSessionIsRearmedLikeABuildRun() {
+    var runId = adhocSession(5678);
+    var relaunched = new ConcurrentLinkedQueue<String>();
+
+    var rearmed =
+        rearmer(
+                (project, id, unit) -> true,
+                NO_UNIT,
+                DEAD,
+                run -> {
+                  relaunched.add(run.id());
+                  return Optional.of(LAUNCHED);
+                })
+            .rearm();
+
+    assertEquals(1, rearmed);
+    assertEquals(List.of(runId), List.copyOf(relaunched));
+  }
+
+  @Test
+  void aSessionWhoseUnitIsNotActiveInSystemdIsNeverArmed() {
+    runningSession("auth", null);
+    adhocSession(null);
+    var relaunches = new AtomicInteger();
+
+    var rearmed =
+        rearmer(
+                (project, runId, unit) -> false,
+                NO_UNIT,
+                DEAD,
+                run -> {
+                  relaunches.incrementAndGet();
+                  return Optional.of(LAUNCHED);
+                })
+            .rearm();
+
+    assertEquals(0, rearmed, "a foreground or exited session runs as no unit a watcher could own");
+    assertEquals(0, relaunches.get());
+  }
+
+  @Test
+  void aLegacyRowWithNoRecordedUnitHasNothingToSupervise() {
+    session("", "adhoc", null, false);
+    var probes = new AtomicInteger();
+
+    var rearmed =
+        rearmer(
+                (project, runId, unit) -> {
+                  probes.incrementAndGet();
+                  return true;
+                },
+                NO_UNIT,
+                DEAD,
+                run -> Optional.of(LAUNCHED))
+            .rearm();
+
+    assertEquals(0, rearmed);
+    assertEquals(0, probes.get());
+  }
+
+  @Test
+  void anActiveWatcherUnitCoversTheRunWithoutConsultingPidOrAgentUnit() {
     runningSession("auth", null);
     var probed = new AtomicInteger();
 
@@ -208,8 +242,7 @@ class WatcherRearmerTest {
   }
 
   @Test
-  void aLiveRecordedWatcherPidCoversTheProject() {
-    createInProgressSpec("auth");
+  void aLiveRecordedWatcherPidCoversTheRun() {
     runningSession("auth", 5678);
     var relaunches = new AtomicInteger();
 
@@ -230,7 +263,6 @@ class WatcherRearmerTest {
 
   @Test
   void aSessionWithNoRecordedPidAndNoUnitIsRearmedBecauseDoublingIsUnrepresentable() {
-    createInProgressSpec("auth");
     runningSession("auth", null);
 
     var rearmed =
@@ -240,32 +272,9 @@ class WatcherRearmerTest {
   }
 
   @Test
-  void anInactiveAgentUnitIsTheSweepsJobNotARearm() {
-    createInProgressSpec("auth");
-    runningSession("auth", 5678);
-    var relaunches = new AtomicInteger();
-
-    var rearmed =
-        rearmer(
-                (project, runId, unit) -> false,
-                NO_UNIT,
-                DEAD,
-                run -> {
-                  relaunches.incrementAndGet();
-                  return Optional.of(LAUNCHED);
-                })
-            .rearm();
-
-    assertEquals(0, rearmed);
-    assertEquals(0, relaunches.get());
-  }
-
-  @Test
-  void terminalSessionsAndSpecsWithoutSessionsAreIgnored() {
-    createInProgressSpec("finished");
+  void terminalSessionsAreIgnored() {
     var completed = runningSession("finished", 5678);
     sessionStore.complete(completed, "stopped", 0);
-    createInProgressSpec("bare");
 
     var rearmed =
         rearmer((project, runId, unit) -> true, NO_UNIT, DEAD, run -> Optional.of(LAUNCHED))
@@ -276,7 +285,6 @@ class WatcherRearmerTest {
 
   @Test
   void anEmptyRelaunchIsLoggedNotCounted() {
-    createInProgressSpec("auth");
     runningSession("auth", 5678);
 
     var rearmed =
@@ -286,10 +294,8 @@ class WatcherRearmerTest {
   }
 
   @Test
-  void aFailingRelaunchIsLoggedAndDoesNotShadowOtherSpecs() {
-    createInProgressSpec("broken");
+  void aFailingRelaunchIsLoggedAndDoesNotShadowOtherRuns() {
     runningSession("broken", 1111);
-    createInProgressSpec("auth");
     runningSession("auth", 2222);
     var attempts = new AtomicInteger();
 
@@ -312,7 +318,6 @@ class WatcherRearmerTest {
 
   @Test
   void aStoreErrorIsSwallowedSoStartupIsNeverBlocked() {
-    createInProgressSpec("auth");
     runningSession("auth", 5678);
     var rearmer =
         rearmer((project, runId, unit) -> true, NO_UNIT, DEAD, run -> Optional.of(LAUNCHED));
@@ -324,7 +329,6 @@ class WatcherRearmerTest {
 
   @Test
   void periodicRearmSchedulesRunsAndClosesWithoutStackingPasses() {
-    createInProgressSpec("auth");
     runningSession("auth", 5678);
     try (var rearmer =
         rearmer((project, runId, unit) -> true, NO_UNIT, DEAD, run -> Optional.of(LAUNCHED))) {

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentLogCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentLogCommandTest.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.RunStore;
@@ -59,18 +60,6 @@ class AgentLogCommandTest {
   }
 
   @Test
-  void reviewFlagSelectsTheReviewLogOtherwiseTheBuildLog() {
-    assertEquals(
-        "/home/dev/.sail/agent.log",
-        AgentLogCommand.logPathFor(false),
-        "default follows the coder's build log");
-    assertEquals(
-        "/home/dev/.sail/review.log",
-        AgentLogCommand.logPathFor(true),
-        "--review follows the reviewer/fix negotiation log");
-  }
-
-  @Test
   void buildLogFollowsTheLatestRunsRunScopedLog() {
     assertEquals(
         "/home/dev/.sail/runs/r1/agent.log",
@@ -79,13 +68,15 @@ class AgentLogCommandTest {
   }
 
   @Test
-  void buildLogFallsBackToTheSharedLogWhenNoRunExists() {
-    assertEquals("/home/dev/.sail/agent.log", AgentLogCommand.logPathFrom(Optional.empty()));
+  void noRunRowMeansNoBuildLog() {
+    assertNull(
+        AgentLogCommand.logPathFrom(Optional.empty()),
+        "every session is a run, so without a run there is no log to fall back to");
   }
 
   @Test
-  void buildLogFallsBackToTheSharedLogWhenTheRunHasNoLogPath() {
-    assertEquals("/home/dev/.sail/agent.log", AgentLogCommand.logPathFrom(Optional.of(run(""))));
+  void aRunWithoutARecordedLogPathMeansNoBuildLog() {
+    assertNull(AgentLogCommand.logPathFrom(Optional.of(run(""))));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentLogCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentLogCommandTest.java
@@ -40,7 +40,8 @@ class AgentLogCommandTest {
         null,
         "t0",
         null,
-        java.util.List.of());
+        java.util.List.of(),
+        null);
   }
 
   private static final String STREAM_EVENT =

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentWatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentWatchCommandTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.api.Event;
 import ai.singlr.sail.engine.AgentSession;
+import ai.singlr.sail.engine.AgentUnit;
 import ai.singlr.sail.engine.ScriptedShellExecutor;
 import java.time.Instant;
 import java.util.Map;
@@ -23,6 +24,8 @@ import picocli.CommandLine;
 
 class AgentWatchCommandTest {
 
+  private static final String RUN_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
   @Test
   void helpTextIncludes() {
     var cmd = new CommandLine(new AgentWatchCommand());
@@ -30,6 +33,8 @@ class AgentWatchCommandTest {
 
     assertTrue(usage.contains("watch"));
     assertTrue(usage.contains("guardrails"));
+    assertTrue(usage.contains("--run"));
+    assertTrue(usage.contains("--unit"));
     assertTrue(usage.contains("--dry-run"));
     assertTrue(usage.contains("--json"));
     assertTrue(usage.contains("--host"));
@@ -40,9 +45,9 @@ class AgentWatchCommandTest {
   }
 
   @Test
-  void requiresProjectName() {
+  void refusesToStartWithoutARunId() {
     var cmd = new CommandLine(new AgentWatchCommand());
-    var exitCode = cmd.execute();
+    var exitCode = cmd.execute("acme");
 
     assertNotEquals(0, exitCode);
   }
@@ -162,15 +167,7 @@ class AgentWatchCommandTest {
   void anUnstampedEventNeverResetsARunScopedStallTimer() {
     var event = sampleEvent(Event.WellKnownTypes.AGENT_TOOL_STARTED);
 
-    assertFalse(AgentWatchCommand.matchesRun(event, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"));
-  }
-
-  @Test
-  void aProjectScopedWatcherAcceptsEveryHeartbeat() {
-    assertTrue(
-        AgentWatchCommand.matchesRun(sampleEvent(Event.WellKnownTypes.AGENT_TOOL_STARTED), null));
-    assertTrue(
-        AgentWatchCommand.matchesRun(sampleEvent(Event.WellKnownTypes.AGENT_TOOL_STARTED), ""));
+    assertFalse(AgentWatchCommand.matchesRun(event, RUN_ID));
   }
 
   @Test
@@ -274,7 +271,7 @@ class AgentWatchCommandTest {
   }
 
   @Test
-  void emitSyntheticStopSkipsAnAdHocSessionWithNoSpec() throws Exception {
+  void emitSyntheticStopSkipsOnlyWhenNeitherSpecNorRunIdIsKnown() throws Exception {
     var captured = new java.util.concurrent.atomic.AtomicReference<Event>();
     var exit = new AgentSession.ExitState(false, 0, "", "codex", "");
 
@@ -284,22 +281,40 @@ class AgentWatchCommandTest {
   }
 
   @Test
+  void emitSyntheticStopPublishesARunAddressedStopForABlankSpec() throws Exception {
+    var captured = new java.util.concurrent.atomic.AtomicReference<Event>();
+    var exit = new AgentSession.ExitState(false, 3, "", "codex", RUN_ID);
+
+    AgentWatchCommand.emitSyntheticStop(captured::set, "acme", exit);
+
+    var event = captured.get();
+    assertNotNull(event, "a run-addressed session with no spec must still publish its stop");
+    assertEquals(Event.WellKnownTypes.AGENT_SESSION_STOPPED, event.type());
+    assertNull(event.spec());
+    assertEquals(RUN_ID, event.data().get("run_id"));
+    assertEquals(3, event.data().get("exit_code"));
+    assertEquals("watcher", event.data().get("source"));
+  }
+
+  @Test
   void watcherProducesASpecAttributedStopWhenTheUnitWasAlreadyCollected() throws Exception {
+    var unit = AgentUnit.forRun(RUN_ID);
     var shell =
         new ScriptedShellExecutor()
             .onOk(
-                "systemctl --user show sail-agent.service",
+                "systemctl --user show " + unit.service(),
                 """
                 ActiveState=inactive
                 ExecMainStatus=0
                 Environment=
                 """)
             .onOk(
-                "cat /home/dev/.sail/agent-session.json",
+                "cat " + unit.sessionPath(),
                 """
-                {"task":"t","branch":"b","spec_id":"auth","agent_type":"claude-code","started_at":"2026-06-30T16:55:14Z","log_path":"/home/dev/.sail/agent.log"}
-                """);
-    var exit = new AgentSession(shell).queryExitStatus("acme");
+                {"task":"t","branch":"b","spec_id":"auth","agent_type":"claude-code","run_id":"%s","started_at":"2026-06-30T16:55:14Z","log_path":"%s"}
+                """
+                    .formatted(RUN_ID, unit.logPath()));
+    var exit = new AgentSession(shell).queryExitStatus("acme", unit);
 
     var captured = new java.util.concurrent.atomic.AtomicReference<Event>();
     AgentWatchCommand.emitSyntheticStop(captured::set, "acme", exit);
@@ -311,6 +326,7 @@ class AgentWatchCommandTest {
     assertEquals("auth", event.spec());
     assertEquals("claude-code", event.agent());
     assertEquals(0, event.data().get("exit_code"));
+    assertEquals(RUN_ID, event.data().get("run_id"));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/RunCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/RunCommandTest.java
@@ -6,10 +6,13 @@
 package ai.singlr.sail.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.Sail;
+import ai.singlr.sail.api.ApiException;
+import ai.singlr.sail.api.ErrorCode;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;
 import java.io.ByteArrayOutputStream;
@@ -161,6 +164,20 @@ class RunCommandTest {
     assertTrue(task.contains("(id: auth)"));
     assertTrue(task.contains("Implement the login flow."));
     assertTrue(task.contains("sail spec status acme auth done"));
+  }
+
+  @Test
+  void rollbackIsReservedForLaunchFailuresThatLeftNoActiveRun() {
+    var launchFailed = new ApiException(ErrorCode.AGENT_LAUNCH_FAILED, "launch failed");
+    var alreadyRunning = new ApiException(ErrorCode.AGENT_ALREADY_RUNNING, "container busy");
+
+    assertTrue(RunCommand.rollbackSafe(launchFailed, false));
+    assertFalse(
+        RunCommand.rollbackSafe(launchFailed, true),
+        "a live run must never have the container restored underneath it");
+    assertFalse(
+        RunCommand.rollbackSafe(alreadyRunning, false),
+        "a reservation refusal must not disturb the existing owner");
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SpecListCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SpecListCommandTest.java
@@ -228,7 +228,7 @@ class SpecListCommandTest {
             new String[] {"agent", "log"},
             new String[] {"agent", "review"},
             new String[] {"agent", "sweep"},
-            new String[] {"agent", "watch"},
+            new String[] {"agent", "watch", "--run", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"},
             new String[] {"agent", "report"},
             new String[] {"agent", "context", "regen"},
             new String[] {"spec", "dispatch"})) {

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/GuardrailWatcherTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/GuardrailWatcherTest.java
@@ -5,7 +5,6 @@
 
 package ai.singlr.sail.engine;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Path;
@@ -41,10 +40,5 @@ class GuardrailWatcherTest {
         "Guardrail watcher started (pid 4242, detached process — no systemd available, log:"
             + " /tmp/watch.log)",
         line);
-  }
-
-  @Test
-  void launchIsANoOpWithoutAnAgentBlock() {
-    assertDoesNotThrow(() -> GuardrailWatcher.launch("acme", "sail.yaml", null, null));
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/WatcherSpawnerIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/WatcherSpawnerIT.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -25,7 +26,8 @@ import org.junit.jupiter.api.io.TempDir;
  */
 class WatcherSpawnerIT {
 
-  private static final String PROJECT = "wsit-" + ProcessHandle.current().pid();
+  private static final String RUN_ID = UUID.randomUUID().toString();
+  private static final String UNIT = WatcherSpawner.unitNameForRun(RUN_ID);
 
   @TempDir Path tempDir;
 
@@ -34,8 +36,8 @@ class WatcherSpawnerIT {
 
   @AfterEach
   void tearDown() {
-    stopQuietly(List.of("systemctl", "--user", "stop", WatcherSpawner.unitName(PROJECT)));
-    stopQuietly(List.of("systemctl", "stop", WatcherSpawner.unitName(PROJECT)));
+    stopQuietly(List.of("systemctl", "--user", "stop", UNIT));
+    stopQuietly(List.of("systemctl", "stop", UNIT));
   }
 
   private void stopQuietly(List<String> command) {
@@ -63,16 +65,15 @@ class WatcherSpawnerIT {
     var log = tempDir.resolve("watch.log");
     var argv = List.of("sleep", "30");
 
-    var unitName = WatcherSpawner.unitName(PROJECT);
-    var spawned = spawner.spawnUnit(unitName, argv, log);
+    var spawned = spawner.spawnUnit(UNIT, argv, log);
 
     if (spawned.isPresent()) {
       assertFalse(spawned.get().adopted(), "first spawn must launch, not adopt");
-      assertTrue(unitActive(unitName), "unit must be active right after spawn");
+      assertTrue(unitActive(UNIT), "unit must be active right after spawn");
 
-      var second = spawner.spawnUnit(unitName, argv, log).orElseThrow();
+      var second = spawner.spawnUnit(UNIT, argv, log).orElseThrow();
       assertTrue(second.adopted(), "second spawn must adopt the active unit");
-      assertEquals(WatcherSpawner.unitName(PROJECT), second.name());
+      assertEquals(UNIT, second.name());
     } else {
       var pid = WatcherSpawner.spawnProcess(List.of("sleep", "30"), log);
       var handle = ProcessHandle.of(pid).orElseThrow();
@@ -84,16 +85,15 @@ class WatcherSpawnerIT {
   @Test
   void aStoppedUnitIsCollectedSoTheNameIsReusable() throws Exception {
     var log = tempDir.resolve("watch.log");
-    var unitName = WatcherSpawner.unitName(PROJECT);
-    var first = spawner.spawnUnit(unitName, List.of("sleep", "30"), log);
+    var first = spawner.spawnUnit(UNIT, List.of("sleep", "30"), log);
     if (first.isEmpty()) {
-      assertFalse(unitActive(unitName));
+      assertFalse(unitActive(UNIT));
       return;
     }
     tearDown();
 
-    assertFalse(unitActive(unitName), "stopped unit must not read as active");
-    var respawned = spawner.spawnUnit(unitName, List.of("sleep", "30"), log).orElseThrow();
+    assertFalse(unitActive(UNIT), "stopped unit must not read as active");
+    var respawned = spawner.spawnUnit(UNIT, List.of("sleep", "30"), log).orElseThrow();
     assertFalse(respawned.adopted(), "collected name must be reusable for a fresh launch");
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/WatcherSpawnerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/WatcherSpawnerTest.java
@@ -7,7 +7,6 @@ package ai.singlr.sail.engine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -38,28 +37,8 @@ class WatcherSpawnerTest {
     return tempDir.resolve("sail.yaml");
   }
 
-  private Path log() {
-    return tempDir.resolve("acme").resolve("watch.log");
-  }
-
-  @Test
-  void watchCommandNamesTheBinaryProjectAndDescriptor() {
-    var command = WatcherSpawner.watchCommand("acme", yaml());
-
-    assertEquals(
-        List.of(
-            SailPaths.binaryPath().toString(),
-            "agent",
-            "watch",
-            "acme",
-            "-f",
-            yaml().toAbsolutePath().toString()),
-        command);
-  }
-
-  @Test
-  void unitNameIsDeterministicPerProject() {
-    assertEquals("sail-watch-acme", WatcherSpawner.unitName("acme"));
+  private Path runLog() {
+    return WatcherSpawner.watchLogForRun("acme", RUN_ID).toAbsolutePath();
   }
 
   @Test
@@ -99,9 +78,7 @@ class WatcherSpawnerTest {
     assertTrue(invocation.contains("--unit " + WATCH_UNIT));
     assertTrue(invocation.contains("--run " + RUN_ID));
     assertTrue(invocation.contains("--unit " + AGENT_UNIT));
-    assertTrue(
-        invocation.contains(
-            WatcherSpawner.watchLogForRun("acme", RUN_ID).toAbsolutePath().toString()));
+    assertTrue(invocation.contains(runLog().toString()));
     assertTrue(shell.invocationsMatching("is-active").isEmpty(), "per-run units never collide");
     assertTrue(shell.invocationsMatching("systemctl --user stop").isEmpty());
   }
@@ -123,24 +100,23 @@ class WatcherSpawnerTest {
   }
 
   @Test
-  void spawnLaunchesAUserScopeUnitFirst() throws Exception {
+  void spawnForRunEmitsTheFullSystemdRunInvocationOnTheUserScope() throws Exception {
     var shell = new FakeShell().on("systemd-run --user", ok());
     var spawner = new WatcherSpawner(shell, WatcherSpawnerTest::failingFallback);
 
-    var spawned = spawner.spawn("acme", yaml(), log());
+    var spawned = spawner.spawnForRun("acme", yaml(), RUN_ID, AGENT_UNIT);
 
-    var unit = assertInstanceOf(WatcherSpawner.Unit.class, spawned);
-    assertEquals(new WatcherSpawner.Unit("sail-watch-acme", "user", false), unit);
+    assertEquals(new WatcherSpawner.Unit(WATCH_UNIT, "user", false), spawned);
     assertEquals(
         String.join(
                 " ",
-                "systemd-run --user --collect --quiet --unit sail-watch-acme",
+                "systemd-run --user --collect --quiet --unit " + WATCH_UNIT,
                 "--property Type=exec",
-                "--property StandardOutput=append:" + log().toAbsolutePath(),
-                "--property StandardError=append:" + log().toAbsolutePath(),
+                "--property StandardOutput=append:" + runLog(),
+                "--property StandardError=append:" + runLog(),
                 forwardedEnvArgs(),
-                SailPaths.binaryPath().toString(),
-                "agent watch acme -f " + yaml().toAbsolutePath())
+                String.join(
+                    " ", WatcherSpawner.watchCommandForRun("acme", yaml(), RUN_ID, AGENT_UNIT)))
             .replace("  ", " "),
         shell.invocationsMatching("systemd-run").getFirst());
   }
@@ -158,17 +134,17 @@ class WatcherSpawnerTest {
   }
 
   @Test
-  void spawnFallsToSystemScopeWhenTheUserManagerRefuses() throws Exception {
+  void spawnForRunFallsToSystemScopeWhenTheUserManagerRefuses() throws Exception {
     var shell = new FakeShell().on("systemd-run --user", fail()).on("systemd-run --collect", ok());
     var spawner = new WatcherSpawner(shell, WatcherSpawnerTest::failingFallback);
 
-    var spawned = spawner.spawn("acme", yaml(), log());
+    var spawned = spawner.spawnForRun("acme", yaml(), RUN_ID, AGENT_UNIT);
 
-    assertEquals(new WatcherSpawner.Unit("sail-watch-acme", "system", false), spawned);
+    assertEquals(new WatcherSpawner.Unit(WATCH_UNIT, "system", false), spawned);
   }
 
   @Test
-  void spawnFallsBackToADetachedProcessWhenNoScopeAccepts() throws Exception {
+  void spawnForRunFallsBackToADetachedProcessWhenNoScopeAccepts() throws Exception {
     var launched = new LinkedHashMap<String, Object>();
     var spawner =
         new WatcherSpawner(
@@ -179,40 +155,26 @@ class WatcherSpawnerTest {
               return 4242L;
             });
 
-    var spawned = spawner.spawn("acme", yaml(), log());
+    var spawned = spawner.spawnForRun("acme", yaml(), RUN_ID, AGENT_UNIT);
 
     assertEquals(new WatcherSpawner.Fallback(4242L), spawned);
     var command = new ArrayList<>(List.of("nohup"));
-    command.addAll(WatcherSpawner.watchCommand("acme", yaml()));
+    command.addAll(WatcherSpawner.watchCommandForRun("acme", yaml(), RUN_ID, AGENT_UNIT));
     assertEquals(command, launched.get("command"));
-    assertEquals(log(), launched.get("log"));
-    assertTrue(Files.isDirectory(log().getParent()));
+    assertEquals(WatcherSpawner.watchLogForRun("acme", RUN_ID), launched.get("log"));
+    assertTrue(Files.isDirectory(runLog().getParent()));
   }
 
   @Test
-  void spawnWithoutAFallbackFailsLoudWhenNoScopeAccepts() {
+  void spawnForRunWithoutAFallbackFailsLoudWhenNoScopeAccepts() {
     var spawner = new WatcherSpawner(new FakeShell(), null);
 
-    var error = assertThrows(IOException.class, () -> spawner.spawn("acme", yaml(), log()));
+    var error =
+        assertThrows(
+            IOException.class, () -> spawner.spawnForRun("acme", yaml(), RUN_ID, AGENT_UNIT));
 
-    assertTrue(error.getMessage().contains("sail-watch-acme"));
+    assertTrue(error.getMessage().contains(WATCH_UNIT));
     assertTrue(error.getMessage().contains("no fallback"));
-  }
-
-  @Test
-  void spawnStopsAStaleUnitAndLaunchesFreshInsteadOfAdoptingItsOldDeadline() throws Exception {
-    var shell =
-        new FakeShell()
-            .onSequence("systemctl --user --quiet is-active", ok(), fail())
-            .on("systemctl --user stop sail-watch-acme", ok())
-            .on("systemd-run --user", ok());
-    var spawner = new WatcherSpawner(shell, WatcherSpawnerTest::failingFallback);
-
-    var spawned = spawner.spawn("acme", yaml(), log());
-
-    assertEquals(new WatcherSpawner.Unit("sail-watch-acme", "user", false), spawned);
-    assertEquals(1, shell.invocationsMatching("stop sail-watch-acme").size());
-    assertEquals(1, shell.invocationsMatching("systemd-run").size());
   }
 
   @Test
@@ -231,7 +193,9 @@ class WatcherSpawnerTest {
     var shell = new FakeShell().interruptOn("systemd-run");
     var spawner = new WatcherSpawner(shell, (command, logPath) -> 4242L);
 
-    var error = assertThrows(IOException.class, () -> spawner.spawn("acme", yaml(), log()));
+    var error =
+        assertThrows(
+            IOException.class, () -> spawner.spawnForRun("acme", yaml(), RUN_ID, AGENT_UNIT));
 
     assertTrue(error.getMessage().contains("Interrupted"));
     assertTrue(Thread.interrupted(), "interrupt flag must be restored");
@@ -271,7 +235,8 @@ class WatcherSpawnerTest {
     var shell = new FakeShell().throwOn("systemd-run", new IOException("no bus"));
     var spawner = new WatcherSpawner(shell, (command, logPath) -> 7L);
 
-    assertEquals(new WatcherSpawner.Fallback(7L), spawner.spawn("acme", yaml(), log()));
+    assertEquals(
+        new WatcherSpawner.Fallback(7L), spawner.spawnForRun("acme", yaml(), RUN_ID, AGENT_UNIT));
   }
 
   @Test


### PR DESCRIPTION
Implements spec `sail-adhoc-run-scoped`: kill the fixed ad-hoc agent identity — every agent session is a run.

## What changed

**Launch.** `sail agent run --task` and `sail agent sweep` now go through the shared dispatch launch machinery via `DispatchOperations.startAdhoc`: a minted run id, `role='adhoc'`, no spec, run-scoped unit `sail-agent-<runId>` and files under `~/.sail/runs/<runId>/`, and a **whole-container reservation through the same `reserveDispatch` `BEGIN IMMEDIATE` transaction** that gates dispatches. Dispatch-vs-adhoc, adhoc-vs-dispatch, and adhoc-vs-adhoc are mutually exclusive by one atomic mechanism — closing the one-sided gate where an ad-hoc agent could be started beside a dispatched one. Background sessions get the same run-addressed guardrail watcher; foreground launches write the run's pid file and `exec` into the agent, so they are probeable and stoppable through the same identity.

**Stop.** `StopOperations.stopAdHoc`, the project-lane fixed-unit fallback, and the pid-identity-theft guards (`NotActive`, reason `run_not_active`) are deleted: a run-scoped transient unit can only host its own run's process, the kill goes through the run's own pid file, and the verified halt re-probes before finalizing. `agent stop`'s outcome vocabulary is otherwise unchanged; an ad-hoc stop now reports its run id. Ad-hoc runs are owned by their launching node handle in `RunPolicy` (API members can stop their own; fails closed otherwise).

**Status / logs / retention.** `agent status`, `agent logs`, `agent report`, `GET /v1/runs/{id}/log`, and the SSE log stream resolve ad-hoc sessions through their run rows exactly like dispatches (`AgentUnit.logPathForRole` replaces `fromRole`; roles widened to build|adhoc|review). No run rows means no session — the fixed-unit fallback probes are gone. `RunRetention`, `RunTracker`, `WatcherRearmer`, and `ReviewPipelineController` inherit ad-hoc runs with zero `adhoc` branches.

**Reconciler.** The stranded-reservation release now requires probed evidence of death: a spec-less run is released only when its recorded pid probes dead, no reservation is ever freed under a live agent, and the release is a `running → stopped` CAS so it never overwrites a watcher-recorded exit. Interrupted ad-hoc stops finalize through the existing `stopping` sweep, whose unit probe moved inside the per-run try so one bad row can't abort the pass.

**Review-run identity.** `createReview` records the real execution identity (`sail-review-<id>`) instead of `unit = ''` — the blank-unit state leaves the live schema vocabulary.

**Schema.** `runs.role` CHECK widens to `('build','adhoc','review')` via a `runs_v4` table rebuild migration.

## Notable behavior changes

- `sail agent run --task` now opens the control-plane DB and refuses while any dispatched agent (or in-flight review run) occupies the container — previously it launched unconditionally. This is the correctness fix the spec targets.
- Ad-hoc launches on a handled box stamp the node handle on the run, so cross-lane exclusion and ownership hold fleet-wide.
- The watcher publishes run-addressed synthetic stops for spec-less sessions (spec absent, `run_id` present) so `RunTracker` completes their rows; `SlackReactor` filters spec-less events so ad-hoc lifecycle noise never posts to spec threads.
- Upgrading with a live old-binary fixed-unit ad-hoc session is unsupported: stop agents before `sail upgrade` (documented in CHANGELOG).

## Testing

- Design pass reviewed adversarially before coding (two independent review passes over the design doc; their findings — release-pass liveness veto + CAS, blank-unit probe semantics, RunPolicy owner for spec-less runs, node-handle stamping, SlackReactor guard, the sweep lane — are folded in).
- Store-level mutual-exclusion matrix (`RunStoreTest`): dispatch-then-adhoc, adhoc-then-dispatch, adhoc-then-adhoc, release-then-reserve, plus the existing cross-connection `BEGIN IMMEDIATE` race test.
- `AdhocDispatchTest` (new): launch/reserve/watcher/foreground-exit/dry-run/failure-release/no-store refusal for `startAdhoc`.
- `StopOperationsTest`: ad-hoc stop happy path, interrupted ad-hoc stop resume, blank-unit foreground probe/rescue, ownership; `MissedStopReconcilerTest`: spec-less release matrix (dead/live/pid-less/unprobeable/grace/CAS-race), ad-hoc interrupted-stop finalization, blank-unit claim probe.
- `AdhocRunLifecycleIT` (new, Incus lane): real ad-hoc background lifecycle — launch under `sail-agent-<runId>`, dispatch refused while live, clean stop verifies the kill and releases the reservation, next dispatch admitted.
- `mvn clean verify` green: 2900+ tests, JaCoCo gates met (`api.*` 100% line/method on gated classes), fixed identity grep-clean from main source.
