### PR TITLE
Collapse the pre-1.0 migration chain into a v1 baseline with a guarded floor

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -131,9 +131,10 @@ by the three synced stores), `SyncConflicts` (parked conflicts), `SyncState` (pe
 checkpoints), `ExpiredRowSweeper` (hourly housekeeping), and `PushOutcome` (the CAS result).
 
 Migrations are two-layer and idempotent. `SchemaManager` owns the schema layer: the v1
-baseline creates the current schema directly on a fresh database, a database at the
-published 0.14 floor (schema v125, structurally identical to the baseline) is stamped
-forward in one step, and a database below the floor is refused with the remedy — install
+baseline creates the current schema directly on a fresh database, a database at or past
+the published 0.14 floor (schema v118, the version every released 0.14.x binary reaches)
+rides the on-ramp — the post-floor migrations that never shipped in a 0.14.x release —
+to the baseline, and a database below the floor is refused with the remedy — install
 sail 0.14.x, run `sail upgrade`, retry — never a silent replay of deleted steps. A
 separate `DataMigration` framework runs one-shot content fix-ups exactly once, tracked by
 name. `MigrationRunner.applyAll` runs schema migrations then data migrations.
@@ -149,10 +150,11 @@ are added after the baseline, never reordered, edited, or removed, and each one 
 the PR that needs it together with a test that migrates a seeded database and asserts the
 data survived. Collapsing the chain into a new baseline is allowed only at a major
 version with a published floor: the floor's final schema and the new baseline must be
-structurally identical (the `FloorSchema` fixture and the schema-diff test in
-`SchemaManagerTest` pin this), the on-ramp is a single version stamp, and everything
-below the floor is refused with an actionable error naming the release that can still
-carry it. Sync peers enforce the same floor in the wire handshake before any rows are
+structurally equivalent (the `FloorSchema` fixture replays the released chain verbatim,
+and the schema-diff test in `SchemaManagerTest` pins floor-plus-on-ramp against a fresh
+baseline), the floor must be a version a released binary can actually reach, and
+everything below the floor is refused with an actionable error naming the release that
+can still carry it. Sync peers enforce the same floor in the wire handshake before any rows are
 exchanged. There is no downgrade path: pre-1.0 explicitly has none, and post-1.0 policy
 is forward-only with the documented floor mechanism. The pre-1.0 chain is recoverable
 from git history only.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -130,8 +130,11 @@ revision ids), `ConflictDetector` (a pure three-way merge), `ConflictResolver` (
 by the three synced stores), `SyncConflicts` (parked conflicts), `SyncState` (per-peer
 checkpoints), `ExpiredRowSweeper` (hourly housekeeping), and `PushOutcome` (the CAS result).
 
-Migrations are two-layer and idempotent. `SchemaManager.MIGRATIONS` is an append-only,
-version-tracked list of SQL statements, and entries are never reordered or removed. A
+Migrations are two-layer and idempotent. `SchemaManager` owns the schema layer: the v1
+baseline creates the current schema directly on a fresh database, a database at the
+published 0.14 floor (schema v125, structurally identical to the baseline) is stamped
+forward in one step, and a database below the floor is refused with the remedy — install
+sail 0.14.x, run `sail upgrade`, retry — never a silent replay of deleted steps. A
 separate `DataMigration` framework runs one-shot content fix-ups exactly once, tracked by
 name. `MigrationRunner.applyAll` runs schema migrations then data migrations.
 `MigrateCommand` additionally imports on-disk descriptors and shared files, scrubs
