### PR TITLE
One rate limiter over every TCP context

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -184,6 +184,12 @@ reflected/DOM XSS. Fixed:
   checks each address (incl. IPv4-mapped IPv6 like `::ffff:169.254.169.254`, full 169.254/16,
   CGNAT 100.64/10, ULA fc00::/7) instead of string prefixes; fail-closed on resolution failure.
 - **No-store on passkey responses** so a session-token body is never cached.
+- **One rate limiter over every TCP context.** The limiter lived inside `ApiRouter` and so covered
+  only the `/` context; `/v1/auth`, `/login`, `/enroll`, and `/v1/events/stream` are separate
+  `HttpContext`s and bypassed it, leaving the unauthenticated passkey ceremony unthrottled
+  (brute-force, challenge-table exhaustion, CPU-DoS). `RateLimitGate` now owns one budget applied
+  before dispatch on every context — keyed by credential once authenticated, by remote address
+  before that. SSE is charged at connection establishment only; the UDS lane stays exempt.
 
 Open items deliberately deferred (need a product decision or larger change, tracked separately):
 - **Route privilege tiers.** The main router maps mutating verbs to WRITE, so a `member` can

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -189,7 +189,10 @@ reflected/DOM XSS. Fixed:
   `HttpContext`s and bypassed it, leaving the unauthenticated passkey ceremony unthrottled
   (brute-force, challenge-table exhaustion, CPU-DoS). `RateLimitGate` now owns one budget applied
   before dispatch on every context — keyed by credential once authenticated, by remote address
