### PR TITLE
sail up reconciles the container's sail surface on every start

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/UpCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/UpCommand.java
@@ -9,10 +9,12 @@ import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.Banner;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerManager;
+import ai.singlr.sail.engine.ContainerSailSetup;
 import ai.singlr.sail.engine.ContainerState;
 import ai.singlr.sail.engine.HostDetector;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.ResourceChecker;
+import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.ShellExecutor;
 import java.util.LinkedHashMap;
 import picocli.CommandLine.Command;
@@ -52,6 +54,7 @@ public final class UpCommand implements Runnable {
 
     switch (state) {
       case ContainerState.Running r -> {
+        reconcileSetup(shell, name);
         if (json) {
           printJson("running", r.ipv4());
           return;
@@ -68,6 +71,7 @@ public final class UpCommand implements Runnable {
           System.out.println(Ansi.AUTO.string("  @|bold Starting|@ " + name + "..."));
         }
         mgr.start(name);
+        reconcileSetup(shell, name);
         var newState = mgr.queryState(name);
         var ip = newState instanceof ContainerState.Running r ? r.ipv4() : null;
         if (json) {
@@ -86,6 +90,21 @@ public final class UpCommand implements Runnable {
               "Project '" + name + "' does not exist. Run 'sail project create' first.");
       case ContainerState.Error e ->
           throw new IllegalStateException("Container error: " + e.message());
+    }
+  }
+
+  /**
+   * Reconciles the sail-owned surface — the socket bind mount and the helper scripts — every time a
+   * project comes up or is confirmed up, so a container that slept through the server's boot sweep
+   * still converges the moment anyone reaches for it. Idempotent and best-effort: a wedged
+   * container is a warning, never a failed start.
+   */
+  static void reconcileSetup(ShellExec shell, String name) {
+    try {
+      ContainerSailSetup.ensureInstalled(shell, name);
+    } catch (Exception e) {
+      System.err.println(
+          "  [up] Warning: could not refresh the sail helpers in " + name + ": " + e.getMessage());
     }
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/UpCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/UpCommandTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.engine.ScriptedShellExecutor;
+import ai.singlr.sail.engine.ShellExec;
+import org.junit.jupiter.api.Test;
+
+class UpCommandTest {
+
+  @Test
+  void reconcileSetupRefreshesTheMountAndHelperScripts() {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
+
+    UpCommand.reconcileSetup(shell, "acme");
+
+    var commands = String.join("\n", shell.invocations());
+    assertTrue(
+        commands.contains("config device"),
+        "up must force-refresh the socket bind mount: " + commands);
+    assertTrue(
+        commands.contains("grep -qsF"),
+        "up must probe the helper scripts' staleness markers: " + commands);
+  }
+
+  @Test
+  void reconcileSetupIsBestEffortAndNeverBlocksTheStart() {
+    var wedged =
+        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+            .onFail("device add acme", "container wedged");
+
+    assertDoesNotThrow(() -> UpCommand.reconcileSetup(wedged, "acme"));
+  }
+}


### PR DESCRIPTION
## Why

Follow-up to #174: the boot sweep refreshes helper scripts only in containers **running** at server start. A stopped project started later with `sail up` and used purely interactively kept the stale actor-based `spec` script indefinitely. (The ambient `box.credential` itself was never affected — it rides the shared mount.)

## What

`sail up` now runs `ContainerSailSetup.ensureInstalled` on both branches (starting and already-running) — the same idempotent seam provisioning, recovery, dispatch, and the boot sweep share. Force-refreshes the socket mount (healing stranded inodes) and rewrites marker-stale scripts. Best-effort: a wedged container warns, the start never fails.

## Verification

- `UpCommandTest`: the reconcile probes markers + refreshes the device; a wedged container never blocks the start
- `mvn -Pintegration -Dsail.it.requireIncus=false clean verify` green