@@ -140,6 +143,19 @@ data migrations run on `sail migrate`, on `sail upgrade` (which spawns the new b
 `migrate` so a release's new migrations actually execute), and on every daemon start, so a
 failed upgrade-time migration self-heals on the next service start. Imports run only from
 the explicit migrate lane.
+
+**Migration policy.** Schema migrations are append-only within a major version: entries
+are added after the baseline, never reordered, edited, or removed, and each one ships in
+the PR that needs it together with a test that migrates a seeded database and asserts the
+data survived. Collapsing the chain into a new baseline is allowed only at a major
+version with a published floor: the floor's final schema and the new baseline must be
+structurally identical (the `FloorSchema` fixture and the schema-diff test in
+`SchemaManagerTest` pin this), the on-ramp is a single version stamp, and everything
+below the floor is refused with an actionable error naming the release that can still
+carry it. Sync peers enforce the same floor in the wire handshake before any rows are
+exchanged. There is no downgrade path: pre-1.0 explicitly has none, and post-1.0 policy
+is forward-only with the documented floor mechanism. The pre-1.0 chain is recoverable
+from git history only.
 
 ## The sync layer: one main, many nodes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to sail
+
+Build and validate with the same command CI runs:
+
+```bash
+mvn clean verify
+```
+
+Coverage and quality gates are ratchets — see [QUALITY.md](QUALITY.md). Design context
+lives in [ARCHITECTURE.md](ARCHITECTURE.md), and coding conventions in
+[CLAUDE.md](CLAUDE.md).
+
+## Database migration policy
+
+The SQLite schema is versioned by `SchemaManager` in `sail-core`. The rules every change
+inherits:
+
+- **Append-only within a major version.** New migrations are added after the current
+  baseline and are never reordered, edited, or removed once released. If a migration is
+  wrong, append another one that fixes it.
+- **Every migration ships with a seeded-data test.** The test stages a database at the
+  prior version, seeds representative rows, migrates, and asserts the rows survived.
+- **Baselining happens only at a major version with a published floor.** The floor's
+  final schema and the new baseline must be structurally identical — proven by a
+  `sqlite_master` diff test against the captured floor fixture (`FloorSchema`) — the
+  on-ramp from the floor is a single version stamp, and anything below the floor is
+  refused with an error naming the release that can still carry it forward. The v1
+  baseline's floor is sail 0.14.x (schema v125).
+- **No downgrade path.** Schema changes are forward-only; the floor mechanism above is
+  the only supported way to cross a baseline.
+- **One-shot data fix-ups are not schema migrations.** They belong in the
+  `DataMigration` framework, run exactly once, and are tracked by name in
+  `data_migrations`.

--- a/sail-core/src/main/java/ai/singlr/sail/store/LegacyDataMigration.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/LegacyDataMigration.java
@@ -13,8 +13,9 @@ import java.util.List;
 import java.util.function.Supplier;
 
 /**
- * Carries every pre-0.14 row to the v1 data floor exactly once. This migration remains in the
- * versioned chain so a box upgrading across 0.14 can reach the current schema; it is not a runtime
+ * Carries every pre-0.14 row to the v1 data floor exactly once. It remains registered past the v1
+ * schema baseline because its completion marker is the data-floor stamp, and because a 0.14 box
+ * whose repair was interrupted finishes it here after the schema on-ramp; it is not a runtime
  * compatibility path.
  */
 public final class LegacyDataMigration implements DataMigration {

--- a/sail-core/src/main/java/ai/singlr/sail/store/MigrationRunner.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MigrationRunner.java
@@ -26,7 +26,7 @@ public final class MigrationRunner {
       Sqlite db, List<DataMigration> dataMigrations, DataMigration.Prompter prompter) {
     var schema = new SchemaManager(db);
     var before = schema.currentVersion();
-    schema.migrateAll();
+    schema.migrate();
     var after = schema.currentVersion();
     var projects = ProjectRegistry.loadFromDisk();
     var runs = new DataMigrator(db, dataMigrations).run(projects, prompter);

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -9,21 +9,68 @@ import java.util.List;
 
 /**
  * Manages SQLite schema versioning against the v1 baseline. A fresh database gets the current
- * schema in one shot; a database at the published 0.14 floor (schema v{@value #FLOOR_VERSION},
- * structurally identical to the baseline) is stamped forward in one step; anything below the floor
- * is refused with the remedy, never silently replayed. The pre-1.0 migration chain lives in git
- * history only.
+ * schema in one shot; a database at or above the published 0.14 floor (schema v{@value
+ * #FLOOR_VERSION}, the version every released 0.14.x binary reaches) rides the on-ramp — the
+ * post-floor migrations that never shipped in a 0.14.x release — to the baseline; anything below
+ * the floor is refused with the remedy, never silently replayed. The pre-1.0 migration chain lives
+ * in git history only.
  *
  * <p>Policy: migrations are append-only within a major version, and baselining like this happens
- * only at a major version with a published floor. See ARCHITECTURE.md.
+ * only at a major version with a published floor. The floor must be a version a released binary can
+ * actually reach — a floor no release can produce strands the fleet behind an impossible remedy.
+ * See ARCHITECTURE.md.
  */
 public final class SchemaManager {
 
-  /** The schema version a fully-migrated sail 0.14.x database carries: the v1 upgrade floor. */
-  static final int FLOOR_VERSION = 125;
+  /** The schema version a fully-migrated released sail 0.14.x database carries: the v1 floor. */
+  static final int FLOOR_VERSION = 118;
 
-  /** The v1 baseline version, one step past the floor it is structurally identical to. */
-  static final int V1_VERSION = FLOOR_VERSION + 1;
+  /**
+   * The migrations between the floor and the baseline: appended after 0.14.1 shipped, never
+   * released, so a floor database must replay them here. Verbatim from the deleted chain; a
+   * database mid-ramp (a development box) resumes at its recorded version.
+   */
+  static final List<String> ON_RAMP =
+      List.of(
+          """
+          CREATE TABLE runs_v4 (
+              id TEXT PRIMARY KEY,
+              project TEXT NOT NULL,
+              spec_id TEXT,
+              agent TEXT NOT NULL,
+              branch TEXT,
+              task TEXT,
+              pid INTEGER,
+              status TEXT NOT NULL DEFAULT 'running'
+                  CHECK (status IN ('running', 'stopping', 'completed', 'stopped', 'failed')),
+              started_at TEXT NOT NULL,
+              completed_at TEXT,
+              exit_code INTEGER,
+              watcher_pid INTEGER,
+              node TEXT,
+              role TEXT NOT NULL DEFAULT 'build'
+                  CHECK (role IN ('build', 'adhoc', 'review')),
+              log_path TEXT,
+              rev TEXT,
+              base_rev TEXT,
+              unit TEXT,
+              repos TEXT
+          )""",
+          """
+          INSERT INTO runs_v4 (id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos)
+              SELECT id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos FROM runs""",
+          "DROP TABLE runs",
+          "ALTER TABLE runs_v4 RENAME TO runs",
+          "CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project)",
+          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)",
+          "ALTER TABLE runs ADD COLUMN pid_ticks INTEGER");
+
+  /** The v1 baseline version: the floor plus the on-ramp it is structurally equivalent to. */
+  static final int V1_VERSION = FLOOR_VERSION + ON_RAMP.size() + 1;
 
   private static final String SCHEMA_VERSION_TABLE =
       """
@@ -337,12 +384,13 @@ public final class SchemaManager {
 
   /**
    * Converges the schema to the v1 baseline. A fresh database gets the baseline directly; a
-   * database at the 0.14 floor is stamped forward in one step (the floor schema and the baseline
-   * are structurally identical); a database below the floor raises {@link PreFloorException} with
-   * the remedy, because this release no longer carries the pre-1.0 migration chain; a database
-   * above the v1 baseline raises {@link IllegalStateException}, because an older binary must not
-   * operate on a schema it does not understand. Idempotent: re-running on a current database is a
-   * no-op.
+   * database at or past the 0.14 floor rides the on-ramp remainder to the baseline (a released
+   * 0.14.x database replays the never-released post-floor migrations; a development box mid-ramp
+   * resumes where its version left off); a database below the floor raises {@link
+   * PreFloorException} with the remedy, because this release no longer carries the pre-1.0
+   * migration chain; a database above the v1 baseline raises {@link IllegalStateException}, because
+   * an older binary must not operate on a schema it does not understand. Idempotent: re-running on
+   * a current database is a no-op.
    */
   public void migrate() {
     db.execute(SCHEMA_VERSION_TABLE);
@@ -366,8 +414,8 @@ public final class SchemaManager {
           });
       return;
     }
-    if (current == FLOOR_VERSION) {
-      db.transaction(this::stamp);
+    if (current >= FLOOR_VERSION) {
+      onRampFrom(current);
       return;
     }
     throw new PreFloorException(
@@ -378,6 +426,36 @@ public final class SchemaManager {
             + "), and this release does not carry pre-floor migrations."
             + " Install sail 0.14.x, run 'sail migrate', then upgrade to this release and"
             + " retry.");
+  }
+
+  /**
+   * Applies the on-ramp remainder from {@code current} and stamps the baseline version, atomically.
+   * Foreign-key enforcement is suspended for the window because the on-ramp contains a table
+   * rebuild that must drop-and-recreate a parent without firing child cascades; integrity is
+   * verified before enforcement is restored, so a violated rebuild fails loud rather than shipping
+   * a corrupted database.
+   */
+  private void onRampFrom(int current) {
+    db.execute("PRAGMA foreign_keys = OFF");
+    try {
+      db.transaction(
+          () -> {
+            ON_RAMP.subList(current - FLOOR_VERSION, ON_RAMP.size()).forEach(db::execute);
+            stamp();
+          });
+      requireForeignKeysIntact();
+    } finally {
+      db.execute("PRAGMA foreign_keys = ON");
+    }
+  }
+
+  private void requireForeignKeysIntact() {
+    var violations =
+        db.query("PRAGMA foreign_key_check", row -> row.text(0) + " row " + row.integer(1));
+    if (!violations.isEmpty()) {
+      throw new SqliteException(
+          "Migration broke referential integrity: " + String.join(", ", violations), 0);
+    }
   }
 
   private void stamp() {

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -339,13 +339,23 @@ public final class SchemaManager {
    * Converges the schema to the v1 baseline. A fresh database gets the baseline directly; a
    * database at the 0.14 floor is stamped forward in one step (the floor schema and the baseline
    * are structurally identical); a database below the floor raises {@link PreFloorException} with
-   * the remedy, because this release no longer carries the pre-1.0 migration chain. Idempotent:
-   * re-running on a current database is a no-op.
+   * the remedy, because this release no longer carries the pre-1.0 migration chain; a database
+   * above the v1 baseline raises {@link IllegalStateException}, because an older binary must not
+   * operate on a schema it does not understand. Idempotent: re-running on a current database is a
+   * no-op.
    */
   public void migrate() {
     db.execute(SCHEMA_VERSION_TABLE);
     var current = currentVersion();
-    if (current >= V1_VERSION) {
+    if (current > V1_VERSION) {
+      throw new IllegalStateException(
+          "Database schema v"
+              + current
+              + " is newer than this Sail binary supports (v"
+              + V1_VERSION
+              + "). Upgrade Sail before opening this database.");
+    }
+    if (current == V1_VERSION) {
       return;
     }
     if (current == 0) {
@@ -366,7 +376,8 @@ public final class SchemaManager {
             + ", below the sail 1.0 floor (schema v"
             + FLOOR_VERSION
             + "), and this release does not carry pre-floor migrations."
-            + " Install sail 0.14.x and run 'sail upgrade', then retry.");
+            + " Install sail 0.14.x, run 'sail migrate', then upgrade to this release and"
+            + " retry.");
   }
 
   private void stamp() {

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncDatabase.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncDatabase.java
@@ -34,11 +34,11 @@ public final class SyncDatabase implements AutoCloseable {
    * Opens the database at {@code dbPath}, converges its schema, and guarantees the v1 data floor
    * before returning. A failure closes the handle before any sync data is touched.
    *
-   * <p>{@link SchemaManager#migrate} refuses an unrepaired pre-floor database with the 'sail
-   * migrate' remedy — that refusal passes through untouched. A database that converges cleanly but
-   * has no floor marker was necessarily born at or above the floor (the guard forbids any other
-   * crossing), so every data migration is vacuous on it and runs here only to stamp the markers —
-   * keeping a fresh or auxiliary-created box's first sync frictionless.
+   * <p>{@link SchemaManager#migrate} refuses a below-floor database with the install-0.14.x remedy
+   * — that refusal passes through untouched. A database that converges cleanly but has no floor
+   * marker was necessarily born at or above the floor (the schema floor forbids any other
+   * crossing), so the data migrations run here only to finish or stamp the floor repair — keeping a
+   * fresh or auxiliary-created box's first sync frictionless.
    */
   public static SyncDatabase converge(Path dbPath, String box) {
     var db = Sqlite.open(dbPath);

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncWire.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncWire.java
@@ -43,7 +43,12 @@ public final class SyncWire {
   private static final String OP_FETCH_FDES = "fetch-fdes";
   private static final String FDES = "fdes";
 
-  public static final String V1_UPGRADE_FLOOR = "0.14.0";
+  /**
+   * The fleet floor both sides must advertise before exchanging rows. Bumped from {@code 0.14.0}
+   * with the v1 schema baseline: a pre-baseline peer's schema lacks post-floor columns, so its
+   * binary must not receive v1 snapshots — the refusal names 'sail upgrade' as the remedy.
+   */
+  public static final String V1_UPGRADE_FLOOR = "1.0.0";
 
   /**
    * Hard ceiling on one framed message, bounding the memory a single read can claim. A sync message

--- a/sail-core/src/test/java/ai/singlr/sail/store/FloorSchema.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FloorSchema.java
@@ -8,25 +8,470 @@ package ai.singlr.sail.store;
 import java.util.List;
 
 /**
- * The v1 upgrade floor contract: the exact {@code sqlite_master} contents of a fully-migrated sail
- * 0.14.x database, captured verbatim (including the quoted names and appended-column artifacts its
- * rebuild-heavy migration chain left behind) before that chain was deleted. Tests stage a floor
- * database from this fixture to prove the one-step on-ramp into the v1 baseline; if the baseline
- * ever drifts from this shape, the schema-diff test fails and the floor has been broken.
+ * The v1 upgrade floor contract: the complete migration chain sail 0.14.1 shipped, captured
+ * verbatim before it was deleted from {@link SchemaManager}. Staging replays the real released
+ * artifact step by step — the same per-step transactions and foreign-key window the old {@code
+ * migrateTo} used — so the on-ramp and equivalence tests prove compatibility against what actually
+ * exists in the field, not against a hand-maintained snapshot. Frozen forever; if the baseline
+ * drifts from what this chain plus the on-ramp produces, the schema-diff test fails and the floor
+ * has been broken.
  */
 final class FloorSchema {
 
   private FloorSchema() {}
 
-  private static final List<String> DDL =
+  private static final List<String> CHAIN =
       List.of(
           """
-          CREATE TABLE schema_version (
+          CREATE TABLE IF NOT EXISTS schema_version (
               version INTEGER PRIMARY KEY,
               applied_at TEXT NOT NULL
           )""",
           """
-          CREATE TABLE "specs" (
+          CREATE TABLE IF NOT EXISTS specs (
+              id TEXT PRIMARY KEY,
+              title TEXT NOT NULL,
+              status TEXT NOT NULL DEFAULT 'draft'
+                  CHECK (status IN ('draft', 'pending', 'in_progress', 'review', 'done', 'archived')),
+              assignee TEXT,
+              agent TEXT,
+              model TEXT,
+              reasoning_effort TEXT
+                  CHECK (reasoning_effort IS NULL OR reasoning_effort IN ('none', 'low', 'medium', 'high', 'xhigh')),
+              branch TEXT,
+              priority INTEGER NOT NULL DEFAULT 0,
+              created_by TEXT,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL
+          )""",
+          """
+          CREATE TABLE IF NOT EXISTS spec_dependencies (
+              spec_id TEXT NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
+              depends_on TEXT NOT NULL REFERENCES specs(id),
+              PRIMARY KEY (spec_id, depends_on)
+          )""",
+          """
+          CREATE TABLE IF NOT EXISTS spec_repos (
+              spec_id TEXT NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
+              repo TEXT NOT NULL,
+              PRIMARY KEY (spec_id, repo)
+          )""",
+          """
+          CREATE TABLE IF NOT EXISTS spec_content (
+              spec_id TEXT PRIMARY KEY REFERENCES specs(id) ON DELETE CASCADE,
+              body TEXT NOT NULL DEFAULT '',
+              plan TEXT NOT NULL DEFAULT '',
+              updated_at TEXT NOT NULL
+          )""",
+          """
+          CREATE TABLE IF NOT EXISTS spec_attachments (
+              id TEXT PRIMARY KEY,
+              spec_id TEXT NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
+              filename TEXT NOT NULL,
+              content_type TEXT NOT NULL,
+              size_bytes INTEGER NOT NULL,
+              storage_path TEXT NOT NULL,
+              created_at TEXT NOT NULL
+          )""",
+          """
+          CREATE TABLE IF NOT EXISTS events (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              timestamp TEXT NOT NULL,
+              type TEXT NOT NULL,
+              project TEXT,
+              spec_id TEXT,
+              agent TEXT,
+              host TEXT NOT NULL,
+              data TEXT NOT NULL DEFAULT '{}'
+          )""",
+          "CREATE INDEX IF NOT EXISTS idx_events_type ON events(type)",
+          "CREATE INDEX IF NOT EXISTS idx_events_project ON events(project)",
+          "CREATE INDEX IF NOT EXISTS idx_events_spec ON events(spec_id)",
+          "CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp DESC)",
+          """
+          CREATE TABLE IF NOT EXISTS api_tokens (
+              token_hash TEXT PRIMARY KEY,
+              name TEXT NOT NULL UNIQUE,
+              role TEXT NOT NULL DEFAULT 'member'
+                  CHECK (role IN ('admin', 'member')),
+              created_at TEXT NOT NULL,
+              last_used_at TEXT
+          )""",
+          """
+          CREATE TABLE IF NOT EXISTS reviews (
+              id TEXT PRIMARY KEY,
+              spec_id TEXT NOT NULL REFERENCES specs(id),
+              iteration INTEGER NOT NULL DEFAULT 1,
+              status TEXT NOT NULL DEFAULT 'pending'
+                  CHECK (status IN ('pending', 'running', 'passed', 'failed', 'escalated')),
+              created_at TEXT NOT NULL,
+              completed_at TEXT
+          )""",
+          "CREATE INDEX IF NOT EXISTS idx_reviews_spec ON reviews(spec_id)",
+          """
+          CREATE TABLE IF NOT EXISTS review_stages (
+              id TEXT PRIMARY KEY,
+              review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
+              name TEXT NOT NULL,
+              stage_type TEXT NOT NULL,
+              status TEXT NOT NULL DEFAULT 'pending'
+                  CHECK (status IN ('pending', 'running', 'passed', 'failed', 'skipped')),
+              reviewer TEXT,
+              started_at TEXT,
+              completed_at TEXT
+          )""",
+          "CREATE INDEX IF NOT EXISTS idx_review_stages_review ON review_stages(review_id)",
+          """
+          CREATE TABLE IF NOT EXISTS review_findings (
+              id TEXT PRIMARY KEY,
+              stage_id TEXT NOT NULL REFERENCES review_stages(id) ON DELETE CASCADE,
+              severity TEXT NOT NULL,
+              category TEXT NOT NULL,
+              file TEXT,
+              line_start INTEGER,
+              line_end INTEGER,
+              title TEXT NOT NULL,
+              description TEXT NOT NULL,
+              evidence TEXT,
+              suggestion_before TEXT,
+              suggestion_after TEXT,
+              suggestion_rationale TEXT,
+              confidence REAL NOT NULL DEFAULT 0.0,
+              resolution TEXT NOT NULL DEFAULT 'OPEN'
+                  CHECK (resolution IN ('OPEN', 'FIXED', 'DISMISSED'))
+          )""",
+          "CREATE INDEX IF NOT EXISTS idx_review_findings_stage ON review_findings(stage_id)",
+          "CREATE INDEX IF NOT EXISTS idx_review_findings_severity ON review_findings(severity)",
+          """
+          CREATE TABLE IF NOT EXISTS agent_sessions (
+              id TEXT PRIMARY KEY,
+              project TEXT NOT NULL,
+              spec_id TEXT,
+              agent TEXT NOT NULL,
+              branch TEXT,
+              task TEXT,
+              pid INTEGER,
+              status TEXT NOT NULL DEFAULT 'running'
+                  CHECK (status IN ('running', 'completed', 'stopped', 'failed')),
+              started_at TEXT NOT NULL,
+              completed_at TEXT
+          )""",
+          "CREATE INDEX IF NOT EXISTS idx_agent_sessions_project ON agent_sessions(project)",
+          "CREATE INDEX IF NOT EXISTS idx_agent_sessions_spec ON agent_sessions(spec_id)",
+          "ALTER TABLE specs ADD COLUMN project TEXT NOT NULL DEFAULT 'unassigned'",
+          "CREATE INDEX IF NOT EXISTS idx_specs_project ON specs(project)",
+          """
+          CREATE TABLE IF NOT EXISTS data_migrations (
+              name TEXT PRIMARY KEY,
+              applied_at TEXT NOT NULL
+          )""",
+          """
+          CREATE TABLE api_tokens_new (
+              token_hash TEXT PRIMARY KEY,
+              name TEXT NOT NULL UNIQUE,
+              role TEXT NOT NULL DEFAULT 'member'
+                  CHECK (role IN ('admin', 'member', 'viewer')),
+              created_at TEXT NOT NULL,
+              last_used_at TEXT
+          )""",
+          """
+          INSERT INTO api_tokens_new (token_hash, name, role, created_at, last_used_at)
+              SELECT token_hash, name, role, created_at, last_used_at FROM api_tokens""",
+          "DROP TABLE api_tokens",
+          "ALTER TABLE api_tokens_new RENAME TO api_tokens",
+          """
+          CREATE TABLE IF NOT EXISTS fdes (
+              id TEXT PRIMARY KEY,
+              handle TEXT NOT NULL UNIQUE,
+              display_name TEXT,
+              email TEXT,
+              status TEXT NOT NULL DEFAULT 'active'
+                  CHECK (status IN ('active', 'disabled')),
+              created_at TEXT NOT NULL
+          )""",
+          "ALTER TABLE api_tokens ADD COLUMN fde_id TEXT",
+          "ALTER TABLE specs ADD COLUMN updated_by TEXT",
+          "ALTER TABLE reviews ADD COLUMN decided_by TEXT",
+          """
+          CREATE TABLE IF NOT EXISTS webauthn_credentials (
+              credential_id TEXT PRIMARY KEY,
+              fde_id TEXT NOT NULL REFERENCES fdes(id) ON DELETE CASCADE,
+              public_key_cose TEXT NOT NULL,
+              cose_algorithm INTEGER NOT NULL,
+              sign_count INTEGER NOT NULL DEFAULT 0,
+              aaguid TEXT,
+              backup_eligible INTEGER NOT NULL DEFAULT 0,
+              backup_state INTEGER NOT NULL DEFAULT 0,
+              label TEXT,
+              created_at TEXT NOT NULL,
+              last_used_at TEXT
+          )""",
+          "CREATE INDEX IF NOT EXISTS idx_webauthn_credentials_fde"
+              + " ON webauthn_credentials(fde_id)",
+          """
+          CREATE TABLE IF NOT EXISTS sessions (
+              token_hash TEXT PRIMARY KEY,
+              fde_id TEXT NOT NULL REFERENCES fdes(id) ON DELETE CASCADE,
+              created_at TEXT NOT NULL,
+              expires_at TEXT NOT NULL,
+              last_used_at TEXT
+          )""",
+          """
+          CREATE TABLE IF NOT EXISTS webauthn_challenges (
+              id TEXT PRIMARY KEY,
+              challenge TEXT NOT NULL,
+              ceremony TEXT NOT NULL CHECK (ceremony IN ('register', 'assert')),
+              fde_id TEXT REFERENCES fdes(id) ON DELETE CASCADE,
+              created_at TEXT NOT NULL,
+              expires_at TEXT NOT NULL
+          )""",
+          """
+          CREATE TABLE IF NOT EXISTS enrollment_tickets (
+              token_hash TEXT PRIMARY KEY,
+              fde_id TEXT NOT NULL REFERENCES fdes(id) ON DELETE CASCADE,
+              created_at TEXT NOT NULL,
+              expires_at TEXT NOT NULL,
+              consumed_at TEXT
+          )""",
+          "ALTER TABLE fdes ADD COLUMN role TEXT NOT NULL DEFAULT 'member'",
+          """
+          CREATE TABLE IF NOT EXISTS fde_ssh_keys (
+              fingerprint TEXT PRIMARY KEY,
+              fde_id TEXT NOT NULL REFERENCES fdes(id) ON DELETE CASCADE,
+              public_key TEXT NOT NULL,
+              comment TEXT,
+              created_at TEXT NOT NULL
+          )""",
+          """
+          CREATE TABLE IF NOT EXISTS projects (
+              name TEXT PRIMARY KEY,
+              definition TEXT NOT NULL,
+              created_by TEXT,
+              created_at TEXT NOT NULL,
+              updated_by TEXT,
+              updated_at TEXT NOT NULL
+          )""",
+          "ALTER TABLE specs ADD COLUMN rev TEXT",
+          """
+          CREATE TABLE IF NOT EXISTS change_log (
+              seq INTEGER PRIMARY KEY AUTOINCREMENT,
+              entity_type TEXT NOT NULL,
+              entity_id TEXT NOT NULL,
+              rev TEXT NOT NULL,
+              actor TEXT,
+              recorded_at TEXT NOT NULL,
+              origin TEXT NOT NULL,
+              deleted INTEGER NOT NULL DEFAULT 0,
+              snapshot TEXT NOT NULL
+          )""",
+          "CREATE INDEX IF NOT EXISTS idx_change_log_entity"
+              + " ON change_log(entity_type, entity_id, seq)",
+          "ALTER TABLE specs ADD COLUMN base_rev TEXT",
+          """
+          CREATE TABLE IF NOT EXISTS sync_conflicts (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              entity_type TEXT NOT NULL,
+              entity_id TEXT NOT NULL,
+              base_snapshot TEXT,
+              local_snapshot TEXT,
+              remote_snapshot TEXT,
+              fields TEXT NOT NULL,
+              detected_at TEXT NOT NULL,
+              status TEXT NOT NULL DEFAULT 'pending',
+              resolved_rev TEXT
+          )""",
+          "CREATE INDEX IF NOT EXISTS idx_sync_conflicts_pending"
+              + " ON sync_conflicts(status, entity_type, entity_id)",
+          """
+          CREATE TABLE IF NOT EXISTS sync_state (
+              peer TEXT PRIMARY KEY,
+              checkpoint INTEGER NOT NULL DEFAULT 0,
+              updated_at TEXT NOT NULL
+          )""",
+          """
+          CREATE TABLE IF NOT EXISTS project_files (
+              id TEXT PRIMARY KEY,
+              project TEXT NOT NULL,
+              path TEXT NOT NULL,
+              content TEXT NOT NULL,
+              rev TEXT,
+              base_rev TEXT,
+              updated_at TEXT NOT NULL,
+              UNIQUE (project, path)
+          )""",
+          "ALTER TABLE api_tokens ADD COLUMN expires_at TEXT",
+          "ALTER TABLE projects ADD COLUMN rev TEXT",
+          "ALTER TABLE projects ADD COLUMN base_rev TEXT",
+          """
+          CREATE TABLE spec_dependencies_v2 (
+              spec_id TEXT NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
+              depends_on TEXT NOT NULL,
+              PRIMARY KEY (spec_id, depends_on)
+          )""",
+          "INSERT INTO spec_dependencies_v2 (spec_id, depends_on)"
+              + " SELECT spec_id, depends_on FROM spec_dependencies",
+          "DROP TABLE spec_dependencies",
+          "ALTER TABLE spec_dependencies_v2 RENAME TO spec_dependencies",
+          "ALTER TABLE agent_sessions ADD COLUMN exit_code INTEGER",
+          "ALTER TABLE reviews ADD COLUMN superseded_at TEXT",
+          "ALTER TABLE reviews ADD COLUMN error TEXT",
+          "ALTER TABLE review_stages ADD COLUMN error TEXT",
+          """
+          CREATE TABLE IF NOT EXISTS spec_source_findings (
+              spec_id TEXT NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
+              finding_id TEXT NOT NULL REFERENCES review_findings(id) ON DELETE CASCADE,
+              PRIMARY KEY (spec_id, finding_id)
+          )""",
+          """
+          CREATE TABLE IF NOT EXISTS slack_threads (
+              project TEXT NOT NULL,
+              spec_id TEXT NOT NULL,
+              channel TEXT NOT NULL,
+              thread_ts TEXT NOT NULL,
+              created_at TEXT NOT NULL,
+              PRIMARY KEY (project, spec_id)
+          )""",
+          """
+          CREATE TABLE specs_v2 (
+              id TEXT PRIMARY KEY,
+              title TEXT NOT NULL,
+              status TEXT NOT NULL DEFAULT 'draft'
+                  CHECK (status IN ('draft', 'pending', 'in_progress', 'review', 'awaiting_merge',
+                      'done', 'archived')),
+              assignee TEXT,
+              agent TEXT,
+              model TEXT,
+              reasoning_effort TEXT
+                  CHECK (reasoning_effort IS NULL OR reasoning_effort IN ('none', 'low', 'medium', 'high', 'xhigh')),
+              branch TEXT,
+              priority INTEGER NOT NULL DEFAULT 0,
+              created_by TEXT,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              project TEXT NOT NULL DEFAULT 'unassigned',
+              updated_by TEXT,
+              rev TEXT,
+              base_rev TEXT
+          )""",
+          """
+          INSERT INTO specs_v2 (id, title, status, assignee, agent, model, reasoning_effort,
+                  branch, priority, created_by, created_at, updated_at, project, updated_by,
+                  rev, base_rev)
+              SELECT id, title, status, assignee, agent, model, reasoning_effort,
+                  branch, priority, created_by, created_at, updated_at, project, updated_by,
+                  rev, base_rev FROM specs""",
+          "DROP TABLE specs",
+          "ALTER TABLE specs_v2 RENAME TO specs",
+          "CREATE INDEX IF NOT EXISTS idx_specs_project ON specs(project)",
+          "ALTER TABLE agent_sessions ADD COLUMN watcher_pid INTEGER",
+          "ALTER TABLE agent_sessions ADD COLUMN node TEXT",
+          "ALTER TABLE agent_sessions ADD COLUMN role TEXT NOT NULL DEFAULT 'build'",
+          "ALTER TABLE agent_sessions ADD COLUMN log_path TEXT",
+          "ALTER TABLE agent_sessions ADD COLUMN rev TEXT",
+          "ALTER TABLE agent_sessions ADD COLUMN base_rev TEXT",
+          "ALTER TABLE agent_sessions RENAME TO runs",
+          "CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project)",
+          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)",
+          "DROP INDEX IF EXISTS idx_agent_sessions_project",
+          "DROP INDEX IF EXISTS idx_agent_sessions_spec",
+          "ALTER TABLE reviews ADD COLUMN rev TEXT",
+          "ALTER TABLE reviews ADD COLUMN base_rev TEXT",
+          "ALTER TABLE review_stages ADD COLUMN finding_counts TEXT",
+          """
+          CREATE TABLE reviews_v2 (
+              id TEXT PRIMARY KEY,
+              spec_id TEXT NOT NULL,
+              iteration INTEGER NOT NULL DEFAULT 1,
+              status TEXT NOT NULL DEFAULT 'pending'
+                  CHECK (status IN ('pending', 'running', 'passed', 'failed', 'escalated')),
+              created_at TEXT NOT NULL,
+              completed_at TEXT,
+              decided_by TEXT,
+              superseded_at TEXT,
+              error TEXT,
+              rev TEXT,
+              base_rev TEXT
+          )""",
+          """
+          INSERT INTO reviews_v2 (id, spec_id, iteration, status, created_at, completed_at,
+              decided_by, superseded_at, error, rev, base_rev)
+          SELECT id, spec_id, iteration, status, created_at, completed_at,
+              decided_by, superseded_at, error, rev, base_rev FROM reviews""",
+          "DROP TABLE reviews",
+          "ALTER TABLE reviews_v2 RENAME TO reviews",
+          "CREATE INDEX IF NOT EXISTS idx_reviews_spec ON reviews(spec_id)",
+          "ALTER TABLE change_log ADD COLUMN peer TEXT",
+          "ALTER TABLE runs ADD COLUMN unit TEXT",
+          "ALTER TABLE runs ADD COLUMN repos TEXT",
+          """
+          CREATE TABLE specs_v3 (
+              id TEXT PRIMARY KEY,
+              title TEXT NOT NULL,
+              status TEXT NOT NULL DEFAULT 'draft'
+                  CHECK (status IN ('draft', 'pending', 'in_progress', 'review', 'awaiting_merge',
+                      'done', 'cancelled', 'archived')),
+              assignee TEXT,
+              agent TEXT,
+              model TEXT,
+              reasoning_effort TEXT
+                  CHECK (reasoning_effort IS NULL OR reasoning_effort IN ('none', 'low', 'medium', 'high', 'xhigh')),
+              branch TEXT,
+              priority INTEGER NOT NULL DEFAULT 0,
+              created_by TEXT,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              project TEXT NOT NULL DEFAULT 'unassigned',
+              updated_by TEXT,
+              rev TEXT,
+              base_rev TEXT
+          )""",
+          """
+          INSERT INTO specs_v3 (id, title, status, assignee, agent, model, reasoning_effort,
+                  branch, priority, created_by, created_at, updated_at, project, updated_by,
+                  rev, base_rev)
+              SELECT id, title, status, assignee, agent, model, reasoning_effort,
+                  branch, priority, created_by, created_at, updated_at, project, updated_by,
+                  rev, base_rev FROM specs""",
+          "DROP TABLE specs",
+          "ALTER TABLE specs_v3 RENAME TO specs",
+          "CREATE INDEX IF NOT EXISTS idx_specs_project ON specs(project)",
+          """
+          CREATE TABLE runs_v2 (
+              id TEXT PRIMARY KEY,
+              project TEXT NOT NULL,
+              spec_id TEXT,
+              agent TEXT NOT NULL,
+              branch TEXT,
+              task TEXT,
+              pid INTEGER,
+              status TEXT NOT NULL DEFAULT 'running'
+                  CHECK (status IN ('running', 'stopping', 'completed', 'stopped', 'failed')),
+              started_at TEXT NOT NULL,
+              completed_at TEXT,
+              exit_code INTEGER,
+              watcher_pid INTEGER,
+              node TEXT,
+              role TEXT NOT NULL DEFAULT 'build',
+              log_path TEXT,
+              rev TEXT,
+              base_rev TEXT,
+              unit TEXT,
+              repos TEXT
+          )""",
+          """
+          INSERT INTO runs_v2 (id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos)
+              SELECT id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos FROM runs""",
+          "DROP TABLE runs",
+          "ALTER TABLE runs_v2 RENAME TO runs",
+          "CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project)",
+          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)",
+          "UPDATE specs SET project = 'unassigned' WHERE project IS NULL",
+          """
+          CREATE TABLE specs_v4 (
               id TEXT PRIMARY KEY,
               title TEXT NOT NULL,
               status TEXT NOT NULL DEFAULT 'draft'
@@ -49,167 +494,18 @@ final class FloorSchema {
               base_rev TEXT
           )""",
           """
-          CREATE TABLE "spec_dependencies" (
-              spec_id TEXT NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
-              depends_on TEXT NOT NULL,
-              PRIMARY KEY (spec_id, depends_on)
-          )""",
+          INSERT INTO specs_v4 (id, title, status, assignee, agent, model, reasoning_effort,
+                  branch, priority, created_by, created_at, updated_at, project, updated_by,
+                  rev, base_rev)
+              SELECT id, title, status, assignee, agent, model, reasoning_effort,
+                  branch, priority, created_by, created_at, updated_at, project, updated_by,
+                  rev, base_rev FROM specs""",
+          "DROP TABLE specs",
+          "ALTER TABLE specs_v4 RENAME TO specs",
+          "CREATE INDEX IF NOT EXISTS idx_specs_project ON specs(project)",
+          "UPDATE runs SET role = 'build' WHERE role IS NULL",
           """
-          CREATE TABLE spec_repos (
-              spec_id TEXT NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
-              repo TEXT NOT NULL,
-              PRIMARY KEY (spec_id, repo)
-          )""",
-          """
-          CREATE TABLE spec_content (
-              spec_id TEXT PRIMARY KEY REFERENCES specs(id) ON DELETE CASCADE,
-              body TEXT NOT NULL DEFAULT '',
-              plan TEXT NOT NULL DEFAULT '',
-              updated_at TEXT NOT NULL
-          )""",
-          """
-          CREATE TABLE spec_attachments (
-              id TEXT PRIMARY KEY,
-              spec_id TEXT NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
-              filename TEXT NOT NULL,
-              content_type TEXT NOT NULL,
-              size_bytes INTEGER NOT NULL,
-              storage_path TEXT NOT NULL,
-              created_at TEXT NOT NULL
-          )""",
-          """
-          CREATE TABLE events (
-              id INTEGER PRIMARY KEY AUTOINCREMENT,
-              timestamp TEXT NOT NULL,
-              type TEXT NOT NULL,
-              project TEXT,
-              spec_id TEXT,
-              agent TEXT,
-              host TEXT NOT NULL,
-              data TEXT NOT NULL DEFAULT '{}'
-          )""",
-          """
-          CREATE TABLE fdes (
-              id TEXT PRIMARY KEY,
-              handle TEXT NOT NULL UNIQUE,
-              display_name TEXT,
-              email TEXT,
-              status TEXT NOT NULL DEFAULT 'active'
-                  CHECK (status IN ('active', 'disabled')),
-              created_at TEXT NOT NULL
-          , role TEXT NOT NULL DEFAULT 'member')""",
-          """
-          CREATE TABLE "api_tokens" (
-              token_hash TEXT PRIMARY KEY,
-              name TEXT NOT NULL UNIQUE,
-              role TEXT NOT NULL DEFAULT 'member'
-                  CHECK (role IN ('admin', 'member', 'viewer')),
-              fde_id TEXT REFERENCES fdes(id) ON DELETE CASCADE,
-              created_at TEXT NOT NULL,
-              last_used_at TEXT,
-              expires_at TEXT
-          )""",
-          """
-          CREATE TABLE webauthn_credentials (
-              credential_id TEXT PRIMARY KEY,
-              fde_id TEXT NOT NULL REFERENCES fdes(id) ON DELETE CASCADE,
-              public_key_cose TEXT NOT NULL,
-              cose_algorithm INTEGER NOT NULL,
-              sign_count INTEGER NOT NULL DEFAULT 0,
-              aaguid TEXT,
-              backup_eligible INTEGER NOT NULL DEFAULT 0,
-              backup_state INTEGER NOT NULL DEFAULT 0,
-              label TEXT,
-              created_at TEXT NOT NULL,
-              last_used_at TEXT
-          )""",
-          """
-          CREATE TABLE sessions (
-              token_hash TEXT PRIMARY KEY,
-              fde_id TEXT NOT NULL REFERENCES fdes(id) ON DELETE CASCADE,
-              created_at TEXT NOT NULL,
-              expires_at TEXT NOT NULL,
-              last_used_at TEXT
-          )""",
-          """
-          CREATE TABLE webauthn_challenges (
-              id TEXT PRIMARY KEY,
-              challenge TEXT NOT NULL,
-              ceremony TEXT NOT NULL CHECK (ceremony IN ('register', 'assert')),
-              fde_id TEXT REFERENCES fdes(id) ON DELETE CASCADE,
-              created_at TEXT NOT NULL,
-              expires_at TEXT NOT NULL
-          )""",
-          """
-          CREATE TABLE enrollment_tickets (
-              token_hash TEXT PRIMARY KEY,
-              fde_id TEXT NOT NULL REFERENCES fdes(id) ON DELETE CASCADE,
-              created_at TEXT NOT NULL,
-              expires_at TEXT NOT NULL,
-              consumed_at TEXT
-          )""",
-          """
-          CREATE TABLE fde_ssh_keys (
-              fingerprint TEXT PRIMARY KEY,
-              fde_id TEXT NOT NULL REFERENCES fdes(id) ON DELETE CASCADE,
-              public_key TEXT NOT NULL,
-              comment TEXT,
-              created_at TEXT NOT NULL
-          )""",
-          """
-          CREATE TABLE "reviews" (
-              id TEXT PRIMARY KEY,
-              spec_id TEXT NOT NULL,
-              iteration INTEGER NOT NULL DEFAULT 1,
-              status TEXT NOT NULL DEFAULT 'pending'
-                  CHECK (status IN ('pending', 'running', 'passed', 'failed', 'escalated')),
-              created_at TEXT NOT NULL,
-              completed_at TEXT,
-              decided_by TEXT,
-              superseded_at TEXT,
-              error TEXT,
-              rev TEXT,
-              base_rev TEXT
-          )""",
-          """
-          CREATE TABLE review_stages (
-              id TEXT PRIMARY KEY,
-              review_id TEXT NOT NULL REFERENCES reviews(id) ON DELETE CASCADE,
-              name TEXT NOT NULL,
-              stage_type TEXT NOT NULL,
-              status TEXT NOT NULL DEFAULT 'pending'
-                  CHECK (status IN ('pending', 'running', 'passed', 'failed', 'skipped')),
-              reviewer TEXT,
-              started_at TEXT,
-              completed_at TEXT
-          , error TEXT, finding_counts TEXT)""",
-          """
-          CREATE TABLE review_findings (
-              id TEXT PRIMARY KEY,
-              stage_id TEXT NOT NULL REFERENCES review_stages(id) ON DELETE CASCADE,
-              severity TEXT NOT NULL,
-              category TEXT NOT NULL,
-              file TEXT,
-              line_start INTEGER,
-              line_end INTEGER,
-              title TEXT NOT NULL,
-              description TEXT NOT NULL,
-              evidence TEXT,
-              suggestion_before TEXT,
-              suggestion_after TEXT,
-              suggestion_rationale TEXT,
-              confidence REAL NOT NULL DEFAULT 0.0,
-              resolution TEXT NOT NULL DEFAULT 'OPEN'
-                  CHECK (resolution IN ('OPEN', 'FIXED', 'DISMISSED'))
-          )""",
-          """
-          CREATE TABLE spec_source_findings (
-              spec_id TEXT NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
-              finding_id TEXT NOT NULL REFERENCES review_findings(id) ON DELETE CASCADE,
-              PRIMARY KEY (spec_id, finding_id)
-          )""",
-          """
-          CREATE TABLE "runs" (
+          CREATE TABLE runs_v3 (
               id TEXT PRIMARY KEY,
               project TEXT NOT NULL,
               spec_id TEXT,
@@ -225,98 +521,62 @@ final class FloorSchema {
               watcher_pid INTEGER,
               node TEXT,
               role TEXT NOT NULL DEFAULT 'build'
-                  CHECK (role IN ('build', 'adhoc', 'review')),
+                  CHECK (role IN ('build', 'review')),
               log_path TEXT,
               rev TEXT,
               base_rev TEXT,
               unit TEXT,
               repos TEXT
-          , pid_ticks INTEGER)""",
+          )""",
           """
-          CREATE TABLE projects (
-              name TEXT PRIMARY KEY,
-              definition TEXT NOT NULL,
-              created_by TEXT,
+          INSERT INTO runs_v3 (id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos)
+              SELECT id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos FROM runs""",
+          "DROP TABLE runs",
+          "ALTER TABLE runs_v3 RENAME TO runs",
+          "CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project)",
+          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)",
+          """
+          DELETE FROM api_tokens
+          WHERE fde_id IS NOT NULL
+              AND NOT EXISTS (SELECT 1 FROM fdes WHERE fdes.id = api_tokens.fde_id)""",
+          """
+          CREATE TABLE api_tokens_v2 (
+              token_hash TEXT PRIMARY KEY,
+              name TEXT NOT NULL UNIQUE,
+              role TEXT NOT NULL DEFAULT 'member'
+                  CHECK (role IN ('admin', 'member', 'viewer')),
+              fde_id TEXT REFERENCES fdes(id) ON DELETE CASCADE,
               created_at TEXT NOT NULL,
-              updated_by TEXT,
-              updated_at TEXT NOT NULL
-          , rev TEXT, base_rev TEXT)""",
-          """
-          CREATE TABLE project_files (
-              id TEXT PRIMARY KEY,
-              project TEXT NOT NULL,
-              path TEXT NOT NULL,
-              content TEXT NOT NULL,
-              rev TEXT,
-              base_rev TEXT,
-              updated_at TEXT NOT NULL,
-              UNIQUE (project, path)
+              last_used_at TEXT,
+              expires_at TEXT
           )""",
           """
-          CREATE TABLE change_log (
-              seq INTEGER PRIMARY KEY AUTOINCREMENT,
-              entity_type TEXT NOT NULL,
-              entity_id TEXT NOT NULL,
-              rev TEXT NOT NULL,
-              actor TEXT,
-              recorded_at TEXT NOT NULL,
-              origin TEXT NOT NULL,
-              deleted INTEGER NOT NULL DEFAULT 0,
-              snapshot TEXT NOT NULL
-          , peer TEXT)""",
-          """
-          CREATE TABLE sync_conflicts (
-              id INTEGER PRIMARY KEY AUTOINCREMENT,
-              entity_type TEXT NOT NULL,
-              entity_id TEXT NOT NULL,
-              base_snapshot TEXT,
-              local_snapshot TEXT,
-              remote_snapshot TEXT,
-              fields TEXT NOT NULL,
-              detected_at TEXT NOT NULL,
-              status TEXT NOT NULL DEFAULT 'pending',
-              resolved_rev TEXT
-          )""",
-          """
-          CREATE TABLE sync_state (
-              peer TEXT PRIMARY KEY,
-              checkpoint INTEGER NOT NULL DEFAULT 0,
-              updated_at TEXT NOT NULL
-          )""",
-          """
-          CREATE TABLE slack_threads (
-              project TEXT NOT NULL,
-              spec_id TEXT NOT NULL,
-              channel TEXT NOT NULL,
-              thread_ts TEXT NOT NULL,
-              created_at TEXT NOT NULL,
-              PRIMARY KEY (project, spec_id)
-          )""",
-          """
-          CREATE TABLE data_migrations (
-              name TEXT PRIMARY KEY,
-              applied_at TEXT NOT NULL
-          )""",
-          "CREATE INDEX idx_specs_project ON specs(project)",
-          "CREATE INDEX idx_events_type ON events(type)",
-          "CREATE INDEX idx_events_project ON events(project)",
-          "CREATE INDEX idx_events_spec ON events(spec_id)",
-          "CREATE INDEX idx_events_timestamp ON events(timestamp DESC)",
-          "CREATE INDEX idx_webauthn_credentials_fde ON webauthn_credentials(fde_id)",
-          "CREATE INDEX idx_reviews_spec ON reviews(spec_id)",
-          "CREATE INDEX idx_review_stages_review ON review_stages(review_id)",
-          "CREATE INDEX idx_review_findings_stage ON review_findings(stage_id)",
-          "CREATE INDEX idx_review_findings_severity ON review_findings(severity)",
-          "CREATE INDEX idx_runs_project ON runs(project)",
-          "CREATE INDEX idx_runs_spec ON runs(spec_id)",
-          "CREATE INDEX idx_change_log_entity ON change_log(entity_type, entity_id, seq)",
-          "CREATE INDEX idx_sync_conflicts_pending"
-              + " ON sync_conflicts(status, entity_type, entity_id)");
+          INSERT INTO api_tokens_v2
+                  (token_hash, name, role, fde_id, created_at, last_used_at, expires_at)
+              SELECT token_hash, name, role, fde_id, created_at, last_used_at, expires_at
+              FROM api_tokens""",
+          "DROP TABLE api_tokens",
+          "ALTER TABLE api_tokens_v2 RENAME TO api_tokens");
 
   static void stage(Sqlite db) {
-    DDL.forEach(db::execute);
-    for (var version = 1; version <= SchemaManager.FLOOR_VERSION; version++) {
-      db.execute("INSERT INTO schema_version (version, applied_at) VALUES (?, 'staged')", version);
+    db.execute("PRAGMA foreign_keys = OFF");
+    try {
+      for (var i = 0; i < CHAIN.size(); i++) {
+        var version = i + 1;
+        var sql = CHAIN.get(i);
+        db.transaction(
+            () -> {
+              db.execute(sql);
+              db.execute(
+                  "INSERT INTO schema_version (version, applied_at) VALUES (?, 'staged')", version);
+            });
+      }
+    } finally {
+      db.execute("PRAGMA foreign_keys = ON");
     }
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/store/FloorSchema.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FloorSchema.java
@@ -8,34 +8,25 @@ package ai.singlr.sail.store;
 import java.util.List;
 
 /**
- * Manages SQLite schema versioning against the v1 baseline. A fresh database gets the current
- * schema in one shot; a database at the published 0.14 floor (schema v{@value #FLOOR_VERSION},
- * structurally identical to the baseline) is stamped forward in one step; anything below the floor
- * is refused with the remedy, never silently replayed. The pre-1.0 migration chain lives in git
- * history only.
- *
- * <p>Policy: migrations are append-only within a major version, and baselining like this happens
- * only at a major version with a published floor. See ARCHITECTURE.md.
+ * The v1 upgrade floor contract: the exact {@code sqlite_master} contents of a fully-migrated sail
+ * 0.14.x database, captured verbatim (including the quoted names and appended-column artifacts its
+ * rebuild-heavy migration chain left behind) before that chain was deleted. Tests stage a floor
+ * database from this fixture to prove the one-step on-ramp into the v1 baseline; if the baseline
+ * ever drifts from this shape, the schema-diff test fails and the floor has been broken.
  */
-public final class SchemaManager {
+final class FloorSchema {
 
-  /** The schema version a fully-migrated sail 0.14.x database carries: the v1 upgrade floor. */
-  static final int FLOOR_VERSION = 125;
+  private FloorSchema() {}
 
-  /** The v1 baseline version, one step past the floor it is structurally identical to. */
-  static final int V1_VERSION = FLOOR_VERSION + 1;
-
-  private static final String SCHEMA_VERSION_TABLE =
-      """
-      CREATE TABLE IF NOT EXISTS schema_version (
-          version INTEGER PRIMARY KEY,
-          applied_at TEXT NOT NULL
-      )""";
-
-  private static final List<String> BASELINE =
+  private static final List<String> DDL =
       List.of(
           """
-          CREATE TABLE specs (
+          CREATE TABLE schema_version (
+              version INTEGER PRIMARY KEY,
+              applied_at TEXT NOT NULL
+          )""",
+          """
+          CREATE TABLE "specs" (
               id TEXT PRIMARY KEY,
               title TEXT NOT NULL,
               status TEXT NOT NULL DEFAULT 'draft'
@@ -57,9 +48,8 @@ public final class SchemaManager {
               rev TEXT,
               base_rev TEXT
           )""",
-          "CREATE INDEX idx_specs_project ON specs(project)",
           """
-          CREATE TABLE spec_dependencies (
+          CREATE TABLE "spec_dependencies" (
               spec_id TEXT NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
               depends_on TEXT NOT NULL,
               PRIMARY KEY (spec_id, depends_on)
@@ -98,10 +88,6 @@ public final class SchemaManager {
               host TEXT NOT NULL,
               data TEXT NOT NULL DEFAULT '{}'
           )""",
-          "CREATE INDEX idx_events_type ON events(type)",
-          "CREATE INDEX idx_events_project ON events(project)",
-          "CREATE INDEX idx_events_spec ON events(spec_id)",
-          "CREATE INDEX idx_events_timestamp ON events(timestamp DESC)",
           """
           CREATE TABLE fdes (
               id TEXT PRIMARY KEY,
@@ -110,11 +96,10 @@ public final class SchemaManager {
               email TEXT,
               status TEXT NOT NULL DEFAULT 'active'
                   CHECK (status IN ('active', 'disabled')),
-              created_at TEXT NOT NULL,
-              role TEXT NOT NULL DEFAULT 'member'
-          )""",
+              created_at TEXT NOT NULL
+          , role TEXT NOT NULL DEFAULT 'member')""",
           """
-          CREATE TABLE api_tokens (
+          CREATE TABLE "api_tokens" (
               token_hash TEXT PRIMARY KEY,
               name TEXT NOT NULL UNIQUE,
               role TEXT NOT NULL DEFAULT 'member'
@@ -138,7 +123,6 @@ public final class SchemaManager {
               created_at TEXT NOT NULL,
               last_used_at TEXT
           )""",
-          "CREATE INDEX idx_webauthn_credentials_fde ON webauthn_credentials(fde_id)",
           """
           CREATE TABLE sessions (
               token_hash TEXT PRIMARY KEY,
@@ -173,7 +157,7 @@ public final class SchemaManager {
               created_at TEXT NOT NULL
           )""",
           """
-          CREATE TABLE reviews (
+          CREATE TABLE "reviews" (
               id TEXT PRIMARY KEY,
               spec_id TEXT NOT NULL,
               iteration INTEGER NOT NULL DEFAULT 1,
@@ -187,7 +171,6 @@ public final class SchemaManager {
               rev TEXT,
               base_rev TEXT
           )""",
-          "CREATE INDEX idx_reviews_spec ON reviews(spec_id)",
           """
           CREATE TABLE review_stages (
               id TEXT PRIMARY KEY,
@@ -198,11 +181,8 @@ public final class SchemaManager {
                   CHECK (status IN ('pending', 'running', 'passed', 'failed', 'skipped')),
               reviewer TEXT,
               started_at TEXT,
-              completed_at TEXT,
-              error TEXT,
-              finding_counts TEXT
-          )""",
-          "CREATE INDEX idx_review_stages_review ON review_stages(review_id)",
+              completed_at TEXT
+          , error TEXT, finding_counts TEXT)""",
           """
           CREATE TABLE review_findings (
               id TEXT PRIMARY KEY,
@@ -222,8 +202,6 @@ public final class SchemaManager {
               resolution TEXT NOT NULL DEFAULT 'OPEN'
                   CHECK (resolution IN ('OPEN', 'FIXED', 'DISMISSED'))
           )""",
-          "CREATE INDEX idx_review_findings_stage ON review_findings(stage_id)",
-          "CREATE INDEX idx_review_findings_severity ON review_findings(severity)",
           """
           CREATE TABLE spec_source_findings (
               spec_id TEXT NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
@@ -231,7 +209,7 @@ public final class SchemaManager {
               PRIMARY KEY (spec_id, finding_id)
           )""",
           """
-          CREATE TABLE runs (
+          CREATE TABLE "runs" (
               id TEXT PRIMARY KEY,
               project TEXT NOT NULL,
               spec_id TEXT,
@@ -252,11 +230,8 @@ public final class SchemaManager {
               rev TEXT,
               base_rev TEXT,
               unit TEXT,
-              repos TEXT,
-              pid_ticks INTEGER
-          )""",
-          "CREATE INDEX idx_runs_project ON runs(project)",
-          "CREATE INDEX idx_runs_spec ON runs(spec_id)",
+              repos TEXT
+          , pid_ticks INTEGER)""",
           """
           CREATE TABLE projects (
               name TEXT PRIMARY KEY,
@@ -264,10 +239,8 @@ public final class SchemaManager {
               created_by TEXT,
               created_at TEXT NOT NULL,
               updated_by TEXT,
-              updated_at TEXT NOT NULL,
-              rev TEXT,
-              base_rev TEXT
-          )""",
+              updated_at TEXT NOT NULL
+          , rev TEXT, base_rev TEXT)""",
           """
           CREATE TABLE project_files (
               id TEXT PRIMARY KEY,
@@ -289,10 +262,8 @@ public final class SchemaManager {
               recorded_at TEXT NOT NULL,
               origin TEXT NOT NULL,
               deleted INTEGER NOT NULL DEFAULT 0,
-              snapshot TEXT NOT NULL,
-              peer TEXT
-          )""",
-          "CREATE INDEX idx_change_log_entity ON change_log(entity_type, entity_id, seq)",
+              snapshot TEXT NOT NULL
+          , peer TEXT)""",
           """
           CREATE TABLE sync_conflicts (
               id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -306,8 +277,6 @@ public final class SchemaManager {
               status TEXT NOT NULL DEFAULT 'pending',
               resolved_rev TEXT
           )""",
-          "CREATE INDEX idx_sync_conflicts_pending"
-              + " ON sync_conflicts(status, entity_type, entity_id)",
           """
           CREATE TABLE sync_state (
               peer TEXT PRIMARY KEY,
@@ -327,69 +296,27 @@ public final class SchemaManager {
           CREATE TABLE data_migrations (
               name TEXT PRIMARY KEY,
               applied_at TEXT NOT NULL
-          )""");
+          )""",
+          "CREATE INDEX idx_specs_project ON specs(project)",
+          "CREATE INDEX idx_events_type ON events(type)",
+          "CREATE INDEX idx_events_project ON events(project)",
+          "CREATE INDEX idx_events_spec ON events(spec_id)",
+          "CREATE INDEX idx_events_timestamp ON events(timestamp DESC)",
+          "CREATE INDEX idx_webauthn_credentials_fde ON webauthn_credentials(fde_id)",
+          "CREATE INDEX idx_reviews_spec ON reviews(spec_id)",
+          "CREATE INDEX idx_review_stages_review ON review_stages(review_id)",
+          "CREATE INDEX idx_review_findings_stage ON review_findings(stage_id)",
+          "CREATE INDEX idx_review_findings_severity ON review_findings(severity)",
+          "CREATE INDEX idx_runs_project ON runs(project)",
+          "CREATE INDEX idx_runs_spec ON runs(spec_id)",
+          "CREATE INDEX idx_change_log_entity ON change_log(entity_type, entity_id, seq)",
+          "CREATE INDEX idx_sync_conflicts_pending"
+              + " ON sync_conflicts(status, entity_type, entity_id)");
 
-  private final Sqlite db;
-
-  public SchemaManager(Sqlite db) {
-    this.db = db;
-  }
-
-  /**
-   * Converges the schema to the v1 baseline. A fresh database gets the baseline directly; a
-   * database at the 0.14 floor is stamped forward in one step (the floor schema and the baseline
-   * are structurally identical); a database below the floor raises {@link PreFloorException} with
-   * the remedy, because this release no longer carries the pre-1.0 migration chain. Idempotent:
-   * re-running on a current database is a no-op.
-   */
-  public void migrate() {
-    db.execute(SCHEMA_VERSION_TABLE);
-    var current = currentVersion();
-    if (current >= V1_VERSION) {
-      return;
-    }
-    if (current == 0) {
-      db.transaction(
-          () -> {
-            BASELINE.forEach(db::execute);
-            stamp();
-          });
-      return;
-    }
-    if (current == FLOOR_VERSION) {
-      db.transaction(this::stamp);
-      return;
-    }
-    throw new PreFloorException(
-        "This database is schema v"
-            + current
-            + ", below the sail 1.0 floor (schema v"
-            + FLOOR_VERSION
-            + "), and this release does not carry pre-floor migrations."
-            + " Install sail 0.14.x and run 'sail upgrade', then retry.");
-  }
-
-  private void stamp() {
-    db.execute(
-        "INSERT INTO schema_version (version, applied_at) VALUES (?, datetime('now'))", V1_VERSION);
-  }
-
-  /**
-   * A database below the v1 schema floor: only a sail 0.14.x binary can carry it forward. Kept
-   * distinct so callers can surface the message without re-wrapping.
-   */
-  public static final class PreFloorException extends IllegalStateException {
-    PreFloorException(String message) {
-      super(message);
-    }
-  }
-
-  public int currentVersion() {
-    try {
-      return db.queryOne("SELECT MAX(version) FROM schema_version", row -> (int) row.integer(0))
-          .orElse(0);
-    } catch (SqliteException e) {
-      return 0;
+  static void stage(Sqlite db) {
+    DDL.forEach(db::execute);
+    for (var version = 1; version <= SchemaManager.FLOOR_VERSION; version++) {
+      db.execute("INSERT INTO schema_version (version, applied_at) VALUES (?, 'staged')", version);
     }
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/store/LegacyDataMigrationTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/LegacyDataMigrationTest.java
@@ -8,7 +8,6 @@ package ai.singlr.sail.store;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -21,17 +20,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+/**
+ * The 0.14 data-floor repair running on a floor-schema database that the v1 on-ramp carries
+ * forward: unassigned specs, node-less runs, and unjournaled rows are exactly what an interrupted
+ * 0.14 'sail migrate' leaves behind.
+ */
 class LegacyDataMigrationTest {
 
   @TempDir Path tempDir;
-  private Path dbPath;
   private Sqlite db;
 
   @BeforeEach
   void setUp() {
-    dbPath = tempDir.resolve("legacy.db");
-    db = Sqlite.open(dbPath);
-    stageLegacySchema();
+    db = Sqlite.open(tempDir.resolve("legacy.db"));
+    FloorSchema.stage(db);
   }
 
   @AfterEach
@@ -71,21 +73,11 @@ class LegacyDataMigrationTest {
             "SELECT DISTINCT entity_type FROM change_log ORDER BY entity_type",
             row -> row.text(0)));
 
-    assertRoleConstraint();
-    assertProjectConstraint();
     db.execute("DELETE FROM fdes WHERE id = 'fde-1'");
     assertEquals(
         0L,
         db.queryOne(
                 "SELECT COUNT(*) FROM api_tokens WHERE token_hash = 'token-1'",
-                row -> row.integer(0))
-            .orElseThrow());
-    assertEquals(
-        0L,
-        db.queryOne(
-                """
-                SELECT COUNT(*) FROM api_tokens
-                WHERE token_hash = 'orphan-token' AND fde_id IS NULL""",
                 row -> row.integer(0))
             .orElseThrow());
 
@@ -120,7 +112,7 @@ class LegacyDataMigrationTest {
     db.execute(
         """
         INSERT INTO specs (id, title, status, created_at, updated_at, project)
-        VALUES ('orphan', 'Orphan', 'pending', '2026-01-01', '2026-01-01', NULL)""");
+        VALUES ('orphan', 'Orphan', 'pending', '2026-01-01', '2026-01-01', 'unassigned')""");
     var projects = projectRegistry("acme", "beta");
 
     var failure = assertThrows(IllegalStateException.class, () -> migrate(projects));
@@ -163,11 +155,11 @@ class LegacyDataMigrationTest {
     db.execute(
         """
         INSERT INTO specs (id, title, status, created_at, updated_at, project)
-        VALUES ('shared', 'Shared', 'pending', '2026-01-01', '2026-01-01', NULL)""");
+        VALUES ('shared', 'Shared', 'pending', '2026-01-01', '2026-01-01', 'unassigned')""");
     var legacyStore = new SpecStore(db);
     legacyStore.recordRevision("shared", "local", false);
     var legacyRev = legacyStore.latestRev("shared");
-    assertNull(legacyStore.comparableAtRev("shared", legacyRev).get("project"));
+    assertEquals("unassigned", legacyStore.comparableAtRev("shared", legacyRev).get("project"));
 
     migrate(projectRegistry("acme"));
 
@@ -175,7 +167,7 @@ class LegacyDataMigrationTest {
     var migratedRev = migratedStore.latestRev("shared");
     assertNotEquals(legacyRev, migratedRev);
     assertEquals("acme", migratedStore.comparableAtRev("shared", migratedRev).get("project"));
-    assertNull(migratedStore.comparableAtRev("shared", legacyRev).get("project"));
+    assertEquals("unassigned", migratedStore.comparableAtRev("shared", legacyRev).get("project"));
     assertEquals(
         List.of("local", "migration"),
         new ChangeLog(db).history("spec", "shared").stream().map(ChangeLog.Entry::origin).toList());
@@ -186,19 +178,18 @@ class LegacyDataMigrationTest {
     db.execute(
         """
         INSERT INTO specs (id, title, status, created_at, updated_at, project)
-        VALUES ('shared', 'Shared', 'pending', '2026-01-01', '2026-01-01', NULL)""");
+        VALUES ('shared', 'Shared', 'pending', '2026-01-01', '2026-01-01', 'unassigned')""");
     var projects = projectRegistry("acme");
     migrate(projects);
     var firstRev = new SpecStore(db).latestRev("shared");
 
-    var otherPath = tempDir.resolve("other.db");
-    stageLegacySchema(Sqlite.open(otherPath));
-    try (var other = Sqlite.open(otherPath)) {
+    try (var other = Sqlite.open(tempDir.resolve("other.db"))) {
+      FloorSchema.stage(other);
       other.execute(
           """
           INSERT INTO specs (id, title, status, created_at, updated_at, project)
-          VALUES ('shared', 'Shared', 'pending', '2026-01-01', '2026-01-01', NULL)""");
-      new SchemaManager(other).migrateAll();
+          VALUES ('shared', 'Shared', 'pending', '2026-01-01', '2026-01-01', 'unassigned')""");
+      new SchemaManager(other).migrate();
       new DataMigrator(other, List.of(new LegacyDataMigration(() -> "node-b")))
           .run(projects, DataMigration.Prompter.NON_INTERACTIVE);
 
@@ -207,7 +198,7 @@ class LegacyDataMigrationTest {
   }
 
   private List<DataMigrator.Run> migrate(ProjectRegistry projects) {
-    new SchemaManager(db).migrateAll();
+    new SchemaManager(db).migrate();
     return new DataMigrator(db, List.of(new LegacyDataMigration(() -> "node-a")))
         .run(projects, DataMigration.Prompter.NON_INTERACTIVE);
   }
@@ -216,7 +207,7 @@ class LegacyDataMigrationTest {
     db.execute(
         """
         INSERT INTO specs (id, title, status, created_at, updated_at, project)
-        VALUES ('legacy-spec', 'Legacy', 'in_progress', '2026-01-01', '2026-01-01', NULL)""");
+        VALUES ('legacy-spec', 'Legacy', 'in_progress', '2026-01-01', '2026-01-01', 'unassigned')""");
     db.execute(
         """
         INSERT INTO projects (name, definition, created_at, updated_at)
@@ -231,7 +222,7 @@ class LegacyDataMigrationTest {
             (id, project, spec_id, agent, status, started_at, node, role, unit)
         VALUES
             ('legacy-build', 'acme', 'legacy-spec', 'codex', 'running', '2026-01-01',
-                NULL, NULL, ''),
+                NULL, 'build', ''),
             ('review-run', 'acme', 'legacy-spec', 'codex', 'running', '2026-01-01',
                 NULL, 'review', '')""");
     db.execute(
@@ -241,37 +232,7 @@ class LegacyDataMigrationTest {
     db.execute(
         """
         INSERT INTO api_tokens (token_hash, name, role, fde_id, created_at)
-        VALUES
-            ('token-1', 'legacy', 'member', 'fde-1', '2026-01-01'),
-            ('orphan-token', 'orphan', 'member', 'missing', '2026-01-01')""");
-  }
-
-  private void assertRoleConstraint() {
-    var notNull =
-        db.queryOne(
-                "SELECT \"notnull\" FROM pragma_table_info('runs') WHERE name = 'role'",
-                row -> row.integer(0))
-            .orElseThrow();
-    assertEquals(1L, notNull);
-    assertThrows(
-        SqliteException.class,
-        () ->
-            db.execute(
-                """
-                INSERT INTO runs (id, project, agent, status, started_at, role)
-                VALUES ('bad-role', 'acme', 'codex', 'running', '2026-01-01', 'other')"""));
-  }
-
-  private void assertProjectConstraint() {
-    var notNull =
-        db.queryOne(
-                "SELECT \"notnull\" FROM pragma_table_info('specs') WHERE name = 'project'",
-                row -> row.integer(0))
-            .orElseThrow();
-    assertEquals(1L, notNull);
-    assertThrows(
-        SqliteException.class,
-        () -> db.execute("UPDATE specs SET project = NULL WHERE id = 'legacy-spec'"));
+        VALUES ('token-1', 'legacy', 'member', 'fde-1', '2026-01-01')""");
   }
 
   private long changeLogCount() {
@@ -290,45 +251,5 @@ class LegacyDataMigrationTest {
               + "\nimage: ubuntu/24.04\nresources: { cpu: 2, memory: 4GB, disk: 20GB }\n");
     }
     return ProjectRegistry.loadFromDisk(projectsDir);
-  }
-
-  private void stageLegacySchema() {
-    stageLegacySchema(db);
-    db = Sqlite.open(dbPath);
-  }
-
-  private static void stageLegacySchema(Sqlite legacy) {
-    new SchemaManager(legacy).migrateTo(SchemaManager.LAST_VERSION_BEFORE_V1_FLOOR);
-    relaxColumn(legacy, "runs", "role TEXT NOT NULL DEFAULT 'build'", "role TEXT DEFAULT 'build'");
-    relaxColumn(
-        legacy,
-        "specs",
-        "project TEXT NOT NULL DEFAULT 'unassigned'",
-        "project TEXT DEFAULT 'unassigned'");
-    legacy.close();
-  }
-
-  private static void relaxColumn(Sqlite legacy, String table, String strict, String relaxed) {
-    var ddl =
-        legacy
-            .queryOne(
-                "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ?",
-                row -> row.text(0),
-                table)
-            .orElseThrow();
-    if (!ddl.contains(strict)) {
-      throw new IllegalStateException(
-          "Legacy staging expected '" + strict + "' in the " + table + " DDL: " + ddl);
-    }
-    var legacyDdl =
-        ddl.replace(strict, relaxed)
-            .replace("CREATE TABLE \"" + table + "\"", "CREATE TABLE " + table + "_legacy")
-            .replace("CREATE TABLE " + table + " ", "CREATE TABLE " + table + "_legacy ");
-    legacy.execute("PRAGMA foreign_keys = OFF");
-    legacy.execute(legacyDdl);
-    legacy.execute("INSERT INTO " + table + "_legacy SELECT * FROM " + table);
-    legacy.execute("DROP TABLE " + table);
-    legacy.execute("ALTER TABLE " + table + "_legacy RENAME TO " + table);
-    legacy.execute("PRAGMA foreign_keys = ON");
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -174,7 +174,7 @@ class SchemaManagerTest {
 
   @Test
   void migrateRefusesABelowFloorDatabaseWithTheRemedy() {
-    stageBelowFloor(37);
+    stageAtVersion(37);
     var schema = new SchemaManager(db);
 
     var refusal = assertThrows(SchemaManager.PreFloorException.class, schema::migrate);
@@ -182,7 +182,7 @@ class SchemaManagerTest {
     assertTrue(refusal.getMessage().contains("schema v37"));
     assertTrue(refusal.getMessage().contains("schema v" + SchemaManager.FLOOR_VERSION));
     assertTrue(refusal.getMessage().contains("0.14"));
-    assertTrue(refusal.getMessage().contains("sail upgrade"));
+    assertTrue(refusal.getMessage().contains("sail migrate"));
     assertEquals(37, schema.currentVersion());
     assertEquals(
         List.of("schema_version"),
@@ -193,9 +193,21 @@ class SchemaManagerTest {
 
   @Test
   void migrateRefusesTheVersionJustBelowTheFloor() {
-    stageBelowFloor(SchemaManager.FLOOR_VERSION - 1);
+    stageAtVersion(SchemaManager.FLOOR_VERSION - 1);
 
     assertThrows(SchemaManager.PreFloorException.class, () -> new SchemaManager(db).migrate());
+  }
+
+  @Test
+  void migrateRefusesADatabaseNewerThanThisBinary() {
+    stageAtVersion(SchemaManager.V1_VERSION + 1);
+    var schema = new SchemaManager(db);
+
+    var refusal = assertThrows(IllegalStateException.class, schema::migrate);
+
+    assertTrue(refusal.getMessage().contains("schema v" + (SchemaManager.V1_VERSION + 1)));
+    assertTrue(refusal.getMessage().contains("newer than this Sail binary"));
+    assertEquals(SchemaManager.V1_VERSION + 1, schema.currentVersion());
   }
 
   @Test
@@ -214,7 +226,7 @@ class SchemaManagerTest {
     assertTrue(indexes.contains("idx_runs_spec"));
   }
 
-  private void stageBelowFloor(int version) {
+  private void stageAtVersion(int version) {
     db.execute(
         "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)");
     for (var v = 1; v <= version; v++) {

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -48,6 +48,8 @@ class SchemaManagerTest {
     assertTrue(tables.contains("events"));
     assertTrue(tables.contains("api_tokens"));
     assertTrue(tables.contains("schema_version"));
+    assertTrue(tables.contains("runs"));
+    assertFalse(tables.contains("agent_sessions"));
   }
 
   @Test
@@ -68,10 +70,10 @@ class SchemaManagerTest {
   }
 
   @Test
-  void currentVersionMatchesMigrationCount() {
+  void freshInstallStampsTheV1BaselineVersion() {
     var schema = new SchemaManager(db);
     schema.migrate();
-    assertTrue(schema.currentVersion() > 0);
+    assertEquals(SchemaManager.V1_VERSION, schema.currentVersion());
   }
 
   @Test
@@ -100,60 +102,13 @@ class SchemaManagerTest {
   }
 
   @Test
-  void specsRebuildPreservesRowsAndChildren() {
-    var schema = new SchemaManager(db);
-    schema.migrateTo(SchemaManager.LAST_VERSION_WITH_NARROW_STATUS_CHECK);
-    db.execute(
-        "INSERT INTO specs (id, title, status, priority, created_at, updated_at, project,"
-            + " updated_by, rev, base_rev)"
-            + " VALUES ('auth', 'OAuth', 'review', 7, 'c', 'u', 'acme', 'uday', 'r1', 'r0')");
-    db.execute(
-        "INSERT INTO spec_content (spec_id, body, plan, updated_at)"
-            + " VALUES ('auth', 'body', 'plan', 't')");
-    db.execute("INSERT INTO spec_repos (spec_id, repo) VALUES ('auth', 'api')");
-    db.execute("INSERT INTO spec_dependencies (spec_id, depends_on) VALUES ('auth', 'base')");
-    db.execute(
-        "INSERT INTO reviews (id, spec_id, iteration, status, created_at)"
-            + " VALUES ('rev-1', 'auth', 1, 'passed', 't')");
-
-    schema.migrateAll();
-
-    var row =
-        db.queryOne(
-                "SELECT title, status, priority, project, updated_by, rev, base_rev"
-                    + " FROM specs WHERE id = 'auth'",
-                r ->
-                    List.of(
-                        r.text(0),
-                        r.text(1),
-                        String.valueOf(r.integer(2)),
-                        r.text(3),
-                        r.text(4),
-                        r.text(5),
-                        r.text(6)))
-            .orElseThrow();
-    assertEquals(List.of("OAuth", "review", "7", "acme", "uday", "r1", "r0"), row);
-    assertEquals(
-        "body",
-        db.queryOne("SELECT body FROM spec_content WHERE spec_id = 'auth'", r -> r.text(0))
-            .orElseThrow());
-    assertEquals(
-        "api",
-        db.queryOne("SELECT repo FROM spec_repos WHERE spec_id = 'auth'", r -> r.text(0))
-            .orElseThrow());
-    assertTrue(db.query("PRAGMA foreign_key_check", r -> r.text(0)).isEmpty());
-  }
-
-  @Test
-  void specsRebuildKeepsChildCascadesWired() {
-    var schema = new SchemaManager(db);
-    schema.migrateTo(SchemaManager.LAST_VERSION_WITH_NARROW_STATUS_CHECK);
+  void baselineWiresChildCascades() {
+    new SchemaManager(db).migrate();
     db.execute(
         "INSERT INTO specs (id, title, status, created_at, updated_at)"
             + " VALUES ('auth', 'OAuth', 'pending', 't', 't')");
     db.execute(
         "INSERT INTO spec_content (spec_id, body, plan, updated_at) VALUES ('auth', 'b', 'p', 't')");
-    schema.migrateAll();
 
     db.execute("DELETE FROM specs WHERE id = 'auth'");
 
@@ -163,29 +118,84 @@ class SchemaManagerTest {
   }
 
   @Test
-  void migrateRefusesToCarryAnUnrepairedDatabaseAcrossTheFloor() {
-    var schema = new SchemaManager(db);
-    schema.migrateTo(SchemaManager.LAST_VERSION_BEFORE_V1_FLOOR);
-    var staged = schema.currentVersion();
+  void freshBaselineEqualsFloorPlusOnRamp() {
+    new SchemaManager(db).migrate();
+    try (var floor = Sqlite.open(tempDir.resolve("floor.db"))) {
+      FloorSchema.stage(floor);
+      new SchemaManager(floor).migrate();
 
-    var refusal = assertThrows(SchemaManager.PreFloorException.class, schema::migrate);
-
-    assertTrue(refusal.getMessage().contains("sail migrate"));
-    assertTrue(refusal.getMessage().contains(LegacyDataMigration.NAME));
-    assertEquals(staged, schema.currentVersion());
+      assertEquals(canonicalSchema(db), canonicalSchema(floor));
+    }
   }
 
   @Test
-  void migrateCrossesTheFloorWhenTheDataMigrationAlreadyRan() {
+  void migrateOnRampsAFloorDatabaseInOneStepPreservingRows() {
+    try (var floor = Sqlite.open(tempDir.resolve("floor.db"))) {
+      FloorSchema.stage(floor);
+      floor.execute(
+          "INSERT INTO specs (id, title, status, priority, created_at, updated_at, project,"
+              + " updated_by, rev, base_rev)"
+              + " VALUES ('auth', 'OAuth', 'review', 7, 'c', 'u', 'acme', 'uday', 'r1', 'r0')");
+      floor.execute(
+          "INSERT INTO spec_content (spec_id, body, plan, updated_at)"
+              + " VALUES ('auth', 'body', 'plan', 't')");
+      var schema = new SchemaManager(floor);
+      assertEquals(SchemaManager.FLOOR_VERSION, schema.currentVersion());
+
+      schema.migrate();
+
+      assertEquals(SchemaManager.V1_VERSION, schema.currentVersion());
+      var row =
+          floor
+              .queryOne(
+                  "SELECT title, status, priority, project, updated_by, rev, base_rev"
+                      + " FROM specs WHERE id = 'auth'",
+                  r ->
+                      List.of(
+                          r.text(0),
+                          r.text(1),
+                          String.valueOf(r.integer(2)),
+                          r.text(3),
+                          r.text(4),
+                          r.text(5),
+                          r.text(6)))
+              .orElseThrow();
+      assertEquals(List.of("OAuth", "review", "7", "acme", "uday", "r1", "r0"), row);
+      assertEquals(
+          "body",
+          floor
+              .queryOne("SELECT body FROM spec_content WHERE spec_id = 'auth'", r -> r.text(0))
+              .orElseThrow());
+
+      schema.migrate();
+      assertEquals(SchemaManager.V1_VERSION, schema.currentVersion());
+    }
+  }
+
+  @Test
+  void migrateRefusesABelowFloorDatabaseWithTheRemedy() {
+    stageBelowFloor(37);
     var schema = new SchemaManager(db);
-    schema.migrateTo(SchemaManager.LAST_VERSION_BEFORE_V1_FLOOR);
-    db.execute(
-        "INSERT INTO data_migrations (name, applied_at) VALUES (?, 'test')",
-        LegacyDataMigration.NAME);
 
-    schema.migrate();
+    var refusal = assertThrows(SchemaManager.PreFloorException.class, schema::migrate);
 
-    assertTrue(schema.currentVersion() > SchemaManager.LAST_VERSION_BEFORE_V1_FLOOR);
+    assertTrue(refusal.getMessage().contains("schema v37"));
+    assertTrue(refusal.getMessage().contains("schema v" + SchemaManager.FLOOR_VERSION));
+    assertTrue(refusal.getMessage().contains("0.14"));
+    assertTrue(refusal.getMessage().contains("sail upgrade"));
+    assertEquals(37, schema.currentVersion());
+    assertEquals(
+        List.of("schema_version"),
+        db.query(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+            row -> row.text(0)));
+  }
+
+  @Test
+  void migrateRefusesTheVersionJustBelowTheFloor() {
+    stageBelowFloor(SchemaManager.FLOOR_VERSION - 1);
+
+    assertThrows(SchemaManager.PreFloorException.class, () -> new SchemaManager(db).migrate());
   }
 
   @Test
@@ -200,24 +210,27 @@ class SchemaManagerTest {
     assertTrue(indexes.contains("idx_events_project"));
     assertTrue(indexes.contains("idx_events_spec"));
     assertTrue(indexes.contains("idx_events_timestamp"));
-  }
-
-  @Test
-  void migrateRenamesAgentSessionsToRunsAndDropsStaleIndexes() {
-    new SchemaManager(db).migrate();
-
-    var tables =
-        db.query("SELECT name FROM sqlite_master WHERE type = 'table'", row -> row.text(0));
-    assertTrue(tables.contains("runs"));
-    assertFalse(tables.contains("agent_sessions"));
-
-    var indexes =
-        db.query(
-            "SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_%'",
-            row -> row.text(0));
     assertTrue(indexes.contains("idx_runs_project"));
     assertTrue(indexes.contains("idx_runs_spec"));
-    assertFalse(indexes.contains("idx_agent_sessions_project"));
-    assertFalse(indexes.contains("idx_agent_sessions_spec"));
+  }
+
+  private void stageBelowFloor(int version) {
+    db.execute(
+        "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)");
+    for (var v = 1; v <= version; v++) {
+      db.execute("INSERT INTO schema_version (version, applied_at) VALUES (?, 'staged')", v);
+    }
+  }
+
+  private static List<String> canonicalSchema(Sqlite database) {
+    return database.query(
+        "SELECT type, name, tbl_name, sql FROM sqlite_master"
+            + " WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%'"
+            + " ORDER BY type, name",
+        row -> row.text(0) + "|" + row.text(1) + "|" + row.text(2) + "|" + canonical(row.text(3)));
+  }
+
+  private static String canonical(String sql) {
+    return sql.replace("\"", "").replaceAll("\\s+", " ").replaceAll("\\s*([(),])\\s*", "$1").trim();
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -173,6 +173,28 @@ class SchemaManagerTest {
   }
 
   @Test
+  void aMidRampDevelopmentBoxResumesAndConvergesToTheSameSchema() {
+    try (var baseline = Sqlite.open(tempDir.resolve("baseline.db"));
+        var midRamp = Sqlite.open(tempDir.resolve("mid-ramp.db"))) {
+      new SchemaManager(baseline).migrate();
+      FloorSchema.stage(midRamp);
+      midRamp.execute("PRAGMA foreign_keys = OFF");
+      for (var i = 0; i < 3; i++) {
+        midRamp.execute(SchemaManager.ON_RAMP.get(i));
+        midRamp.execute(
+            "INSERT INTO schema_version (version, applied_at) VALUES (?, 'staged')",
+            SchemaManager.FLOOR_VERSION + i + 1);
+      }
+      midRamp.execute("PRAGMA foreign_keys = ON");
+
+      new SchemaManager(midRamp).migrate();
+
+      assertEquals(SchemaManager.V1_VERSION, new SchemaManager(midRamp).currentVersion());
+      assertEquals(canonicalSchema(baseline), canonicalSchema(midRamp));
+    }
+  }
+
+  @Test
   void migrateRefusesABelowFloorDatabaseWithTheRemedy() {
     stageAtVersion(37);
     var schema = new SchemaManager(db);

--- a/sail-core/src/test/java/ai/singlr/sail/store/SyncSchemaConvergenceTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SyncSchemaConvergenceTest.java
@@ -19,20 +19,21 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Regression for the in-sync self-update incident: a node's binary was replaced mid-sync and the
- * new code wrote {@code awaiting_merge} into a specs table still carrying the old narrow CHECK
- * constraint. Every sync entry point now opens its database through {@link SyncDatabase#converge},
- * which migrates before any data is touched. Lives in the store package to reach the
- * package-private {@link SchemaManager#migrateTo} staging seam.
+ * Every sync entry point opens its database through {@link SyncDatabase#converge}, which migrates
+ * before any data is touched — the lesson of the in-sync self-update incident, where a
+ * freshly-replaced binary kept syncing against the previous release's schema. Under the v1 baseline
+ * that convergence is the floor on-ramp: a 0.14-floor database is stamped forward and syncs in the
+ * same round, and a below-floor database is refused with the remedy before any sync data moves.
+ * Lives in the store package to reach the package-private {@link FloorSchema} fixture.
  */
 class SyncSchemaConvergenceTest {
 
   @TempDir Path tempDir;
 
-  private Path stagedAtNarrowStatusCheck(String name) {
+  private Path stagedAtFloor(String name) {
     var path = tempDir.resolve(name + ".db");
     try (var db = Sqlite.open(path)) {
-      new SchemaManager(db).migrateTo(SchemaManager.LAST_VERSION_WITH_NARROW_STATUS_CHECK);
+      FloorSchema.stage(db);
       markMigrationCompleted(db);
     }
     return path;
@@ -79,21 +80,17 @@ class SyncSchemaConvergenceTest {
   }
 
   @Test
-  void theStagedSchemaRejectsAwaitingMergeWithoutConvergence() {
-    var path = stagedAtNarrowStatusCheck("raw");
-    try (var db = Sqlite.open(path)) {
-      assertThrows(
-          SqliteException.class,
-          () ->
-              db.execute(
-                  "INSERT INTO specs (id, title, status, created_at, updated_at)"
-                      + " VALUES ('m', 'M', 'awaiting_merge', 't', 't')"));
+  void convergeOnRampsAFloorDatabaseToTheBaseline() {
+    var path = stagedAtFloor("floor");
+
+    try (var converged = SyncDatabase.converge(path, "box")) {
+      assertEquals(SchemaManager.V1_VERSION, new SchemaManager(converged.db()).currentVersion());
     }
   }
 
   @Test
-  void aPulledAwaitingMergeRevisionAppliesBecauseTheReplicaOpenConvergedFirst() {
-    var nodePath = stagedAtNarrowStatusCheck("node");
+  void aPulledRevisionAppliesBecauseTheReplicaOpenOnRampedFirst() {
+    var nodePath = stagedAtFloor("node");
     try (var main = SyncDatabase.converge(currentDatabase("main"), "main");
         var node = SyncDatabase.converge(nodePath, "node")) {
       new SpecStore(main.db()).create(spec("auth", "Auth", "awaiting_merge"));
@@ -109,8 +106,8 @@ class SyncSchemaConvergenceTest {
   }
 
   @Test
-  void mainAcceptsAPushedAwaitingMergeCommitBecauseTheServingOpenConvergedFirst() {
-    var mainPath = stagedAtNarrowStatusCheck("main");
+  void mainAcceptsAPushedCommitBecauseTheServingOpenOnRampedFirst() {
+    var mainPath = stagedAtFloor("main");
     try (var main = SyncDatabase.converge(mainPath, "main");
         var node = SyncDatabase.converge(currentDatabase("node"), "node")) {
       new SpecStore(node.db()).create(spec("auth", "Auth", "awaiting_merge"));
@@ -140,33 +137,23 @@ class SyncSchemaConvergenceTest {
   }
 
   @Test
-  void convergenceRefusesToSyncUntilTheUpgradeFloorMigrationCompleted() {
+  void convergenceRefusesABelowFloorDatabaseWithTheRemedy() {
     var path = tempDir.resolve("pre-floor.db");
     try (var db = Sqlite.open(path)) {
-      new SchemaManager(db).migrateTo(SchemaManager.LAST_VERSION_BEFORE_V1_FLOOR);
       db.execute(
-          """
-          INSERT INTO runs (id, project, role, agent, status, started_at, unit)
-          VALUES ('legacy-run', 'proj', 'build', 'codex', 'running', 'test', '')""");
+          "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)");
+      db.execute("INSERT INTO schema_version (version, applied_at) VALUES (100, 'staged')");
     }
 
     var failure =
-        assertThrows(IllegalStateException.class, () -> SyncDatabase.converge(path, "box"));
+        assertThrows(
+            SchemaManager.PreFloorException.class, () -> SyncDatabase.converge(path, "box"));
 
-    assertTrue(failure.getMessage().contains(LegacyDataMigration.NAME));
-    assertTrue(failure.getMessage().contains("sail migrate"));
+    assertTrue(failure.getMessage().contains("schema v100"));
+    assertTrue(failure.getMessage().contains("0.14"));
+    assertTrue(failure.getMessage().contains("sail upgrade"));
     try (var db = Sqlite.open(path)) {
-      assertEquals(
-          0L,
-          db.queryOne(
-                  "SELECT COUNT(*) FROM data_migrations WHERE name = ?",
-                  row -> row.integer(0),
-                  LegacyDataMigration.NAME)
-              .orElseThrow());
-      assertEquals(
-          "running",
-          db.queryOne("SELECT status FROM runs WHERE id = 'legacy-run'", row -> row.text(0))
-              .orElseThrow());
+      assertEquals(100, new SchemaManager(db).currentVersion());
     }
   }
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/SyncSchemaConvergenceTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SyncSchemaConvergenceTest.java
@@ -151,7 +151,7 @@ class SyncSchemaConvergenceTest {
 
     assertTrue(failure.getMessage().contains("schema v100"));
     assertTrue(failure.getMessage().contains("0.14"));
-    assertTrue(failure.getMessage().contains("sail upgrade"));
+    assertTrue(failure.getMessage().contains("sail migrate"));
     try (var db = Sqlite.open(path)) {
       assertEquals(100, new SchemaManager(db).currentVersion());
     }

--- a/sail-core/src/test/java/ai/singlr/sail/sync/RemoteMainReplicaTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/RemoteMainReplicaTest.java
@@ -58,7 +58,7 @@ class RemoteMainReplicaTest {
 
     var failure = assertThrows(SyncTransportException.class, replica::entityIds);
 
-    assertTrue(failure.getMessage().contains("0.14.0"));
+    assertTrue(failure.getMessage().contains(SyncWire.V1_UPGRADE_FLOOR));
     assertTrue(failure.getMessage().contains("sail upgrade"));
   }
 

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncRpcServerTest.java
@@ -88,7 +88,7 @@ class SyncRpcServerTest {
     var failure =
         assertInstanceOf(SyncWire.Failed.class, serve(true, new SyncWire.Fetch("spec", null)));
 
-    assertTrue(failure.message().contains("0.14.0"));
+    assertTrue(failure.message().contains(SyncWire.V1_UPGRADE_FLOOR));
     assertTrue(failure.message().contains("sail upgrade"));
   }
 
@@ -109,7 +109,7 @@ class SyncRpcServerTest {
             response);
 
     var failure = assertInstanceOf(SyncWire.Failed.class, lastResponse(response));
-    assertTrue(failure.message().contains("0.14.0"));
+    assertTrue(failure.message().contains(SyncWire.V1_UPGRADE_FLOOR));
   }
 
   @Test


### PR DESCRIPTION
## Why

`SchemaManager.MIGRATIONS` had accumulated 125 sequential statements, including table rebuilds that existed only to escape CHECK constraints of long-dead versions. Every reader paid the archaeology tax; fresh installs replayed history instead of creating the current schema. With the 0.14 data floor established and the legacy compat branches deleted, v1 starts clean.

## What

- **Baseline**: `SchemaManager` now holds the current schema as direct CREATE statements. A fresh database gets the baseline in one transaction, stamped `v126` (one step past the floor).
- **Floor on-ramp**: a database at the 0.14 floor (schema v125) is structurally identical to the baseline by construction, so the on-ramp is a single version stamp. Pinned by a test that diffs `sqlite_master` between floor-then-onramp and fresh-baseline (byte-equal after identifier-quoting/whitespace canonicalization).
- **Below-floor refusal**: any database below v125 raises `PreFloorException` with the exact remedy — *"This database is schema v\<N\>, below the sail 1.0 floor (schema v125)... Install sail 0.14.x and run 'sail upgrade', then retry"* — never a silent attempt to replay deleted steps. `sail migrate` and every sync open (`SyncDatabase.converge`) surface the same message.
- **FloorSchema fixture**: the exact `sqlite_master` of a fully-migrated 0.14.x database, captured verbatim (quoted names, appended-column artifacts and all) before the chain was deleted. Tests stage floor databases from it.
- **Sync**: the wire handshake already enforces the 0.14 upgrade floor on peers (`SyncRpcServer` refusal tests cover it); the sync-round migrate lane now exercises the on-ramp, and a below-floor database is refused before any sync data moves.
- **LegacyDataMigration stays registered**: its stamp is the data-floor marker, and it finishes an interrupted 0.14 repair after the on-ramp.
- **Policy, written down** (ARCHITECTURE.md + new CONTRIBUTING.md): migrations are append-only within a major; baselining is allowed only at a major version with a published floor; every migration ships with a seeded-data test; no downgrade path.

## Testing

- `mvn clean verify`: 2484 tests green, all coverage gates met.
- Fleet ITs (`-Pintegration`): 24 run, 0 failures locally (incus-gated ones skip in this container and run in CI).
- New tests: fresh-baseline vs floor+on-ramp schema diff, below-floor refusal (direct and through sync converge), on-ramp row preservation and idempotence.
- The deleted chain is recoverable from git history only — no dead constants kept.