### PR TITLE
Spec list carries last_activity_at for accurate room ordering

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
@@ -108,6 +108,18 @@ public final class MessageStore {
     return List.copyOf(oldest);
   }
 
+  /** Each room's newest message timestamp — one aggregate query, keyed by spec id. */
+  public Map<String, String> latestBySpec() {
+    var latest = new LinkedHashMap<String, String>();
+    for (var entry :
+        db.query(
+            "SELECT spec_id, MAX(created_at) FROM spec_messages GROUP BY spec_id",
+            row -> Map.entry(row.text(0), row.text(1)))) {
+      latest.put(entry.getKey(), entry.getValue());
+    }
+    return latest;
+  }
+
   public Optional<MessageRow> findById(String id) {
     return db.queryOne(
         "SELECT " + COLUMNS + " FROM spec_messages WHERE id = ?", MessageStore::map, id);

--- a/sail-core/src/test/java/ai/singlr/sail/store/MessageStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/MessageStoreTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.singlr.sail.config.YamlUtil;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -79,6 +80,22 @@ class MessageStoreTest {
     assertThrows(IllegalArgumentException.class, () -> messages.list("room", null, 0));
     assertThrows(IllegalArgumentException.class, () -> messages.list("room", "not-a-uuid", 1));
     assertTrue(messages.list("room", null, 10).isEmpty());
+  }
+
+  @Test
+  void latestBySpecReportsEachRoomsNewestMessageTime() {
+    assertEquals(Map.of(), messages.latestBySpec());
+
+    messages.append("room", "uday", "first", null);
+    var second = messages.append("room", "uday", "second", null);
+    db.execute(
+        """
+        INSERT INTO specs (id, title, project, created_at, updated_at)
+        VALUES ('other', 'Other', 'acme', 'now', 'now')""");
+    var other = messages.append("other", "uday", "solo", null);
+
+    assertEquals(
+        Map.of("room", second.createdAt(), "other", other.createdAt()), messages.latestBySpec());
   }
 
   @Test

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -731,11 +731,40 @@ record GlobalSpecView(
   }
 }
 
-record GlobalSpecsListResponse(List<GlobalSpecView> specs, int total) implements Mappable {
+record GlobalSpecsListResponse(
+    List<GlobalSpecView> specs, int total, Map<String, String> latestMessageAt)
+    implements Mappable {
+
+  GlobalSpecsListResponse(List<GlobalSpecView> specs, int total) {
+    this(specs, total, null);
+  }
+
+  /**
+   * Each spec's {@code last_activity_at} = max(updated_at, its room's newest message) — the one
+   * activity source {@code updated_at} cannot see. Emitted only when the serving box has the
+   * message store, so a skewed client can detect absence and fall back.
+   */
   @Override
   public Map<String, Object> toMap() {
     var m = new LinkedHashMap<String, Object>();
-    m.put("specs", specs);
+    if (latestMessageAt == null) {
+      m.put("specs", specs);
+    } else {
+      m.put(
+          "specs",
+          specs.stream()
+              .map(
+                  view -> {
+                    var spec = view.toMap();
+                    var message = latestMessageAt.get(view.id());
+                    var updated = view.updatedAt();
+                    spec.put(
+                        "last_activity_at",
+                        message != null && message.compareTo(updated) > 0 ? message : updated);
+                    return spec;
+                  })
+              .toList());
+    }
     m.put("total", total);
     return m;
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -1046,7 +1046,15 @@ public final class SailOperations implements Operations {
 
   @Override
   public Result<GlobalSpecsListResponse> globalSpecs(SpecStore.SpecFilter filter) {
-    return safeRead(() -> globalSpecOps.list(filter));
+    return safeRead(
+        () -> {
+          var listed = globalSpecOps.list(filter);
+          if (messageStore == null) {
+            return listed;
+          }
+          return new GlobalSpecsListResponse(
+              listed.specs(), listed.total(), messageStore.latestBySpec());
+        });
   }
 
   @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SpecMessageOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SpecMessageOperationsTest.java
@@ -155,6 +155,29 @@ class SpecMessageOperationsTest {
   }
 
   @Test
+  void specListCarriesLastActivityFromMessagesOrUpdatedAt() throws Exception {
+    db.execute(
+        """
+        INSERT INTO specs (id, title, project, assignee, created_by, created_at, updated_at)
+        VALUES ('quiet', 'Quiet', 'acme', 'ada', 'ada', '2026-07-01T00:00:00Z',
+            '2026-07-02T00:00:00Z')""");
+    db.execute("UPDATE specs SET updated_at = '2026-07-01T00:00:00Z' WHERE id = 'room'");
+    var posted =
+        operations
+            .postSpecMessage("room", new SpecMessageRequest("activity", null), member("ada"), "ada")
+            .orThrow();
+
+    var listed = operations.globalSpecs(new SpecStore.SpecFilter(null, null, null, null, null));
+    @SuppressWarnings("unchecked")
+    var maps = (List<Map<String, Object>>) listed.orThrow().toMap().get("specs");
+
+    var room = maps.stream().filter(m -> "room".equals(m.get("id"))).findFirst().orElseThrow();
+    assertEquals(posted.message().createdAt(), room.get("last_activity_at"));
+    var quiet = maps.stream().filter(m -> "quiet".equals(m.get("id"))).findFirst().orElseThrow();
+    assertEquals(quiet.get("updated_at"), quiet.get("last_activity_at"));
+  }
+
+  @Test
   void messageModelsMapOptionalFieldsAndDefaults() {
     var emptyRequest = SpecMessageRequest.fromMap(Map.of());
     assertEquals(null, emptyRequest.body());


### PR DESCRIPTION
Mast's rooms sidebar orders by activity, but message traffic is invisible to `updated_at` and the client-side approximation (recent-events window) decays for rooms whose last message is older than the window.

- `MessageStore.latestBySpec()`: one `GROUP BY` aggregate, spec id → newest message time
- `GlobalSpecsListResponse` gains an optional decoration: each spec map carries `last_activity_at` = max(`updated_at`, latest message), computed at the response seam — no SpecRow/GlobalSpecView shape change (8 ctor sites untouched)
- Omitted entirely when the box has no message store → version-skew-safe client fallback

TDD; `mvn -Pintegration -Dsail.it.requireIncus=false clean verify` green (all gates).