### PR TITLE
Review fix lane: gated, tuned, and narrated

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/engine/FixTaskBuilder.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/FixTaskBuilder.java
@@ -17,6 +17,23 @@ public final class FixTaskBuilder {
 
   private FixTaskBuilder() {}
 
+  /**
+   * The commit message for a fix iteration's work — used by the guardrail rescue when the fix agent
+   * leaves the tree dirty, so the PR history explains what the commit addresses instead of only
+   * recording that an agent forgot to commit.
+   */
+  public static String commitMessage(List<Finding> findings) {
+    var subject =
+        "fix: address %d review finding%s"
+            .formatted(findings.size(), findings.size() == 1 ? "" : "s");
+    var body =
+        findings.stream()
+            .map(f -> "- [%s] %s".formatted(f.severity(), f.title()))
+            .reduce((a, b) -> a + "\n" + b)
+            .orElse("");
+    return body.isEmpty() ? subject : subject + "\n\n" + body;
+  }
+
   public static String build(String specTitle, List<Finding> findings) {
     if (findings.isEmpty()) {
       return "No review findings to address for spec \"%s\".".formatted(specTitle);

--- a/sail-core/src/test/java/ai/singlr/sail/engine/FixTaskBuilderTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/FixTaskBuilderTest.java
@@ -179,4 +179,60 @@ class FixTaskBuilderTest {
     var task = FixTaskBuilder.build("Payment Integration", List.of(finding));
     assertTrue(task.contains("\"Payment Integration\""));
   }
+
+  @Test
+  void commitMessageNamesEveryFindingItAddresses() {
+    var high =
+        Finding.create(
+            Finding.Severity.HIGH,
+            Finding.Category.SECURITY,
+            "a.java",
+            1,
+            1,
+            "SQL injection in login",
+            "",
+            "",
+            null,
+            0.9);
+    var low =
+        Finding.create(
+            Finding.Severity.LOW,
+            Finding.Category.LOGIC,
+            "b.java",
+            2,
+            2,
+            "Off-by-one in pager",
+            "",
+            "",
+            null,
+            0.5);
+
+    var message = FixTaskBuilder.commitMessage(List.of(high, low));
+
+    assertTrue(
+        message.startsWith("fix: address 2 review findings"),
+        "the subject says what the commit is, not that an agent forgot to commit");
+    assertTrue(message.contains("[HIGH] SQL injection in login"));
+    assertTrue(message.contains("[LOW] Off-by-one in pager"));
+  }
+
+  @Test
+  void commitMessageUsesSingularForOneFinding() {
+    var finding =
+        Finding.create(
+            Finding.Severity.HIGH,
+            Finding.Category.SECURITY,
+            "a.java",
+            1,
+            1,
+            "Bad",
+            "",
+            "",
+            null,
+            0.9);
+
+    assertTrue(
+        FixTaskBuilder.commitMessage(List.of(finding))
+            .startsWith("fix: address 1 review finding\n"));
+  }
 }

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/AgentUnit.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/AgentUnit.java
@@ -58,8 +58,11 @@ public record AgentUnit(
    * ~/.sail/runs/<reviewId>/}. The pipeline reviews concurrently completed specs on concurrent
    * virtual threads, so each review (and its fix agent, which shares the file set) must own its
    * prompt, log offsets, and output — a shared file would attach one spec's findings to another's
-   * review. Review runs as a blocking foreground exec, not a systemd unit, so only the task file
-   * and log are used in practice.
+   * review. Review runs as a blocking foreground exec, not a systemd unit, so only the task file,
+   * log, and session file are used in practice. The session file is named {@code
+   * agent-session.json} because that is the {@link SailStopGate} contract — the gate resolves
+   * {@code RUN_ID/agent-session.json} to scope its checks, and the fix lane stamps the spec's repos
+   * there so the gate never nudges over another spec's dirty repo.
    */
   public static AgentUnit forReview(String reviewId) {
     var id = Ids.requireUuid(reviewId);
@@ -68,7 +71,7 @@ public record AgentUnit(
         "sail-review-" + id,
         dir + "/review.log",
         dir + "/review.pid",
-        dir + "/review-session.json",
+        dir + "/agent-session.json",
         dir + "/review-prompt.txt");
   }
 

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/ClaudeCodeHookConfig.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/ClaudeCodeHookConfig.java
@@ -52,6 +52,18 @@ public final class ClaudeCodeHookConfig {
   /** Container-side absolute path to the settings file. Used with {@code claude --settings}. */
   public static final String SETTINGS_PATH = SETTINGS_DIR + "/" + SETTINGS_FILE;
 
+  /** Fix-lane settings filename. */
+  public static final String FIX_SETTINGS_FILE = "claude-fix-settings.json";
+
+  /**
+   * Container-side absolute path of the fix-lane settings file: the {@code Stop} gate and nothing
+   * else. The review pipeline's fix agent must be gated — the dispatch protocol's commit discipline
+   * lives in the gate, not in the prompt, and a hook-free fix agent ends its turn with a dirty tree
+   * every time — but it must stay off the event bus: no {@code SAIL_SPEC_ID} is exported, so even
+   * the gate's own publishes no-op, and the pipeline can never re-enter on a fix agent's stop.
+   */
+  public static final String FIX_SETTINGS_PATH = SETTINGS_DIR + "/" + FIX_SETTINGS_FILE;
+
   /**
    * Event type of the {@code PreToolUse} heartbeat, and the marker {@link
    * ai.singlr.sail.engine.ContainerSailSetup} greps for to detect a settings file written before
@@ -90,8 +102,22 @@ public final class ClaudeCodeHookConfig {
   }
 
   /**
-   * Idempotently writes {@link #SETTINGS_PATH} inside the container. Install-once at provision or
-   * {@code sail project sync}; not rewritten per dispatch.
+   * The fix-lane settings: the {@code Stop} gate as the only hook. See {@link #FIX_SETTINGS_PATH}
+   * for why the fix agent is gated but silent. Pure function — no I/O.
+   */
+  public static String renderFixLane() {
+    var hooks = new LinkedHashMap<String, Object>();
+    hooks.put("Stop", List.of(matcherGroup(null, stopGateCommand())));
+
+    var root = new LinkedHashMap<String, Object>();
+    root.put("includeCoAuthoredBy", false);
+    root.put("hooks", hooks);
+    return YamlUtil.dumpJson(root);
+  }
+
+  /**
+   * Idempotently writes {@link #SETTINGS_PATH} and {@link #FIX_SETTINGS_PATH} inside the container.
+   * Install-once at provision or {@code sail project sync}; not rewritten per dispatch.
    */
   public void install(String container) throws IOException, InterruptedException, TimeoutException {
     NameValidator.requireValidProjectName(container);
@@ -103,15 +129,19 @@ public final class ClaudeCodeHookConfig {
           "Failed to create " + SETTINGS_DIR + " in " + container + ": " + mkdir.stderr());
     }
 
+    writeSettings(container, render(), SETTINGS_PATH);
+    writeSettings(container, renderFixLane(), FIX_SETTINGS_PATH);
+  }
+
+  private void writeSettings(String container, String content, String path)
+      throws IOException, InterruptedException, TimeoutException {
     var write =
         shell.exec(
             ContainerExec.asDevUser(
                 container,
-                List.of(
-                    "bash", "-c", "printf '%s' \"$1\" > \"$2\"", "bash", render(), SETTINGS_PATH)));
+                List.of("bash", "-c", "printf '%s' \"$1\" > \"$2\"", "bash", content, path)));
     if (!write.ok()) {
-      throw new IOException(
-          "Failed to write " + SETTINGS_PATH + " in " + container + ": " + write.stderr());
+      throw new IOException("Failed to write " + path + " in " + container + ": " + write.stderr());
     }
   }
 

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/SailStopGate.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/SailStopGate.java
@@ -20,9 +20,12 @@ import java.util.concurrent.TimeoutException;
  * (a run must never mark itself finished and release its reservation), so run completion comes
  * solely from the watcher's verified exit, with the missed-stop reconciler as the rescue lane.
  *