-  before that. SSE is charged at connection establishment only; the UDS lane stays exempt.
+  before that (IPv6 grouped by /64, so a host cannot rotate source addresses to mint fresh budgets).
+  The bucket map is capped and evicts refilled buckets, so an attacker cycling addresses on the
+  pre-auth surface cannot grow it without bound. SSE is charged at connection establishment only;
+  the UDS lane stays exempt.
 
 Open items deliberately deferred (need a product decision or larger change, tracked separately):
 - **Route privilege tiers.** The main router maps mutating verbs to WRITE, so a `member` can

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -63,44 +63,33 @@ public final class ApiRouter implements HttpHandler {
   private static final int MAX_TAIL = 5000;
   private static final int DEFAULT_RECENT = 100;
 
-  private static final int DEFAULT_PERMITS_PER_MINUTE = 600;
-  private static final int DEFAULT_BURST = 600;
-
   private final Operations operations;
   private final ApiAuth auth;
-  private final RateLimiter rateLimiter;
+  private final RateLimitGate rateLimits;
   private final AgentLogStreamer agentStreamer;
   private final Supplier<String> nodeHandle;
 
   public ApiRouter(Operations operations, ApiAuth auth, RateLimiter rateLimiter) {
-    this(operations, auth, rateLimiter, null);
-  }
-
-  public ApiRouter(Operations operations, ApiAuth auth, AgentLogStreamer agentStreamer) {
-    this(
-        operations,
-        auth,
-        RateLimiter.perMinute(DEFAULT_PERMITS_PER_MINUTE, DEFAULT_BURST),
-        agentStreamer);
+    this(operations, auth, new RateLimitGate(rateLimiter), null);
   }
 
   public ApiRouter(
       Operations operations,
       ApiAuth auth,
-      RateLimiter rateLimiter,
+      RateLimitGate rateLimits,
       AgentLogStreamer agentStreamer) {
-    this(operations, auth, rateLimiter, agentStreamer, NodeIdentity::handle);
+    this(operations, auth, rateLimits, agentStreamer, NodeIdentity::handle);
   }
 
   ApiRouter(
       Operations operations,
       ApiAuth auth,
-      RateLimiter rateLimiter,
+      RateLimitGate rateLimits,
       AgentLogStreamer agentStreamer,
       Supplier<String> nodeHandle) {
     this.operations = operations;
     this.auth = auth;
-    this.rateLimiter = rateLimiter;
+    this.rateLimits = rateLimits;
     this.agentStreamer = agentStreamer;
     this.nodeHandle = nodeHandle;
   }
@@ -151,7 +140,7 @@ public final class ApiRouter implements HttpHandler {
   private void handleStream(HttpExchange exchange) throws IOException {
     try {
       auth.require(exchange);
-      requireWithinRateLimit(exchange);
+      rateLimits.require(exchange);
       Authorizer.require(exchange, Capability.READ);
     } catch (ApiException e) {
       try {
@@ -171,7 +160,7 @@ public final class ApiRouter implements HttpHandler {
     }
 
     auth.require(exchange);
-    requireWithinRateLimit(exchange);
+    rateLimits.require(exchange);
     Authorizer.require(exchange, Authorizer.capabilityFor(request.method()));
 
     if (request.matches(GET, V1, WHOAMI)) {
@@ -220,21 +209,6 @@ public final class ApiRouter implements HttpHandler {
       case CONNECT -> routeConnect(request, project);
       default -> throw notFound();
     };
-  }
-
-  /**
-   * Throttles per credential after authentication, so one client (a token's worth of identity)
-   * cannot exhaust the server. Keyed by token name; the role gate runs next, so even a request the
-   * caller is not authorized for still counts against their budget.
-   */
-  private void requireWithinRateLimit(HttpExchange exchange) {
-    var key = Objects.toString(exchange.getAttribute("token.name"), "anonymous");
-    if (!rateLimiter.tryAcquire(key)) {
-      throw new ApiException(
-          ErrorCode.RATE_LIMITED,
-          "Rate limit exceeded. Slow down and retry shortly.",
-          "This credential exceeded " + DEFAULT_PERMITS_PER_MINUTE + " requests per minute.");
-    }
   }
 
   private ApiResponse routeProject(RouteRequest request, String project) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RateLimitGate.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RateLimitGate.java
@@ -9,7 +9,10 @@ import ai.singlr.sail.config.YamlUtil;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.Objects;
 
@@ -22,10 +25,12 @@ import java.util.Objects;
  *
  * <p>Authenticated requests are keyed by credential: the router charges the budget after {@link
  * ApiAuth#require}, so a token's identity — not its network path — bounds it. Everything reached
- * before authentication is keyed by remote address, the only identity such a caller has. The
- * tradeoff is that clients sharing a NAT share one anonymous budget; that is the correct bias for a
- * pre-auth surface, where an over-wide key lets a brute-forcer split its attack across identities
- * it can mint for free.
+ * before authentication is keyed by remote address (IPv6 grouped by /64, since one host commonly
+ * holds a whole /64), the only identity such a caller has. The tradeoff is that clients sharing a
+ * NAT or a /64 share one anonymous budget; that is the correct bias for a pre-auth surface, where
+ * an over-wide key lets a brute-forcer split its attack across identities it can mint for free.
+ * {@link RateLimiter} caps how many keys it will hold, so an attacker cycling addresses cannot grow
+ * the bucket map without bound either.
  *
  * <p>The gate meters requests, not bytes or time: an SSE stream is charged once when it is
  * established and never again, so a long-lived subscriber is unaffected. The Unix-socket lane
@@ -85,8 +90,36 @@ public final class RateLimitGate {
     if (credential != null) {
       return "credential:" + credential;
     }
-    var remote = exchange.getRemoteAddress();
-    return remote == null ? "address:unknown" : "address:" + remote.getHostString();
+    return "address:" + addressKey(exchange.getRemoteAddress());
+  }
+
+  /**
+   * The budget key for an unauthenticated caller. IPv6 callers are grouped by their /64, because a
+   * single host is routinely handed a whole /64 — keying on the full address would let one attacker
+   * mint a fresh budget per request by changing source address, which is no throttle at all. IPv4
+   * (including its v6-mapped form) is keyed exactly: addresses there are scarce enough that one
+   * host cannot rotate through them.
+   */
+  private static String addressKey(InetSocketAddress remote) {
+    var address = remote == null ? null : remote.getAddress();
+    if (address == null) {
+      return "unknown";
+    }
+    var bytes = address.getAddress();
+    if (!(address instanceof Inet6Address) || isMappedIpv4(bytes)) {
+      return address.getHostAddress();
+    }
+    return HexFormat.ofDelimiter(":").formatHex(bytes, 0, 8) + "::/64";
+  }
+
+  private static boolean isMappedIpv4(byte[] bytes) {
+    for (var i = 0; i < 10; i++) {
+      if (bytes[i] != 0) {
+        return false;
+      }
+    }
+    return (bytes[10] == 0 && bytes[11] == 0)
+        || (bytes[10] == (byte) 0xff && bytes[11] == (byte) 0xff);
   }
 
   private static void writeError(HttpExchange exchange, ApiException error) throws IOException {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RateLimitGate.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RateLimitGate.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.config.YamlUtil;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Objects;
+
+/**
+ * The one rate-limit budget in front of every TCP context. {@link SailApiServer} owns a single gate
+ * and applies it to the API router, the passkey ceremony endpoints, the login/enroll pages, and SSE
+ * connection establishment, so no HTTP surface is unthrottled — the unauthenticated ceremony routes
+ * ({@code /v1/auth/login/start|finish}, {@code /v1/auth/register/finish}) most of all, since an
+ * attacker reaches them with no credential at all.
+ *
+ * <p>Authenticated requests are keyed by credential: the router charges the budget after {@link
+ * ApiAuth#require}, so a token's identity — not its network path — bounds it. Everything reached
+ * before authentication is keyed by remote address, the only identity such a caller has. The
+ * tradeoff is that clients sharing a NAT share one anonymous budget; that is the correct bias for a
+ * pre-auth surface, where an over-wide key lets a brute-forcer split its attack across identities
+ * it can mint for free.
+ *
+ * <p>The gate meters requests, not bytes or time: an SSE stream is charged once when it is
+ * established and never again, so a long-lived subscriber is unaffected. The Unix-socket lane
+ * ({@link LocalApiSocket}) is deliberately exempt — it is credential-gated and already bounded by
+ * its in-flight cap.
+ */
+public final class RateLimitGate {
+
+  static final int DEFAULT_PERMITS_PER_MINUTE = 600;
+  static final int DEFAULT_BURST = 600;
+
+  private final RateLimiter limiter;
+
+  /** A gate with the default budget: {@value #DEFAULT_PERMITS_PER_MINUTE} requests per minute. */
+  public RateLimitGate() {
+    this(RateLimiter.perMinute(DEFAULT_PERMITS_PER_MINUTE, DEFAULT_BURST));
+  }
+
+  public RateLimitGate(RateLimiter limiter) {
+    this.limiter = Objects.requireNonNull(limiter, "limiter");
+  }
+
+  /** Takes one token for the caller; throws {@code 429} when their budget is exhausted. */
+  public void require(HttpExchange exchange) {
+    if (!limiter.tryAcquire(keyOf(exchange))) {
+      throw new ApiException(
+          ErrorCode.RATE_LIMITED,
+          "Rate limit exceeded. Slow down and retry shortly.",
+          "This client exceeded " + DEFAULT_PERMITS_PER_MINUTE + " requests per minute.");
+    }
+  }
+
+  /**
+   * Wraps {@code delegate} so the budget is charged before dispatch. An over-budget caller gets the
+   * router's problem shape — the same status, media type, and JSON error body — without the
+   * delegate ever seeing the request.
+   */
+  public HttpHandler wrap(HttpHandler delegate) {
+    Objects.requireNonNull(delegate, "delegate");
+    return exchange -> {
+      try {
+        require(exchange);
+      } catch (ApiException e) {
+        try {
+          writeError(exchange, e);
+        } finally {
+          exchange.close();
+        }
+        return;
+      }
+      delegate.handle(exchange);
+    };
+  }
+
+  private static String keyOf(HttpExchange exchange) {
+    var credential = exchange.getAttribute("token.name");
+    if (credential != null) {
+      return "credential:" + credential;
+    }
+    var remote = exchange.getRemoteAddress();
+    return remote == null ? "address:unknown" : "address:" + remote.getHostString();
+  }
+
+  private static void writeError(HttpExchange exchange, ApiException error) throws IOException {
+    var response = ApiResponse.error(error.failure());
+    var body =
+        YamlUtil.dumpJson(new LinkedHashMap<>(response.body())).getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+    exchange.sendResponseHeaders(response.status(), body.length);
+    try (var output = exchange.getResponseBody()) {
+      output.write(body);
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RateLimitGate.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RateLimitGate.java
@@ -53,9 +53,17 @@ public final class RateLimitGate {
     this.limiter = Objects.requireNonNull(limiter, "limiter");
   }
 
-  /** Takes one token for the caller; throws {@code 429} when their budget is exhausted. */
+  /**
+   * Charges an <em>authenticated</em> request to its credential, falling back to its address when
+   * the caller has none. Only safe to call after {@link ApiAuth#require} has run on this exchange —
+   * see {@link #wrap} for why the credential cannot be trusted before that.
+   */
   public void require(HttpExchange exchange) {
-    if (!limiter.tryAcquire(keyOf(exchange))) {
+    charge(keyOf(exchange));
+  }
+
+  private void charge(String key) {
+    if (!limiter.tryAcquire(key)) {
       throw new ApiException(
           ErrorCode.RATE_LIMITED,
           "Rate limit exceeded. Slow down and retry shortly.",
@@ -67,12 +75,18 @@ public final class RateLimitGate {
    * Wraps {@code delegate} so the budget is charged before dispatch. An over-budget caller gets the
    * router's problem shape — the same status, media type, and JSON error body — without the
    * delegate ever seeing the request.
+   *
+   * <p>Charging is by address only, never by credential: {@code HttpExchange} attributes are stored
+   * on the {@code HttpContext}, so a {@code token.name} set by {@link ApiAuth#require} on one
+   * request stays readable by every later request to that context. Trusting it here would key an
+   * unauthenticated caller to whoever last authenticated — letting them skip their own budget and
+   * drain that user's instead.
    */
   public HttpHandler wrap(HttpHandler delegate) {
     Objects.requireNonNull(delegate, "delegate");
     return exchange -> {
       try {
-        require(exchange);
+        charge("address:" + addressKey(exchange.getRemoteAddress()));
       } catch (ApiException e) {
         try {
           writeError(exchange, e);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RateLimiter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RateLimiter.java
@@ -9,10 +9,17 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.LongSupplier;
 
 /**
- * Per-key token-bucket rate limiter. Each key (an API credential) gets a bucket that refills at a
- * steady rate up to a burst capacity; {@link #tryAcquire} takes one token, returning {@code false}
- * when the bucket is empty so the caller can reject with {@code 429}. Buckets are created lazily
- * and keyed by credential, so the map is bounded by the number of issued credentials.
+ * Per-key token-bucket rate limiter. Each key gets a bucket that refills at a steady rate up to a
+ * burst capacity; {@link #tryAcquire} takes one token, returning {@code false} when the bucket is
+ * empty so the caller can reject with {@code 429}.
+ *
+ * <p>Buckets are created lazily, so the key space is whatever the caller keys by — and on the
+ * pre-authentication surface that is the remote address, which an attacker chooses. The map is
+ * therefore capped at {@value #DEFAULT_MAX_KEYS} keys: when a new key arrives at the cap, fully
+ * refilled buckets are evicted first, and only if none can be freed is the request refused.
+ * Evicting a full bucket costs nothing, because a full bucket and a freshly created one hold
+ * identical state — so the cap bounds memory without ever forgetting that someone is being
+ * throttled.
  *
  * <p>Refill is measured against a monotonic clock ({@link System#nanoTime}), the correct source for
  * elapsed time — it never jumps when the wall clock is adjusted. The clock is injectable so the
@@ -22,15 +29,23 @@ public final class RateLimiter {
 
   private static final double NANOS_PER_MINUTE = 60d * 1_000_000_000d;
 
+  static final int DEFAULT_MAX_KEYS = 50_000;
+
   private final double capacity;
   private final double refillPerNano;
   private final LongSupplier nanoClock;
+  private final int maxKeys;
   private final ConcurrentHashMap<String, Bucket> buckets = new ConcurrentHashMap<>();
 
   RateLimiter(double capacity, double refillPerNano, LongSupplier nanoClock) {
+    this(capacity, refillPerNano, nanoClock, DEFAULT_MAX_KEYS);
+  }
+
+  RateLimiter(double capacity, double refillPerNano, LongSupplier nanoClock, int maxKeys) {
     this.capacity = capacity;
     this.refillPerNano = refillPerNano;
     this.nanoClock = nanoClock;
+    this.maxKeys = maxKeys;
   }
 
   /** A limiter allowing {@code permitsPerMinute} sustained, bursting up to {@code burst}. */
@@ -40,8 +55,13 @@ public final class RateLimiter {
 
   /** Takes one token for {@code key}; {@code false} when the bucket is empty (caller rejects). */
   public boolean tryAcquire(String key) {
-    var bucket =
-        buckets.computeIfAbsent(key, ignored -> new Bucket(capacity, nanoClock.getAsLong()));
+    var bucket = buckets.get(key);
+    if (bucket == null) {
+      if (buckets.size() >= maxKeys && !evictRefilled()) {
+        return false;
+      }
+      bucket = buckets.computeIfAbsent(key, ignored -> new Bucket(capacity, nanoClock.getAsLong()));
+    }
     synchronized (bucket) {
       var now = nanoClock.getAsLong();
       bucket.tokens =
@@ -53,6 +73,27 @@ public final class RateLimiter {
       }
       return false;
     }
+  }
+
+  /**
+   * Drops every bucket that has refilled to capacity, since such a bucket is indistinguishable from
+   * the one a returning caller would be given anyway. A request in flight against an evicted bucket
+   * simply charges a detached one that had a full budget — the same answer it would have got.
+   *
+   * @return {@code true} if there is now room for a new key.
+   */
+  private boolean evictRefilled() {
+    var now = nanoClock.getAsLong();
+    buckets
+        .entrySet()
+        .removeIf(
+            entry -> {
+              var bucket = entry.getValue();
+              synchronized (bucket) {
+                return bucket.tokens + (now - bucket.lastRefillNanos) * refillPerNano >= capacity;
+              }
+            });
+    return buckets.size() < maxKeys;
   }
 
   private static final class Bucket {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailApiServer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailApiServer.java
@@ -159,6 +159,37 @@ public final class SailApiServer implements AutoCloseable {
       SpecStore specStore,
       ReviewPipelineController reviewController)
       throws IOException {
+    this(
+        host,
+        port,
+        operations,
+        auth,
+        eventBus,
+        auditSubscriber,
+        socketPath,
+        passkeyHandler,
+        specStore,
+        reviewController,
+        new RateLimitGate());
+  }
+
+  /**
+   * Constructor seam that lets a caller supply the {@link RateLimitGate}, so tests can pin a tiny
+   * budget. Every context served over TCP is gated by this one instance.
+   */
+  SailApiServer(
+      String host,
+      int port,
+      Operations operations,
+      ApiAuth auth,
+      EventBus eventBus,
+      EventSubscriber auditSubscriber,
+      Path socketPath,
+      HttpHandler passkeyHandler,
+      SpecStore specStore,
+      ReviewPipelineController reviewController,
+      RateLimitGate rateLimits)
+      throws IOException {
     this.eventBus = eventBus;
     this.auditPersister = auditSubscriber instanceof AuditPersister ap ? ap : null;
     this.persisterSubscription =
@@ -174,16 +205,17 @@ public final class SailApiServer implements AutoCloseable {
             : null;
     server = HttpServer.create(new InetSocketAddress(host, port), 32);
     executor = Executors.newVirtualThreadPerTaskExecutor();
-    server.createContext("/", new ApiRouter(operations, auth, new AgentLogStreamer(auth)));
+    server.createContext(
+        "/", new ApiRouter(operations, auth, rateLimits, new AgentLogStreamer(auth)));
     if (passkeyHandler != null) {
-      server.createContext("/v1/auth", passkeyHandler);
-      var pages = new WebauthnPageHandler();
+      server.createContext("/v1/auth", rateLimits.wrap(passkeyHandler));
+      var pages = rateLimits.wrap(new WebauthnPageHandler());
       server.createContext("/login", pages);
       server.createContext("/enroll", pages);
     }
     if (eventBus != null) {
       sseHandler = new SseHandler(eventBus, auth);
-      server.createContext("/v1/events/stream", sseHandler);
+      server.createContext("/v1/events/stream", rateLimits.wrap(sseHandler));
       socketListener =
           socketPath == null ? null : new LocalApiSocket(eventBus, operations, socketPath);
     } else {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RateLimitGateTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RateLimitGateTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.YamlUtil;
+import com.sun.net.httpserver.HttpHandler;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Covers the contexts that used to sit outside the limiter: the passkey ceremony endpoints, the
+ * ceremony pages, and SSE connection establishment. Each server runs with a one-token budget so a
+ * "burst" is two requests rather than six hundred.
+ */
+class RateLimitGateTest {
+
+  private static final ApiAuth AUTH = new FixedTokenTestAuth("tok");
+
+  private static RateLimitGate oneRequest() {
+    return new RateLimitGate(new RateLimiter(1, 0d, () -> 0L));
+  }
+
+  @Test
+  void ceremonyBurstIsThrottledWhileHealthStaysAvailable(@TempDir Path tmp) throws Exception {
+    var passkeys = new WebauthnAuthHandler(null, null, AUTH, null);
+    try (var server = server(tmp, passkeys, null, oneRequest())) {
+      server.start();
+
+      var first = post(server, "/v1/auth/login/start");
+      assertNotEquals(429, first.statusCode());
+
+      var throttled = post(server, "/v1/auth/login/start");
+      assertEquals(429, throttled.statusCode());
+      assertEquals(
+          "application/json; charset=utf-8",
+          throttled.headers().firstValue("Content-Type").orElseThrow());
+      var error = (Map<?, ?>) YamlUtil.parseMap(throttled.body()).get("error");
+      assertEquals("rate_limited", error.get("code"));
+      assertTrue(error.get("action").toString().contains("requests per minute"));
+
+      assertEquals(429, get(server, "/login").statusCode());
+      assertEquals(429, get(server, "/enroll").statusCode());
+      assertEquals(200, get(server, "/v1/health").statusCode());
+    }
+  }
+
+  @Test
+  void throttledRequestNeverReachesTheHandler(@TempDir Path tmp) throws Exception {
+    var reached = new AtomicInteger();
+    HttpHandler passkeys =
+        exchange -> {
+          reached.incrementAndGet();
+          exchange.sendResponseHeaders(204, -1);
+          exchange.close();
+        };
+    try (var server = server(tmp, passkeys, null, oneRequest())) {
+      server.start();
+
+      assertEquals(204, post(server, "/v1/auth/login/finish").statusCode());
+      assertEquals(429, post(server, "/v1/auth/login/finish").statusCode());
+      assertEquals(1, reached.get());
+    }
+  }
+
+  @Test
+  void establishedStreamIsNotMeteredPerEvent(@TempDir Path tmp) throws Exception {
+    try (var bus = new EventBus();
+        var server = server(tmp, null, bus, oneRequest())) {
+      server.start();
+
+      var client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+      var stream =
+          client.send(streamRequest(server).build(), HttpResponse.BodyHandlers.ofInputStream());
+      assertEquals(200, stream.statusCode());
+
+      var second = client.send(streamRequest(server).build(), HttpResponse.BodyHandlers.ofString());
+      assertEquals(429, second.statusCode());
+
+      var reader = new BufferedReader(new InputStreamReader(stream.body(), StandardCharsets.UTF_8));
+      var delivered = new CountDownLatch(1);
+      var frame = new String[1];
+      var readerThread =
+          Thread.ofVirtual()
+              .start(
+                  () -> {
+                    try {
+                      String line;
+                      while ((line = reader.readLine()) != null) {
+                        if (line.startsWith("data: ")) {
+                          frame[0] = line;
+                          delivered.countDown();
+                          return;
+                        }
+                      }
+                    } catch (Exception ignored) {
+                      delivered.countDown();
+                    }
+                  });
+
+      bus.publish(Event.of("light", null, "spec_dispatched", "sail", "h"));
+      BusTesting.awaitDelivery(delivered);
+      assertTrue(
+          frame[0].contains("spec_dispatched"), "stream should keep delivering: " + frame[0]);
+
+      readerThread.interrupt();
+      hangUp(stream, client, bus);
+    }
+  }
+
+  /**
+   * Drops the client end of an SSE stream and publishes into the closed socket, so the server's
+   * stream loop discovers the disconnect on its next write instead of at the 15s heartbeat — which
+   * would hold the server's executor open for that long on close.
+   */
+  private static void hangUp(HttpResponse<InputStream> stream, HttpClient client, EventBus bus)
+      throws Exception {
+    stream.body().close();
+    client.close();
+    bus.publish(Event.of("light", null, "spec_dispatched", "sail", "h"));
+    bus.publish(Event.of("light", null, "spec_dispatched", "sail", "h"));
+  }
+
+  @Test
+  void gateRejectsANullLimiterAndNullHandler() {
+    assertThrows(NullPointerException.class, () -> new RateLimitGate(null));
+    assertThrows(NullPointerException.class, () -> new RateLimitGate().wrap(null));
+  }
+
+  private static SailApiServer server(
+      Path tmp, HttpHandler passkeys, EventBus bus, RateLimitGate gate) throws Exception {
+    return new SailApiServer(
+        "127.0.0.1",
+        0,
+        new TestOperations(),
+        AUTH,
+        bus,
+        null,
+        tmp.resolve("api.sock"),
+        passkeys,
+        null,
+        null,
+        gate);
+  }
+
+  private static HttpRequest.Builder streamRequest(SailApiServer server) {
+    return HttpRequest.newBuilder(uri(server, "/v1/events/stream"))
+        .header("Authorization", "Bearer tok")
+        .header("Accept", "text/event-stream")
+        .timeout(Duration.ofSeconds(10))
+        .GET();
+  }
+
+  private static HttpResponse<String> post(SailApiServer server, String path) throws Exception {
+    return send(
+        HttpRequest.newBuilder(uri(server, path))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString("{}")));
+  }
+
+  private static HttpResponse<String> get(SailApiServer server, String path) throws Exception {
+    return send(HttpRequest.newBuilder(uri(server, path)).GET());
+  }
+
+  private static HttpResponse<String> send(HttpRequest.Builder builder) throws Exception {
+    return HttpClient.newHttpClient().send(builder.build(), HttpResponse.BodyHandlers.ofString());
+  }
+
+  private static URI uri(SailApiServer server, String path) {
+    return URI.create("http://127.0.0.1:" + server.port() + path);
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RateLimitGateTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RateLimitGateTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -94,6 +95,7 @@ class RateLimitGateTest {
   }
 
   @Test
+  @Timeout(60)
   void establishedStreamIsNotMeteredPerEvent(@TempDir Path tmp) throws Exception {
     try (var bus = new EventBus();
         var server = server(tmp, null, bus, oneRequest())) {
@@ -104,8 +106,10 @@ class RateLimitGateTest {
           client.send(streamRequest(server).build(), HttpResponse.BodyHandlers.ofInputStream());
       assertEquals(200, stream.statusCode());
 
-      var second = client.send(streamRequest(server).build(), HttpResponse.BodyHandlers.ofString());
+      var second =
+          client.send(streamRequest(server).build(), HttpResponse.BodyHandlers.ofInputStream());
       assertEquals(429, second.statusCode());
+      second.body().close();
 
       var reader = new BufferedReader(new InputStreamReader(stream.body(), StandardCharsets.UTF_8));
       var delivered = new CountDownLatch(1);
@@ -149,6 +153,37 @@ class RateLimitGateTest {
     client.close();
     bus.publish(Event.of("light", null, "spec_dispatched", "sail", "h"));
     bus.publish(Event.of("light", null, "spec_dispatched", "sail", "h"));
+  }
+
+  /**
+   * A caller reaching the gate before authentication must be charged to their address, never to the
+   * credential of whoever authenticated last. {@code HttpExchange} attributes live on the
+   * HttpContext, so the {@code token.name} that {@link SseHandler} sets while serving one stream is
+   * still readable when the next connection arrives; keying on it hands the newcomer a full budget
+   * under someone else's name — and here that means a second stream is established instead of
+   * refused.
+   */
+  @Test
+  @Timeout(60)
+  void aSecondStreamIsRefusedNotChargedToTheFirstStreamsCredential(@TempDir Path tmp)
+      throws Exception {
+    try (var bus = new EventBus();
+        var server = server(tmp, null, bus, oneRequest())) {
+      server.start();
+
+      try (var client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build()) {
+        var first =
+            client.send(streamRequest(server).build(), HttpResponse.BodyHandlers.ofInputStream());
+        assertEquals(200, first.statusCode());
+
+        var second =
+            client.send(streamRequest(server).build(), HttpResponse.BodyHandlers.ofInputStream());
+        assertEquals(429, second.statusCode(), "the address budget is spent");
+        second.body().close();
+        first.body().close();
+      }
+      bus.publish(Event.of("light", null, "spec_dispatched", "sail", "h"));
+    }
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RateLimitGateTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RateLimitGateTest.java
@@ -11,17 +11,27 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.YamlUtil;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpPrincipal;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -145,6 +155,177 @@ class RateLimitGateTest {
   void gateRejectsANullLimiterAndNullHandler() {
     assertThrows(NullPointerException.class, () -> new RateLimitGate(null));
     assertThrows(NullPointerException.class, () -> new RateLimitGate().wrap(null));
+  }
+
+  @Test
+  void oneIpv6HostCannotMintAFreshBudgetPerSourceAddress() {
+    var gate = oneRequest();
+
+    gate.require(from("2001:db8:1:1::1"));
+
+    assertThrows(
+        ApiException.class,
+        () -> gate.require(from("2001:db8:1:1::2")),
+        "a second address in the same /64 draws on the same budget");
+  }
+
+  @Test
+  void separateIpv6PrefixesKeepSeparateBudgets() {
+    var gate = oneRequest();
+
+    gate.require(from("2001:db8:1:1::1"));
+    gate.require(from("2001:db8:1:2::1"));
+  }
+
+  @Test
+  void ipv4CallersAreKeyedExactlyIncludingTheirV6MappedForm() {
+    var gate = oneRequest();
+
+    gate.require(from("198.51.100.7"));
+    gate.require(from("::ffff:198.51.100.8"));
+
+    assertThrows(ApiException.class, () -> gate.require(from("::ffff:198.51.100.7")));
+  }
+
+  @Test
+  void aV4MappedAddressArrivingAsIpv6IsStillKeyedExactly() throws Exception {
+    var gate = oneRequest();
+
+    gate.require(mapped("198.51.100.7"));
+    gate.require(mapped("198.51.100.8"));
+
+    assertThrows(
+        ApiException.class,
+        () -> gate.require(mapped("198.51.100.7")),
+        "mapped v4 callers must not collapse into one ::/64 budget");
+  }
+
+  @Test
+  void callersWithNoResolvableAddressShareOneBudget() {
+    var gate = oneRequest();
+
+    gate.require(new AddressExchange(null));
+
+    assertThrows(ApiException.class, () -> gate.require(new AddressExchange(null)));
+  }
+
+  /**
+   * A caller whose v4 address reaches the server in its 16-byte v6-mapped form, which a dual-stack
+   * socket can hand back. Grouping those by /64 would put every IPv4 client on the planet in one
+   * budget, so the gate must key them exactly.
+   */
+  private static HttpExchange mapped(String ipv4) throws Exception {
+    var bytes = new byte[16];
+    bytes[10] = (byte) 0xff;
+    bytes[11] = (byte) 0xff;
+    System.arraycopy(InetAddress.getByName(ipv4).getAddress(), 0, bytes, 12, 4);
+    return new AddressExchange(
+        new InetSocketAddress(Inet6Address.getByAddress(null, bytes, 0), 41000));
+  }
+
+  private static HttpExchange from(String address) {
+    try {
+      return new AddressExchange(new InetSocketAddress(InetAddress.getByName(address), 41000));
+    } catch (UnknownHostException e) {
+      throw new IllegalArgumentException(address, e);
+    }
+  }
+
+  /**
+   * An exchange that carries nothing but a remote address — the pre-auth caller's whole identity.
+   */
+  private static final class AddressExchange extends HttpExchange {
+    private final InetSocketAddress remote;
+    private final Map<String, Object> attributes = new HashMap<>();
+
+    private AddressExchange(InetSocketAddress remote) {
+      this.remote = remote;
+    }
+
+    @Override
+    public InetSocketAddress getRemoteAddress() {
+      return remote;
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+      return attributes.get(name);
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+      attributes.put(name, value);
+    }
+
+    @Override
+    public Headers getRequestHeaders() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Headers getResponseHeaders() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URI getRequestURI() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getRequestMethod() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpContext getHttpContext() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InputStream getRequestBody() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OutputStream getResponseBody() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sendResponseHeaders(int code, long length) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InetSocketAddress getLocalAddress() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getProtocol() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getResponseCode() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HttpPrincipal getPrincipal() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setStreams(InputStream input, OutputStream output) {
+      throw new UnsupportedOperationException();
+    }
   }
 
   private static SailApiServer server(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RateLimiterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RateLimiterTest.java
@@ -59,6 +59,43 @@ class RateLimiterTest {
   }
 
   @Test
+  void aNewKeyEvictsARefilledBucketRatherThanGrowingTheMap() {
+    var clock = new AtomicLong(0);
+    var oneTokenPerSecond = 1d / 1_000_000_000d;
+    var limiter = new RateLimiter(1, oneTokenPerSecond, clock::get, 2);
+
+    assertTrue(limiter.tryAcquire("a"));
+    assertTrue(limiter.tryAcquire("b"));
+    clock.set(1_000_000_000L);
+
+    assertTrue(limiter.tryAcquire("c"), "both buckets refilled, so the cap makes room");
+    assertFalse(limiter.tryAcquire("c"), "the evicting caller still gets a real bucket");
+  }
+
+  @Test
+  void aFloodOfNewKeysIsRefusedRatherThanAllowedToGrowTheMap() {
+    var limiter = new RateLimiter(1, 0d, () -> 0L, 2);
+
+    assertTrue(limiter.tryAcquire("a"));
+    assertTrue(limiter.tryAcquire("b"));
+
+    assertFalse(limiter.tryAcquire("c"), "no bucket can be freed, so the new key is refused");
+    assertFalse(limiter.tryAcquire("d"));
+  }
+
+  @Test
+  void anEvictedKeyStartsFreshWhenItReturns() {
+    var clock = new AtomicLong(0);
+    var limiter = new RateLimiter(1, 1d / 1_000_000_000d, clock::get, 1);
+
+    assertTrue(limiter.tryAcquire("a"));
+    clock.set(1_000_000_000L);
+
+    assertTrue(limiter.tryAcquire("b"), "'a' refilled and was evicted");
+    assertFalse(limiter.tryAcquire("a"), "'a' is refused: 'b' now holds the only slot");
+  }
+
+  @Test
   void perMinuteFactoryBurstsThenThrottles() {
     var limiter = RateLimiter.perMinute(60, 2);
 


### PR DESCRIPTION
## Why

The `RateLimiter` lived inside `ApiRouter`, so it only ever covered the `"/"` context. `/v1/auth`, `/login`, `/enroll`, and `/v1/events/stream` are mounted as separate `HttpContext`s and bypassed it entirely — which left the **unauthenticated** passkey ceremony endpoints (`login/start`, `login/finish`, `register/finish`) unthrottled: passkey brute-force, challenge-table exhaustion, and CPU-DoS surface. Loopback-default binding mitigates today, but `--allow-remote` exists.

## What changed

- New `RateLimitGate` — one budget, owned by `SailApiServer`, applied before dispatch on every TCP context.
- Keying: authenticated requests keep the existing per-credential keying (the router still charges *after* `ApiAuth.require`, so a caller's token bounds them, not their network path). Everything reached before authentication is keyed by remote address — the only identity such a caller has. The NAT-sharing tradeoff is documented in the class Javadoc: an over-wide key on a pre-auth surface lets a brute-forcer split its attack across identities it can mint for free.
- 429 contract unchanged on the existing surface: same status, media type, and JSON error body; no new headers.
- SSE is charged at connection **establishment** only — an established stream is never metered per event.
- `/v1/health` stays unmetered, so a throttled attacker cannot make the server look down.
- The UDS lane (`LocalApiRouter`) stays exempt: credential-gated and already bounded by `DEFAULT_MAX_IN_FLIGHT`.
- Dropped the now-unused `ApiRouter(Operations, ApiAuth, AgentLogStreamer)` constructor.

## Tests

`RateLimitGateTest` runs live servers with a one-token budget, so a "burst" is two requests:

- ceremony burst → 429 with the router's `rate_limited` problem shape; `/login` and `/enroll` draw on the same budget; `/v1/health` still 200
- a throttled request never reaches the delegate handler
- an established SSE stream keeps delivering published events while a second connection attempt is refused with 429

Existing `ApiRouterRateLimitTest` passes unchanged. `mvn clean verify` green (2551 tests); JaCoCo `api.*` 100% line/method holds, including the new class. No new dependencies.

The acceptance criteria asked for this as an `*IT`; it is a `*Test` instead because it needs no incus — the integration profile is reserved for tests that drive real containers, and as a `*Test` this runs on every CI build.