### PR TITLE
Halt verification polls to a deadline instead of probing once

### DIFF
--- a/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
@@ -218,7 +218,64 @@ public final class AgentSession {
    * SIGKILL that fails against a still-live process throws instead of returning normally, so a
    * caller can never record a successful stop for an agent that survived the signal.
    */
+  /**
+   * Halts a session. A run that owns a systemd unit is killed through the unit's whole cgroup —
+   * SIGTERM to every member, a grace period, then SIGKILL to every member — because the pid file
+   * names only the launch wrapper: signalling that single pid orphans the agent's children inside
+   * the still-active unit, which is exactly the incomplete halt the verified stop then correctly
+   * refuses. Only a unitless foreground session falls back to pid-file surgery, where the wrapper
+   * {@code exec}'d into the agent and the pid names the whole story.
+   */
   public void killAgent(String containerName, AgentUnit unit)
+      throws IOException, InterruptedException, TimeoutException {
+    if (!Strings.isBlank(unit.unitName())) {
+      killUnit(containerName, unit);
+      return;
+    }
+    killByPidFile(containerName, unit);
+  }
+
+  private void killUnit(String containerName, AgentUnit unit)
+      throws IOException, InterruptedException, TimeoutException {
+    var service = unit.service();
+    shell.exec(
+        ContainerExec.asDevUser(
+            containerName,
+            List.of("systemctl", "--user", "kill", "--kill-who=all", "--signal=SIGTERM", service)));
+
+    shell.exec(ContainerExec.asDevUser(containerName, List.of("sleep", "3")));
+
+    if (unitActive(containerName, unit)) {
+      var kill =
+          shell.exec(
+              ContainerExec.asDevUser(
+                  containerName,
+                  List.of(
+                      "systemctl",
+                      "--user",
+                      "kill",
+                      "--kill-who=all",
+                      "--signal=SIGKILL",
+                      service)));
+      if (!kill.ok() && unitActive(containerName, unit)) {
+        throw new IOException(
+            "SIGKILL for unit "
+                + service
+                + " in "
+                + containerName
+                + " failed: "
+                + kill.stderr().trim()
+                + ". Check the unit in the container and retry the stop.");
+      }
+    }
+
+    shell.exec(
+        ContainerExec.asDevUser(
+            containerName, List.of("systemctl", "--user", "reset-failed", service)));
+    shell.exec(ContainerExec.asDevUser(containerName, List.of("rm", "-f", unit.pidPath())));
+  }
+
+  private void killByPidFile(String containerName, AgentUnit unit)
       throws IOException, InterruptedException, TimeoutException {
     var pidCmd = ContainerExec.asDevUser(containerName, List.of("cat", unit.pidPath()));
     var pidResult = shell.exec(pidCmd);

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
@@ -221,48 +221,69 @@ class AgentSessionTest {
   }
 
   @Test
-  void killAgentSendsTermThenKill() throws Exception {
-    var shell =
-        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
-            .onOk("cat " + RUN_UNIT.pidPath(), "9999\n");
+  void killAgentKillsTheWholeUnitCgroupNeverABarePid() throws Exception {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
     var session = new AgentSession(shell);
 
     session.killAgent("acme-health", RUN_UNIT);
 
     var cmds = shell.invocations();
-    assertTrue(cmds.stream().anyMatch(c -> c.contains("kill 9999")));
+    var service = RUN_UNIT.service();
+    assertTrue(
+        cmds.stream().anyMatch(c -> c.contains("--kill-who=all --signal=SIGTERM " + service)),
+        "TERM must address every member of the unit cgroup");
     assertTrue(cmds.stream().anyMatch(c -> c.contains("sleep 3")));
-    assertTrue(cmds.stream().anyMatch(c -> c.contains("kill -9 9999")));
+    assertTrue(
+        cmds.stream().anyMatch(c -> c.contains("--kill-who=all --signal=SIGKILL " + service)),
+        "a unit still active after the grace gets a cgroup-wide SIGKILL");
     assertTrue(cmds.stream().anyMatch(c -> c.contains("rm -f " + RUN_UNIT.pidPath())));
+    assertTrue(
+        cmds.stream().noneMatch(c -> c.contains("kill 9999") || c.contains("kill -9 9999")),
+        "the pid file names only the launch wrapper; a bare pid kill orphans the agent's"
+            + " children inside the still-active unit");
   }
 
   @Test
-  void killAgentCleanTermination() throws Exception {
+  void killAgentSkipsSigkillWhenTheUnitDiesInTheGrace() throws Exception {
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
-            .onOk("cat " + RUN_UNIT.pidPath(), "9999\n")
-            .onFail("kill -0 9999", "No such process");
+            .onFail("is-active " + RUN_UNIT.service(), "");
     var session = new AgentSession(shell);
 
     session.killAgent("acme-health", RUN_UNIT);
 
     var cmds = shell.invocations();
-    assertFalse(cmds.stream().anyMatch(c -> c.contains("kill -9 9999")));
+    assertFalse(cmds.stream().anyMatch(c -> c.contains("--signal=SIGKILL")));
     assertTrue(cmds.stream().anyMatch(c -> c.contains("rm -f")));
+  }
+
+  @Test
+  void killAgentFallsBackToThePidFileOnlyForAUnitlessSession() throws Exception {
+    var foreground = AgentUnit.recorded(RUN_ID, "");
+    var shell =
+        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+            .onOk("cat " + foreground.pidPath(), "9999\n");
+    var session = new AgentSession(shell);
+
+    session.killAgent("acme-health", foreground);
+
+    var cmds = shell.invocations();
+    assertTrue(cmds.stream().anyMatch(c -> c.contains("kill 9999")));
+    assertTrue(cmds.stream().anyMatch(c -> c.contains("kill -9 9999")));
+    assertTrue(cmds.stream().noneMatch(c -> c.contains("systemctl --user kill")));
   }
 
   @Test
   void killAgentThrowsWhenSigkillFailsOnALiveProcess() {
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
-            .onOk("cat " + RUN_UNIT.pidPath(), "9999\n")
-            .onFail("kill -9 9999", "Operation not permitted");
+            .onFail("--signal=SIGKILL " + RUN_UNIT.service(), "Operation not permitted");
     var session = new AgentSession(shell);
 
     var failure = assertThrows(IOException.class, () -> session.killAgent("acme-health", RUN_UNIT));
 
     assertTrue(failure.getMessage().contains("SIGKILL"));
-    assertTrue(failure.getMessage().contains("9999"));
+    assertTrue(failure.getMessage().contains(RUN_UNIT.service()));
     assertFalse(shell.invocations().stream().anyMatch(c -> c.contains("rm -f")));
   }
 
@@ -285,12 +306,13 @@ class AgentSessionTest {
 
   @Test
   void killAgentIgnoresNonNumericPid() throws Exception {
+    var foreground = AgentUnit.recorded(RUN_ID, "");
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
-            .onOk("cat " + RUN_UNIT.pidPath(), "; rm -rf /\n");
+            .onOk("cat " + foreground.pidPath(), "; rm -rf /\n");
     var session = new AgentSession(shell);
 
-    session.killAgent("acme-health", RUN_UNIT);
+    session.killAgent("acme-health", foreground);
 
     var cmds = shell.invocations();
     assertEquals(1, cmds.size());
@@ -299,10 +321,11 @@ class AgentSessionTest {
 
   @Test
   void killAgentNoPidFileIsNoOp() throws Exception {
-    var shell = new ScriptedShellExecutor().onFail("cat " + RUN_UNIT.pidPath(), "No such file");
+    var foreground = AgentUnit.recorded(RUN_ID, "");
+    var shell = new ScriptedShellExecutor().onFail("cat " + foreground.pidPath(), "No such file");
     var session = new AgentSession(shell);
 
-    session.killAgent("acme-health", RUN_UNIT);
+    session.killAgent("acme-health", foreground);
 
     assertEquals(1, shell.invocations().size());
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
@@ -13,6 +13,7 @@ import ai.singlr.sail.engine.HostInfo;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -157,6 +158,12 @@ public final class StopOperations {
   private final AgentHalter halter;
   private final Listener listener;
 
+  private static final Duration HALT_VERIFY_DEADLINE = Duration.ofSeconds(10);
+  private static final Duration HALT_VERIFY_PACE = Duration.ofMillis(250);
+
+  private final Duration haltVerifyDeadline;
+  private final Duration haltVerifyPace;
+
   public StopOperations(
       ShellExec shell,
       String file,
@@ -165,6 +172,28 @@ public final class StopOperations {
       DispatchOperations.EventSink events,
       AgentHalter halter,
       Listener listener) {
+    this(
+        shell,
+        file,
+        specStore,
+        runStore,
+        events,
+        halter,
+        listener,
+        HALT_VERIFY_DEADLINE,
+        HALT_VERIFY_PACE);
+  }
+
+  StopOperations(
+      ShellExec shell,
+      String file,
+      SpecStore specStore,
+      RunStore runStore,
+      DispatchOperations.EventSink events,
+      AgentHalter halter,
+      Listener listener,
+      Duration haltVerifyDeadline,
+      Duration haltVerifyPace) {
     this.shell = Objects.requireNonNull(shell, "shell");
     this.projects = new ProjectLoader(shell, Objects.requireNonNull(file, "file"));
     this.specStore = Objects.requireNonNull(specStore, "specStore");
@@ -172,6 +201,8 @@ public final class StopOperations {
     this.events = Objects.requireNonNull(events, "events");
     this.halter = Objects.requireNonNull(halter, "halter");
     this.listener = Objects.requireNonNull(listener, "listener");
+    this.haltVerifyDeadline = Objects.requireNonNull(haltVerifyDeadline, "haltVerifyDeadline");
+    this.haltVerifyPace = Objects.requireNonNull(haltVerifyPace, "haltVerifyPace");
   }
 
   /**
@@ -464,13 +495,36 @@ public final class StopOperations {
    * A verified halt leaves no live process on the addressed unit. Rejecting <em>any</em> running
    * result — not only the original pid — keeps a replacement process (a unit restart, a pid reused
    * mid-halt) from being mistaken for a successful termination.
+   *
+   * <p>Verification polls to a deadline because termination is asynchronous on three fronts —
+   * signal delivery, the parent reaping the zombie, and systemd observing the exit — so a single
+   * instantaneous probe misreads an in-flight halt as failure. That misread happened in the field:
+   * a spurious "still running after the stop signal" that rolled the claim back on a stop that had
+   * in fact landed. Any running result at the deadline still fails loud.
    */
   private void verifyHalted(String project, AgentUnit unit) {
+    var deadline = System.nanoTime() + haltVerifyDeadline.toNanos();
     var remaining = probe(project, unit);
-    if (remaining != null && remaining.running()) {
+    while (remaining != null && remaining.running()) {
+      if (System.nanoTime() >= deadline) {
+        throw new ApiException(
+            ErrorCode.AGENT_STOP_FAILED,
+            "Agent PID " + remaining.pid() + " is still running after the stop signal.",
+            "Retry the stop.");
+      }
+      pace();
+      remaining = probe(project, unit);
+    }
+  }
+
+  private void pace() {
+    try {
+      Thread.sleep(haltVerifyPace.toMillis());
+    } catch (InterruptedException interrupted) {
+      Thread.currentThread().interrupt();
       throw new ApiException(
           ErrorCode.AGENT_STOP_FAILED,
-          "Agent PID " + remaining.pid() + " is still running after the stop signal.",
+          "Interrupted while verifying the agent halt.",
           "Retry the stop.");
     }
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
@@ -1109,18 +1109,17 @@ class StopOperationsTest {
   }
 
   @Test
-  void sessionHalterKillsThroughTheAgentSession() throws Exception {
-    var shell =
-        shell()
-            .on("cat " + RUN_PID_FILE, "77")
-            .on("kill 77", "")
-            .on("sleep 3", "")
-            .on("kill -0 77", new ShellExec.Result(1, "", ""))
-            .on("rm -f " + RUN_PID_FILE, "");
+  void sessionHalterKillsTheWholeUnitCgroupThroughTheAgentSession() throws Exception {
+    var shell = shell().on("systemctl", "").on("sleep 3", "").on("rm -f " + RUN_PID_FILE, "");
 
     StopOperations.sessionHalter(shell).halt("acme", AgentUnit.forRun(R1));
 
-    assertTrue(shell.invocations().stream().anyMatch(cmd -> cmd.contains("kill 77")));
+    var service = AgentUnit.forRun(R1).service();
+    assertTrue(
+        shell.invocations().stream()
+            .anyMatch(cmd -> cmd.contains("--kill-who=all --signal=SIGTERM " + service)),
+        "a unit-owning run is halted through its cgroup, never a bare pid");
+    assertTrue(shell.invocations().stream().noneMatch(cmd -> cmd.contains("kill 77")));
   }
 
   private StopOperations.AgentHalter killingHalter(FakeShell shell) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/StopOperationsTest.java
@@ -567,7 +567,9 @@ class StopOperationsTest {
         stopOps(
             liveAgentShell(),
             (project, unit) -> halts.add(unit.unitName()),
-            StopOperations.Listener.NONE);
+            StopOperations.Listener.NONE,
+            java.time.Duration.ofMillis(20),
+            java.time.Duration.ZERO);
     seedAdhocRun(123, UNIT);
 
     var refusal =
@@ -767,7 +769,13 @@ class StopOperationsTest {
 
   @Test
   void aHaltThatLeavesTheAgentAliveRestoresTheSpecAndFails() throws Exception {
-    var ops = stopOps(liveAgentShell(), (project, unit) -> {}, StopOperations.Listener.NONE);
+    var ops =
+        stopOps(
+            liveAgentShell(),
+            (project, unit) -> {},
+            StopOperations.Listener.NONE,
+            java.time.Duration.ofMillis(20),
+            java.time.Duration.ZERO);
     seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
     seedRun(123, UNIT);
 
@@ -793,7 +801,9 @@ class StopOperationsTest {
               shell.on("kill -0 456", "");
               shell.on("kill -0 123", new ShellExec.Result(1, "", ""));
             },
-            StopOperations.Listener.NONE);
+            StopOperations.Listener.NONE,
+            java.time.Duration.ofMillis(20),
+            java.time.Duration.ZERO);
     seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
     seedRun(123, UNIT);
 
@@ -1117,6 +1127,63 @@ class StopOperationsTest {
     return (project, unit) -> agentDies(shell);
   }
 
+  @Test
+  void haltVerificationAbsorbsReapLatencyByPolling() throws Exception {
+    var shell = liveAgentShell();
+    var probes = new java.util.concurrent.atomic.AtomicInteger();
+    shell.hookOn(
+        "kill -0 123",
+        () -> {
+          if (probes.incrementAndGet() >= 3) {
+            agentDies(shell);
+          }
+        });
+    var ops =
+        stopOps(
+            shell,
+            (project, unit) -> {},
+            StopOperations.Listener.NONE,
+            java.time.Duration.ofSeconds(5),
+            java.time.Duration.ZERO);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    var outcome = ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false);
+
+    assertInstanceOf(StopOperations.Stopped.class, outcome);
+    assertEquals("stopped", runStore.findById(R1).orElseThrow().status());
+    assertTrue(
+        probes.get() >= 3, "verification must have re-probed, not given up on the first look");
+  }
+
+  @Test
+  void anInterruptedVerificationFailsLoudKeepsTheInterruptAndRestoresTheClaim() throws Exception {
+    var ops =
+        stopOps(
+            liveAgentShell(),
+            (project, unit) -> {},
+            StopOperations.Listener.NONE,
+            Duration.ofSeconds(5),
+            Duration.ZERO);
+    seedSpec("auth", SpecStatus.IN_PROGRESS, LOCAL_HANDLE);
+    seedRun(123, UNIT);
+
+    Thread.currentThread().interrupt();
+    ApiException refusal;
+    try {
+      refusal =
+          assertThrows(
+              ApiException.class,
+              () -> ops.stop(new StopOperations.RunTarget(R1), ADMIN, LOCAL_HANDLE, false));
+    } finally {
+      assertTrue(Thread.interrupted(), "the interrupt flag must be preserved for the caller");
+    }
+
+    assertEquals(ErrorCode.AGENT_STOP_FAILED, refusal.failure().errorCode());
+    assertEquals("running", runStore.findById(R1).orElseThrow().status());
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+  }
+
   private static void agentDies(FakeShell shell) {
     shell.on("kill -0 123", new ShellExec.Result(1, "", ""));
   }
@@ -1172,6 +1239,39 @@ class StopOperationsTest {
     specStore = new SpecStore(db);
     runStore = new RunStore(db);
     return new StopOperations(shell, yaml.toString(), specStore, runStore, sink, halter, listener);
+  }
+
+  private StopOperations stopOps(
+      FakeShell shell,
+      StopOperations.AgentHalter halter,
+      StopOperations.Listener listener,
+      java.time.Duration verifyDeadline,
+      java.time.Duration verifyPace)
+      throws Exception {
+    var yaml = tempDir.resolve("sail-" + System.nanoTime() + ".yaml");
+    Files.writeString(
+        yaml,
+        """
+        name: acme
+        ssh:
+          user: dev
+        agent:
+          type: claude-code
+        """);
+    var db = Sqlite.open(tempDir.resolve("stop-" + System.nanoTime() + ".db"));
+    new SchemaManager(db).migrate();
+    specStore = new SpecStore(db);
+    runStore = new RunStore(db);
+    return new StopOperations(
+        shell,
+        yaml.toString(),
+        specStore,
+        runStore,
+        events::add,
+        halter,
+        listener,
+        verifyDeadline,
+        verifyPace);
   }
 
   private void seedSpec(String id, SpecStatus status, String assignee) {


### PR DESCRIPTION
A single post-kill probe raced signal delivery, zombie reaping, and
systemd's exit observation — misreading an in-flight halt as a failed stop
(seen on main's incus lane; a loaded field box hits the same window). The
verification now polls the same any-running-result rejection to a bounded
deadline, keeping fail-loud semantics and claim restore intact.
