### PR TITLE
Add spec conversation messages

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/engine/PromptConversation.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/PromptConversation.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+/** Renders the newest conversation entries within a deterministic prompt budget. */
+public final class PromptConversation {
+
+  public static final int MAX_CODE_POINTS = 32_000;
+
+  private PromptConversation() {}
+
+  public static <T> String renderNewest(List<T> messages, Function<T, String> renderer) {
+    Objects.requireNonNull(messages, "messages");
+    Objects.requireNonNull(renderer, "renderer");
+    var remaining = MAX_CODE_POINTS;
+    var rendered = new ArrayDeque<String>();
+    for (var index = messages.size() - 1; index >= 0 && remaining > 0; index--) {
+      var message = Objects.requireNonNull(renderer.apply(messages.get(index)), "rendered message");
+      var codePoints = message.codePointCount(0, message.length());
+      if (codePoints <= remaining) {
+        rendered.addFirst(message);
+        remaining -= codePoints;
+      } else {
+        rendered.addFirst(message.substring(0, message.offsetByCodePoints(0, remaining)));
+        remaining = 0;
+      }
+    }
+    return String.join("", rendered);
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/engine/ReviewPromptBuilder.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/ReviewPromptBuilder.java
@@ -72,10 +72,8 @@ public final class ReviewPromptBuilder {
     if (messages.isEmpty()) {
       return "";
     }
-    var room = new StringBuilder("Conversation on this spec:\n\n");
-    for (var message : messages) {
-      room.append(message.author()).append(": ").append(message.body()).append("\n\n");
-    }
-    return room.toString();
+    return "Conversation on this spec:\n\n"
+        + PromptConversation.renderNewest(
+            messages, message -> message.author() + ": " + message.body() + "\n\n");
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/engine/ReviewPromptBuilder.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/ReviewPromptBuilder.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.store.MessageStore;
 import java.util.List;
 
 /**
@@ -22,11 +23,20 @@ public final class ReviewPromptBuilder {
    *     repos, and a wrong name sends the reviewer into an unrelated codebase)
    */
   public static String build(String branch, List<String> repos, List<String> categories) {
+    return build(branch, repos, categories, List.of());
+  }
+
+  public static String build(
+      String branch,
+      List<String> repos,
+      List<String> categories,
+      List<MessageStore.MessageRow> messages) {
     var categoryList =
         categories.isEmpty() ? "any relevant category" : String.join(", ", categories);
     var repoList = repos.isEmpty() ? "the repository in the workspace" : String.join(", ", repos);
 
-    return """
+    return conversation(messages)
+        + """
         Review the changes on branch %s in the following repository director%s inside this
         workspace: %s. Review only those checkouts — ignore any other repositories present.
         If that branch no longer exists, review the spec's changes as merged on the default
@@ -55,6 +65,17 @@ public final class ReviewPromptBuilder {
 
         Begin your response with ```json and end with ```.
         """
-        .formatted(branch, repos.size() == 1 ? "y" : "ies", repoList, categoryList);
+            .formatted(branch, repos.size() == 1 ? "y" : "ies", repoList, categoryList);
+  }
+
+  private static String conversation(List<MessageStore.MessageRow> messages) {
+    if (messages.isEmpty()) {
+      return "";
+    }
+    var room = new StringBuilder("Conversation on this spec:\n\n");
+    for (var message : messages) {
+      room.append(message.author()).append(": ").append(message.body()).append("\n\n");
+    }
+    return room.toString();
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
@@ -242,6 +242,8 @@ public final class AgentContextGenerator {
 
         ### Working with specs
         - `spec board` — kanban summary; `spec list [--status pending] [--assignee me]`
+        - `spec comment <id> --body <text>|-` — post progress, a question, or a final summary;
+          `spec comments <id>` — read the room
         - `spec show <id>` — metadata, dependencies, and the full body
         - `spec create --id <id> --title "<title>" --body-file <file>` — create one; add
           `--depends-on a,b`, `--repos api,web`, `--agent codex|claude-code`, `--model <id>`,

--- a/sail-core/src/main/java/ai/singlr/sail/gen/SpecSkillGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/SpecSkillGenerator.java
@@ -91,6 +91,9 @@ public final class SpecSkillGenerator {
         Run `spec board` for the kanban summary, or `spec list` for the full set (add
         `--status pending` or `--assignee me` to filter). Render the result as status columns:
 
+        Use `spec comment <id> --body <text>|-` to post progress, questions, and summaries in the
+        spec's conversation; use `spec comments <id>` to read it.
+
         ```
         ┌─────────────┬─────────────────┬──────────────┬────────────────────┬──────────────┐
         │ Pending (3)  │ In Progress (1) │ Review (0)   │ Awaiting Merge (1) │ Done (2)     │

--- a/sail-core/src/main/java/ai/singlr/sail/store/EventStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/EventStore.java
@@ -5,6 +5,8 @@
 
 package ai.singlr.sail.store;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,12 +105,12 @@ public final class EventStore {
     if (batchSize <= 0) {
       throw new IllegalArgumentException("batchSize must be positive");
     }
-    var placeholders = String.join(", ", java.util.Collections.nCopies(types.size(), "?"));
+    var placeholders = String.join(", ", Collections.nCopies(types.size(), "?"));
     var sql =
         "DELETE FROM events WHERE id IN (SELECT id FROM events WHERE timestamp < ? AND type IN ("
             + placeholders
             + ") ORDER BY id LIMIT ?)";
-    var parameters = new java.util.ArrayList<Object>();
+    var parameters = new ArrayList<Object>();
     parameters.add(before);
     parameters.addAll(types);
     parameters.add((long) batchSize);

--- a/sail-core/src/main/java/ai/singlr/sail/store/EventStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/EventStore.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.store;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /** Persists events to SQLite. Replaces the file-based JSONL audit log with a queryable table. */
 public final class EventStore {
@@ -93,6 +94,38 @@ public final class EventStore {
       typeMap.put((String) row[0], (long) row[1]);
     }
     return Map.copyOf(typeMap);
+  }
+
+  public int pruneBefore(String before, Set<String> types, int batchSize) {
+    if (types.isEmpty()) {
+      return 0;
+    }
+    if (batchSize <= 0) {
+      throw new IllegalArgumentException("batchSize must be positive");
+    }
+    var placeholders = String.join(", ", java.util.Collections.nCopies(types.size(), "?"));
+    var sql =
+        "DELETE FROM events WHERE id IN (SELECT id FROM events WHERE timestamp < ? AND type IN ("
+            + placeholders
+            + ") ORDER BY id LIMIT ?)";
+    var parameters = new java.util.ArrayList<Object>();
+    parameters.add(before);
+    parameters.addAll(types);
+    parameters.add((long) batchSize);
+    var total = 0;
+    while (true) {
+      var deleted =
+          db.transaction(
+              () -> {
+                db.execute(sql, parameters.toArray());
+                return db.changes();
+              });
+      total += deleted;
+      if (deleted < batchSize) {
+        return total;
+      }
+      Thread.yield();
+    }
   }
 
   private EventRow mapEvent(Sqlite.Row row) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
@@ -11,6 +11,7 @@ import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -103,7 +104,7 @@ public final class MessageStore {
                 before,
                 limit);
     var oldest = new ArrayList<>(newest);
-    java.util.Collections.reverse(oldest);
+    Collections.reverse(oldest);
     return List.copyOf(oldest);
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Ids;
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.YamlUtil;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/** Append-only messages attached to specs and journaled as independently synced records. */
+public final class MessageStore {
+
+  public static final int MAX_BODY_BYTES = 64 * 1024;
+  private static final String ENTITY = "message";
+  private static final String COLUMNS =
+      "id, spec_id, author, body, reply_to, created_at, rev, base_rev";
+
+  private final Sqlite db;
+  private final ChangeLog changeLog;
+
+  public MessageStore(Sqlite db) {
+    this.db = Objects.requireNonNull(db, "db");
+    this.changeLog = new ChangeLog(db);
+  }
+
+  public record MessageRow(
+      String id,
+      String specId,
+      String author,
+      String body,
+      String replyTo,
+      String createdAt,
+      String rev,
+      String baseRev) {}
+
+  public MessageRow append(String specId, String author, String body, String replyTo) {
+    requireBody(body);
+    if (Strings.isBlank(author)) {
+      throw new IllegalArgumentException("message author is required");
+    }
+    if (replyTo != null) {
+      Ids.requireUuid(replyTo);
+    }
+    return db.transaction(
+        () -> {
+          var id = Ids.newId().toString();
+          var row =
+              new MessageRow(
+                  id,
+                  specId,
+                  author.strip(),
+                  body,
+                  replyTo,
+                  DateTimeUtils.now().toString(),
+                  null,
+                  null);
+          requireReplyTarget(row);
+          var snapshot = snapshot(row);
+          var rev = Revisions.next(null, YamlUtil.dumpJson(snapshot));
+          write(row, rev, null);
+          changeLog.append(
+              ENTITY, id, rev, author.strip(), "local", false, YamlUtil.dumpJson(snapshot));
+          return findById(id).orElseThrow();
+        });
+  }
+
+  public List<MessageRow> list(String specId, String before, int limit) {
+    if (before != null) {
+      Ids.requireUuid(before);
+    }
+    if (limit <= 0) {
+      throw new IllegalArgumentException("limit must be positive");
+    }
+    var newest =
+        before == null
+            ? db.query(
+                "SELECT "
+                    + COLUMNS
+                    + " FROM spec_messages WHERE spec_id = ?"
+                    + " ORDER BY id DESC LIMIT ?",
+                MessageStore::map,
+                specId,
+                limit)
+            : db.query(
+                "SELECT "
+                    + COLUMNS
+                    + " FROM spec_messages WHERE spec_id = ? AND id < ?"
+                    + " ORDER BY id DESC LIMIT ?",
+                MessageStore::map,
+                specId,
+                before,
+                limit);
+    var oldest = new ArrayList<>(newest);
+    java.util.Collections.reverse(oldest);
+    return List.copyOf(oldest);
+  }
+
+  public Optional<MessageRow> findById(String id) {
+    return db.queryOne(
+        "SELECT " + COLUMNS + " FROM spec_messages WHERE id = ?", MessageStore::map, id);
+  }
+
+  public Map<String, Object> comparableSnapshot(String id) {
+    return findById(id).map(MessageStore::snapshot).orElse(null);
+  }
+
+  public Map<String, Object> comparableAtRev(String id, String rev) {
+    if (Strings.isBlank(rev)) {
+      return null;
+    }
+    return changeLog
+        .at(ENTITY, id, rev)
+        .map(entry -> YamlUtil.parseMap(entry.snapshot()))
+        .orElse(null);
+  }
+
+  public String latestRev(String id) {
+    return findById(id).map(MessageRow::rev).orElse(null);
+  }
+
+  public String baseRevOf(String id) {
+    return findById(id).map(MessageRow::baseRev).orElse(null);
+  }
+
+  public Set<String> syncEntityIds() {
+    return new LinkedHashSet<>(
+        db.query(
+            "SELECT entity_id FROM change_log WHERE entity_type = ?"
+                + " GROUP BY entity_id ORDER BY MIN(seq)",
+            row -> row.text(0),
+            ENTITY));
+  }
+
+  public void applyRevision(String id, Map<String, Object> snapshot, String rev) {
+    if (snapshot == null) {
+      throw new IllegalArgumentException("messages are immutable and cannot be deleted");
+    }
+    db.transaction(
+        () -> {
+          var existing = findById(id);
+          if (existing.isPresent() && !comparableSnapshot(id).equals(snapshot)) {
+            throw new IllegalArgumentException("message '" + id + "' is immutable");
+          }
+          var row = fromSnapshot(id, snapshot);
+          requireReplyTarget(row);
+          write(row, rev, rev);
+          if (!Objects.equals(existing.map(MessageRow::rev).orElse(null), rev)) {
+            changeLog.append(
+                ENTITY,
+                id,
+                rev,
+                Objects.toString(snapshot.get("author"), null),
+                "sync",
+                false,
+                YamlUtil.dumpJson(snapshot));
+          }
+        });
+  }
+
+  public PushOutcome commitRevision(String id, Map<String, Object> snapshot, String expectedRev) {
+    return db.immediateTransaction(
+        () -> {
+          var currentRev = latestRev(id);
+          if (!Objects.equals(currentRev, expectedRev)) {
+            return new PushOutcome.Stale(currentRev, comparableSnapshot(id));
+          }
+          if (snapshot == null) {
+            throw new IllegalArgumentException("messages are immutable and cannot be deleted");
+          }
+          if (currentRev != null) {
+            throw new IllegalArgumentException("message '" + id + "' is immutable");
+          }
+          var json = YamlUtil.dumpJson(snapshot);
+          var rev = Revisions.next(null, json);
+          var row = fromSnapshot(id, snapshot);
+          requireReplyTarget(row);
+          write(row, rev, null);
+          changeLog.append(ENTITY, id, rev, row.author(), "sync", false, json);
+          return new PushOutcome.Accepted(rev);
+        });
+  }
+
+  private void write(MessageRow row, String rev, String baseRev) {
+    db.execute(
+        """
+        INSERT INTO spec_messages
+            (id, spec_id, author, body, reply_to, created_at, rev, base_rev)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET rev = excluded.rev, base_rev = excluded.base_rev""",
+        row.id(),
+        row.specId(),
+        row.author(),
+        row.body(),
+        row.replyTo(),
+        row.createdAt(),
+        rev,
+        baseRev);
+  }
+
+  private void requireReplyTarget(MessageRow row) {
+    if (row.replyTo() != null
+        && findById(row.replyTo())
+            .filter(parent -> parent.specId().equals(row.specId()))
+            .isEmpty()) {
+      throw new IllegalArgumentException(
+          "reply_to must reference a message on spec '" + row.specId() + "'");
+    }
+  }
+
+  private static MessageRow fromSnapshot(String id, Map<String, Object> snapshot) {
+    Ids.requireUuid(id);
+    var body = Objects.toString(snapshot.get("body"), null);
+    requireBody(body);
+    var author = Objects.toString(snapshot.get("author"), null);
+    if (Strings.isBlank(author)) {
+      throw new IllegalArgumentException("message author is required");
+    }
+    var replyTo = nullable(snapshot.get("reply_to"));
+    if (replyTo != null) {
+      Ids.requireUuid(replyTo);
+    }
+    return new MessageRow(
+        id,
+        required(snapshot, "spec_id"),
+        author,
+        body,
+        replyTo,
+        required(snapshot, "created_at"),
+        null,
+        null);
+  }
+
+  private static Map<String, Object> snapshot(MessageRow row) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("spec_id", row.specId());
+    map.put("author", row.author());
+    map.put("body", row.body());
+    if (row.replyTo() != null) {
+      map.put("reply_to", row.replyTo());
+    }
+    map.put("created_at", row.createdAt());
+    return map;
+  }
+
+  private static MessageRow map(Sqlite.Row row) {
+    return new MessageRow(
+        row.text(0),
+        row.text(1),
+        row.text(2),
+        row.text(3),
+        row.text(4),
+        row.text(5),
+        row.text(6),
+        row.text(7));
+  }
+
+  private static void requireBody(String body) {
+    if (Strings.isBlank(body)) {
+      throw new IllegalArgumentException("message body must not be empty");
+    }
+    if (body.getBytes(StandardCharsets.UTF_8).length > MAX_BODY_BYTES) {
+      throw new IllegalArgumentException("message body exceeds 65536 bytes");
+    }
+  }
+
+  private static String required(Map<String, Object> map, String key) {
+    var value = nullable(map.get(key));
+    if (Strings.isBlank(value)) {
+      throw new IllegalArgumentException("message " + key + " is required");
+    }
+    return value;
+  }
+
+  private static String nullable(Object value) {
+    return value == null ? null : value.toString();
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
@@ -201,15 +201,28 @@ public final class MessageStore {
     if (peer == null) {
       return false;
     }
-    if (peer.equals(author)) {
-      return true;
+    var ownsAuthor =
+        peer.equals(author)
+            || db.queryOne(
+                    "SELECT 1 FROM runs WHERE principal = ? AND owner = ? AND spec_id = ? LIMIT 1",
+                    row -> true,
+                    author,
+                    peer,
+                    specId)
+                .orElse(false);
+    if (!ownsAuthor) {
+      return false;
     }
     return db.queryOne(
-            "SELECT 1 FROM runs WHERE principal = ? AND owner = ? AND spec_id = ? LIMIT 1",
+            "SELECT 1 FROM specs s LEFT JOIN fdes f ON f.handle = ? "
+                + "WHERE s.id = ? AND (lower(coalesce(f.role, '')) = 'admin' "
+                + "OR s.assignee = ? OR "
+                + "(trim(coalesce(s.assignee, '')) = '' AND s.created_by = ?)) LIMIT 1",
             row -> true,
-            author,
             peer,
-            specId)
+            specId,
+            peer,
+            peer)
         .orElse(false);
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
@@ -185,11 +185,32 @@ public final class MessageStore {
           var json = YamlUtil.dumpJson(snapshot);
           var rev = Revisions.next(null, json);
           var row = fromSnapshot(id, snapshot);
+          var peer = SyncPeer.current();
+          if (!mayPostAs(peer, row.author(), row.specId())) {
+            throw new IllegalArgumentException(
+                "sync principal '" + peer + "' may not post as '" + row.author() + "'");
+          }
           requireReplyTarget(row);
           write(row, rev, null);
           changeLog.append(ENTITY, id, rev, row.author(), "sync", false, json);
           return new PushOutcome.Accepted(rev);
         });
+  }
+
+  private boolean mayPostAs(String peer, String author, String specId) {
+    if (peer == null) {
+      return false;
+    }
+    if (peer.equals(author)) {
+      return true;
+    }
+    return db.queryOne(
+            "SELECT 1 FROM runs WHERE principal = ? AND owner = ? AND spec_id = ? LIMIT 1",
+            row -> true,
+            author,
+            peer,
+            specId)
+        .orElse(false);
   }
 
   private void write(MessageRow row, String rev, String baseRev) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -89,7 +89,19 @@ public final class SchemaManager {
               credential_hash TEXT NOT NULL UNIQUE,
               created_at TEXT NOT NULL,
               expires_at TEXT
-          )""");
+          )""",
+          """
+          CREATE TABLE spec_messages (
+              id TEXT PRIMARY KEY,
+              spec_id TEXT NOT NULL,
+              author TEXT NOT NULL,
+              body TEXT NOT NULL,
+              reply_to TEXT REFERENCES spec_messages(id),
+              created_at TEXT NOT NULL,
+              rev TEXT NOT NULL,
+              base_rev TEXT
+          )""",
+          "CREATE INDEX idx_spec_messages_page ON spec_messages(spec_id, id DESC)");
 
   /** The schema version this binary converges every database to. */
   static final int CURRENT_VERSION = V1_VERSION + MIGRATIONS.size();

--- a/sail-core/src/main/java/ai/singlr/sail/sync/MessageReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/MessageReplica.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.store.ChangeLog;
+import ai.singlr.sail.store.MessageStore;
+import ai.singlr.sail.store.PushOutcome;
+import ai.singlr.sail.store.SyncConflicts;
+import ai.singlr.sail.store.SyncState;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/** Sync adapter for immutable, append-only spec messages. */
+public final class MessageReplica implements LocalReplica, MainReplica {
+
+  private static final String ENTITY = "message";
+
+  private final String id;
+  private final MessageStore messages;
+  private final ChangeLog changeLog;
+  private final SyncConflicts conflicts;
+  private final SyncState syncState;
+
+  public MessageReplica(
+      String id,
+      MessageStore messages,
+      ChangeLog changeLog,
+      SyncConflicts conflicts,
+      SyncState syncState) {
+    this.id = Objects.requireNonNull(id, "id");
+    this.messages = Objects.requireNonNull(messages, "messages");
+    this.changeLog = Objects.requireNonNull(changeLog, "changeLog");
+    this.conflicts = Objects.requireNonNull(conflicts, "conflicts");
+    this.syncState = Objects.requireNonNull(syncState, "syncState");
+  }
+
+  @Override
+  public String id() {
+    return id;
+  }
+
+  @Override
+  public Set<String> entityIds() {
+    return messages.syncEntityIds();
+  }
+
+  @Override
+  public Map<String, Object> current(String entityId) {
+    return messages.comparableSnapshot(entityId);
+  }
+
+  @Override
+  public Map<String, Object> base(String entityId) {
+    return messages.comparableAtRev(entityId, messages.baseRevOf(entityId));
+  }
+
+  @Override
+  public String currentRev(String entityId) {
+    return messages.latestRev(entityId);
+  }
+
+  @Override
+  public void adopt(String entityId, Map<String, Object> snapshot, String rev) {
+    messages.applyRevision(entityId, snapshot, rev);
+  }
+
+  @Override
+  public CommitOutcome commit(String entityId, Map<String, Object> snapshot, String expectedRev) {
+    return switch (messages.commitRevision(entityId, snapshot, expectedRev)) {
+      case PushOutcome.Accepted accepted -> new CommitOutcome.Accepted(accepted.rev());
+      case PushOutcome.Stale stale ->
+          new CommitOutcome.Rejected(stale.currentRev(), stale.currentSnapshot());
+    };
+  }
+
+  @Override
+  public long maxSeq() {
+    return changeLog.maxSeq(ENTITY);
+  }
+
+  @Override
+  public void recordConflict(
+      String entityId,
+      Map<String, Object> base,
+      Map<String, Object> local,
+      Map<String, Object> remote,
+      List<String> fields) {
+    conflicts.record(ENTITY, entityId, json(base), json(local), json(remote), fields);
+  }
+
+  @Override
+  public void advanceCheckpoint(String peerId, long seq) {
+    syncState.advance(peerId + ":" + ENTITY, seq);
+  }
+
+  private static String json(Map<String, Object> snapshot) {
+    return snapshot == null ? null : YamlUtil.dumpJson(snapshot);
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/sync/RemoteMainReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/RemoteMainReplica.java
@@ -86,6 +86,10 @@ public final class RemoteMainReplica implements MainReplica {
   private SyncWire.Fetched fetched() {
     if (fetched == null) {
       var response = Rpc.exchange(in, out, new SyncWire.Fetch(entityType));
+      if (response instanceof SyncWire.Failed failed) {
+        throw new SyncTransportException(
+            "Main refused entity type '" + entityType + "': " + failed.message());
+      }
       if (!(response instanceof SyncWire.Fetched f)) {
         throw new SyncTransportException("Expected a fetch response, got: " + response);
       }

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncTransition.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncTransition.java
@@ -16,7 +16,8 @@ import java.util.Objects;
  * transition, the stage's map augmented with the review's {@code spec_id}), giving a consumer
  * everything it needs to narrate the transition without re-reading the store.
  *
- * @param entityType {@code spec}, {@code run}, {@code review}, or {@code review_stage}
+ * @param entityType {@code spec}, {@code run}, {@code review}, {@code review_stage}, or {@code
+ *     message}
  * @param entityId the entity's id ({@code review_stage} carries the stage's id)
  * @param from the prior status, or {@code null} when the entity is new to main
  * @param to the committed status

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncTransitions.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncTransitions.java
@@ -13,11 +13,11 @@ import java.util.Objects;
 
 /**
  * Pure detection of real state transitions between two comparable snapshots of a synced entity.
- * Compares only what narration cares about — the {@code status} of a spec, run, or review, and for
- * the review aggregate each stage's status — so a re-applied identical revision, a timestamp churn,
- * or a metadata-only edit yields nothing. A deletion (null after-state) also yields nothing: a
- * tombstone has no lifecycle to narrate. No I/O and no store access; the {@link SyncRpcServer}
- * feeds it the snapshots it already holds around a commit.
+ * Compares only what narration cares about — the {@code status} of a spec, run, or review, each
+ * review stage's status, and the creation of an append-only message — so a re-applied identical
+ * revision, a timestamp churn, or a metadata-only edit yields nothing. A deletion (null
+ * after-state) also yields nothing: a tombstone has no lifecycle to narrate. No I/O and no store
+ * access; the {@link SyncRpcServer} feeds it the snapshots it already holds around a commit.
  */
 public final class SyncTransitions {
 
@@ -31,6 +31,10 @@ public final class SyncTransitions {
     return switch (entityType) {
       case "spec", "run" -> statusChange(entityType, entityId, before, after);
       case "review" -> reviewChanges(entityId, before, after);
+      case "message" ->
+          before == null
+              ? List.of(new SyncTransition("message", entityId, null, "posted", after))
+              : List.of();
       default -> List.of();
     };
   }

--- a/sail-core/src/test/java/ai/singlr/sail/engine/PromptConversationTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/PromptConversationTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PromptConversationTest {
+
+  @Test
+  void keepsNewestContentWithinTheAggregateBudgetInChronologicalOrder() {
+    var messages =
+        List.of("old:" + "a".repeat(20_000) + ":old-end", "middle:" + "b".repeat(20_000), "new");
+
+    var rendered = PromptConversation.renderNewest(messages, message -> message + "\n");
+
+    assertEquals(PromptConversation.MAX_CODE_POINTS, rendered.codePointCount(0, rendered.length()));
+    assertFalse(rendered.contains(":old-end"));
+    assertTrue(rendered.contains("middle:"));
+    assertTrue(rendered.endsWith("new\n"));
+  }
+
+  @Test
+  void truncatesWithoutSplittingAUnicodeCodePoint() {
+    var message = "😀".repeat(PromptConversation.MAX_CODE_POINTS + 1);
+
+    var rendered = PromptConversation.renderNewest(List.of(message), value -> value);
+
+    assertEquals(PromptConversation.MAX_CODE_POINTS, rendered.codePointCount(0, rendered.length()));
+    assertEquals(PromptConversation.MAX_CODE_POINTS * 2, rendered.length());
+    assertTrue(Character.isLowSurrogate(rendered.charAt(rendered.length() - 1)));
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/engine/ReviewPromptBuilderTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/ReviewPromptBuilderTest.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.engine;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.singlr.sail.store.MessageStore;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -73,5 +74,24 @@ class ReviewPromptBuilderTest {
         prompt.contains("If that branch no longer exists"),
         "a deleted work branch must not send the reviewer hunting: " + prompt);
     assertTrue(prompt.contains("ignore any other repositories"), prompt);
+  }
+
+  @Test
+  void placesConversationBeforeReviewInstructions() {
+    var message =
+        new MessageStore.MessageRow(
+            "01900000-0000-7000-8000-000000000001",
+            "auth",
+            "ada",
+            "The token decision is intentional",
+            null,
+            "2026-07-28T00:00:00Z",
+            "1-a",
+            null);
+
+    var prompt = ReviewPromptBuilder.build("main", List.of("app"), List.of(), List.of(message));
+
+    assertTrue(prompt.startsWith("Conversation on this spec:"));
+    assertTrue(prompt.indexOf("token decision") < prompt.indexOf("Review the changes"));
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/store/EventStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/EventStoreTest.java
@@ -7,9 +7,11 @@ package ai.singlr.sail.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
+import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -175,5 +177,24 @@ class EventStoreTest {
     assertNull(events.getFirst().project());
     assertNull(events.getFirst().specId());
     assertNull(events.getFirst().agent());
+  }
+
+  @Test
+  void pruneBeforeDeletesOnlyMatchingOldTypesAcrossBatches() {
+    for (var i = 0; i < 5; i++) {
+      store.insert(event("telemetry", "p", null));
+    }
+    store.insert(event("record", "p", null));
+    store.insert(
+        new EventStore.EventRow(
+            0, "2099-01-01T00:00:00Z", "telemetry", "p", null, "sail", "h", "{}"));
+
+    assertEquals(5, store.pruneBefore("2026-06-01T00:00:00Z", Set.of("telemetry"), 2));
+    assertEquals(2, store.recent(10).size());
+    assertTrue(store.recent(10).stream().anyMatch(row -> row.type().equals("record")));
+    assertEquals(0, store.pruneBefore("2099-12-01T00:00:00Z", Set.of(), 2));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> store.pruneBefore("2099-12-01T00:00:00Z", Set.of("telemetry"), 0));
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/store/MessageStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/MessageStoreTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.YamlUtil;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MessageStoreTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private MessageStore messages;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("messages.db"));
+    new SchemaManager(db).migrate();
+    db.execute(
+        """
+        INSERT INTO specs (id, title, project, created_at, updated_at)
+        VALUES ('room', 'Room', 'acme', 'now', 'now')""");
+    messages = new MessageStore(db);
+  }
+
+  @AfterEach
+  void tearDown() {
+    db.close();
+  }
+
+  @Test
+  void appendPersistsAnImmutableRevisionAndReply() {
+    var first = messages.append("room", "ada", "First", null);
+    var reply = messages.append("room", "codex/a1b2c3", "Reply", first.id());
+
+    assertEquals(first.id(), reply.replyTo());
+    assertEquals("codex/a1b2c3", messages.findById(reply.id()).orElseThrow().author());
+    var history = new ChangeLog(db).history("message", reply.id());
+    assertEquals(1, history.size());
+    assertEquals(reply.rev(), history.getFirst().rev());
+    assertEquals("Reply", YamlUtil.parseMap(history.getFirst().snapshot()).get("body"));
+  }
+
+  @Test
+  void pagesNewestLastWithAnExclusiveBeforeCursor() {
+    var first = messages.append("room", "ada", "one", null);
+    var second = messages.append("room", "ada", "two", null);
+    var third = messages.append("room", "ada", "three", null);
+
+    assertEquals(List.of(second.id(), third.id()), ids(messages.list("room", null, 2)));
+    assertEquals(List.of(first.id()), ids(messages.list("room", second.id(), 2)));
+    assertEquals(List.of(first.id(), second.id(), third.id()), ids(messages.list("room", null, 3)));
+    assertTrue(messages.list("missing", null, 10).isEmpty());
+  }
+
+  @Test
+  void rejectsEmptyOversizedAndInvalidRepliesBeforeWriting() {
+    assertThrows(IllegalArgumentException.class, () -> messages.append("room", "ada", " \n", null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> messages.append("room", "ada", "x".repeat(MessageStore.MAX_BODY_BYTES + 1), null));
+    assertThrows(IllegalArgumentException.class, () -> messages.append("room", "", "body", null));
+    assertThrows(
+        IllegalArgumentException.class, () -> messages.append("room", "ada", "body", "not-a-uuid"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> messages.append("room", "ada", "body", "00000000-0000-0000-0000-000000000000"));
+    assertThrows(IllegalArgumentException.class, () -> messages.list("room", null, 0));
+    assertThrows(IllegalArgumentException.class, () -> messages.list("room", "not-a-uuid", 1));
+    assertTrue(messages.list("room", null, 10).isEmpty());
+  }
+
+  @Test
+  void acceptsTheExactByteCapAndSurvivesSpecLifecycleChanges() {
+    var row = messages.append("room", "ada", "x".repeat(MessageStore.MAX_BODY_BYTES), null);
+    db.execute("UPDATE specs SET status = 'archived' WHERE id = 'room'");
+    assertEquals(row.id(), messages.list("room", null, 10).getFirst().id());
+
+    db.execute("DELETE FROM specs WHERE id = 'room'");
+    assertEquals(row.id(), messages.findById(row.id()).orElseThrow().id());
+    db.execute(
+        """
+        INSERT INTO specs (id, title, project, created_at, updated_at)
+        VALUES ('room', 'Room restored', 'acme', 'later', 'later')""");
+    assertEquals(row.id(), messages.list("room", null, 10).getFirst().id());
+  }
+
+  private static List<String> ids(List<MessageStore.MessageRow> rows) {
+    return rows.stream().map(MessageStore.MessageRow::id).toList();
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -246,6 +246,7 @@ class SchemaManagerTest {
     assertTrue(indexes.contains("idx_events_timestamp"));
     assertTrue(indexes.contains("idx_runs_project"));
     assertTrue(indexes.contains("idx_runs_spec"));
+    assertTrue(indexes.contains("idx_spec_messages_page"));
   }
 
   private void stageAtVersion(int version) {
@@ -291,6 +292,14 @@ class SchemaManagerTest {
                 "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'run_credentials'",
                 r -> r.text(0))
             .contains("run_credentials"));
+    assertTrue(
+        db.query(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'spec_messages'",
+                r -> r.text(0))
+            .contains("spec_messages"));
+    assertEquals(
+        "acme",
+        db.queryOne("SELECT project FROM runs WHERE id = 'r1'", r -> r.text(0)).orElseThrow());
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.ChangeLog;
+import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.Sqlite;
@@ -70,6 +71,8 @@ class MessageSyncTest {
 
   @Test
   void messagesFromDifferentBoxesConvergeWithoutConflict() {
+    new FdeStore(main.db).add("node", null, null, "admin");
+    new FdeStore(main.db).add("other", null, null, "admin");
     var fromNode = node.messages.append("room", "node", "node message", null);
     var fromOther = other.messages.append("room", "other", "other message", null);
     var engine = new SyncEngine();
@@ -86,6 +89,7 @@ class MessageSyncTest {
 
   @Test
   void syncedMessagesCannotBeChangedOrDeleted() {
+    main.db.execute("UPDATE specs SET assignee = 'node' WHERE id = 'room'");
     var row = node.messages.append("room", "node", "original", null);
     SyncPeer.with("node", () -> new SyncEngine().reconcile(node.replica, main.replica));
     var changed = new java.util.LinkedHashMap<>(main.messages.comparableSnapshot(row.id()));
@@ -117,7 +121,36 @@ class MessageSyncTest {
   }
 
   @Test
+  void authenticatedPeerCannotPostToForeignOrMissingSpec() {
+    main.db.execute("UPDATE specs SET assignee = 'ada', created_by = 'ada' WHERE id = 'room'");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            SyncPeer.with(
+                "mallory",
+                () ->
+                    main.messages.commitRevision(
+                        "00000000-0000-7000-8000-000000000002",
+                        snapshot("mallory", "room"),
+                        null)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            SyncPeer.with(
+                "mallory",
+                () ->
+                    main.messages.commitRevision(
+                        "00000000-0000-7000-8000-000000000003",
+                        snapshot("mallory", "missing"),
+                        null)));
+
+    assertTrue(main.messages.list("room", null, 10).isEmpty());
+  }
+
+  @Test
   void authenticatedPeerMayPostAsItsRunPrincipalOnlyOnThatRunsSpec() {
+    main.db.execute("UPDATE specs SET assignee = 'node' WHERE id = 'room'");
     main.db.execute(
         """
         INSERT INTO runs

--- a/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
@@ -18,6 +18,7 @@ import ai.singlr.sail.store.SyncConflicts;
 import ai.singlr.sail.store.SyncPeer;
 import ai.singlr.sail.store.SyncState;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -92,7 +93,7 @@ class MessageSyncTest {
     main.db.execute("UPDATE specs SET assignee = 'node' WHERE id = 'room'");
     var row = node.messages.append("room", "node", "original", null);
     SyncPeer.with("node", () -> new SyncEngine().reconcile(node.replica, main.replica));
-    var changed = new java.util.LinkedHashMap<>(main.messages.comparableSnapshot(row.id()));
+    var changed = new LinkedHashMap<>(main.messages.comparableSnapshot(row.id()));
     changed.put("body", "changed");
 
     assertThrows(

--- a/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
@@ -14,8 +14,10 @@ import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.SyncConflicts;
+import ai.singlr.sail.store.SyncPeer;
 import ai.singlr.sail.store.SyncState;
 import java.nio.file.Path;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,14 +70,14 @@ class MessageSyncTest {
 
   @Test
   void messagesFromDifferentBoxesConvergeWithoutConflict() {
-    var fromNode = node.messages.append("room", "codex/node", "node message", null);
-    var fromOther = other.messages.append("room", "ada", "other message", null);
+    var fromNode = node.messages.append("room", "node", "node message", null);
+    var fromOther = other.messages.append("room", "other", "other message", null);
     var engine = new SyncEngine();
 
-    engine.reconcile(node.replica, main.replica);
-    engine.reconcile(other.replica, main.replica);
-    engine.reconcile(node.replica, main.replica);
-    engine.reconcile(other.replica, main.replica);
+    SyncPeer.with("node", () -> engine.reconcile(node.replica, main.replica));
+    SyncPeer.with("other", () -> engine.reconcile(other.replica, main.replica));
+    SyncPeer.with("node", () -> engine.reconcile(node.replica, main.replica));
+    SyncPeer.with("other", () -> engine.reconcile(other.replica, main.replica));
 
     assertEquals(2, main.messages.list("room", null, 10).size());
     assertTrue(node.messages.findById(fromOther.id()).isPresent());
@@ -84,8 +86,8 @@ class MessageSyncTest {
 
   @Test
   void syncedMessagesCannotBeChangedOrDeleted() {
-    var row = node.messages.append("room", "codex/node", "original", null);
-    new SyncEngine().reconcile(node.replica, main.replica);
+    var row = node.messages.append("room", "node", "original", null);
+    SyncPeer.with("node", () -> new SyncEngine().reconcile(node.replica, main.replica));
     var changed = new java.util.LinkedHashMap<>(main.messages.comparableSnapshot(row.id()));
     changed.put("body", "changed");
 
@@ -95,5 +97,68 @@ class MessageSyncTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> main.messages.commitRevision(row.id(), null, main.messages.latestRev(row.id())));
+  }
+
+  @Test
+  void authenticatedPeerCannotForgeAnotherFdeAuthor() {
+    var messageId = "00000000-0000-7000-8000-000000000001";
+
+    var error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                SyncPeer.with(
+                    "node",
+                    () ->
+                        main.messages.commitRevision(messageId, snapshot("admin", "room"), null)));
+
+    assertTrue(error.getMessage().contains("may not post as 'admin'"));
+    assertTrue(main.messages.findById(messageId).isEmpty());
+  }
+
+  @Test
+  void authenticatedPeerMayPostAsItsRunPrincipalOnlyOnThatRunsSpec() {
+    main.db.execute(
+        """
+        INSERT INTO runs
+            (id, project, spec_id, node, role, agent, branch, task, status, started_at,
+             principal, owner)
+        VALUES
+            ('00000000-0000-7000-8000-000000000010', 'acme', 'room', 'node', 'build',
+             'codex', 'agent/messages', 'task', 'running', 'now', 'codex/run-1', 'node')""");
+    var acceptedId = "00000000-0000-7000-8000-000000000011";
+
+    SyncPeer.with(
+        "node",
+        () -> main.messages.commitRevision(acceptedId, snapshot("codex/run-1", "room"), null));
+
+    assertEquals("codex/run-1", main.messages.findById(acceptedId).orElseThrow().author());
+
+    main.db.execute(
+        """
+        INSERT INTO specs (id, title, project, created_at, updated_at)
+        VALUES ('other-room', 'Other room', 'acme', 'now', 'now')""");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            SyncPeer.with(
+                "node",
+                () ->
+                    main.messages.commitRevision(
+                        "00000000-0000-7000-8000-000000000012",
+                        snapshot("codex/run-1", "other-room"),
+                        null)));
+  }
+
+  private static Map<String, Object> snapshot(String author, String specId) {
+    return Map.of(
+        "spec_id",
+        specId,
+        "author",
+        author,
+        "body",
+        "sync message",
+        "created_at",
+        "2026-07-28T00:00:00Z");
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.sync;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.store.ChangeLog;
+import ai.singlr.sail.store.MessageStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import ai.singlr.sail.store.SyncConflicts;
+import ai.singlr.sail.store.SyncState;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MessageSyncTest {
+
+  @TempDir Path tempDir;
+  private Box main;
+  private Box node;
+  private Box other;
+
+  private final class Box implements AutoCloseable {
+    final Sqlite db;
+    final MessageStore messages;
+    final MessageReplica replica;
+
+    Box(String id) {
+      db = Sqlite.open(tempDir.resolve(id + ".db"));
+      new SchemaManager(db).migrate();
+      db.execute(
+          """
+          INSERT INTO specs (id, title, project, created_at, updated_at)
+          VALUES ('room', 'Room', 'acme', 'now', 'now')""");
+      messages = new MessageStore(db);
+      replica =
+          new MessageReplica(
+              id, messages, new ChangeLog(db), new SyncConflicts(db), new SyncState(db));
+    }
+
+    @Override
+    public void close() {
+      db.close();
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    main = new Box("main");
+    node = new Box("node");
+    other = new Box("other");
+  }
+
+  @AfterEach
+  void tearDown() {
+    other.close();
+    node.close();
+    main.close();
+  }
+
+  @Test
+  void messagesFromDifferentBoxesConvergeWithoutConflict() {
+    var fromNode = node.messages.append("room", "codex/node", "node message", null);
+    var fromOther = other.messages.append("room", "ada", "other message", null);
+    var engine = new SyncEngine();
+
+    engine.reconcile(node.replica, main.replica);
+    engine.reconcile(other.replica, main.replica);
+    engine.reconcile(node.replica, main.replica);
+    engine.reconcile(other.replica, main.replica);
+
+    assertEquals(2, main.messages.list("room", null, 10).size());
+    assertTrue(node.messages.findById(fromOther.id()).isPresent());
+    assertTrue(other.messages.findById(fromNode.id()).isPresent());
+  }
+
+  @Test
+  void syncedMessagesCannotBeChangedOrDeleted() {
+    var row = node.messages.append("room", "codex/node", "original", null);
+    new SyncEngine().reconcile(node.replica, main.replica);
+    var changed = new java.util.LinkedHashMap<>(main.messages.comparableSnapshot(row.id()));
+    changed.put("body", "changed");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> main.messages.applyRevision(row.id(), changed, row.rev()));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> main.messages.commitRevision(row.id(), null, main.messages.latestRev(row.id())));
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/sync/RemoteMainReplicaTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/RemoteMainReplicaTest.java
@@ -52,6 +52,21 @@ class RemoteMainReplicaTest {
   }
 
   @Test
+  void anOlderMainLoudlyNamesTheUnknownEntityType() {
+    var replica =
+        new RemoteMainReplica(
+            new StringReader(
+                SyncWire.encode(new SyncWire.Failed("Unknown entity type: message")) + "\n"),
+            new StringWriter(),
+            "message");
+
+    var failure = assertThrows(SyncTransportException.class, replica::entityIds);
+
+    assertTrue(failure.getMessage().contains("message"));
+    assertTrue(failure.getMessage().contains("Unknown entity type"));
+  }
+
+  @Test
   void aPreFloorMainIsRefusedBeforeItsDataIsRead() {
     var legacy = new SyncWire.Fetched("old-main", 1, Map.of(), null);
     var replica = replica(SyncWire.encode(legacy));

--- a/sail-core/src/test/java/ai/singlr/sail/sync/SyncTransitionsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/SyncTransitionsTest.java
@@ -68,6 +68,30 @@ class SyncTransitionsTest {
   }
 
   @Test
+  void aNewMessageEmitsOnePostedTransition() {
+    var snapshot =
+        Map.<String, Object>of("spec_id", "auth", "author", "ada", "body", "Progress update");
+
+    var emitted = SyncTransitions.detect("message", "m1", null, snapshot);
+
+    assertEquals(1, emitted.size());
+    var transition = emitted.getFirst();
+    assertEquals("message", transition.entityType());
+    assertEquals("m1", transition.entityId());
+    assertNull(transition.from());
+    assertEquals("posted", transition.to());
+    assertEquals(snapshot, transition.snapshot());
+  }
+
+  @Test
+  void anExistingMessageEmitsNothing() {
+    var snapshot =
+        Map.<String, Object>of("spec_id", "auth", "author", "ada", "body", "Progress update");
+
+    assertTrue(SyncTransitions.detect("message", "m1", snapshot, snapshot).isEmpty());
+  }
+
+  @Test
   void aRunCompletingEmitsAnAgentStoppedTransition() {
     var running = Map.<String, Object>of("project", "proj", "status", "running");
     var completed =

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/SpecCliHelper.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/SpecCliHelper.java
@@ -41,6 +41,9 @@ public final class SpecCliHelper {
   /** Fixed-string marker proving the installed script presents the run credential. */
   public static final String CREDENTIAL_MARKER = "SAIL_RUN_CREDENTIAL";
 
+  /** Fixed-string marker proving the installed script has the conversation commands. */
+  public static final String MESSAGES_MARKER = "spec comment";
+
   private static final String SCRIPT =
       """
       #!/usr/bin/env bash
@@ -103,6 +106,8 @@ public final class SpecCliHelper {
                     [--reasoning-effort none|low|medium|high|xhigh] [--priority N] [--plan-file F]
         spec update <id> [--status S] [--title T] [--assignee H] [--force] [...]  (alias: edit)
         spec content <id> --body-file F [--plan-file F]   revise the body
+        spec comment <id> --body <text>|- [--reply-to <message-id>]
+        spec comments <id> [--before <message-id>] [--limit N]
         spec archive <id>
         spec whoami                        show this run's principal identity
       USAGE
@@ -132,6 +137,33 @@ public final class SpecCliHelper {
           id="$1"; shift
           collect_fields "$@"
           api -X PUT "${FIELDS[@]}" "$BASE/$id/content";;
+        comment)
+          [ $# -ge 3 ] || die "comment needs a spec id and --body <text>|-"
+          id="$1"; shift
+          [ "$1" = "--body" ] || die "comment needs --body <text>|-"
+          body="$2"; shift 2
+          if [ "$body" = "-" ]; then
+            FIELDS=(--data-urlencode "body@-")
+          else
+            FIELDS=(--data-urlencode "body=$body")
+          fi
+          if [ $# -gt 0 ]; then
+            [ "$1" = "--reply-to" ] && [ $# -eq 2 ] || die "comment accepts only --reply-to <message-id>"
+            FIELDS+=(--data-urlencode "reply_to=$2")
+          fi
+          api -X POST "${FIELDS[@]}" "$BASE/$id/messages";;
+        comments)
+          [ $# -ge 1 ] || die "comments needs a spec id"
+          id="$1"; shift
+          FIELDS=()
+          while [ $# -gt 0 ]; do
+            case "$1" in
+              --before) FIELDS+=(--data-urlencode "before=$2"); shift 2;;
+              --limit) FIELDS+=(--data-urlencode "limit=$2"); shift 2;;
+              *) die "unknown option: $1";;
+            esac
+          done
+          api -G "${FIELDS[@]}" "$BASE/$id/messages";;
         archive)
           [ $# -ge 1 ] || die "archive needs a spec id"
           api -X PUT --data-urlencode "status=archived" "$BASE/$1";;

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/SpecCliHelperTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/SpecCliHelperTest.java
@@ -44,7 +44,15 @@ class SpecCliHelperTest {
     var content = SpecCliHelper.scriptContent();
     for (var sub :
         new String[] {
-          "board)", "list)", "show)", "create)", "update|edit)", "content)", "archive)"
+          "board)",
+          "list)",
+          "show)",
+          "create)",
+          "update|edit)",
+          "content)",
+          "archive)",
+          "comment)",
+          "comments)"
         }) {
       assertTrue(content.contains(sub), "missing subcommand: " + sub);
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.api;
 
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.store.ChangeLog;
+import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
@@ -791,6 +792,53 @@ record GlobalSpecContentResponse(String specId, String body, String plan) implem
     m.put("body", body);
     m.put("plan", plan);
     return m;
+  }
+}
+
+record SpecMessageRequest(String body, String replyTo) {
+  static SpecMessageRequest fromMap(Map<String, Object> map) {
+    return new SpecMessageRequest(
+        map.get("body") == null ? null : map.get("body").toString(),
+        map.get("reply_to") == null ? null : map.get("reply_to").toString());
+  }
+}
+
+record SpecMessageView(
+    String id, String specId, String author, String body, String replyTo, String createdAt)
+    implements Mappable {
+  static SpecMessageView from(MessageStore.MessageRow row) {
+    return new SpecMessageView(
+        row.id(), row.specId(), row.author(), row.body(), row.replyTo(), row.createdAt());
+  }
+
+  @Override
+  public Map<String, Object> toMap() {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("id", id);
+    map.put("spec_id", specId);
+    map.put("author", author);
+    map.put("body", body);
+    if (replyTo != null) map.put("reply_to", replyTo);
+    map.put("created_at", createdAt);
+    return map;
+  }
+}
+
+record SpecMessageResponse(SpecMessageView message) implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    return Map.of("message", message.toMap());
+  }
+}
+
+record SpecMessagesResponse(String specId, List<SpecMessageView> messages) implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("spec_id", specId);
+    map.put("messages", messages);
+    map.put("total", messages.size());
+    return map;
   }
 }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -392,13 +392,21 @@ public final class ApiRouter implements HttpHandler {
                     params.get("before"),
                     clampedLimit(params.get(LIMIT), DEFAULT_MESSAGES, MAX_MESSAGES)));
           }
-          case POST ->
-              ApiResponse.fromCreated(
-                  operations.postSpecMessage(
-                      specId,
-                      SpecMessageRequest.fromMap(JsonBody.readMessageMap(exchange)),
-                      actorOf(exchange),
-                      actor(exchange)));
+          case POST -> {
+            var principal = actorOf(exchange);
+            if (principal.handle() == null) {
+              throw new ApiException(
+                  ErrorCode.FORBIDDEN,
+                  "Spec messages require an FDE-bound credential so authorship can be"
+                      + " synchronized.");
+            }
+            yield ApiResponse.fromCreated(
+                operations.postSpecMessage(
+                    specId,
+                    SpecMessageRequest.fromMap(JsonBody.readMessageMap(exchange)),
+                    principal,
+                    principal.handle()));
+          }
           default -> throw methodNotAllowed();
         };
       }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -55,6 +55,9 @@ public final class ApiRouter implements HttpHandler {
   private static final String APPROVE = "approve";
   private static final String DISMISS = "dismiss";
   private static final String FOLLOWUP = "followup";
+  private static final String MESSAGES = "messages";
+  private static final int DEFAULT_MESSAGES = 50;
+  private static final int MAX_MESSAGES = 100;
   private static final int DEFAULT_TAIL = 200;
   private static final int MIN_TAIL = 1;
   private static final int MAX_TAIL = 5000;
@@ -379,6 +382,25 @@ public final class ApiRouter implements HttpHandler {
                 FollowupCreateRequest.fromMap(JsonBody.readMap(exchange))
                     .withCreatedBy(actor(exchange))));
       }
+      if (MESSAGES.equals(sub)) {
+        return switch (request.method()) {
+          case GET -> {
+            var params = QueryParameters.from(request.uri()).values();
+            yield ApiResponse.from(
+                operations.specMessages(
+                    specId,
+                    params.get("before"),
+                    clampedLimit(params.get(LIMIT), DEFAULT_MESSAGES, MAX_MESSAGES)));
+          }
+          case POST ->
+              ApiResponse.fromCreated(
+                  operations.postSpecMessage(
+                      specId,
+                      SpecMessageRequest.fromMap(JsonBody.readMap(exchange)),
+                      actor(exchange)));
+          default -> throw methodNotAllowed();
+        };
+      }
     }
     throw notFound();
   }
@@ -541,6 +563,17 @@ public final class ApiRouter implements HttpHandler {
     }
     var name = exchange.getAttribute("token.name");
     return name == null ? null : name.toString();
+  }
+
+  private static int clampedLimit(String value, int fallback, int maximum) {
+    if (Strings.isBlank(value)) {
+      return fallback;
+    }
+    try {
+      return Math.clamp(Integer.parseInt(value), 1, maximum);
+    } catch (NumberFormatException e) {
+      throw new ApiException(ErrorCode.BAD_REQUEST, "limit must be an integer");
+    }
   }
 
   private static ApiException methodNotAllowed() {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -396,7 +396,7 @@ public final class ApiRouter implements HttpHandler {
               ApiResponse.fromCreated(
                   operations.postSpecMessage(
                       specId,
-                      SpecMessageRequest.fromMap(JsonBody.readMap(exchange)),
+                      SpecMessageRequest.fromMap(JsonBody.readMessageMap(exchange)),
                       actorOf(exchange),
                       actor(exchange)));
           default -> throw methodNotAllowed();

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -397,6 +397,7 @@ public final class ApiRouter implements HttpHandler {
                   operations.postSpecMessage(
                       specId,
                       SpecMessageRequest.fromMap(JsonBody.readMap(exchange)),
+                      actorOf(exchange),
                       actor(exchange)));
           default -> throw methodNotAllowed();
         };

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -28,6 +28,7 @@ import ai.singlr.sail.engine.SnapshotManager;
 import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.store.DispatchGate;
 import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
@@ -194,6 +195,7 @@ public final class DispatchOperations {
   private final ReviewStore reviewStore;
   private final RunStore runStore;
   private final FdeStore fdeStore;
+  private MessageStore messageStore;
   private final EventSink events;
   private final WatcherSpawner watcherSpawner;
   private final Snapshotter snapshotter;
@@ -233,6 +235,11 @@ public final class DispatchOperations {
     this.listener = Objects.requireNonNull(listener, "listener");
   }
 
+  public DispatchOperations useMessages(MessageStore messages) {
+    this.messageStore = Objects.requireNonNull(messages, "messages");
+    return this;
+  }
+
   /**
    * Executes one dispatch: resolve the spec (honoring {@code restart}), enforce {@link
    * DispatchPolicy}, refuse while an ad-hoc agent is live, atomically reserve the run against the
@@ -268,7 +275,12 @@ public final class DispatchOperations {
     var taskSpec = DispatchRepos.withTargetRepos(nextSpec, targetRepos);
     var branch = BranchPolicy.branchName(loaded.config(), nextSpec);
     var specBody = specStore.getContent(nextSpec.id()).map(SpecStore.SpecContent::body).orElse("");
-    var task = AgentTaskPrompt.build(taskSpec, specBody.isBlank() ? nextSpec.title() : specBody);
+    var room =
+        messageStore == null
+            ? List.<MessageStore.MessageRow>of()
+            : messageStore.list(nextSpec.id(), null, 20);
+    var task =
+        AgentTaskPrompt.build(taskSpec, specBody.isBlank() ? nextSpec.title() : specBody, room);
     var agentType = taskSpec.agent() != null ? taskSpec.agent() : loaded.config().agent().type();
 
     if (request.dryRun()) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ErrorCode.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ErrorCode.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.api;
 
 public enum ErrorCode {
+  BAD_REQUEST(400),
   INVALID_REQUEST(422),
   INVALID_JSON(400),
   INVALID_MODE(422),

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
@@ -43,6 +43,12 @@ public record Event(
     String host,
     Map<String, Object> data) {
 
+  public enum RetentionClass {
+    RECORD,
+    TELEMETRY,
+    EPHEMERAL
+  }
+
   /** Current schema version. */
   public static final int CURRENT_VERSION = 1;
 
@@ -87,6 +93,9 @@ public record Event(
     public static final String PROJECT_STARTED = "project_started";
     public static final String PROJECT_STOPPED = "project_stopped";
     public static final String BOARD_UPDATED = "board_updated";
+    public static final String SPEC_MESSAGE_POSTED = "spec_message_posted";
+    public static final String AGENT_PRESENCE = "agent_presence";
+    public static final String HEARTBEAT = "heartbeat";
 
     /** A spec left in_progress/review past the reconciler threshold — surfaced for triage. */
     public static final String SPEC_STRANDED = "spec_stranded";
@@ -96,6 +105,14 @@ public record Event(
      * exit code in {@code data.exit_code} so the failure can be triaged.
      */
     public static final String AGENT_FAILED = "agent_failed";
+
+    public static RetentionClass retentionClass(String type) {
+      return switch (type) {
+        case AGENT_TOOL_STARTED, AGENT_TOOL_FINISHED, AGENT_LOG_CHUNK -> RetentionClass.TELEMETRY;
+        case AGENT_PRESENCE, HEARTBEAT -> RetentionClass.EPHEMERAL;
+        default -> RetentionClass.RECORD;
+      };
+    }
 
     private WellKnownTypes() {}
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/EventRetentionSweeper.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/EventRetentionSweeper.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.store.EventStore;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/** Periodically prunes old telemetry events in bounded transactions. */
+public final class EventRetentionSweeper implements AutoCloseable {
+
+  public static final Duration DEFAULT_RETENTION = Duration.ofDays(60);
+  public static final int BATCH_SIZE = 5000;
+
+  private static final Set<String> TELEMETRY_TYPES =
+      Set.of(
+          Event.WellKnownTypes.AGENT_TOOL_STARTED,
+          Event.WellKnownTypes.AGENT_TOOL_FINISHED,
+          Event.WellKnownTypes.AGENT_LOG_CHUNK);
+
+  private final EventStore events;
+  private final Duration retention;
+  private final ScheduledExecutorService scheduler =
+      Executors.newSingleThreadScheduledExecutor(
+          Thread.ofPlatform().name("sail-event-retention").daemon(true).factory());
+
+  public EventRetentionSweeper(EventStore events) {
+    this(events, DEFAULT_RETENTION);
+  }
+
+  EventRetentionSweeper(EventStore events, Duration retention) {
+    this.events = events;
+    this.retention = retention;
+  }
+
+  public void start() {
+    scheduler.scheduleAtFixedRate(this::sweepQuietly, 1, 24, TimeUnit.HOURS);
+  }
+
+  int sweep() {
+    return events.pruneBefore(
+        DateTimeUtils.now().minus(retention).toString(), TELEMETRY_TYPES, BATCH_SIZE);
+  }
+
+  void sweepQuietly() {
+    try {
+      sweep();
+    } catch (RuntimeException e) {
+      System.err.println(
+          "sail event retention: could not prune telemetry (" + e.getMessage() + ").");
+    }
+  }
+
+  @Override
+  public void close() {
+    scheduler.shutdownNow();
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/JsonBody.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/JsonBody.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 
 public final class JsonBody {
 
-  private static final int MAX_BYTES = 64 * 1024;
+  private static final int MAX_BYTES = 66 * 1024;
 
   private JsonBody() {}
 
@@ -54,7 +54,7 @@ public final class JsonBody {
     if (bytes.length > MAX_BYTES) {
       throw new ApiException(
           ErrorCode.REQUEST_TOO_LARGE,
-          "Request body exceeds 65536 bytes.",
+          "Request body exceeds 67584 bytes.",
           "Send a smaller JSON body.");
     }
     if (bytes.length == 0) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/JsonBody.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/JsonBody.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.api;
 
 import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.store.MessageStore;
 import com.sun.net.httpserver.HttpExchange;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -16,11 +17,12 @@ import java.util.Objects;
 public final class JsonBody {
 
   private static final int MAX_BYTES = 66 * 1024;
+  private static final int MAX_MESSAGE_REQUEST_BYTES = MessageStore.MAX_BODY_BYTES * 6 + 2048;
 
   private JsonBody() {}
 
   public static DispatchRequest readDispatchRequest(HttpExchange exchange) throws IOException {
-    var map = read(exchange);
+    var map = read(exchange, MAX_BYTES);
     return new DispatchRequest(
         optionalString(map, "spec_id"),
         optionalString(map, "mode"),
@@ -30,11 +32,15 @@ public final class JsonBody {
   }
 
   public static Map<String, Object> readMap(HttpExchange exchange) throws IOException {
-    return read(exchange);
+    return read(exchange, MAX_BYTES);
+  }
+
+  public static Map<String, Object> readMessageMap(HttpExchange exchange) throws IOException {
+    return read(exchange, MAX_MESSAGE_REQUEST_BYTES);
   }
 
   public static Event readEvent(HttpExchange exchange) throws IOException {
-    var map = read(exchange);
+    var map = read(exchange, MAX_BYTES);
     try {
       return Event.fromMap(map);
     } catch (IllegalArgumentException e) {
@@ -42,7 +48,7 @@ public final class JsonBody {
     }
   }
 
-  private static Map<String, Object> read(HttpExchange exchange) throws IOException {
+  private static Map<String, Object> read(HttpExchange exchange, int maxBytes) throws IOException {
     var contentType = exchange.getRequestHeaders().getFirst("Content-Type");
     if (contentType != null && !contentType.toLowerCase().startsWith("application/json")) {
       throw new ApiException(
@@ -50,12 +56,10 @@ public final class JsonBody {
           "Requests with a body must use application/json.",
           "Set Content-Type to application/json.");
     }
-    var bytes = exchange.getRequestBody().readNBytes(MAX_BYTES + 1);
-    if (bytes.length > MAX_BYTES) {
+    var bytes = exchange.getRequestBody().readNBytes(maxBytes + 1);
+    if (bytes.length > maxBytes) {
       throw new ApiException(
-          ErrorCode.REQUEST_TOO_LARGE,
-          "Request body exceeds 67584 bytes.",
-          "Send a smaller JSON body.");
+          ErrorCode.REQUEST_TOO_LARGE, "Request body is too large.", "Send a smaller JSON body.");
     }
     if (bytes.length == 0) {
       return Map.of();

--- a/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
@@ -175,10 +175,11 @@ final class LocalApiRouter implements LocalApiHandler {
     if (slash >= 0) {
       var id = tail.substring(0, slash);
       var sub = tail.substring(slash + 1);
-      if (!"content".equals(sub)) {
-        return problem(404, "No route for spec sub-resource " + sub);
-      }
-      return content(request, run, id);
+      return switch (sub) {
+        case "content" -> content(request, run, id);
+        case "messages" -> messages(request, run, id);
+        default -> problem(404, "No route for spec sub-resource " + sub);
+      };
     }
     return switch (request.method()) {
       case "GET" -> ApiResponse.from(operations.globalSpec(tail));
@@ -189,6 +190,35 @@ final class LocalApiRouter implements LocalApiHandler {
       case "DELETE" -> ApiResponse.from(operations.deleteGlobalSpec(tail, actorFrom(run)));
       default -> problem(405, "spec accepts GET, PUT, or DELETE");
     };
+  }
+
+  private ApiResponse messages(LocalApiRequest request, RunStore.RunRow run, String id) {
+    return switch (request.method()) {
+      case "GET" ->
+          ApiResponse.from(
+              operations.specMessages(
+                  id, request.query().get("before"), clampedLimit(request.query().get("limit"))));
+      case "POST" -> {
+        var form = request.form();
+        yield ApiResponse.fromCreated(
+            operations.postSpecMessage(
+                id,
+                new SpecMessageRequest(form.get("body"), form.get("reply_to")),
+                run.principal()));
+      }
+      default -> problem(405, "messages accepts GET or POST");
+    };
+  }
+
+  private static int clampedLimit(String value) {
+    if (Strings.isBlank(value)) {
+      return 50;
+    }
+    try {
+      return Math.clamp(Integer.parseInt(value), 1, 100);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("limit must be an integer");
+    }
   }
 
   private ApiResponse content(LocalApiRequest request, RunStore.RunRow run, String id) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
@@ -204,6 +204,7 @@ final class LocalApiRouter implements LocalApiHandler {
             operations.postSpecMessage(
                 id,
                 new SpecMessageRequest(form.get("body"), form.get("reply_to")),
+                actorFrom(run),
                 run.principal()));
       }
       default -> problem(405, "messages accepts GET or POST");

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
@@ -107,7 +107,7 @@ public interface Operations {
       String specId, SpecContentRequest request, Actor actor);
 
   Result<SpecMessageResponse> postSpecMessage(
-      String specId, SpecMessageRequest request, String author);
+      String specId, SpecMessageRequest request, Actor actor, String author);
 
   Result<SpecMessagesResponse> specMessages(String specId, String before, int limit);
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
@@ -106,6 +106,11 @@ public interface Operations {
   Result<GlobalSpecContentResponse> setGlobalSpecContent(
       String specId, SpecContentRequest request, Actor actor);
 
+  Result<SpecMessageResponse> postSpecMessage(
+      String specId, SpecMessageRequest request, String author);
+
+  Result<SpecMessagesResponse> specMessages(String specId, String before, int limit);
+
   Result<GlobalSpecHistoryResponse> globalSpecHistory(String specId);
 
   Result<GlobalSpecRestoredResponse> restoreGlobalSpec(

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -14,6 +14,7 @@ import ai.singlr.sail.engine.FindingParser;
 import ai.singlr.sail.engine.FixTaskBuilder;
 import ai.singlr.sail.engine.ReviewPromptBuilder;
 import ai.singlr.sail.store.Finding;
+import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
@@ -69,6 +70,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
   private final Runnable syncTrigger;
   private final RunStore runStore;
   private final Supplier<String> localHandle;
+  private MessageStore messageStore;
   private final ConcurrentHashMap<String, CompletableFuture<Void>> inFlight =
       new ConcurrentHashMap<>();
   private final ExecutorService pipelineExecutor;
@@ -154,6 +156,11 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     this.pipelineExecutor = pipelineExecutor;
     this.runStore = runStore;
     this.localHandle = runStore == null ? null : Objects.requireNonNull(localHandle, "localHandle");
+  }
+
+  public ReviewPipelineController useMessages(MessageStore messages) {
+    this.messageStore = Objects.requireNonNull(messages, "messages");
+    return this;
   }
 
   /**
@@ -409,7 +416,11 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       var spec = specStore.findById(specId);
       var branch = spec.map(SpecStore.SpecRow::branch).orElse("main");
       var repos = spec.map(SpecStore.SpecRow::repos).orElse(List.of());
-      var prompt = ReviewPromptBuilder.build(branch, repos, stageConfig.categories());
+      var room =
+          messageStore == null
+              ? List.<MessageStore.MessageRow>of()
+              : messageStore.list(specId, null, 20);
+      var prompt = ReviewPromptBuilder.build(branch, repos, stageConfig.categories(), room);
 
       var credential = startReviewRun(stage.reviewId(), project, specId, agent, branch, prompt);
       var output = agentRunner.run(project, agent, prompt, stage.reviewId(), credential);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -1098,7 +1098,7 @@ public final class SailOperations implements Operations {
 
   @Override
   public Result<SpecMessageResponse> postSpecMessage(
-      String specId, SpecMessageRequest request, String author) {
+      String specId, SpecMessageRequest request, Actor actor, String author) {
     return safeWrite(
         () -> {
           var store = requireMessageStore();
@@ -1109,6 +1109,7 @@ public final class SailOperations implements Operations {
                       () ->
                           new ApiException(
                               ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
+          SpecPolicy.mutate(actor, spec.id(), spec.assignee(), spec.createdBy()).enforce();
           MessageStore.MessageRow row;
           try {
             row = store.append(specId, author, request.body(), request.replyTo());

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -16,11 +16,13 @@ import ai.singlr.sail.engine.ConnectEnvironment;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.HostInfo;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.RunStore;
@@ -54,6 +56,7 @@ public final class SailOperations implements Operations {
   private final DispatchOperations dispatchOps;
   private final StopOperations stopOps;
   private final FdeStore fdeStore;
+  private MessageStore messageStore;
 
   public SailOperations() {
     this(new ShellExecutor(false), SailPaths.PROJECT_DESCRIPTOR);
@@ -89,6 +92,19 @@ public final class SailOperations implements Operations {
         auditSubscriber instanceof AuditPersister ap ? ap : null,
         specStore,
         reviewStore);
+  }
+
+  public SailOperations(
+      ShellExec shell,
+      String file,
+      EventBus eventBus,
+      EventSubscriber auditSubscriber,
+      SpecStore specStore,
+      ReviewStore reviewStore,
+      MessageStore messageStore) {
+    this(shell, file, eventBus, auditSubscriber, specStore, reviewStore);
+    this.messageStore = Objects.requireNonNull(messageStore, "messageStore");
+    this.dispatchOps.useMessages(messageStore);
   }
 
   /** Construct with database-backed spec store (no review store). */
@@ -155,6 +171,33 @@ public final class SailOperations implements Operations {
         ConnectEnvironment::detect,
         syncScheduler,
         fdeStore);
+  }
+
+  public SailOperations(
+      ShellExec shell,
+      String file,
+      EventBus eventBus,
+      EventSubscriber auditSubscriber,
+      SpecStore specStore,
+      ReviewStore reviewStore,
+      RunStore runStore,
+      MessageStore messageStore,
+      ProjectStore projectStore,
+      SyncScheduler syncScheduler,
+      FdeStore fdeStore) {
+    this(
+        shell,
+        file,
+        eventBus,
+        auditSubscriber,
+        specStore,
+        reviewStore,
+        runStore,
+        projectStore,
+        syncScheduler,
+        fdeStore);
+    this.messageStore = Objects.requireNonNull(messageStore, "messageStore");
+    this.dispatchOps.useMessages(messageStore);
   }
 
   SailOperations(
@@ -1051,6 +1094,74 @@ public final class SailOperations implements Operations {
   public Result<GlobalSpecContentResponse> setGlobalSpecContent(
       String specId, SpecContentRequest request, Actor actor) {
     return safeWrite(() -> globalSpecOps.setContent(specId, request, actor));
+  }
+
+  @Override
+  public Result<SpecMessageResponse> postSpecMessage(
+      String specId, SpecMessageRequest request, String author) {
+    return safeWrite(
+        () -> {
+          var store = requireMessageStore();
+          var spec =
+              specStore
+                  .findById(specId)
+                  .orElseThrow(
+                      () ->
+                          new ApiException(
+                              ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
+          MessageStore.MessageRow row;
+          try {
+            row = store.append(specId, author, request.body(), request.replyTo());
+          } catch (IllegalArgumentException invalid) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, invalid.getMessage());
+          }
+          publishOnBus(
+              Event.of(
+                  spec.project(),
+                  specId,
+                  Event.WellKnownTypes.SPEC_MESSAGE_POSTED,
+                  author,
+                  HostInfo.hostname(),
+                  Map.of("message_id", row.id(), "preview", preview(row.body()))));
+          return new SpecMessageResponse(SpecMessageView.from(row));
+        });
+  }
+
+  @Override
+  public Result<SpecMessagesResponse> specMessages(String specId, String before, int limit) {
+    return safeRead(
+        () -> {
+          if (specStore.findById(specId).isEmpty()) {
+            throw new ApiException(
+                ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found.");
+          }
+          List<SpecMessageView> messages;
+          try {
+            messages =
+                requireMessageStore().list(specId, before, limit).stream()
+                    .map(SpecMessageView::from)
+                    .toList();
+          } catch (IllegalArgumentException invalid) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, invalid.getMessage());
+          }
+          return new SpecMessagesResponse(specId, messages);
+        });
+  }
+
+  private MessageStore requireMessageStore() {
+    if (messageStore == null) {
+      throw new ApiException(
+          ErrorCode.INTERNAL,
+          "Message store not available. Start the server with 'sail server start'.");
+    }
+    return messageStore;
+  }
+
+  private static String preview(String body) {
+    var normalized = body.replaceAll("\\s+", " ").strip();
+    return normalized.codePointCount(0, normalized.length()) <= 160
+        ? normalized
+        : normalized.substring(0, normalized.offsetByCodePoints(0, 160));
   }
 
   @Override

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -94,19 +94,6 @@ public final class SailOperations implements Operations {
         reviewStore);
   }
 
-  public SailOperations(
-      ShellExec shell,
-      String file,
-      EventBus eventBus,
-      EventSubscriber auditSubscriber,
-      SpecStore specStore,
-      ReviewStore reviewStore,
-      MessageStore messageStore) {
-    this(shell, file, eventBus, auditSubscriber, specStore, reviewStore);
-    this.messageStore = Objects.requireNonNull(messageStore, "messageStore");
-    this.dispatchOps.useMessages(messageStore);
-  }
-
   /** Construct with database-backed spec store (no review store). */
   public SailOperations(
       ShellExec shell,
@@ -173,31 +160,11 @@ public final class SailOperations implements Operations {
         fdeStore);
   }
 
-  public SailOperations(
-      ShellExec shell,
-      String file,
-      EventBus eventBus,
-      EventSubscriber auditSubscriber,
-      SpecStore specStore,
-      ReviewStore reviewStore,
-      RunStore runStore,
-      MessageStore messageStore,
-      ProjectStore projectStore,
-      SyncScheduler syncScheduler,
-      FdeStore fdeStore) {
-    this(
-        shell,
-        file,
-        eventBus,
-        auditSubscriber,
-        specStore,
-        reviewStore,
-        runStore,
-        projectStore,
-        syncScheduler,
-        fdeStore);
+  /** Wires the message store into the operations and dispatch lanes; returns {@code this}. */
+  public SailOperations useMessages(MessageStore messageStore) {
     this.messageStore = Objects.requireNonNull(messageStore, "messageStore");
     this.dispatchOps.useMessages(messageStore);
+    return this;
   }
 
   SailOperations(

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SpecStoreAuditPersister.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SpecStoreAuditPersister.java
@@ -29,7 +29,8 @@ public final class SpecStoreAuditPersister implements EventSubscriber {
 
   @Override
   public Predicate<Event> filter() {
-    return EventSubscriber.all();
+    return event ->
+        Event.WellKnownTypes.retentionClass(event.type()) != Event.RetentionClass.EPHEMERAL;
   }
 
   @Override

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SyncTransitionEvents.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SyncTransitionEvents.java
@@ -44,6 +44,7 @@ public final class SyncTransitionEvents {
       case "run" -> runEvents(transition, host);
       case "review" -> reviewEvents(transition, projectOfSpec, host);
       case "review_stage" -> stageEvents(transition, projectOfSpec, host);
+      case "message" -> messageEvents(transition, projectOfSpec, host);
       default -> List.of();
     };
   }
@@ -193,6 +194,24 @@ public final class SyncTransitionEvents {
     };
   }
 
+  private static List<Event> messageEvents(
+      SyncTransition transition, Function<String, String> projectOfSpec, String host) {
+    var located = locate(transition, projectOfSpec);
+    var author = text(transition.snapshot(), "author");
+    var body = text(transition.snapshot(), "body");
+    if (located == null || author == null || body == null || !"posted".equals(transition.to())) {
+      return List.of();
+    }
+    return List.of(
+        event(
+            located.project(),
+            located.specId(),
+            Event.WellKnownTypes.SPEC_MESSAGE_POSTED,
+            author,
+            host,
+            Map.of("message_id", transition.entityId(), "preview", preview(body))));
+  }
+
   /** A review-side transition addressed to its spec and project, or null when unresolvable. */
   private record Located(String project, String specId) {
     Event event(String type, Map<String, Object> data, String host) {
@@ -241,5 +260,12 @@ public final class SyncTransitionEvents {
   private static String text(Map<String, Object> map, String key) {
     var value = map.get(key);
     return value == null ? null : value.toString();
+  }
+
+  private static String preview(String body) {
+    var normalized = body.replaceAll("\\s+", " ").strip();
+    return normalized.codePointCount(0, normalized.length()) <= 160
+        ? normalized
+        : normalized.substring(0, normalized.offsetByCodePoints(0, 160));
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCommentCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCommentCommand.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.api.SailApiClient;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.NameValidator;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+@Command(
+    name = "comment",
+    description = "Post a message to a spec's conversation.",
+    mixinStandardHelpOptions = true)
+public final class ApiSpecCommentCommand implements Runnable {
+
+  @Parameters(index = "0", description = "Spec ID.")
+  private String specId;
+
+  @Option(names = "--body", required = true, description = "Message text, or - to read stdin.")
+  private String body;
+
+  @Option(names = "--reply-to", description = "Message ID to reply to.")
+  private String replyTo;
+
+  @Mixin private SyncOptions syncOptions;
+  @Mixin private ConnectionOptions connection;
+  @Spec private CommandSpec commandSpec;
+
+  @Override
+  public void run() {
+    CliCommand.run(commandSpec, this::execute);
+  }
+
+  private void execute() throws Exception {
+    NameValidator.requireValidSpecId(specId);
+    var text =
+        "-".equals(body) ? new String(System.in.readAllBytes(), StandardCharsets.UTF_8) : body;
+    var request = new LinkedHashMap<String, Object>();
+    request.put("body", text);
+    if (replyTo != null) {
+      request.put("reply_to", replyTo);
+    }
+    var config = connection.resolve();
+    try (var client = new SailApiClient(config.serverUrl(), config.token(), syncOptions.noSync())) {
+      Map<String, Object> result = client.post("/v1/specs/" + specId + "/messages", request);
+      System.out.println(YamlUtil.dumpJson(new LinkedHashMap<>(result)));
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCommentsCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCommentsCommand.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.api.SailApiClient;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.NameValidator;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+@Command(
+    name = "comments",
+    description = "List a spec's conversation.",
+    mixinStandardHelpOptions = true)
+public final class ApiSpecCommentsCommand implements Runnable {
+
+  @Parameters(index = "0", description = "Spec ID.")
+  private String specId;
+
+  @Option(names = "--before", description = "Return messages before this message ID.")
+  private String before;
+
+  @Option(names = "--limit", defaultValue = "50", description = "Page size (max 100).")
+  private int limit;
+
+  @Mixin private SyncOptions syncOptions;
+  @Mixin private ConnectionOptions connection;
+  @Spec private CommandSpec commandSpec;
+
+  @Override
+  public void run() {
+    CliCommand.run(commandSpec, this::execute);
+  }
+
+  private void execute() throws Exception {
+    NameValidator.requireValidSpecId(specId);
+    var path =
+        new StringBuilder("/v1/specs/").append(specId).append("/messages?limit=").append(limit);
+    if (before != null) {
+      path.append("&before=").append(URLEncoder.encode(before, StandardCharsets.UTF_8));
+    }
+    var config = connection.resolve();
+    try (var client = new SailApiClient(config.serverUrl(), config.token(), syncOptions.noSync())) {
+      var result = client.get(path.toString());
+      System.out.println(YamlUtil.dumpJson(new LinkedHashMap<>(result)));
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
@@ -22,6 +22,7 @@ import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.SnapshotManager;
 import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
@@ -156,17 +157,18 @@ public final class DispatchCommand implements Runnable {
       DispatchOperations.AgentLauncher launcher,
       DispatchOperations.Listener listener) {
     return new DispatchOperations(
-        shell,
-        file,
-        new SpecStore(db),
-        new ReviewStore(db),
-        new RunStore(db),
-        new FdeStore(db),
-        events,
-        watcherSpawner,
-        snapshotter,
-        launcher,
-        listener);
+            shell,
+            file,
+            new SpecStore(db),
+            new ReviewStore(db),
+            new RunStore(db),
+            new FdeStore(db),
+            events,
+            watcherSpawner,
+            snapshotter,
+            launcher,
+            listener)
+        .useMessages(new MessageStore(db));
   }
 
   private DispatchOperations.Outcome dispatch(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.Event;
 import ai.singlr.sail.api.EventBus;
+import ai.singlr.sail.api.EventRetentionSweeper;
 import ai.singlr.sail.api.MissedStopReconciler;
 import ai.singlr.sail.api.ReviewWiring;
 import ai.singlr.sail.api.RunTracker;
@@ -40,6 +41,7 @@ import ai.singlr.sail.store.EnrollmentTicketStore;
 import ai.singlr.sail.store.EventStore;
 import ai.singlr.sail.store.ExpiredRowSweeper;
 import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.MigrationRunner;
 import ai.singlr.sail.store.PendingChallengeStore;
 import ai.singlr.sail.store.ProjectStore;
@@ -170,6 +172,7 @@ public final class ServerStartCommand implements Runnable {
     var persister = new SpecStoreAuditPersister(eventStore);
     var reviewStore = new ReviewStore(db);
     var runStore = new RunStore(db);
+    var messageStore = new MessageStore(db);
     var syncScheduler = NodeSync.scheduler(false);
     shutdown.register(syncScheduler);
     var operations =
@@ -181,6 +184,7 @@ public final class ServerStartCommand implements Runnable {
             specStore,
             reviewStore,
             runStore,
+            messageStore,
             new ProjectStore(db),
             syncScheduler,
             new FdeStore(db));
@@ -198,14 +202,15 @@ public final class ServerStartCommand implements Runnable {
     }
     var reviewController =
         ReviewWiring.controller(
-            specStore,
-            reviewStore,
-            bus,
-            ServerStartCommand::loadProjectYaml,
-            new ShellExecutor(false),
-            syncScheduler::afterWrite,
-            runStore,
-            NodeIdentity::handle);
+                specStore,
+                reviewStore,
+                bus,
+                ServerStartCommand::loadProjectYaml,
+                new ShellExecutor(false),
+                syncScheduler::afterWrite,
+                runStore,
+                NodeIdentity::handle)
+            .useMessages(messageStore);
     bus.subscribe(new RunTracker(runStore, syncScheduler, NodeIdentity::handle));
     if (narratesSlack(HostSync.config())) {
       bus.subscribe(SlackReactor.withDefaults(new SlackThreadStore(db), specStore));
@@ -243,6 +248,7 @@ public final class ServerStartCommand implements Runnable {
             specStore,
             reviewController);
     var sweeper = new ExpiredRowSweeper(dbPath);
+    var eventSweeper = new EventRetentionSweeper(eventStore);
     var reconciler =
         new StuckSpecReconciler(
             dbPath, StuckSpecReconciler.DEFAULT_THRESHOLD, stranded -> surface(bus, stranded));
@@ -270,12 +276,14 @@ public final class ServerStartCommand implements Runnable {
     shutdown
         .register(server)
         .register(sweeper)
+        .register(eventSweeper)
         .register(reconciler)
         .register(missedStops)
         .register(rearmer);
     try {
       server.start();
       sweeper.start();
+      eventSweeper.start();
       reconciler.start();
       var replayed = missedStops.sweep();
       if (replayed > 0) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -177,17 +177,17 @@ public final class ServerStartCommand implements Runnable {
     shutdown.register(syncScheduler);
     var operations =
         new SailOperations(
-            new ShellExecutor(false),
-            SailPaths.PROJECT_DESCRIPTOR,
-            bus,
-            persister,
-            specStore,
-            reviewStore,
-            runStore,
-            messageStore,
-            new ProjectStore(db),
-            syncScheduler,
-            new FdeStore(db));
+                new ShellExecutor(false),
+                SailPaths.PROJECT_DESCRIPTOR,
+                bus,
+                persister,
+                specStore,
+                reviewStore,
+                runStore,
+                new ProjectStore(db),
+                syncScheduler,
+                new FdeStore(db))
+            .useMessages(messageStore);
     var orphaned = reviewStore.failOrphanedRunning();
     var orphanedRuns = runStore.failRunningReviewsOnNode(NodeIdentity.handle());
     if (orphanedRuns > 0) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SpecCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SpecCommand.java
@@ -21,6 +21,8 @@ import picocli.CommandLine.Command;
       ApiSpecBoardCommand.class,
       ApiSpecHistoryCommand.class,
       ApiSpecRestoreCommand.class,
+      ApiSpecCommentCommand.class,
+      ApiSpecCommentsCommand.class,
       DispatchCommand.class,
     })
 public final class SpecCommand implements Runnable {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
@@ -21,6 +21,7 @@ import ai.singlr.sail.engine.SshSyncChannel;
 import ai.singlr.sail.store.ChangeLog;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.FileStore;
+import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.RunStore;
@@ -29,6 +30,7 @@ import ai.singlr.sail.store.SyncConflicts;
 import ai.singlr.sail.store.SyncPeer;
 import ai.singlr.sail.store.SyncState;
 import ai.singlr.sail.sync.FileReplica;
+import ai.singlr.sail.sync.MessageReplica;
 import ai.singlr.sail.sync.ProjectReplica;
 import ai.singlr.sail.sync.ReviewReplica;
 import ai.singlr.sail.sync.RunReplica;
@@ -135,6 +137,7 @@ public final class SyncCommand implements Callable<Integer> {
         new ProjectReplica(host, projectStore, changeLog, conflicts, syncState),
         new RunReplica(host, handle, new RunStore(db), changeLog, conflicts, syncState),
         new ReviewReplica(host, new ReviewStore(db), changeLog, conflicts, syncState),
+        new MessageReplica(host, new MessageStore(db), changeLog, conflicts, syncState),
         new FdeStore(db),
         fileStore,
         projectStore);
@@ -146,6 +149,7 @@ public final class SyncCommand implements Callable<Integer> {
       ProjectReplica project,
       RunReplica run,
       ReviewReplica review,
+      MessageReplica message,
       FdeStore fdes,
       FileStore files,
       ProjectStore projects) {}
@@ -225,6 +229,7 @@ public final class SyncCommand implements Callable<Integer> {
       var projectReport = new SyncEngine().reconcile(boxes.project(), session.replica("project"));
       var runReport = new SyncEngine().reconcile(boxes.run(), session.replica("run"));
       var reviewReport = new SyncEngine().reconcile(boxes.review(), session.replica("review"));
+      var messageReport = new SyncEngine().reconcile(boxes.message(), session.replica("message"));
       var rejected = applyFdes(boxes.fdes(), session.fetchFdes());
       if (!rejected.isEmpty()) {
         System.err.println(
@@ -239,8 +244,10 @@ public final class SyncCommand implements Callable<Integer> {
       materializeProjects(boxes.projects());
       reconcileLiveResources(boxes.projects(), projectReport);
       return combine(
-          combine(combine(combine(specReport, fileReport), projectReport), runReport),
-          reviewReport);
+          combine(
+              combine(combine(combine(specReport, fileReport), projectReport), runReport),
+              reviewReport),
+          messageReport);
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
@@ -17,6 +17,7 @@ import ai.singlr.sail.store.AuthSessionStore;
 import ai.singlr.sail.store.ChangeLog;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.FileStore;
+import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.RunStore;
@@ -26,6 +27,7 @@ import ai.singlr.sail.store.SyncConflicts;
 import ai.singlr.sail.store.SyncState;
 import ai.singlr.sail.sync.FileReplica;
 import ai.singlr.sail.sync.MainReplica;
+import ai.singlr.sail.sync.MessageReplica;
 import ai.singlr.sail.sync.ProjectReplica;
 import ai.singlr.sail.sync.ReviewReplica;
 import ai.singlr.sail.sync.RunReplica;
@@ -108,7 +110,9 @@ public final class SyncServerCommand implements Callable<Integer> {
             "run",
                 new RunReplica(mainId, mainId, new RunStore(db), changeLog, conflicts, syncState),
             "review",
-                new ReviewReplica(mainId, new ReviewStore(db), changeLog, conflicts, syncState));
+                new ReviewReplica(mainId, new ReviewStore(db), changeLog, conflicts, syncState),
+            "message",
+                new MessageReplica(mainId, new MessageStore(db), changeLog, conflicts, syncState));
     new SyncRpcServer(replicas, principal(db, token), () -> roster(db), transitionSink)
         .serve(in, out);
     return 0;

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/AgentTaskPrompt.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/AgentTaskPrompt.java
@@ -6,6 +6,8 @@
 package ai.singlr.sail.engine;
 
 import ai.singlr.sail.config.Spec;
+import ai.singlr.sail.store.MessageStore;
+import java.util.List;
 
 /**
  * Builds the task prompt handed to an agent when a spec is dispatched. Shared by the CLI dispatch
@@ -17,6 +19,11 @@ public final class AgentTaskPrompt {
 
   /** Renders the dispatch prompt for {@code spec}, appending the spec description/body. */
   public static String build(Spec spec, String description) {
+    return build(spec, description, List.of());
+  }
+
+  public static String build(
+      Spec spec, String description, List<MessageStore.MessageRow> messages) {
     var targetRepos =
         spec.repos().isEmpty()
             ? ""
@@ -41,8 +48,21 @@ public final class AgentTaskPrompt {
         + targetModel
         + targetReasoning
         + "\n"
+        + conversation(messages)
         + description
         + autonomousProtocol(spec);
+  }
+
+  private static String conversation(List<MessageStore.MessageRow> messages) {
+    if (messages.isEmpty()) {
+      return "";
+    }
+    var room = new StringBuilder("## Conversation on this spec\n\n");
+    for (var message : messages) {
+      room.append(message.author()).append(" (").append(message.createdAt()).append("):\n");
+      room.append(message.body()).append("\n\n");
+    }
+    return room.toString();
   }
 
   /**
@@ -63,6 +83,9 @@ public final class AgentTaskPrompt {
         Execute without waiting for confirmation: plan, implement, test, commit. When complete, run
         the full local verification the project uses (including any coverage or lint gates), commit
         with a clear message, push the branch, and open a pull request.
+
+        Post progress, questions, and your final summary to this spec's room with
+        `spec comment <id> --body <text>` (or `--body -` for stdin).
 
         The spec is not complete until CI is green: after opening the pull request, watch its
         checks with the CLI of the forge hosting the repo (e.g. `gh pr checks <number> --watch`

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/AgentTaskPrompt.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/AgentTaskPrompt.java
@@ -57,12 +57,11 @@ public final class AgentTaskPrompt {
     if (messages.isEmpty()) {
       return "";
     }
-    var room = new StringBuilder("## Conversation on this spec\n\n");
-    for (var message : messages) {
-      room.append(message.author()).append(" (").append(message.createdAt()).append("):\n");
-      room.append(message.body()).append("\n\n");
-    }
-    return room.toString();
+    return "## Conversation on this spec\n\n"
+        + PromptConversation.renderNewest(
+            messages,
+            message ->
+                message.author() + " (" + message.createdAt() + "):\n" + message.body() + "\n\n");
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
@@ -96,6 +96,10 @@ public final class ContainerSailSetup {
                         + SpecCliHelper.CREDENTIAL_MARKER
                         + " "
                         + SpecCliHelper.SCRIPT_PATH
+                        + " && grep -qsF '"
+                        + SpecCliHelper.MESSAGES_MARKER
+                        + "' "
+                        + SpecCliHelper.SCRIPT_PATH
                         + " && test -f "
                         + SailStopGate.SCRIPT_PATH
                         + " && grep -qsF "

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.api;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -773,7 +774,7 @@ class ApiRouterTest {
   @Test
   void specMessagesPostAndGetReturnJsonAndClampLimit() throws Exception {
     var ops = new MessageActorProbe();
-    try (var server = serverWith(ops, true)) {
+    try (var server = serverWithOwnedToken(ops, true)) {
       var posted =
           post(
               server,
@@ -782,9 +783,10 @@ class ApiRouterTest {
               "{\"body\":\"progress\",\"reply_to\":\"01900000-0000-7000-8000-000000000001\"}");
       assertEquals(201, posted.statusCode());
       assertTrue(posted.body().contains("\"body\": \"progress\""));
+      assertEquals("ada", ops.actor.handle());
       assertEquals(Role.ADMIN, ops.actor.role());
       assertEquals(Actor.Lane.API, ops.actor.lane());
-      assertEquals("admin", ops.author);
+      assertEquals("ada", ops.author);
 
       var listed = get(server, "/v1/specs/auth-flow/messages?limit=999", "token");
       assertEquals(200, listed.statusCode());
@@ -802,11 +804,24 @@ class ApiRouterTest {
     var ops = new MessageActorProbe();
     var body = "\"".repeat(34_000);
     var json = "{\"body\":\"" + "\\\"".repeat(34_000) + "\"}";
-    try (var server = serverWith(ops, true)) {
+    try (var server = serverWithOwnedToken(ops, true)) {
       var response = post(server, "/v1/specs/auth-flow/messages", "token", json);
 
       assertEquals(201, response.statusCode());
       assertEquals(body, ops.body);
+    }
+  }
+
+  @Test
+  void specMessagesRejectUnownedCredentialsBeforePosting() throws Exception {
+    var ops = new MessageActorProbe();
+    try (var server = serverWith(ops, true)) {
+      var response =
+          post(server, "/v1/specs/auth-flow/messages", "token", "{\"body\":\"progress\"}");
+
+      assertEquals(403, response.statusCode());
+      assertTrue(response.body().contains("FDE-bound credential"));
+      assertNull(ops.actor);
     }
   }
 
@@ -1122,8 +1137,23 @@ class ApiRouterTest {
   }
 
   private static SailApiServer serverWith(Operations ops, boolean autoStart) throws IOException {
-    var server =
-        new SailApiServer("127.0.0.1", 0, ops, new FixedTokenTestAuth("token"), null, null, null);
+    return serverWith(ops, autoStart, new FixedTokenTestAuth("token"));
+  }
+
+  private static SailApiServer serverWithOwnedToken(Operations ops, boolean autoStart)
+      throws IOException {
+    var delegate = new FixedTokenTestAuth("token");
+    ApiAuth auth =
+        exchange -> {
+          delegate.require(exchange);
+          exchange.setAttribute("token.fde", "ada");
+        };
+    return serverWith(ops, autoStart, auth);
+  }
+
+  private static SailApiServer serverWith(Operations ops, boolean autoStart, ApiAuth auth)
+      throws IOException {
+    var server = new SailApiServer("127.0.0.1", 0, ops, auth, null, null, null);
     if (autoStart) {
       server.start();
     }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -798,6 +798,19 @@ class ApiRouterTest {
   }
 
   @Test
+  void specMessageAcceptsEscapedJsonBodyBelowTheMessageLimit() throws Exception {
+    var ops = new MessageActorProbe();
+    var body = "\"".repeat(34_000);
+    var json = "{\"body\":\"" + "\\\"".repeat(34_000) + "\"}";
+    try (var server = serverWith(ops, true)) {
+      var response = post(server, "/v1/specs/auth-flow/messages", "token", json);
+
+      assertEquals(201, response.statusCode());
+      assertEquals(body, ops.body);
+    }
+  }
+
+  @Test
   void globalSpecBoardReturns200() throws Exception {
     try (var server = server()) {
       var response = get(server, "/v1/specs/board", "token");
@@ -1088,12 +1101,14 @@ class ApiRouterTest {
   private static final class MessageActorProbe extends FakeOperations {
     private Actor actor;
     private String author;
+    private String body;
 
     @Override
     public Result<SpecMessageResponse> postSpecMessage(
         String specId, SpecMessageRequest request, Actor actor, String author) {
       this.actor = actor;
       this.author = author;
+      this.body = request.body();
       return super.postSpecMessage(specId, request, actor, author);
     }
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -772,7 +772,8 @@ class ApiRouterTest {
 
   @Test
   void specMessagesPostAndGetReturnJsonAndClampLimit() throws Exception {
-    try (var server = server()) {
+    var ops = new MessageActorProbe();
+    try (var server = serverWith(ops, true)) {
       var posted =
           post(
               server,
@@ -781,6 +782,9 @@ class ApiRouterTest {
               "{\"body\":\"progress\",\"reply_to\":\"01900000-0000-7000-8000-000000000001\"}");
       assertEquals(201, posted.statusCode());
       assertTrue(posted.body().contains("\"body\": \"progress\""));
+      assertEquals(Role.ADMIN, ops.actor.role());
+      assertEquals(Actor.Lane.API, ops.actor.lane());
+      assertEquals("admin", ops.author);
 
       var listed = get(server, "/v1/specs/auth-flow/messages?limit=999", "token");
       assertEquals(200, listed.statusCode());
@@ -1078,6 +1082,19 @@ class ApiRouterTest {
         ai.singlr.sail.store.SpecStore.SpecFilter filter) {
       sawNoSync = SyncControl.noSync();
       return Result.success(new GlobalSpecsListResponse(java.util.List.of(), 0));
+    }
+  }
+
+  private static final class MessageActorProbe extends FakeOperations {
+    private Actor actor;
+    private String author;
+
+    @Override
+    public Result<SpecMessageResponse> postSpecMessage(
+        String specId, SpecMessageRequest request, Actor actor, String author) {
+      this.actor = actor;
+      this.author = author;
+      return super.postSpecMessage(specId, request, actor, author);
     }
   }
 
@@ -1435,8 +1452,8 @@ class ApiRouterTest {
 
     @Override
     public Result<SpecMessageResponse> postSpecMessage(
-        String specId, SpecMessageRequest request, String author) {
-      return new TestOperations().postSpecMessage(specId, request, author);
+        String specId, SpecMessageRequest request, Actor actor, String author) {
+      return new TestOperations().postSpecMessage(specId, request, actor, author);
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -771,6 +771,29 @@ class ApiRouterTest {
   }
 
   @Test
+  void specMessagesPostAndGetReturnJsonAndClampLimit() throws Exception {
+    try (var server = server()) {
+      var posted =
+          post(
+              server,
+              "/v1/specs/auth-flow/messages",
+              "token",
+              "{\"body\":\"progress\",\"reply_to\":\"01900000-0000-7000-8000-000000000001\"}");
+      assertEquals(201, posted.statusCode());
+      assertTrue(posted.body().contains("\"body\": \"progress\""));
+
+      var listed = get(server, "/v1/specs/auth-flow/messages?limit=999", "token");
+      assertEquals(200, listed.statusCode());
+      assertTrue(listed.body().contains("\"messages\""));
+      assertEquals(200, get(server, "/v1/specs/auth-flow/messages?limit=0", "token").statusCode());
+      assertEquals(200, get(server, "/v1/specs/auth-flow/messages", "token").statusCode());
+      assertEquals(
+          400, get(server, "/v1/specs/auth-flow/messages?limit=bad", "token").statusCode());
+      assertEquals(405, put(server, "/v1/specs/auth-flow/messages", "token", "{}").statusCode());
+    }
+  }
+
+  @Test
   void globalSpecBoardReturns200() throws Exception {
     try (var server = server()) {
       var response = get(server, "/v1/specs/board", "token");
@@ -1408,6 +1431,17 @@ class ApiRouterTest {
     public Result<GlobalSpecContentResponse> setGlobalSpecContent(
         String specId, SpecContentRequest request, Actor actor) {
       return Result.success(new GlobalSpecContentResponse(specId, request.body(), request.plan()));
+    }
+
+    @Override
+    public Result<SpecMessageResponse> postSpecMessage(
+        String specId, SpecMessageRequest request, String author) {
+      return new TestOperations().postSpecMessage(specId, request, author);
+    }
+
+    @Override
+    public Result<SpecMessagesResponse> specMessages(String specId, String before, int limit) {
+      return new TestOperations().specMessages(specId, before, limit);
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EventRetentionSweeperTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EventRetentionSweeperTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.store.EventStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class EventRetentionSweeperTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void sweepPrunesOldTelemetryAndKeepsRecords() {
+    try (var db = Sqlite.open(tempDir.resolve("events.db"))) {
+      new SchemaManager(db).migrate();
+      var events = new EventStore(db);
+      events.insert(row(Event.WellKnownTypes.AGENT_TOOL_STARTED));
+      events.insert(row(Event.WellKnownTypes.SPEC_MESSAGE_POSTED));
+      try (var sweeper = new EventRetentionSweeper(events, Duration.ofDays(1))) {
+        assertEquals(1, sweeper.sweep());
+        sweeper.sweepQuietly();
+        sweeper.start();
+      }
+      assertEquals(1, events.recent(10).size());
+      assertEquals(Event.WellKnownTypes.SPEC_MESSAGE_POSTED, events.recent(10).getFirst().type());
+    }
+  }
+
+  @Test
+  void defaultConstructorAndQuietFailurePathAreSafe() {
+    var db = Sqlite.open(tempDir.resolve("closed.db"));
+    new SchemaManager(db).migrate();
+    var sweeper = new EventRetentionSweeper(new EventStore(db));
+    assertTrue(EventRetentionSweeper.DEFAULT_RETENTION.toDays() > 0);
+    assertEquals(5000, EventRetentionSweeper.BATCH_SIZE);
+    db.close();
+    sweeper.sweepQuietly();
+    sweeper.close();
+  }
+
+  private static EventStore.EventRow row(String type) {
+    return new EventStore.EventRow(0, "2000-01-01T00:00:00Z", type, "p", "s", "sail", "h", "{}");
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EventTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EventTest.java
@@ -222,6 +222,28 @@ class EventTest {
   }
 
   @Test
+  void wellKnownTypesHaveEnforcedRetentionClasses() {
+    assertEquals(
+        Event.RetentionClass.RECORD,
+        Event.WellKnownTypes.retentionClass(Event.WellKnownTypes.SPEC_MESSAGE_POSTED));
+    assertEquals(
+        Event.RetentionClass.TELEMETRY,
+        Event.WellKnownTypes.retentionClass(Event.WellKnownTypes.AGENT_TOOL_STARTED));
+    assertEquals(
+        Event.RetentionClass.TELEMETRY,
+        Event.WellKnownTypes.retentionClass(Event.WellKnownTypes.AGENT_TOOL_FINISHED));
+    assertEquals(
+        Event.RetentionClass.TELEMETRY,
+        Event.WellKnownTypes.retentionClass(Event.WellKnownTypes.AGENT_LOG_CHUNK));
+    assertEquals(
+        Event.RetentionClass.EPHEMERAL,
+        Event.WellKnownTypes.retentionClass(Event.WellKnownTypes.AGENT_PRESENCE));
+    assertEquals(
+        Event.RetentionClass.EPHEMERAL,
+        Event.WellKnownTypes.retentionClass(Event.WellKnownTypes.HEARTBEAT));
+  }
+
+  @Test
   void sailAgentConstant() {
     assertEquals("sail", Event.SAIL_AGENT);
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/Fleet.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/Fleet.java
@@ -24,6 +24,7 @@ import ai.singlr.sail.store.AuthSessionStore;
 import ai.singlr.sail.store.ChangeLog;
 import ai.singlr.sail.store.EventStore;
 import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.RunStore;
@@ -239,6 +240,7 @@ public final class Fleet implements AutoCloseable {
     private final RunStore runs;
     private final ReviewStore reviews;
     private final FdeStore fdes;
+    private final MessageStore messages;
 
     private Box(String handle, boolean main, Path home, Path bin, Path descriptor, Sqlite db)
         throws Exception {
@@ -253,6 +255,7 @@ public final class Fleet implements AutoCloseable {
       runs = new RunStore(db);
       reviews = new ReviewStore(db);
       fdes = new FdeStore(db);
+      messages = new MessageStore(db);
       fdes.add(handle, handle, handle + "@example.dev", "admin");
       bus = new EventBus();
       reviewsController =
@@ -290,18 +293,19 @@ public final class Fleet implements AutoCloseable {
               StopOperations.Listener.NONE);
       operations =
           new SailOperations(
-              shell,
-              descriptor.toString(),
-              (command, log) -> 4242L,
-              bus,
-              null,
-              specs,
-              reviews,
-              runs,
-              projects,
-              ai.singlr.sail.engine.ConnectEnvironment::detect,
-              SyncScheduler.disabled(),
-              fdes);
+                  shell,
+                  descriptor.toString(),
+                  (command, log) -> 4242L,
+                  bus,
+                  null,
+                  specs,
+                  reviews,
+                  runs,
+                  projects,
+                  ai.singlr.sail.engine.ConnectEnvironment::detect,
+                  SyncScheduler.disabled(),
+                  fdes)
+              .useMessages(messages);
       slack = new CapturingPoster();
       var syncConfig =
           main
@@ -409,6 +413,18 @@ public final class Fleet implements AutoCloseable {
                   0));
       reviewsController.onEvent(event);
       bus.publish(event);
+    }
+
+    public SpecMessageView postMessage(String specId, String body) {
+      return operations
+          .postSpecMessage(
+              specId, new SpecMessageRequest(body, null), Actor.cliOperator(handle), handle)
+          .orThrow()
+          .message();
+    }
+
+    public List<SpecMessageView> listMessages(String specId) {
+      return operations.specMessages(specId, null, 50).orThrow().messages();
     }
 
     public void assertSpecStatus(String id, SpecStatus status) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/LocalApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/LocalApiRouterTest.java
@@ -275,6 +275,38 @@ class LocalApiRouterTest {
   }
 
   @Test
+  void postAndListMessagesUseTheRunPrincipalAndClampPages() {
+    var posted =
+        router.handle(
+            form(
+                "POST",
+                "/v1/specs/oauth/messages",
+                "body=Progress%20update&reply_to=01900000-0000-7000-8000-000000000001"));
+    assertEquals(201, posted.status());
+    assertEquals("Progress update", ops.lastMessage.body());
+    assertEquals(TestOperations.PRINCIPAL, ops.lastMessageAuthor);
+
+    assertEquals(
+        200,
+        router
+            .handle(
+                get(
+                    "/v1/specs/oauth/messages",
+                    Map.of("before", "01900000-0000-7000-8000-000000000001", "limit", "500")))
+            .status());
+    assertEquals(100, ops.lastMessageLimit);
+    assertEquals("01900000-0000-7000-8000-000000000001", ops.lastBefore);
+
+    router.handle(get("/v1/specs/oauth/messages", Map.of("limit", "0")));
+    assertEquals(1, ops.lastMessageLimit);
+    router.handle(get("/v1/specs/oauth/messages", Map.of()));
+    assertEquals(50, ops.lastMessageLimit);
+    assertEquals(
+        400, router.handle(get("/v1/specs/oauth/messages", Map.of("limit", "bad"))).status());
+    assertEquals(405, router.handle(form("DELETE", "/v1/specs/oauth/messages", "")).status());
+  }
+
+  @Test
   void unknownRouteAndUnknownSubResourceAre404() {
     assertEquals(404, router.handle(get("/v1/widgets", Map.of())).status());
     assertEquals(404, router.handle(get("/v1/specs/oauth/history", Map.of())).status());
@@ -297,6 +329,10 @@ class LocalApiRouterTest {
     private String lastShownId;
     private String lastDeletedId;
     private String lastContentId;
+    private SpecMessageRequest lastMessage;
+    private String lastMessageAuthor;
+    private String lastBefore;
+    private int lastMessageLimit;
 
     @Override
     public Result<GlobalSpecsListResponse> globalSpecs(SpecStore.SpecFilter filter) {
@@ -354,6 +390,21 @@ class LocalApiRouterTest {
     public Result<GlobalBoardResponse> globalBoard(String project) {
       lastBoardProject = project;
       return super.globalBoard(project);
+    }
+
+    @Override
+    public Result<SpecMessageResponse> postSpecMessage(
+        String specId, SpecMessageRequest request, String author) {
+      lastMessage = request;
+      lastMessageAuthor = author;
+      return super.postSpecMessage(specId, request, author);
+    }
+
+    @Override
+    public Result<SpecMessagesResponse> specMessages(String specId, String before, int limit) {
+      lastBefore = before;
+      lastMessageLimit = limit;
+      return super.specMessages(specId, before, limit);
     }
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/LocalApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/LocalApiRouterTest.java
@@ -285,6 +285,9 @@ class LocalApiRouterTest {
     assertEquals(201, posted.status());
     assertEquals("Progress update", ops.lastMessage.body());
     assertEquals(TestOperations.PRINCIPAL, ops.lastMessageAuthor);
+    assertEquals(TestOperations.PRINCIPAL, ops.lastActor.handle());
+    assertEquals(TestOperations.OWNER, ops.lastActor.owner());
+    assertTrue(ops.lastActor.agentLane());
 
     assertEquals(
         200,
@@ -394,10 +397,11 @@ class LocalApiRouterTest {
 
     @Override
     public Result<SpecMessageResponse> postSpecMessage(
-        String specId, SpecMessageRequest request, String author) {
+        String specId, SpecMessageRequest request, Actor actor, String author) {
       lastMessage = request;
       lastMessageAuthor = author;
-      return super.postSpecMessage(specId, request, author);
+      lastActor = actor;
+      return super.postSpecMessage(specId, request, actor, author);
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MessageFleetIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MessageFleetIT.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Messages posted through the production API on any box ride the real sync lane — the {@code sync}
+ * subprocess, the ssh shim, and main's {@code _sync} RPC server with its authenticated
+ * peer-attribution check — and converge on every box with author and order intact.
+ */
+class MessageFleetIT {
+
+  @TempDir Path root;
+
+  @Test
+  void messagesPostedOnNodeAndMainConvergeAcrossTheFleet() throws Exception {
+    try (var fleet = Fleet.of(root)) {
+      var main = fleet.main("uday");
+      var sumesh = fleet.node("sumesh", main);
+      var mady = fleet.node("mady", main);
+      fleet.scenario("s", "sumesh", sumesh, mady);
+
+      var fromNode = sumesh.postMessage("s", "starting on the build");
+      var fromMain = main.postMessage("s", "prefer the batched delete");
+      fleet.sync(sumesh);
+      fleet.sync(mady);
+      fleet.sync(sumesh);
+
+      for (var box : new Fleet.Box[] {main, sumesh, mady}) {
+        var room = box.listMessages("s");
+        assertEquals(2, room.size(), "room must converge on " + box.handle());
+        var byId =
+            room.stream().collect(Collectors.toMap(SpecMessageView::id, Function.identity()));
+        assertEquals("sumesh", byId.get(fromNode.id()).author());
+        assertEquals("uday", byId.get(fromMain.id()).author());
+        assertEquals(fromNode.body(), byId.get(fromNode.id()).body());
+        assertEquals(
+            List.of(fromNode.id(), fromMain.id()).stream().sorted().toList(),
+            room.stream().map(SpecMessageView::id).toList(),
+            "every box must page the room in the same id order");
+      }
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.singlr.sail.config.ReviewPipelineConfig;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.store.Finding;
+import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SchemaManager;
@@ -256,6 +257,13 @@ class ReviewPipelineControllerTest {
         review.isPresent(), "a spec clobbered to review out of band must still get its review");
     assertEquals("passed", review.get().status());
     assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void messageStoreWiringIsFluent() {
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+
+    assertEquals(ctrl, ctrl.useMessages(new MessageStore(db)));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -1590,7 +1590,12 @@ class SailOperationsTest {
             SyncScheduler.disabled(),
             new FdeStore(db));
 
-    var result = operations.postSpecMessage("auth", new SpecMessageRequest("Ready", null), "sail");
+    var result =
+        operations.postSpecMessage(
+            "auth",
+            new SpecMessageRequest("Ready", null),
+            new Actor("sail", Role.ADMIN, Actor.Lane.API),
+            "sail");
 
     assertTrue(result.isSuccess());
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -1578,17 +1578,17 @@ class SailOperationsTest {
     seedSpec(specStore, "auth", "Add auth", "pending", List.of(), "Do auth");
     var operations =
         new SailOperations(
-            shell(),
-            yaml.toString(),
-            new EventBus(),
-            null,
-            specStore,
-            new ReviewStore(db),
-            new RunStore(db),
-            new MessageStore(db),
-            new ProjectStore(db),
-            SyncScheduler.disabled(),
-            new FdeStore(db));
+                shell(),
+                yaml.toString(),
+                new EventBus(),
+                null,
+                specStore,
+                new ReviewStore(db),
+                new RunStore(db),
+                new ProjectStore(db),
+                SyncScheduler.disabled(),
+                new FdeStore(db))
+            .useMessages(new MessageStore(db));
 
     var result =
         operations.postSpecMessage(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -16,6 +16,7 @@ import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.Finding;
+import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.RunStore;
@@ -1563,6 +1564,33 @@ class SailOperationsTest {
             new FdeStore(db));
 
     var result = operations.runs("acme", null);
+
+    assertTrue(result.isSuccess());
+  }
+
+  @Test
+  void serverStartConstructorWiresTheMessageLane() throws Exception {
+    var yaml = tempDir.resolve("sail-" + System.nanoTime() + ".yaml");
+    Files.writeString(yaml, baseYaml());
+    var db = Sqlite.open(tempDir.resolve("specs-" + System.nanoTime() + ".db"));
+    new SchemaManager(db).migrate();
+    var specStore = new SpecStore(db);
+    seedSpec(specStore, "auth", "Add auth", "pending", List.of(), "Do auth");
+    var operations =
+        new SailOperations(
+            shell(),
+            yaml.toString(),
+            new EventBus(),
+            null,
+            specStore,
+            new ReviewStore(db),
+            new RunStore(db),
+            new MessageStore(db),
+            new ProjectStore(db),
+            SyncScheduler.disabled(),
+            new FdeStore(db));
+
+    var result = operations.postSpecMessage("auth", new SpecMessageRequest("Ready", null), "sail");
 
     assertTrue(result.isSuccess());
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SpecMessageOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SpecMessageOperationsTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.store.MessageStore;
+import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SpecMessageOperationsTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private EventBus bus;
+  private SailOperations operations;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("messages-api.db"));
+    new SchemaManager(db).migrate();
+    db.execute(
+        """
+        INSERT INTO specs (id, title, project, created_at, updated_at)
+        VALUES ('room', 'Room', 'acme', 'now', 'now')""");
+    bus = new EventBus();
+    operations =
+        new SailOperations(
+            new ShellExecutor(false),
+            "sail.yaml",
+            bus,
+            null,
+            new SpecStore(db),
+            new ReviewStore(db),
+            new MessageStore(db));
+  }
+
+  @AfterEach
+  void tearDown() {
+    bus.close();
+    db.close();
+  }
+
+  @Test
+  void postAttributesPublishesAndListsTheMessage() throws Exception {
+    var event = new AtomicReference<Event>();
+    var delivered = new CountDownLatch(1);
+    bus.subscribe(
+        BusTesting.latching(
+            new EventSubscriber() {
+              @Override
+              public String name() {
+                return "capture";
+              }
+
+              @Override
+              public java.util.function.Predicate<Event> filter() {
+                return ignored -> true;
+              }
+
+              @Override
+              public void onEvent(Event posted) {
+                event.set(posted);
+              }
+            },
+            delivered));
+
+    var posted =
+        operations
+            .postSpecMessage("room", new SpecMessageRequest("Progress\n  update", null), "ada")
+            .orThrow();
+
+    assertEquals("ada", posted.message().author());
+    BusTesting.awaitDelivery(delivered);
+    assertEquals(Event.WellKnownTypes.SPEC_MESSAGE_POSTED, event.get().type());
+    assertEquals("acme", event.get().project());
+    assertEquals("room", event.get().spec());
+    assertEquals(posted.message().id(), event.get().data().get("message_id"));
+    assertEquals("Progress update", event.get().data().get("preview"));
+
+    var listed = operations.specMessages("room", null, 50).orThrow();
+    assertEquals(1, listed.messages().size());
+    assertEquals(posted.message().id(), listed.messages().getFirst().id());
+  }
+
+  @Test
+  void validatesUnknownSpecsBodiesCursorsAndLongPreviews() {
+    assertEquals(
+        ErrorCode.SPEC_NOT_FOUND,
+        operations
+            .postSpecMessage("missing", new SpecMessageRequest("body", null), "ada")
+            .asFailure()
+            .errorCode());
+    assertEquals(
+        ErrorCode.BAD_REQUEST,
+        operations
+            .postSpecMessage("room", new SpecMessageRequest(" ", null), "ada")
+            .asFailure()
+            .errorCode());
+    assertEquals(
+        ErrorCode.BAD_REQUEST,
+        operations.specMessages("room", "not-a-uuid", 50).asFailure().errorCode());
+    assertEquals(
+        ErrorCode.SPEC_NOT_FOUND,
+        operations.specMessages("missing", null, 50).asFailure().errorCode());
+
+    var longMessage = "x".repeat(200);
+    operations.postSpecMessage("room", new SpecMessageRequest(longMessage, null), "ada").orThrow();
+    assertEquals(1, operations.specMessages("room", null, 50).orThrow().messages().size());
+  }
+
+  @Test
+  void messageModelsMapOptionalFieldsAndDefaults() {
+    var emptyRequest = SpecMessageRequest.fromMap(Map.of());
+    assertEquals(null, emptyRequest.body());
+    assertEquals(null, emptyRequest.replyTo());
+    var request = SpecMessageRequest.fromMap(Map.of("body", 42, "reply_to", 7));
+    assertEquals("42", request.body());
+    assertEquals("7", request.replyTo());
+
+    var view = new SpecMessageView("id", "room", "ada", "body", "parent", "2026-07-28T00:00:00Z");
+    assertEquals("parent", view.toMap().get("reply_to"));
+    var withoutReply =
+        new SpecMessageView("id", "room", "ada", "body", null, "2026-07-28T00:00:00Z");
+    assertFalse(withoutReply.toMap().containsKey("reply_to"));
+    assertTrue(new SpecMessageResponse(view).toMap().containsKey("message"));
+    assertEquals(1, new SpecMessagesResponse("room", java.util.List.of(view)).toMap().get("total"));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SpecMessageOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SpecMessageOperationsTest.java
@@ -37,8 +37,9 @@ class SpecMessageOperationsTest {
     new SchemaManager(db).migrate();
     db.execute(
         """
-        INSERT INTO specs (id, title, project, created_at, updated_at)
-        VALUES ('room', 'Room', 'acme', 'now', 'now')""");
+        INSERT INTO specs
+            (id, title, project, assignee, created_by, created_at, updated_at)
+        VALUES ('room', 'Room', 'acme', 'ada', 'ada', 'now', 'now')""");
     bus = new EventBus();
     operations =
         new SailOperations(
@@ -83,7 +84,8 @@ class SpecMessageOperationsTest {
 
     var posted =
         operations
-            .postSpecMessage("room", new SpecMessageRequest("Progress\n  update", null), "ada")
+            .postSpecMessage(
+                "room", new SpecMessageRequest("Progress\n  update", null), member("ada"), "ada")
             .orThrow();
 
     assertEquals("ada", posted.message().author());
@@ -104,13 +106,13 @@ class SpecMessageOperationsTest {
     assertEquals(
         ErrorCode.SPEC_NOT_FOUND,
         operations
-            .postSpecMessage("missing", new SpecMessageRequest("body", null), "ada")
+            .postSpecMessage("missing", new SpecMessageRequest("body", null), member("ada"), "ada")
             .asFailure()
             .errorCode());
     assertEquals(
         ErrorCode.BAD_REQUEST,
         operations
-            .postSpecMessage("room", new SpecMessageRequest(" ", null), "ada")
+            .postSpecMessage("room", new SpecMessageRequest(" ", null), member("ada"), "ada")
             .asFailure()
             .errorCode());
     assertEquals(
@@ -121,8 +123,33 @@ class SpecMessageOperationsTest {
         operations.specMessages("missing", null, 50).asFailure().errorCode());
 
     var longMessage = "x".repeat(200);
-    operations.postSpecMessage("room", new SpecMessageRequest(longMessage, null), "ada").orThrow();
+    operations
+        .postSpecMessage("room", new SpecMessageRequest(longMessage, null), member("ada"), "ada")
+        .orThrow();
     assertEquals(1, operations.specMessages("room", null, 50).orThrow().messages().size());
+  }
+
+  @Test
+  void onlyTheSpecOwnerOrAnAdminCanPost() {
+    var refused =
+        operations
+            .postSpecMessage(
+                "room",
+                new SpecMessageRequest("foreign instruction", null),
+                member("mallory"),
+                "mallory")
+            .asFailure();
+
+    assertEquals(ErrorCode.FORBIDDEN_NOT_ASSIGNEE, refused.errorCode());
+    assertTrue(operations.specMessages("room", null, 50).orThrow().messages().isEmpty());
+
+    var agent = Actor.agentPrincipal("codex/run-1", "ada");
+    var posted =
+        operations
+            .postSpecMessage(
+                "room", new SpecMessageRequest("owner update", null), agent, agent.handle())
+            .orThrow();
+    assertEquals(agent.handle(), posted.message().author());
   }
 
   @Test
@@ -141,5 +168,9 @@ class SpecMessageOperationsTest {
     assertFalse(withoutReply.toMap().containsKey("reply_to"));
     assertTrue(new SpecMessageResponse(view).toMap().containsKey("message"));
     assertEquals(1, new SpecMessagesResponse("room", java.util.List.of(view)).toMap().get("total"));
+  }
+
+  private static Actor member(String handle) {
+    return new Actor(handle, Role.MEMBER, Actor.Lane.API);
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SpecMessageOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SpecMessageOperationsTest.java
@@ -16,9 +16,11 @@ import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,13 +45,13 @@ class SpecMessageOperationsTest {
     bus = new EventBus();
     operations =
         new SailOperations(
-            new ShellExecutor(false),
-            "sail.yaml",
-            bus,
-            null,
-            new SpecStore(db),
-            new ReviewStore(db),
-            new MessageStore(db));
+                new ShellExecutor(false),
+                "sail.yaml",
+                bus,
+                null,
+                new SpecStore(db),
+                new ReviewStore(db))
+            .useMessages(new MessageStore(db));
   }
 
   @AfterEach
@@ -71,7 +73,7 @@ class SpecMessageOperationsTest {
               }
 
               @Override
-              public java.util.function.Predicate<Event> filter() {
+              public Predicate<Event> filter() {
                 return ignored -> true;
               }
 
@@ -167,7 +169,7 @@ class SpecMessageOperationsTest {
         new SpecMessageView("id", "room", "ada", "body", null, "2026-07-28T00:00:00Z");
     assertFalse(withoutReply.toMap().containsKey("reply_to"));
     assertTrue(new SpecMessageResponse(view).toMap().containsKey("message"));
-    assertEquals(1, new SpecMessagesResponse("room", java.util.List.of(view)).toMap().get("total"));
+    assertEquals(1, new SpecMessagesResponse("room", List.of(view)).toMap().get("total"));
   }
 
   private static Actor member(String handle) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SpecStoreAuditPersisterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SpecStoreAuditPersisterTest.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.store.EventStore;
@@ -44,9 +45,19 @@ class SpecStoreAuditPersisterTest {
   }
 
   @Test
-  void filterAcceptsAllEvents() {
+  void filterPersistsRecordsAndTelemetryButRejectsEphemeralEvents() {
     var event = Event.of("proj", "spec-1", "test_type", "sail", "host");
     assertTrue(persister.filter().test(event));
+    assertTrue(
+        persister
+            .filter()
+            .test(
+                Event.of(
+                    "proj", "spec-1", Event.WellKnownTypes.AGENT_TOOL_STARTED, "sail", "host")));
+    assertFalse(
+        persister
+            .filter()
+            .test(Event.of("proj", "spec-1", Event.WellKnownTypes.HEARTBEAT, "sail", "host")));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SyncTransitionEventsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SyncTransitionEventsTest.java
@@ -183,6 +183,44 @@ class SyncTransitionEventsTest {
     assertTrue(map(new SyncTransition("run", "r1", "running", "completed", snapshot)).isEmpty());
   }
 
+  @Test
+  void aPostedMessageBecomesASpecMessageEvent() {
+    var snapshot =
+        Map.<String, Object>of(
+            "spec_id", "auth", "author", "ada", "body", "  Progress\n\nupdate  ");
+
+    var events = map(new SyncTransition("message", "m1", null, "posted", snapshot));
+
+    assertEquals(1, events.size());
+    var event = events.getFirst();
+    assertEquals(Event.WellKnownTypes.SPEC_MESSAGE_POSTED, event.type());
+    assertEquals("proj", event.project());
+    assertEquals("auth", event.spec());
+    assertEquals("ada", event.agent());
+    assertEquals("main", event.host());
+    assertEquals("m1", event.data().get("message_id"));
+    assertEquals("Progress update", event.data().get("preview"));
+    assertEquals(Event.WellKnownData.SOURCE_SYNC, event.data().get(Event.WellKnownData.SOURCE));
+  }
+
+  @Test
+  void aMessageForAnUnknownSpecIsSilent() {
+    var snapshot =
+        Map.<String, Object>of("spec_id", "ghost", "author", "ada", "body", "Progress update");
+
+    assertTrue(map(new SyncTransition("message", "m1", null, "posted", snapshot)).isEmpty());
+  }
+
+  @Test
+  void aMessagePreviewIsLimitedByCodePoints() {
+    var body = "🚢".repeat(161);
+    var snapshot = Map.<String, Object>of("spec_id", "auth", "author", "ada", "body", body);
+
+    var event = map(new SyncTransition("message", "m1", null, "posted", snapshot)).getFirst();
+
+    assertEquals("🚢".repeat(160), event.data().get("preview"));
+  }
+
   private static Map<String, Object> review(String status, String error) {
     var map = new LinkedHashMap<String, Object>();
     map.put("spec_id", "auth");

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -314,7 +314,7 @@ class TestOperations implements Operations {
 
   @Override
   public Result<SpecMessageResponse> postSpecMessage(
-      String specId, SpecMessageRequest request, String author) {
+      String specId, SpecMessageRequest request, Actor actor, String author) {
     return Result.success(
         new SpecMessageResponse(
             SpecMessageView.from(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
 import java.util.List;
@@ -309,6 +310,38 @@ class TestOperations implements Operations {
   public Result<GlobalSpecContentResponse> setGlobalSpecContent(
       String specId, SpecContentRequest request, Actor actor) {
     return Result.success(new GlobalSpecContentResponse(specId, request.body(), request.plan()));
+  }
+
+  @Override
+  public Result<SpecMessageResponse> postSpecMessage(
+      String specId, SpecMessageRequest request, String author) {
+    return Result.success(
+        new SpecMessageResponse(
+            SpecMessageView.from(
+                new MessageStore.MessageRow(
+                    "01900000-0000-7000-8000-000000000001",
+                    specId,
+                    author,
+                    request.body(),
+                    request.replyTo(),
+                    "2026-07-28T00:00:00Z",
+                    "1-a",
+                    null))));
+  }
+
+  @Override
+  public Result<SpecMessagesResponse> specMessages(String specId, String before, int limit) {
+    return Result.success(
+        new SpecMessagesResponse(
+            specId,
+            List.of(
+                new SpecMessageView(
+                    "01900000-0000-7000-8000-000000000001",
+                    specId,
+                    PRINCIPAL,
+                    "hello",
+                    null,
+                    "2026-07-28T00:00:00Z"))));
   }
 
   @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ApiSpecCommandsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ApiSpecCommandsTest.java
@@ -57,13 +57,8 @@ class ApiSpecCommandsTest {
     reviewStore = new ReviewStore(db);
     var operations =
         new SailOperations(
-            new ShellExecutor(false),
-            "sail.yaml",
-            bus,
-            persister,
-            specStore,
-            reviewStore,
-            new MessageStore(db));
+                new ShellExecutor(false), "sail.yaml", bus, persister, specStore, reviewStore)
+            .useMessages(new MessageStore(db));
     server = new SailApiServer("127.0.0.1", 0, operations, tokenStore, bus, persister);
     server.start();
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ApiSpecCommandsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ApiSpecCommandsTest.java
@@ -15,6 +15,7 @@ import ai.singlr.sail.api.SailOperations;
 import ai.singlr.sail.api.SpecStoreAuditPersister;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.store.EventStore;
+import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.Finding;
 import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ReviewStore;
@@ -47,7 +48,8 @@ class ApiSpecCommandsTest {
     db = Sqlite.open(tempDir.resolve("test.db"));
     new SchemaManager(db).migrate();
     var tokenStore = new TokenStore(db);
-    token = tokenStore.create("test", "admin").token();
+    var fde = new FdeStore(db).add("test", "Test", "test@example.com", "admin");
+    token = tokenStore.create("test", "admin", fde.id(), null).token();
     var specStore = new SpecStore(db);
     var eventStore = new EventStore(db);
     var bus = new EventBus();

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ApiSpecCommandsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ApiSpecCommandsTest.java
@@ -16,11 +16,13 @@ import ai.singlr.sail.api.SpecStoreAuditPersister;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.store.EventStore;
 import ai.singlr.sail.store.Finding;
+import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ReviewStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.TokenStore;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
@@ -53,7 +55,13 @@ class ApiSpecCommandsTest {
     reviewStore = new ReviewStore(db);
     var operations =
         new SailOperations(
-            new ShellExecutor(false), "sail.yaml", bus, persister, specStore, reviewStore);
+            new ShellExecutor(false),
+            "sail.yaml",
+            bus,
+            persister,
+            specStore,
+            reviewStore,
+            new MessageStore(db));
     server = new SailApiServer("127.0.0.1", 0, operations, tokenStore, bus, persister);
     server.start();
   }
@@ -187,6 +195,34 @@ class ApiSpecCommandsTest {
     var output = run("show", "payment", "--json");
     assertTrue(output.contains("\"id\": \"payment\""));
     assertTrue(output.contains("\"title\": \"Payment integration\""));
+  }
+
+  @Test
+  void commentAndCommentsRoundTripAsJson() {
+    run("create", "--id", "room", "--title", "Room");
+
+    var posted = run("comment", "room", "--body", "Progress update");
+    assertTrue(posted.contains("\"author\": \"test\""));
+    assertTrue(posted.contains("\"body\": \"Progress update\""));
+
+    var listed = run("comments", "room");
+    assertTrue(listed.contains("\"messages\""));
+    assertTrue(listed.contains("\"body\": \"Progress update\""));
+  }
+
+  @Test
+  void commentReadsBodyFromStdin() {
+    run("create", "--id", "stdin-room", "--title", "Room");
+    var original = System.in;
+    try {
+      System.setIn(
+          new ByteArrayInputStream("Question from stdin".getBytes(StandardCharsets.UTF_8)));
+      assertTrue(
+          run("comment", "stdin-room", "--body", "-")
+              .contains("\"body\": \"Question from stdin\""));
+    } finally {
+      System.setIn(original);
+    }
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
@@ -98,6 +98,8 @@ class CommandTaxonomyTest {
             "board",
             "history",
             "restore",
+            "comment",
+            "comments",
             "dispatch"),
         spec.getSubcommands().keySet());
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
@@ -14,6 +14,7 @@ import ai.singlr.sail.Sail;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.engine.AgentTaskPrompt;
+import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
@@ -198,6 +199,27 @@ class DispatchCommandTest {
         prompt.contains("no Co-Authored-By trailers"),
         "generated work must not carry AI attribution");
     assertFalse(prompt.contains("handoff.md"), "no context-handoff cruft");
+    assertTrue(prompt.contains("spec comment <id> --body <text>"));
+  }
+
+  @Test
+  void buildTaskPromptPlacesTheRecentConversationBeforeTheBody() {
+    var spec = new Spec("oauth", "test", "OAuth", SpecStatus.PENDING, null, List.of(), null);
+    var message =
+        new MessageStore.MessageRow(
+            "01900000-0000-7000-8000-000000000001",
+            "oauth",
+            "ada",
+            "Use PKCE",
+            null,
+            "2026-07-28T00:00:00Z",
+            "1-a",
+            null);
+
+    var prompt = AgentTaskPrompt.build(spec, "Implement the flow", List.of(message));
+
+    assertTrue(prompt.contains("## Conversation on this spec"));
+    assertTrue(prompt.indexOf("Use PKCE") < prompt.indexOf("Implement the flow"));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/SpecCliSocketReachabilityIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/SpecCliSocketReachabilityIT.java
@@ -11,6 +11,7 @@ import ai.singlr.sail.api.EventBus;
 import ai.singlr.sail.api.LocalApiSocket;
 import ai.singlr.sail.api.SailOperations;
 import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
@@ -68,16 +69,17 @@ class SpecCliSocketReachabilityIT extends AbstractIncusIT {
       var bus = new EventBus();
       var operations =
           new SailOperations(
-              new ShellExecutor(false),
-              "sail.yaml",
-              bus,
-              null,
-              specStore,
-              null,
-              runStore,
-              null,
-              ai.singlr.sail.api.SyncScheduler.disabled(),
-              null);
+                  new ShellExecutor(false),
+                  "sail.yaml",
+                  bus,
+                  null,
+                  specStore,
+                  null,
+                  runStore,
+                  null,
+                  ai.singlr.sail.api.SyncScheduler.disabled(),
+                  null)
+              .useMessages(new MessageStore(db));
       try (var server = new LocalApiSocket(bus, operations, socketDir.resolve("api.sock"))) {
         server.start();
 
@@ -121,6 +123,49 @@ class SpecCliSocketReachabilityIT extends AbstractIncusIT {
         assertTrue(
             response.stdout().contains(SPEC_ID),
             "the seeded spec must round-trip back through the socket: " + response.stdout());
+
+        var posted =
+            exec(
+                CONTAINER,
+                List.of(
+                    "curl",
+                    "--silent",
+                    "--show-error",
+                    "--fail-with-body",
+                    "--unix-socket",
+                    CONTAINER_DIR.resolve("api.sock").toString(),
+                    "-H",
+                    "Authorization: Bearer " + credential,
+                    "-X",
+                    "POST",
+                    "--data-urlencode",
+                    "body=mid-run progress from inside the container",
+                    "http://sail/v1/specs/" + SPEC_ID + "/messages"));
+        assertTrue(
+            posted.ok(),
+            "the in-container agent could not post to the spec's room: "
+                + posted.stdout()
+                + posted.stderr());
+        assertTrue(
+            posted.stdout().contains("claude/"),
+            "a posted message must be attributed to the run principal: " + posted.stdout());
+
+        var room =
+            exec(
+                CONTAINER,
+                List.of(
+                    "curl",
+                    "--silent",
+                    "--show-error",
+                    "--fail-with-body",
+                    "--unix-socket",
+                    CONTAINER_DIR.resolve("api.sock").toString(),
+                    "-H",
+                    "Authorization: Bearer " + credential,
+                    "http://sail/v1/specs/" + SPEC_ID + "/messages"));
+        assertTrue(
+            room.stdout().contains("mid-run progress from inside the container"),
+            "the posted message must read back through the socket: " + room.stdout());
       }
     } finally {
       deleteContainerQuietly(CONTAINER);


### PR DESCRIPTION
## Summary

- add immutable spec messages with UUIDv7 IDs, pagination, reply links, append-only replication, and loud version-skew failures
- expose human and agent message APIs plus host and in-container comment commands
- include recent room messages in dispatch and review prompts and publish live message events
- classify event retention and prune telemetry in bounded background batches

## Review pass

- replace the two message-store constructors on `SailOperations` with a `useMessages` wiring method matching `DispatchOperations` and `ReviewPipelineController`
- add `MessageFleetIT`: messages posted through the production API on a node and on main converge across a three-box fleet over the real sync subprocess, ssh shim, and authenticated `_sync` RPC
- extend `SpecCliSocketReachabilityIT`: an in-container agent posts to and reads its spec's room through the bind-mounted socket, attributed to its run principal

## Verification

- mvn clean verify
- 4,207 tests passed
- all Spotless and JaCoCo gates passed
- mvn -Pintegration -Dsail.it.requireIncus=false clean verify green including MessageFleetIT
