### PR TITLE
Bound every CI job with a timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   verify:
     name: Verify, security scan, and native build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,6 +14,7 @@ jobs:
   fleet-integration:
     name: Multi-node control-plane integration tests
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -29,6 +30,7 @@ jobs:
   incus-integration:
     name: Incus-backed integration tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
             binary-name: sail-darwin-arm64
             checksum-cmd: shasum -a 256
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     permissions:
       contents: read
       id-token: write
@@ -69,6 +70,7 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
 


### PR DESCRIPTION
## Why

None of the five jobs across `ci.yml`, `integration.yml`, and `release.yml` set `timeout-minutes`, so a hang runs to GitHub's 6-hour default — and job logs are not fetchable while a run is in progress, so a wedged job is indistinguishable from a slow one until it finally dies.

That is not hypothetical: a wedged unit test on #179 left two runs sitting at "Verify quality gates" for 1h47m and 50m before I cancelled them by hand, against a healthy step time of 3m26s.

## Limits

Roughly 3x observed healthy duration — tight enough to catch a hang, loose enough not to fail a slow-but-working run:

| Job | Healthy | Limit |
|---|---|---|
| Verify, security scan, and native build | ~8m | 30m |
| Multi-node control-plane integration tests | 5m27s | 25m |
| Incus-backed integration tests | 10m47s | 30m |
| Release build (native image, 2 platforms) | — | 45m |
| Release publish | — | 15m |

## Not included

The other half of this — "Require branches to be up to date before merging" — is a branch-protection setting, and this token gets 403 on the protection API, so it needs an admin hand in Settings → Branches.

Worth noting the rationale is narrower than I first thought: `pull_request` runs already check out the *merge* commit (`Merge <head> into <base>`), so a PR is tested against the current base, not against its stale fork point. The residual gap is only that the base can move after the last CI run, leaving the tested merge ref stale at merge time. Whether that is worth the extra re-run friction is a judgement call.