### PR TITLE
Set the SQLite busy timeout before any other pragma

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/Sqlite.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/Sqlite.java
@@ -23,6 +23,13 @@ import java.util.function.Supplier;
  * Thin Panama FFI wrapper over the system {@code libsqlite3.so.0}. Opens a database with WAL mode,
  * foreign keys enabled, and a 5-second busy timeout.
  *
+ * <p>The busy timeout is installed <em>first</em>, before any other pragma. Until it is set the
+ * connection fails instantly on contention, and {@code journal_mode = WAL} briefly needs an
+ * exclusive lock — so opening while any other process held a write lock threw "database is locked"
+ * out of {@link #open} itself, with the very timeout meant to absorb that contention still one
+ * statement away. Every process opens through here (CLI, in-container helpers, the sync server, the
+ * reconciler), so the ordering is what makes concurrent access survivable at all.
+ *
  * <p>Thread-safe at the LOGICAL level, not just the C level: a connection-wide reentrant lock
  * serializes every statement and every whole transaction scope. SQLite's serialized mode ({@code
  * FULLMUTEX}) only protects individual C calls — it happily interleaves two threads' {@code BEGIN}s
@@ -75,9 +82,9 @@ public final class Sqlite implements AutoCloseable {
       }
       var db = dbPtr.get(ValueLayout.ADDRESS, 0);
       var sqlite = new Sqlite(arena, db, lib);
+      sqlite.pragma("busy_timeout", "5000");
       sqlite.pragma("journal_mode", "WAL");
       sqlite.pragma("foreign_keys", "ON");
-      sqlite.pragma("busy_timeout", "5000");
       return sqlite;
     } catch (SqliteException e) {
       throw e;


### PR DESCRIPTION
## Why

`Sqlite.open` ran `PRAGMA journal_mode = WAL` **before** `busy_timeout`. Until the timeout is set, the connection uses SQLite's default busy handler — fail immediately — and switching to WAL briefly needs an exclusive lock. Opening while any other process held a write lock therefore threw `database is locked` out of `open()` itself, with the 5-second timeout meant to absorb that contention still one statement away.

Every process opens through this method: the CLI, the in-container `spec` helper, the sync server, the reconciler. On a box whose server is mid-write, an unlucky CLI invocation simply failed.

## Evidence

`NodeSyncOnWriteIT.aSpecWriteOnANodeReachesMainWithoutAManualSync` went red on `main` at 43cfe33 with `Sqlite database is locked [SQL: PRAGMA journal_mode = WAL] (sqlite error 5)`. Its verifier polls main's database from a second connection while the node's sync server writes — the real-world race, not a test artifact. `Sqlite.java` was last touched in #166, so this is latent, not a regression from #178/#179.

## What changed

One line of ordering, plus a Javadoc note recording why the order is load-bearing.

## Tests

`mvn -Pintegration -Dsail.it.requireIncus=false verify` green locally (2560 unit + the multi-node IT lane, all coverage gates met).

No new unit test: telling the two orderings apart requires holding a write lock for a bounded duration — a sleep by another name, which this repo forbids in tests. `NodeSyncOnWriteIT` is the behavioural cover and has just proven it catches this defect.