- * <p>Only build-role sessions are gated: they carry a non-blank {@code SAIL_RUN_ID}. Review
- * sessions load no settings file at all, and ad-hoc {@code sail agent start} or engineer sessions
- * carry no run id, so all of them keep the old publish-and-allow behavior.
+ * <p>Sessions that write to a spec branch are gated: they carry a non-blank {@code SAIL_RUN_ID} —
+ * build-role dispatches, and the review pipeline's fix lane (which exports the run id but no {@code
+ * SAIL_SPEC_ID}, so this gate blocks its premature stops while its publishes stay silent). Reviewer
+ * sessions carry no run id — a reviewer must be free to stop without committing — and ad-hoc {@code
+ * sail agent start} or engineer sessions carry none either, so all of them keep the old
+ * publish-and-allow behavior.
  *
  * <p>The dirty/unpushed/PR checks are scoped to the run's spec repos — read from {@code repos} in
  * the run's own session file, {@code ~/.sail/runs/<runId>/agent-session.json}, which dispatch

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentUnitTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentUnitTest.java
@@ -72,6 +72,11 @@ class AgentUnitTest {
     assertEquals("/home/dev/.sail/runs/" + reviewId + "/review.log", unit.logPath());
     assertEquals("/home/dev/.sail/runs/" + reviewId + "/review-prompt.txt", unit.taskPath());
     assertEquals(
+        "/home/dev/.sail/runs/" + reviewId + "/agent-session.json",
+        unit.sessionPath(),
+        "the stop gate resolves RUN_ID/agent-session.json, so the fix lane's repo scoping"
+            + " only works when the review unit names exactly that file");
+    assertEquals(
         unit.logPath(),
         AgentUnit.REVIEW.runLogPath(reviewId),
         "the review-role log endpoints resolve exactly the file the review writes");
@@ -94,7 +99,12 @@ class AgentUnitTest {
     assertNotEquals(run.unitName(), review.unitName());
     assertNotEquals(run.logPath(), review.logPath());
     assertNotEquals(run.pidPath(), review.pidPath());
-    assertNotEquals(run.sessionPath(), review.sessionPath());
+    assertEquals(
+        run.sessionPath(),
+        review.sessionPath(),
+        "the session filename is the one deliberate overlap: the stop gate resolves"
+            + " RUN_ID/agent-session.json for whichever lane armed it, and run ids and review"
+            + " ids are minted from disjoint UUID sequences so the same id never names both");
     assertNotEquals(run.taskPath(), review.taskPath());
   }
 

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/ClaudeCodeHookConfigTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/ClaudeCodeHookConfigTest.java
@@ -129,6 +129,35 @@ class ClaudeCodeHookConfigTest {
   }
 
   @Test
+  void fixLaneSettingsPathConstantsMatch() {
+    assertEquals("claude-fix-settings.json", ClaudeCodeHookConfig.FIX_SETTINGS_FILE);
+    assertEquals(
+        "/home/dev/.sail/claude-fix-settings.json", ClaudeCodeHookConfig.FIX_SETTINGS_PATH);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void fixLaneSettingsCarryTheStopGateAndNothingElse() {
+    var json = ClaudeCodeHookConfig.renderFixLane();
+    var hooks = (Map<String, Object>) YamlUtil.parseMap(json).get("hooks");
+    assertEquals(
+        List.of("Stop"),
+        List.copyOf(hooks.keySet()),
+        "the fix lane is gated but must stay off the event bus: a session-start or tool"
+            + " heartbeat from a fix agent would narrate a run the watcher does not own");
+    var stopGroups = (List<Map<String, Object>>) hooks.get("Stop");
+    assertEquals(1, stopGroups.size());
+    var stopHooks = (List<Map<String, Object>>) stopGroups.get(0).get("hooks");
+    assertEquals(1, stopHooks.size());
+    assertEquals(SailStopGate.SCRIPT_PATH, stopHooks.get(0).get("command"));
+    assertEquals(SailStopGate.HOOK_TIMEOUT_SECONDS, stopHooks.get(0).get("timeout"));
+    assertFalse(
+        json.contains(SailEventHelper.SCRIPT_PATH),
+        "no event helper anywhere: the gate's own publishes already no-op without SAIL_SPEC_ID");
+    assertTrue(json.contains("\"includeCoAuthoredBy\": false"));
+  }
+
+  @Test
   void installWritesToSailOwnedSettingsPath() throws Exception {
     var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
     var writer = new ClaudeCodeHookConfig(shell);
@@ -136,9 +165,13 @@ class ClaudeCodeHookConfigTest {
     writer.install("light-grid");
 
     var cmds = shell.invocations();
-    assertEquals(2, cmds.size());
+    assertEquals(3, cmds.size());
     assertTrue(cmds.get(0).contains("mkdir -p /home/dev/.sail"));
     assertTrue(cmds.get(1).contains("/home/dev/.sail/claude-settings.json"));
+    assertTrue(
+        cmds.get(2).contains("/home/dev/.sail/claude-fix-settings.json"),
+        "both lane files install together so a container never has the dispatch settings"
+            + " without the fix-lane settings");
     assertFalse(
         cmds.get(1).contains("settings.local.json"),
         "must not write to the project-scoped settings.local.json anymore");

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ContainerReviewAgentRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ContainerReviewAgentRunner.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.api;
 import ai.singlr.sail.engine.AgentCli;
 import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.AgentUnit;
+import ai.singlr.sail.engine.ClaudeCodeHookConfig;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.StreamJsonResult;
@@ -32,10 +33,13 @@ import java.util.Objects;
  * from the bytes this run appended — parsed via {@link StreamJsonResult} so a streamed reviewer and
  * a plain one are handled uniformly.
  *
- * <p>Run clean: no {@code SAIL_SPEC_ID} and no agent hooks, so the reviewer's own completion never
- * re-enters the pipeline (which would recurse forever). The run credential rides in as a positional
- * shell argument — never interpolated into the script text — and lands in {@code
- * SAIL_RUN_CREDENTIAL}, so the agent's spec commands authenticate as its review run's principal.
+ * <p>Neither lane exports {@code SAIL_SPEC_ID}, so no completion event ever re-enters the pipeline
+ * (which would recurse forever). The reviewer additionally runs hook-free and ungated — it must be
+ * free to stop without committing. The fix lane arms the stop gate (see {@link #runFix}) because it
+ * writes to the spec branch and the commit discipline lives in the gate, not the prompt. The run
+ * credential rides in as a positional shell argument — never interpolated into the script text —
+ * and lands in {@code SAIL_RUN_CREDENTIAL}, so the agent's spec commands authenticate as its review
+ * run's principal.
  */
 final class ContainerReviewAgentRunner implements ReviewAgentRunner {
 
@@ -64,29 +68,100 @@ final class ContainerReviewAgentRunner implements ReviewAgentRunner {
   public String run(
       String project, String agent, String prompt, String reviewId, String runCredential)
       throws Exception {
+    return run(project, agent, prompt, reviewId, runCredential, null, null);
+  }
+
+  @Override
+  public String run(
+      String project,
+      String agent,
+      String prompt,
+      String reviewId,
+      String runCredential,
+      String model,
+      String reasoningEffort)
+      throws Exception {
     var cli = AgentCli.fromYamlName(agent);
+    var unit = stage(project, prompt, reviewId);
+    return launch(project, cli, agent, unit, runCredential, null, null, model, reasoningEffort);
+  }
+
+  /**
+   * The fix lane launches with the stop gate armed: {@code SAIL_RUN_ID} rides in as a positional
+   * argument, the session file carries the spec's branch and repos so the gate checks exactly this
+   * spec's repos, and Claude Code loads the Stop-only settings file. Codex needs no settings flag —
+   * it discovers the global hooks file, armed by the trust bypass every full-permission launch
+   * already passes — so both CLIs gate identically. {@code SAIL_SPEC_ID} stays unset: the gate's
+   * own publishes no-op and the pipeline can never re-enter on the fix agent's stop.
+   */
+  @Override
+  public String runFix(
+      String project,
+      String agent,
+      String prompt,
+      String reviewId,
+      String runCredential,
+      String branch,
+      List<String> repos,
+      String model,
+      String reasoningEffort)
+      throws Exception {
+    var cli = AgentCli.fromYamlName(agent);
+    var unit = stage(project, prompt, reviewId);
+    session.writeSession(project, prompt, branch, "", agent, reviewId, repos, unit);
+    return launch(
+        project,
+        cli,
+        agent,
+        unit,
+        runCredential,
+        ClaudeCodeHookConfig.FIX_SETTINGS_PATH,
+        reviewId,
+        model,
+        reasoningEffort);
+  }
+
+  private AgentUnit stage(String project, String prompt, String reviewId) throws Exception {
     var unit = AgentUnit.forReview(reviewId);
     session.ensureDirectory(project);
     session.writeTaskFile(project, prompt, unit);
+    return unit;
+  }
 
+  private String launch(
+      String project,
+      AgentCli cli,
+      String agent,
+      AgentUnit unit,
+      String runCredential,
+      String claudeSettingsPath,
+      String gateRunId,
+      String model,
+      String reasoningEffort)
+      throws Exception {
     var startOffset = logSize(project, unit);
 
-    var agentCmd = cli.headlessCommand(unit.taskPath(), true, null, null, null, true);
+    var agentCmd =
+        cli.headlessCommand(
+            unit.taskPath(), true, model, reasoningEffort, claudeSettingsPath, true);
+    var gateExport = gateRunId == null ? "" : "export SAIL_RUN_ID=\"$2\"; ";
     var command =
-        "export SAIL_RUN_CREDENTIAL=\"$1\"; cd "
+        "export SAIL_RUN_CREDENTIAL=\"$1\"; "
+            + gateExport
+            + "cd "
             + WORKSPACE
             + " && "
             + agentCmd
             + " >> "
             + unit.logPath()
             + " 2>&1";
-    var result =
-        shell.exec(
-            ContainerExec.asDevUser(
-                project,
-                List.of("bash", "-lc", command, "bash", Objects.toString(runCredential, ""))),
-            null,
-            AGENT_TIMEOUT);
+    var args =
+        new ArrayList<>(
+            List.of("bash", "-lc", command, "bash", Objects.toString(runCredential, "")));
+    if (gateRunId != null) {
+      args.add(gateRunId);
+    }
+    var result = shell.exec(ContainerExec.asDevUser(project, args), null, AGENT_TIMEOUT);
     if (!result.ok()) {
       throw new ReviewAgentExecutionException(
           "Review agent '"

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ContainerReviewAgentRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ContainerReviewAgentRunner.java
@@ -186,27 +186,45 @@ final class ContainerReviewAgentRunner implements ReviewAgentRunner {
    * fail the pipeline.
    */
   @Override
-  public List<String> ensureCommitted(String project, List<String> repos, String branch)
-      throws Exception {
+  public List<Rescue> ensureCommitted(
+      String project, List<String> repos, String branch, String commitMessage) throws Exception {
     if (branch == null || branch.isBlank()) {
       return List.of();
     }
-    var rescued = new ArrayList<String>();
+    var rescued = new ArrayList<Rescue>();
     for (var repo : repos) {
       var dir = WORKSPACE + "/" + repo;
-      if (!onBranch(project, dir, branch) || git(project, dir, "status", "--porcelain").isBlank()) {
+      if (!onBranch(project, dir, branch)) {
+        continue;
+      }
+      var porcelain = git(project, dir, "status", "--porcelain");
+      if (porcelain.isBlank()) {
         continue;
       }
       git(project, dir, "add", "-A");
-      git(project, dir, "commit", "-m", "fix: review-fix changes left uncommitted by the agent");
+      git(project, dir, "commit", "-m", commitMessage);
       var push = shell.exec(ContainerExec.asDevUser(project, List.of("git", "-C", dir, "push")));
       if (!push.ok()) {
         System.err.println(
             "review-pipeline: push failed for " + dir + " on " + branch + ": " + push.stderr());
       }
-      rescued.add(repo);
+      rescued.add(new Rescue(repo, changedFiles(porcelain)));
     }
     return List.copyOf(rescued);
+  }
+
+  /** Paths from {@code status --porcelain} output; a rename resolves to its new path. */
+  private static List<String> changedFiles(String porcelain) {
+    return porcelain
+        .lines()
+        .filter(line -> !line.isBlank())
+        .map(line -> line.length() > 3 ? line.substring(3) : line.strip())
+        .map(
+            path -> {
+              var arrow = path.lastIndexOf(" -> ");
+              return arrow < 0 ? path : path.substring(arrow + 4);
+            })
+        .toList();
   }
 
   private boolean onBranch(String project, String dir, String branch) throws Exception {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewAgentRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewAgentRunner.java
@@ -72,18 +72,21 @@ public interface ReviewAgentRunner {
     return run(project, agent, prompt, reviewId, runCredential, model, reasoningEffort);
   }
 
+  /** One rescued repo and the files the rescue commit swept up, for the guardrail event. */
+  record Rescue(String repo, List<String> files) {}
+
   /**
-   * Commits and pushes any work an agent left uncommitted on the spec's branch. The fix lane runs
-   * hook-free (so a reviewer's completion can never re-enter the pipeline), which also strips the
-   * dispatch lane's stop-readiness gate — so nothing stops a fix agent from ending its run with a
-   * dirty tree, contaminating the shared clone and starving the re-review of the very fixes it is
-   * about to judge. This is the deterministic backstop: a repo is rescued only when it is checked
-   * out on the spec's own branch, never any other.
+   * Commits and pushes any work an agent left uncommitted on the spec's branch, using {@code
+   * commitMessage} so the commit explains the work it contains. The fix lane runs gated, but the
+   * gate is a nudge, not a jail — a fix agent can still end its second stop with a dirty tree,
+   * contaminating the shared clone and starving the re-review of the very fixes it is about to
+   * judge. This is the deterministic backstop: a repo is rescued only when it is checked out on the
+   * spec's own branch, never any other.
    *
-   * @return the repos that had uncommitted work, now committed
+   * @return the repos that had uncommitted work, now committed, each with the files it swept
    */
-  default List<String> ensureCommitted(String project, List<String> repos, String branch)
-      throws Exception {
+  default List<Rescue> ensureCommitted(
+      String project, List<String> repos, String branch, String commitMessage) throws Exception {
     return List.of();
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewAgentRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewAgentRunner.java
@@ -32,6 +32,47 @@ public interface ReviewAgentRunner {
       throws Exception;
 
   /**
+   * Same as {@link #run(String, String, String, String, String)} but carrying the spec's tuning: a
+   * spec dispatched at {@code xhigh} reasoning effort must be judged at {@code xhigh}, not at the
+   * CLI default. {@code model} is passed only when the lane runs the spec's own agent — model names
+   * are agent-specific and the roster reviewer is usually the other agent.
+   */
+  default String run(
+      String project,
+      String agent,
+      String prompt,
+      String reviewId,
+      String runCredential,
+      String model,
+      String reasoningEffort)
+      throws Exception {
+    return run(project, agent, prompt, reviewId, runCredential);
+  }
+
+  /**
+   * Launches the review's fix agent. Unlike a reviewer, a fix agent writes to the spec branch, so
+   * it runs with the stop gate armed ({@code SAIL_RUN_ID} exported, session file stamped with the
+   * spec's {@code branch} and {@code repos}) — the dispatch lane's commit discipline lives in that
+   * gate, not in the prompt, and an ungated fix agent ends its turn with a dirty tree every time.
+   * It still exports no {@code SAIL_SPEC_ID}, so the event helper stays silent and the fix agent's
+   * own stop can never re-enter the pipeline. The fix agent is the spec's own agent, so it carries
+   * the spec's {@code model} and {@code reasoningEffort} exactly as the dispatch lane did.
+   */
+  default String runFix(
+      String project,
+      String agent,
+      String prompt,
+      String reviewId,
+      String runCredential,
+      String branch,
+      List<String> repos,
+      String model,
+      String reasoningEffort)
+      throws Exception {
+    return run(project, agent, prompt, reviewId, runCredential, model, reasoningEffort);
+  }
+
+  /**
    * Commits and pushes any work an agent left uncommitted on the spec's branch. The fix lane runs
    * hook-free (so a reviewer's completion can never re-enter the pipeline), which also strips the
    * dispatch lane's stop-readiness gate — so nothing stops a fix agent from ending its run with a

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -550,12 +550,17 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
           spec.get().repos(),
           spec.get().model(),
           spec.get().reasoningEffort());
-      var rescued = agentRunner.ensureCommitted(project, spec.get().repos(), spec.get().branch());
+      var rescued =
+          agentRunner.ensureCommitted(
+              project,
+              spec.get().repos(),
+              spec.get().branch(),
+              FixTaskBuilder.commitMessage(findings));
       if (!rescued.isEmpty()) {
         publishGuardrail(
             project,
             specId,
-            "fix agent left uncommitted changes in " + String.join(", ", rescued),
+            "fix agent left uncommitted changes in " + describeRescues(rescued),
             "committed and pushed them to " + spec.get().branch());
       }
     } catch (Exception e) {
@@ -571,6 +576,29 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     return reviewStore.reviewsForSpec(specId).stream()
         .filter(r -> !r.superseded() && r.errored() && r.iteration() == iteration)
         .count();
+  }
+
+  /**
+   * Names what each rescue swept — {@code "api (3 files: A.java, B.java, C.java)"} — capped so a
+   * large sweep stays one readable notification line while still revealing debris immediately.
+   */
+  private static String describeRescues(List<ReviewAgentRunner.Rescue> rescued) {
+    return rescued.stream()
+        .map(
+            rescue -> {
+              var files = rescue.files();
+              var shown = files.stream().limit(5).toList();
+              var suffix = files.size() > shown.size() ? ", +" + (files.size() - shown.size()) : "";
+              return "%s (%d file%s: %s%s)"
+                  .formatted(
+                      rescue.repo(),
+                      files.size(),
+                      files.size() == 1 ? "" : "s",
+                      String.join(", ", shown),
+                      suffix);
+            })
+        .reduce((a, b) -> a + ", " + b)
+        .orElse("");
   }
 
   private void publishGuardrail(String project, String specId, String reason, String action) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -376,6 +376,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
 
       reviewStore.updateReviewStatus(reviewId, "passed");
       advanceSpec(specId, SpecStatus.AWAITING_MERGE);
+      postRoom(specId, passedVerdict(reviewId));
       publishEvent(project, specId, "review_completed", null);
 
     } catch (Exception e) {
@@ -416,11 +417,8 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       var spec = specStore.findById(specId);
       var branch = spec.map(SpecStore.SpecRow::branch).orElse("main");
       var repos = spec.map(SpecStore.SpecRow::repos).orElse(List.of());
-      var room =
-          messageStore == null
-              ? List.<MessageStore.MessageRow>of()
-              : messageStore.list(specId, null, 20);
-      var prompt = ReviewPromptBuilder.build(branch, repos, stageConfig.categories(), room);
+      var prompt =
+          ReviewPromptBuilder.build(branch, repos, stageConfig.categories(), roomMessages(specId));
 
       var credential = startReviewRun(stage.reviewId(), project, specId, agent, branch, prompt);
       var effort = spec.map(SpecStore.SpecRow::reasoningEffort).orElse(null);
@@ -492,6 +490,9 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     var review = reviewStore.findReview(reviewId);
     if (review.isEmpty()) return;
 
+    var openFindings = reviewStore.openFindingsForReview(reviewId);
+    postRoom(specId, failedVerdict(review.get().iteration(), openFindings));
+
     if (review.get().iteration() >= config.maxIterations()) {
       escalate(
           project,
@@ -501,7 +502,6 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       return;
     }
 
-    var openFindings = reviewStore.openFindingsForReview(reviewId);
     if (openFindings.isEmpty()) return;
 
     triggerFixIteration(reviewId, specId, openFindings, project);
@@ -576,6 +576,101 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     return reviewStore.reviewsForSpec(specId).stream()
         .filter(r -> !r.superseded() && r.errored() && r.iteration() == iteration)
         .count();
+  }
+
+  /**
+   * Posts the pipeline's own narration to the spec's room. Lifecycle beats (stage started, fix
+   * iteration, guardrail, escalation) already ride the event stream; the room carries only what
+   * events cannot — the findings themselves. This is also the loop's cross-iteration memory: the
+   * reviewer's prompt includes the room's recent messages, so the next pass sees the previous
+   * verdict. Best-effort by design — a room write must never fail the pipeline.
+   */
+  /**
+   * The room's recent messages for the reviewer's prompt. Best-effort like {@link #postRoom}: the
+   * conversation enriches the prompt, it is not a precondition — a dead message store must degrade
+   * the review, never error it.
+   */
+  private List<MessageStore.MessageRow> roomMessages(String specId) {
+    if (messageStore == null) {
+      return List.of();
+    }
+    try {
+      return messageStore.list(specId, null, 20);
+    } catch (RuntimeException e) {
+      System.err.println(
+          "review-pipeline: could not read the room of spec " + specId + ": " + e.getMessage());
+      return List.of();
+    }
+  }
+
+  private void postRoom(String specId, String body) {
+    if (messageStore == null) return;
+    try {
+      messageStore.append(specId, Event.SAIL_AGENT, body, null);
+      syncTrigger.run();
+    } catch (RuntimeException e) {
+      System.err.println(
+          "review-pipeline: could not post to the room of spec " + specId + ": " + e.getMessage());
+    }
+  }
+
+  private static String failedVerdict(int iteration, List<Finding> findings) {
+    return "Review failed (iteration "
+        + iteration
+        + "): "
+        + severitySummary(findings)
+        + "."
+        + findingLines(findings);
+  }
+
+  private String passedVerdict(String reviewId) {
+    var iteration =
+        reviewStore.findReview(reviewId).map(ReviewStore.ReviewRow::iteration).orElse(0);
+    var open =
+        reviewStore.findingsForReview(reviewId).stream()
+            .filter(f -> f.resolution() == Finding.Resolution.OPEN)
+            .toList();
+    if (open.isEmpty()) {
+      return "Review passed (iteration " + iteration + "). Awaiting merge.";
+    }
+    return "Review passed (iteration "
+        + iteration
+        + ") with "
+        + severitySummary(open)
+        + " below the gate — worth a look before merge."
+        + findingLines(open)
+        + "\nAwaiting merge.";
+  }
+
+  /** {@code "2 high, 1 low"} in severity order, or {@code "no findings"}. */
+  private static String severitySummary(List<Finding> findings) {
+    var summary =
+        severityCounts(findings).entrySet().stream()
+            .map(e -> e.getValue() + " " + e.getKey())
+            .reduce((a, b) -> a + ", " + b)
+            .orElse("");
+    return summary.isEmpty() ? "no findings" : summary;
+  }
+
+  /** One line per finding, capped so a noisy review stays one readable room message. */
+  private static String findingLines(List<Finding> findings) {
+    if (findings.isEmpty()) {
+      return "";
+    }
+    var shown =
+        findings.stream()
+            .limit(10)
+            .map(
+                f ->
+                    "- ["
+                        + f.severity()
+                        + "] "
+                        + f.title()
+                        + (f.file() == null ? "" : " (" + f.file() + ":" + f.lineStart() + ")"))
+            .reduce((a, b) -> a + "\n" + b)
+            .orElse("");
+    var more = findings.size() - Math.min(findings.size(), 10);
+    return "\n" + shown + (more > 0 ? "\n- +" + more + " more" : "");
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -423,7 +423,9 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       var prompt = ReviewPromptBuilder.build(branch, repos, stageConfig.categories(), room);
 
       var credential = startReviewRun(stage.reviewId(), project, specId, agent, branch, prompt);
-      var output = agentRunner.run(project, agent, prompt, stage.reviewId(), credential);
+      var effort = spec.map(SpecStore.SpecRow::reasoningEffort).orElse(null);
+      var output =
+          agentRunner.run(project, agent, prompt, stage.reviewId(), credential, null, effort);
       var parseResult = FindingParser.parse(output);
       if (parseResult.findings().isEmpty() && !parseResult.warnings().isEmpty()) {
         var message = "reviewer output unparseable: " + String.join("; ", parseResult.warnings());
@@ -520,10 +522,10 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
 
   /**
    * The fix agent runs under the failed review's identity, appending to that review's log. It runs
-   * hook-free, outside the dispatch lane's stop-readiness gate, so after it finishes {@link
-   * ReviewAgentRunner#ensureCommitted} rescues any work it left uncommitted — otherwise the
-   * re-review judges a branch without the fixes and the shared clone carries the leftovers into the
-   * next dispatch.
+   * with the stop-readiness gate armed ({@link ReviewAgentRunner#runFix}) so it cannot end its turn
+   * with a dirty tree, and {@link ReviewAgentRunner#ensureCommitted} stays as the deterministic
+   * backstop — otherwise the re-review judges a branch without the fixes and the shared clone
+   * carries the leftovers into the next dispatch.
    */
   private void triggerFixIteration(
       String reviewId, String specId, List<Finding> findings, String project) {
@@ -538,7 +540,16 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       var agent = spec.get().agent() != null ? spec.get().agent() : "claude-code";
       var credential =
           startReviewRun(reviewId, project, specId, agent, spec.get().branch(), fixTask);
-      agentRunner.run(project, agent, fixTask, reviewId, credential);
+      agentRunner.runFix(
+          project,
+          agent,
+          fixTask,
+          reviewId,
+          credential,
+          spec.get().branch(),
+          spec.get().repos(),
+          spec.get().model(),
+          spec.get().reasoningEffort());
       var rescued = agentRunner.ensureCommitted(project, spec.get().repos(), spec.get().branch());
       if (!rescued.isEmpty()) {
         publishGuardrail(

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
@@ -125,6 +125,8 @@ public final class ContainerSailSetup {
                         + " && grep -qsF includeCoAuthoredBy "
                         + ClaudeCodeHookConfig.SETTINGS_PATH
                         + " && test -f "
+                        + ClaudeCodeHookConfig.FIX_SETTINGS_PATH
+                        + " && test -f "
                         + CodexHookConfig.SETTINGS_PATH
                         + " && grep -qsF "
                         + ClaudeCodeHookConfig.PROGRESS_HOOK_MARKER

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ContainerReviewAgentRunnerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ContainerReviewAgentRunnerTest.java
@@ -96,6 +96,152 @@ class ContainerReviewAgentRunnerTest {
   }
 
   @Test
+  void theFixLaneArmsTheStopGateWithTheRunIdentity() throws Exception {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", "")).onOk("tail -c", "done");
+
+    runner(shell)
+        .runFix(
+            "acme",
+            "claude-code",
+            "fix it",
+            REVIEW_ID,
+            CREDENTIAL,
+            "agent/spec",
+            List.of("api"),
+            null,
+            null);
+
+    var exec =
+        shell.invocations().stream()
+            .filter(c -> c.contains(">> " + REVIEW_DIR + "/review.log"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("the fix agent must append to the review log"));
+    assertTrue(
+        exec.contains("export SAIL_RUN_ID=\"$2\""),
+        "the run id arms the stop gate, read from its positional argument");
+    assertTrue(exec.contains(REVIEW_ID), "the review id travels as the argument itself");
+    assertTrue(
+        exec.contains("--settings " + "/home/dev/.sail/claude-fix-settings.json"),
+        "claude loads the Stop-only settings so the gate fires without any event hooks");
+    assertFalse(
+        exec.contains("SAIL_SPEC_ID"),
+        "no spec id: the event helper stays silent and the pipeline can never re-enter");
+  }
+
+  @Test
+  void theFixLaneForCodexArmsTheGateWithoutClaudeSettings() throws Exception {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", "")).onOk("tail -c", "done");
+
+    runner(shell)
+        .runFix(
+            "acme",
+            "codex",
+            "fix it",
+            REVIEW_ID,
+            CREDENTIAL,
+            "agent/spec",
+            List.of("api"),
+            null,
+            null);
+
+    var exec =
+        shell.invocations().stream()
+            .filter(c -> c.contains(">> " + REVIEW_DIR + "/review.log"))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(exec.contains("export SAIL_RUN_ID=\"$2\""));
+    assertTrue(
+        exec.contains("--dangerously-bypass-hook-trust"),
+        "codex discovers the global hooks file; the trust bypass is what arms it headlessly");
+    assertFalse(exec.contains("--settings"), "the claude settings flag never leaks into codex");
+  }
+
+  @Test
+  void theFixLaneScopesTheGateToTheSpecReposViaTheSessionFile() throws Exception {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", "")).onOk("tail -c", "done");
+
+    runner(shell)
+        .runFix(
+            "acme",
+            "claude-code",
+            "fix it",
+            REVIEW_ID,
+            CREDENTIAL,
+            "agent/spec",
+            List.of("api", "web"),
+            null,
+            null);
+
+    var write =
+        shell.invocations().stream()
+            .filter(c -> c.contains(REVIEW_DIR + "/agent-session.json"))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new AssertionError(
+                        "the fix lane must stamp the gate's session file, or the gate checks"
+                            + " every repo in the shared container"));
+    assertTrue(write.contains("api") && write.contains("web"), "session carries the spec repos");
+    assertTrue(write.contains("agent/spec"), "session carries the spec branch");
+  }
+
+  @Test
+  void theReviewerLaneCarriesTheSpecsReasoningEffort() throws Exception {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", "")).onOk("tail -c", "[]");
+
+    runner(shell).run("acme", "codex", "review please", REVIEW_ID, CREDENTIAL, null, "xhigh");
+
+    var exec =
+        shell.invocations().stream()
+            .filter(c -> c.contains(">> " + REVIEW_DIR + "/review.log"))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(
+        exec.contains("model_reasoning_effort='\"xhigh\"'"),
+        "a spec dispatched at xhigh must be judged at xhigh — the review lane must not"
+            + " silently drop to the default effort");
+  }
+
+  @Test
+  void theFixLaneCarriesTheSpecsModelAndEffort() throws Exception {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", "")).onOk("tail -c", "done");
+
+    runner(shell)
+        .runFix(
+            "acme",
+            "codex",
+            "fix it",
+            REVIEW_ID,
+            CREDENTIAL,
+            "agent/spec",
+            List.of("api"),
+            "gpt-5.3-codex",
+            "xhigh");
+
+    var exec =
+        shell.invocations().stream()
+            .filter(c -> c.contains(">> " + REVIEW_DIR + "/review.log"))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(exec.contains("--model gpt-5.3-codex"), "the fix agent is the spec's own agent");
+    assertTrue(exec.contains("model_reasoning_effort='\"xhigh\"'"));
+  }
+
+  @Test
+  void theReviewerLaneStaysUngated() throws Exception {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", "")).onOk("tail -c", "[]");
+
+    runner(shell).run("acme", "claude-code", "review please", REVIEW_ID, CREDENTIAL);
+
+    var joined = String.join("\n", shell.invocations());
+    assertFalse(
+        joined.contains("SAIL_RUN_ID"),
+        "a reviewer must be free to stop without committing — gating it would nudge it to"
+            + " commit its own scratch into the spec branch");
+    assertFalse(joined.contains("agent-session.json"), "no gate scope file for the reviewer");
+  }
+
+  @Test
   void ensureCommittedRescuesWorkLeftUncommittedOnTheSpecBranch() throws Exception {
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ContainerReviewAgentRunnerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ContainerReviewAgentRunnerTest.java
@@ -246,15 +246,37 @@ class ContainerReviewAgentRunnerTest {
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
             .onOk("rev-parse --abbrev-ref HEAD", "agent/spec\n")
-            .onOk("status --porcelain", " M Api.java\n");
+            .onOk("status --porcelain", " M Api.java\n?? docs/New.md\n");
 
-    var rescued = runner(shell).ensureCommitted("acme", List.of("api"), "agent/spec");
+    var rescued =
+        runner(shell)
+            .ensureCommitted(
+                "acme", List.of("api"), "agent/spec", "fix: address 2 review findings");
 
-    assertEquals(List.of("api"), rescued);
+    assertEquals(1, rescued.size());
+    assertEquals("api", rescued.getFirst().repo());
+    assertEquals(
+        List.of("Api.java", "docs/New.md"),
+        rescued.getFirst().files(),
+        "the rescue names what it swept up, so the guardrail event can show it");
     var joined = String.join("\n", shell.invocations());
     assertTrue(joined.contains("git -C /home/dev/workspace/api add -A"));
-    assertTrue(joined.contains("git -C /home/dev/workspace/api commit -m"));
+    assertTrue(
+        joined.contains("fix: address 2 review findings"),
+        "the rescue commit says what the work was, not that an agent forgot to commit");
     assertTrue(joined.contains("git -C /home/dev/workspace/api push"));
+  }
+
+  @Test
+  void ensureCommittedResolvesARenameToItsNewPath() throws Exception {
+    var shell =
+        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+            .onOk("rev-parse --abbrev-ref HEAD", "agent/spec\n")
+            .onOk("status --porcelain", "R  Old.java -> New.java\n");
+
+    var rescued = runner(shell).ensureCommitted("acme", List.of("api"), "agent/spec", "fix: x");
+
+    assertEquals(List.of("New.java"), rescued.getFirst().files());
   }
 
   @Test
@@ -263,7 +285,7 @@ class ContainerReviewAgentRunnerTest {
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
             .onOk("rev-parse --abbrev-ref HEAD", "agent/spec\n");
 
-    var rescued = runner(shell).ensureCommitted("acme", List.of("api"), "agent/spec");
+    var rescued = runner(shell).ensureCommitted("acme", List.of("api"), "agent/spec", "fix: x");
 
     assertTrue(rescued.isEmpty());
     assertFalse(String.join("\n", shell.invocations()).contains("add -A"));
@@ -276,7 +298,7 @@ class ContainerReviewAgentRunnerTest {
             .onOk("rev-parse --abbrev-ref HEAD", "main\n")
             .onOk("status --porcelain", " M Api.java\n");
 
-    var rescued = runner(shell).ensureCommitted("acme", List.of("api"), "agent/spec");
+    var rescued = runner(shell).ensureCommitted("acme", List.of("api"), "agent/spec", "fix: x");
 
     assertTrue(
         rescued.isEmpty(),
@@ -289,7 +311,7 @@ class ContainerReviewAgentRunnerTest {
   void ensureCommittedSkipsASpecWithNoBranch() throws Exception {
     var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
 
-    assertTrue(runner(shell).ensureCommitted("acme", List.of("api"), " ").isEmpty());
+    assertTrue(runner(shell).ensureCommitted("acme", List.of("api"), " ", "fix: x").isEmpty());
     assertEquals(0, shell.invocations().size(), "no branch to guard means nothing to touch");
   }
 
@@ -304,7 +326,7 @@ class ContainerReviewAgentRunnerTest {
     var ex =
         assertThrows(
             IllegalStateException.class,
-            () -> runner(shell).ensureCommitted("acme", List.of("api"), "agent/spec"));
+            () -> runner(shell).ensureCommitted("acme", List.of("api"), "agent/spec", "fix: x"));
     assertTrue(ex.getMessage().contains("git identity not configured"), ex.getMessage());
   }
 
@@ -316,9 +338,10 @@ class ContainerReviewAgentRunnerTest {
             .onOk("status --porcelain", " M Api.java\n")
             .onFail("push", "no network");
 
+    var rescued = runner(shell).ensureCommitted("acme", List.of("api"), "agent/spec", "fix: x");
     assertEquals(
         List.of("api"),
-        runner(shell).ensureCommitted("acme", List.of("api"), "agent/spec"),
+        rescued.stream().map(ReviewAgentRunner.Rescue::repo).toList(),
         "the commit is the rescue; a push failure must not fail the pipeline");
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -1031,6 +1031,79 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
+  void theLoopNarratesVerdictsIntoTheSpecRoom() throws Exception {
+    createSpec("auth", "in_progress", List.of("api"));
+    var messages = new MessageStore(db);
+    var failedOutput =
+        """
+        ```json
+        [{"severity": "CRITICAL", "category": "SECURITY", "file": "Auth.java",
+          "line_start": 7, "line_end": 7, "title": "Token logged in plaintext",
+          "description": "d", "confidence": 0.9}]
+        ```
+        """;
+    var passedOutput =
+        """
+        ```json
+        [{"severity": "LOW", "category": "LOGIC", "file": "Pager.java",
+          "line_start": 3, "line_end": 3, "title": "Off-by-one in pager",
+          "description": "d", "confidence": 0.6}]
+        ```
+        """;
+    var calls = new AtomicInteger();
+    ReviewAgentRunner runner =
+        (p, a, pr, rid, cred) -> calls.incrementAndGet() == 1 ? failedOutput : passedOutput;
+
+    try (var bus = new EventBus()) {
+      var captured = captureEvents(bus, Set.of("review_completed"), 1);
+      var ctrl = controller(p -> singleAgentStage("no_critical"), p -> "codex", runner, bus);
+      ctrl.useMessages(messages);
+
+      ctrl.onEvent(agentStoppedEvent("auth"));
+      BusTesting.awaitDelivery(captured.latch());
+
+      var room = messages.list("auth", null, 50);
+      assertEquals(
+          2,
+          room.size(),
+          "one message per verdict and nothing else — lifecycle beats ride the event stream;"
+              + " the room carries only what events cannot: the findings themselves");
+      var failed = room.get(0);
+      assertEquals("sail", failed.author());
+      assertTrue(failed.body().contains("Review failed"), failed.body());
+      assertTrue(
+          failed.body().contains("Token logged in plaintext"),
+          "the failed verdict names its findings — the reviewer's next pass reads the room, so"
+              + " this is also the loop's cross-iteration memory");
+      assertTrue(failed.body().contains("Auth.java:7"), failed.body());
+      var passed = room.get(1);
+      assertTrue(passed.body().contains("Review passed"), passed.body());
+      assertTrue(
+          passed.body().contains("Off-by-one in pager"),
+          "sub-gate findings on a passed review deserve eyes before merge, not silence");
+    }
+  }
+
+  @Test
+  void aRoomWriteFailureNeverFailsThePipeline() {
+    createSpec("auth", "in_progress");
+    var brokenDb = Sqlite.open(tempDir.resolve("broken.db"));
+    new SchemaManager(brokenDb).migrate();
+    var brokenMessages = new MessageStore(brokenDb);
+    brokenDb.close();
+
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    ctrl.useMessages(brokenMessages);
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    assertEquals(
+        SpecStatus.AWAITING_MERGE,
+        specStore.findById("auth").orElseThrow().status(),
+        "narration is best-effort: a dead room store must not strand the verdict");
+  }
+
+  @Test
   void executePipelinePublishesEventsWhenBusProvided() {
     createSpec("auth", "in_progress");
     specStore.updateStatus("auth", SpecStatus.REVIEW);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -932,7 +932,9 @@ class ReviewPipelineControllerTest {
           public List<Rescue> ensureCommitted(
               String project, List<String> repos, String branch, String commitMessage) {
             ensured.set(List.of(project, repos, branch, commitMessage));
-            return List.of(new Rescue("api", List.of("Api.java", "ApiTest.java")));
+            return List.of(
+                new Rescue("api", List.of("Api.java", "ApiTest.java")),
+                new Rescue("web", List.of("App.tsx")));
           }
         };
 
@@ -957,6 +959,9 @@ class ReviewPipelineControllerTest {
       assertTrue(
           reason.contains("Api.java"),
           "the guardrail names the files it swept, so debris is visible the moment it happens");
+      assertTrue(
+          reason.contains("web (1 file: App.tsx)"),
+          "every rescued repo is named, joined into one readable line");
     }
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -929,9 +929,10 @@ class ReviewPipelineControllerTest {
           }
 
           @Override
-          public List<String> ensureCommitted(String project, List<String> repos, String branch) {
-            ensured.set(List.of(project, repos, branch));
-            return List.of("api");
+          public List<Rescue> ensureCommitted(
+              String project, List<String> repos, String branch, String commitMessage) {
+            ensured.set(List.of(project, repos, branch, commitMessage));
+            return List.of(new Rescue("api", List.of("Api.java", "ApiTest.java")));
           }
         };
 
@@ -944,11 +945,18 @@ class ReviewPipelineControllerTest {
 
       assertEquals(
           List.of("test-project", List.of("api"), "feat/test"),
-          ensured.get(),
+          ensured.get().subList(0, 3),
           "after the fix agent runs, its work is verified committed on the spec branch");
+      assertTrue(
+          ensured.get().get(3).toString().contains("Bad"),
+          "the rescue commit message names the findings the fix addressed, so the PR history"
+              + " explains itself instead of reading 'left uncommitted by the agent'");
       var reason =
           java.util.Objects.toString(captured.events().getFirst().data().get("reason"), "");
       assertTrue(reason.contains("api"), "the guardrail names the contaminated repo");
+      assertTrue(
+          reason.contains("Api.java"),
+          "the guardrail names the files it swept, so debris is visible the moment it happens");
     }
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -59,6 +59,11 @@ class ReviewPipelineControllerTest {
   }
 
   private void createSpec(String id, String status, List<String> repos) {
+    createSpec(id, status, repos, null, null);
+  }
+
+  private void createSpec(
+      String id, String status, List<String> repos, String model, String reasoningEffort) {
     specStore.create(
         new SpecStore.SpecRow(
             id,
@@ -67,8 +72,8 @@ class ReviewPipelineControllerTest {
             SpecStatus.fromWire(status),
             null,
             null,
-            null,
-            null,
+            model,
+            reasoningEffort,
             "feat/test",
             0,
             null,
@@ -944,6 +949,76 @@ class ReviewPipelineControllerTest {
       var reason =
           java.util.Objects.toString(captured.events().getFirst().data().get("reason"), "");
       assertTrue(reason.contains("api"), "the guardrail names the contaminated repo");
+    }
+  }
+
+  @Test
+  void theFixLaneCarriesTheSpecBranchReposAndTuningIntoTheGate() throws Exception {
+    createSpec("auth", "in_progress", List.of("api"), "opus-5", "xhigh");
+    var criticalOutput =
+        """
+        ```json
+        [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
+          "line_start": 1, "line_end": 1, "title": "Bad",
+          "description": "Very bad", "confidence": 0.9}]
+        ```
+        """;
+    var fixLaunch = new AtomicReference<List<Object>>();
+    var reviewEffort = new AtomicReference<String>();
+    var calls = new AtomicInteger();
+    var runner =
+        new ReviewAgentRunner() {
+          @Override
+          public String run(String p, String a, String prompt, String rid, String cred) {
+            return calls.incrementAndGet() == 1 ? criticalOutput : "[]";
+          }
+
+          @Override
+          public String run(
+              String p,
+              String a,
+              String prompt,
+              String rid,
+              String cred,
+              String model,
+              String effort) {
+            reviewEffort.set(effort);
+            return run(p, a, prompt, rid, cred);
+          }
+
+          @Override
+          public String runFix(
+              String p,
+              String a,
+              String prompt,
+              String rid,
+              String cred,
+              String branch,
+              List<String> repos,
+              String model,
+              String effort) {
+            fixLaunch.set(List.of(a, branch, repos, model, effort));
+            return "done";
+          }
+        };
+
+    try (var bus = new EventBus()) {
+      var captured = captureEvents(bus, Set.of("review_completed"), 1);
+      var ctrl = controller(p -> singleAgentStage("no_critical"), p -> "codex", runner, bus);
+
+      ctrl.onEvent(agentStoppedEvent("auth"));
+      BusTesting.awaitDelivery(captured.latch());
+
+      assertEquals(
+          List.of("claude-code", "feat/test", List.of("api"), "opus-5", "xhigh"),
+          fixLaunch.get(),
+          "the fix agent launches as the spec's own agent with the spec's branch, repo scope,"
+              + " model, and reasoning effort — a spec dispatched at xhigh is fixed at xhigh");
+      assertEquals(
+          "xhigh",
+          reviewEffort.get(),
+          "the reviewer judges at the spec's effort; the model stays out of the review lane"
+              + " because model names are agent-specific and the reviewer is the other agent");
     }
   }
 


### PR DESCRIPTION
## Why

The linkedin-bulk-capture-campaign dispatch (light-grid) exposed four review-loop defects, verified against the run's artifacts:

1. **Every fix iteration ended with a dirty tree** (3/3 rescue commits on that PR, plus one from July 17). The dispatch lane's commit discipline lives in the stop gate, not the prompt — and the fix lane ran hook-free, so the guardrail auto-commit was the de facto commit path.
2. The rescue commits (`fix: review-fix changes left uncommitted by the agent`, one 547 insertions across 16 files) explained nothing to the PR reviewer, and the guardrail event named only the repo.
3. The loop was invisible in the spec room: fix/review agents post nothing, so only Slack showed reviews failing and fix iterations running.
4. Review and fix invocations dropped the spec's model and reasoning effort — an xhigh spec was judged and fixed at CLI-default effort.

## What

- **Fix lane arms the stop gate**: exports `SAIL_RUN_ID` (positionally), stamps the run's `agent-session.json` with the spec's branch and repos so the gate checks exactly this spec's repos, and Claude Code loads a new Stop-only settings file (`claude-fix-settings.json`). Codex arms via its global hooks file — both CLIs gate identically. `SAIL_SPEC_ID` stays unset, so the event helper stays silent and the pipeline can never re-enter on a fix agent's stop. Reviewer lane stays ungated — a reviewer must be free to stop without committing.
- **Guardrail honesty**: the rescue commit carries a findings-derived message (`fix: address N review findings` + finding titles), and the guardrail event names the files each rescue swept.
- **Room narration**: the pipeline posts each review verdict to the spec room as `sail` — failed verdicts with finding titles and locations, passed verdicts with any sub-gate findings. Since the reviewer's prompt includes the room's recent messages, this doubles as cross-iteration memory. Both the room write and the prompt's room read are best-effort.
- **Tuning threaded**: review runs carry the spec's reasoning effort; fix runs carry the spec's model and effort (fix agent is the spec's own agent; the reviewer is usually the other one, so the model stays out of the review lane).

## Testing

Full `mvn clean test` green (2570+ tests, coverage gates). New render-level tests for both lanes and both CLIs, gate-scoping via the session file, narration content, rescue file parsing, and a dead-message-store degradation test.