### PR TITLE
One hooks layer per CLI; the lane is the environment

### DIFF
--- a/sail-harness/src/main/java/ai/singlr/sail/engine/ClaudeCodeHookConfig.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/ClaudeCodeHookConfig.java
@@ -37,9 +37,13 @@ import java.util.concurrent.TimeoutException;
  * pushes the {@code max_idle} deadline out on every tool call. Without them the stall timer counts
  * from launch and kills even a busy agent at {@code max_idle}.
  *
- * <p>Spec attribution flows in via the {@code SAIL_SPEC_ID} env var that sail sets at launch — no
- * spec id is baked into the hook commands, so the file is install-once at provision/sync time
- * rather than rewritten on every dispatch.
+ * <p>This is the one hooks layer for every sail-launched Claude session; the lane is expressed
+ * entirely by the environment, never by a second settings file. Dispatch exports {@code
+ * SAIL_SPEC_ID} and {@code SAIL_RUN_ID} (events + stop gate); the review pipeline's fix lane
+ * exports only {@code SAIL_RUN_ID} (gate armed, events silent); the reviewer exports neither, so
+ * every hook is inert. The scripts self-gate on those variables, which keeps the file install-once
+ * at provision/sync time rather than rewritten per dispatch — and keeps Claude Code and Codex
+ * symmetric, since Codex's fixed hooks discovery admits no per-session file either.
  */
 public final class ClaudeCodeHookConfig {
 
@@ -51,18 +55,6 @@ public final class ClaudeCodeHookConfig {
 
   /** Container-side absolute path to the settings file. Used with {@code claude --settings}. */
   public static final String SETTINGS_PATH = SETTINGS_DIR + "/" + SETTINGS_FILE;
-
-  /** Fix-lane settings filename. */
-  public static final String FIX_SETTINGS_FILE = "claude-fix-settings.json";
-
-  /**
-   * Container-side absolute path of the fix-lane settings file: the {@code Stop} gate and nothing
-   * else. The review pipeline's fix agent must be gated — the dispatch protocol's commit discipline
-   * lives in the gate, not in the prompt, and a hook-free fix agent ends its turn with a dirty tree
-   * every time — but it must stay off the event bus: no {@code SAIL_SPEC_ID} is exported, so even
-   * the gate's own publishes no-op, and the pipeline can never re-enter on a fix agent's stop.
-   */
-  public static final String FIX_SETTINGS_PATH = SETTINGS_DIR + "/" + FIX_SETTINGS_FILE;
 
   /**
    * Event type of the {@code PreToolUse} heartbeat, and the marker {@link
@@ -102,22 +94,8 @@ public final class ClaudeCodeHookConfig {
   }
 
   /**
-   * The fix-lane settings: the {@code Stop} gate as the only hook. See {@link #FIX_SETTINGS_PATH}
-   * for why the fix agent is gated but silent. Pure function — no I/O.
-   */
-  public static String renderFixLane() {
-    var hooks = new LinkedHashMap<String, Object>();
-    hooks.put("Stop", List.of(matcherGroup(null, stopGateCommand())));
-
-    var root = new LinkedHashMap<String, Object>();
-    root.put("includeCoAuthoredBy", false);
-    root.put("hooks", hooks);
-    return YamlUtil.dumpJson(root);
-  }
-
-  /**
-   * Idempotently writes {@link #SETTINGS_PATH} and {@link #FIX_SETTINGS_PATH} inside the container.
-   * Install-once at provision or {@code sail project sync}; not rewritten per dispatch.
+   * Idempotently writes {@link #SETTINGS_PATH} inside the container. Install-once at provision or
+   * {@code sail project sync}; not rewritten per dispatch.
    */
   public void install(String container) throws IOException, InterruptedException, TimeoutException {
     NameValidator.requireValidProjectName(container);
@@ -129,19 +107,15 @@ public final class ClaudeCodeHookConfig {
           "Failed to create " + SETTINGS_DIR + " in " + container + ": " + mkdir.stderr());
     }
 
-    writeSettings(container, render(), SETTINGS_PATH);
-    writeSettings(container, renderFixLane(), FIX_SETTINGS_PATH);
-  }
-
-  private void writeSettings(String container, String content, String path)
-      throws IOException, InterruptedException, TimeoutException {
     var write =
         shell.exec(
             ContainerExec.asDevUser(
                 container,
-                List.of("bash", "-c", "printf '%s' \"$1\" > \"$2\"", "bash", content, path)));
+                List.of(
+                    "bash", "-c", "printf '%s' \"$1\" > \"$2\"", "bash", render(), SETTINGS_PATH)));
     if (!write.ok()) {
-      throw new IOException("Failed to write " + path + " in " + container + ": " + write.stderr());
+      throw new IOException(
+          "Failed to write " + SETTINGS_PATH + " in " + container + ": " + write.stderr());
     }
   }
 

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/ClaudeCodeHookConfigTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/ClaudeCodeHookConfigTest.java
@@ -129,35 +129,6 @@ class ClaudeCodeHookConfigTest {
   }
 
   @Test
-  void fixLaneSettingsPathConstantsMatch() {
-    assertEquals("claude-fix-settings.json", ClaudeCodeHookConfig.FIX_SETTINGS_FILE);
-    assertEquals(
-        "/home/dev/.sail/claude-fix-settings.json", ClaudeCodeHookConfig.FIX_SETTINGS_PATH);
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  void fixLaneSettingsCarryTheStopGateAndNothingElse() {
-    var json = ClaudeCodeHookConfig.renderFixLane();
-    var hooks = (Map<String, Object>) YamlUtil.parseMap(json).get("hooks");
-    assertEquals(
-        List.of("Stop"),
-        List.copyOf(hooks.keySet()),
-        "the fix lane is gated but must stay off the event bus: a session-start or tool"
-            + " heartbeat from a fix agent would narrate a run the watcher does not own");
-    var stopGroups = (List<Map<String, Object>>) hooks.get("Stop");
-    assertEquals(1, stopGroups.size());
-    var stopHooks = (List<Map<String, Object>>) stopGroups.get(0).get("hooks");
-    assertEquals(1, stopHooks.size());
-    assertEquals(SailStopGate.SCRIPT_PATH, stopHooks.get(0).get("command"));
-    assertEquals(SailStopGate.HOOK_TIMEOUT_SECONDS, stopHooks.get(0).get("timeout"));
-    assertFalse(
-        json.contains(SailEventHelper.SCRIPT_PATH),
-        "no event helper anywhere: the gate's own publishes already no-op without SAIL_SPEC_ID");
-    assertTrue(json.contains("\"includeCoAuthoredBy\": false"));
-  }
-
-  @Test
   void installWritesToSailOwnedSettingsPath() throws Exception {
     var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
     var writer = new ClaudeCodeHookConfig(shell);
@@ -165,13 +136,13 @@ class ClaudeCodeHookConfigTest {
     writer.install("light-grid");
 
     var cmds = shell.invocations();
-    assertEquals(3, cmds.size());
+    assertEquals(
+        2,
+        cmds.size(),
+        "one hooks layer only: lanes are expressed by SAIL_SPEC_ID/SAIL_RUN_ID at launch, never"
+            + " by a second settings file");
     assertTrue(cmds.get(0).contains("mkdir -p /home/dev/.sail"));
     assertTrue(cmds.get(1).contains("/home/dev/.sail/claude-settings.json"));
-    assertTrue(
-        cmds.get(2).contains("/home/dev/.sail/claude-fix-settings.json"),
-        "both lane files install together so a container never has the dispatch settings"
-            + " without the fix-lane settings");
     assertFalse(
         cmds.get(1).contains("settings.local.json"),
         "must not write to the project-scoped settings.local.json anymore");

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ContainerReviewAgentRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ContainerReviewAgentRunner.java
@@ -33,13 +33,14 @@ import java.util.Objects;
  * from the bytes this run appended — parsed via {@link StreamJsonResult} so a streamed reviewer and
  * a plain one are handled uniformly.
  *
- * <p>Neither lane exports {@code SAIL_SPEC_ID}, so no completion event ever re-enters the pipeline
- * (which would recurse forever). The reviewer additionally runs hook-free and ungated — it must be
- * free to stop without committing. The fix lane arms the stop gate (see {@link #runFix}) because it
- * writes to the spec branch and the commit discipline lives in the gate, not the prompt. The run
- * credential rides in as a positional shell argument — never interpolated into the script text —
- * and lands in {@code SAIL_RUN_CREDENTIAL}, so the agent's spec commands authenticate as its review
- * run's principal.
+ * <p>Both lanes run the one sail-owned hooks layer every sail-launched session runs; the lane is
+ * expressed entirely by the environment. Neither exports {@code SAIL_SPEC_ID}, so no completion
+ * event ever re-enters the pipeline (which would recurse forever). The reviewer exports no {@code
+ * SAIL_RUN_ID} either — every hook is inert, and it stays free to stop without committing. The fix
+ * lane exports the run id, arming the stop gate (see {@link #runFix}), because it writes to the
+ * spec branch and the commit discipline lives in the gate, not the prompt. The run credential rides
+ * in as a positional shell argument — never interpolated into the script text — and lands in {@code
+ * SAIL_RUN_CREDENTIAL}, so the agent's spec commands authenticate as its review run's principal.
  */
 final class ContainerReviewAgentRunner implements ReviewAgentRunner {
 
@@ -83,16 +84,15 @@ final class ContainerReviewAgentRunner implements ReviewAgentRunner {
       throws Exception {
     var cli = AgentCli.fromYamlName(agent);
     var unit = stage(project, prompt, reviewId);
-    return launch(project, cli, agent, unit, runCredential, null, null, model, reasoningEffort);
+    return launch(project, cli, agent, unit, runCredential, null, model, reasoningEffort);
   }
 
   /**
    * The fix lane launches with the stop gate armed: {@code SAIL_RUN_ID} rides in as a positional
-   * argument, the session file carries the spec's branch and repos so the gate checks exactly this
-   * spec's repos, and Claude Code loads the Stop-only settings file. Codex needs no settings flag —
-   * it discovers the global hooks file, armed by the trust bypass every full-permission launch
-   * already passes — so both CLIs gate identically. {@code SAIL_SPEC_ID} stays unset: the gate's
-   * own publishes no-op and the pipeline can never re-enter on the fix agent's stop.
+   * argument and the session file carries the spec's branch and repos so the gate checks exactly
+   * this spec's repos. Both CLIs run the same single hooks layer they always run — the run id alone
+   * is what arms the gate. {@code SAIL_SPEC_ID} stays unset: the gate's own publishes no-op and the
+   * pipeline can never re-enter on the fix agent's stop.
    */
   @Override
   public String runFix(
@@ -109,16 +109,7 @@ final class ContainerReviewAgentRunner implements ReviewAgentRunner {
     var cli = AgentCli.fromYamlName(agent);
     var unit = stage(project, prompt, reviewId);
     session.writeSession(project, prompt, branch, "", agent, reviewId, repos, unit);
-    return launch(
-        project,
-        cli,
-        agent,
-        unit,
-        runCredential,
-        ClaudeCodeHookConfig.FIX_SETTINGS_PATH,
-        reviewId,
-        model,
-        reasoningEffort);
+    return launch(project, cli, agent, unit, runCredential, reviewId, model, reasoningEffort);
   }
 
   private AgentUnit stage(String project, String prompt, String reviewId) throws Exception {
@@ -134,7 +125,6 @@ final class ContainerReviewAgentRunner implements ReviewAgentRunner {
       String agent,
       AgentUnit unit,
       String runCredential,
-      String claudeSettingsPath,
       String gateRunId,
       String model,
       String reasoningEffort)
@@ -143,7 +133,12 @@ final class ContainerReviewAgentRunner implements ReviewAgentRunner {
 
     var agentCmd =
         cli.headlessCommand(
-            unit.taskPath(), true, model, reasoningEffort, claudeSettingsPath, true);
+            unit.taskPath(),
+            true,
+            model,
+            reasoningEffort,
+            ClaudeCodeHookConfig.SETTINGS_PATH,
+            true);
     var gateExport = gateRunId == null ? "" : "export SAIL_RUN_ID=\"$2\"; ";
     var command =
         "export SAIL_RUN_CREDENTIAL=\"$1\"; "

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
@@ -125,8 +125,6 @@ public final class ContainerSailSetup {
                         + " && grep -qsF includeCoAuthoredBy "
                         + ClaudeCodeHookConfig.SETTINGS_PATH
                         + " && test -f "
-                        + ClaudeCodeHookConfig.FIX_SETTINGS_PATH
-                        + " && test -f "
                         + CodexHookConfig.SETTINGS_PATH
                         + " && grep -qsF "
                         + ClaudeCodeHookConfig.PROGRESS_HOOK_MARKER

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ContainerReviewAgentRunnerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ContainerReviewAgentRunnerTest.java
@@ -53,7 +53,10 @@ class ContainerReviewAgentRunnerTest {
     assertTrue(
         exec.contains(REVIEW_DIR + "/review-prompt.txt"),
         "prompt staged to the review's own task file");
-    assertFalse(exec.contains("--settings"), "reviewer loads no hooks");
+    assertTrue(
+        exec.contains("--settings /home/dev/.sail/claude-settings.json"),
+        "the reviewer loads the same single hooks layer as every sail-launched claude session;"
+            + " with neither SAIL_SPEC_ID nor SAIL_RUN_ID exported every hook is inert");
     assertFalse(
         exec.contains("SAIL_SPEC_ID"), "reviewer runs without a spec id, so it can't recurse");
     assertFalse(
@@ -121,8 +124,9 @@ class ContainerReviewAgentRunnerTest {
         "the run id arms the stop gate, read from its positional argument");
     assertTrue(exec.contains(REVIEW_ID), "the review id travels as the argument itself");
     assertTrue(
-        exec.contains("--settings " + "/home/dev/.sail/claude-fix-settings.json"),
-        "claude loads the Stop-only settings so the gate fires without any event hooks");
+        exec.contains("--settings /home/dev/.sail/claude-settings.json"),
+        "one hooks layer: the fix lane loads the same settings as dispatch; the run id alone"
+            + " arms the gate and the missing spec id keeps the event hooks silent");
     assertFalse(
         exec.contains("SAIL_SPEC_ID"),
         "no spec id: the event helper stays silent and the pipeline can never re-enter");


### PR DESCRIPTION
## Why

`claude-fix-settings.json` (from #182) was baggage: a second settings file re-encoding in file-space what the environment already expresses. Both hook scripts self-gate — `sail-event.sh` on `SAIL_SPEC_ID`, `sail-stop-gate` on `SAIL_RUN_ID` — so the lane contract is purely environmental. Codex proved the model all along: one global hooks file, lanes distinguished by env. Checked against the current docs of both CLIs: neither Claude Code nor Codex offers any per-session hooks mechanism, so env scoping is the only upstream-supported design.

## What

One hooks layer per CLI; the lane is the environment:

| Lane | `SAIL_SPEC_ID` | `SAIL_RUN_ID` | Effect |
|---|---|---|---|
| dispatch | ✓ | ✓ | events + stop gate |
| fix | — | ✓ | gate armed, events silent |
| review | — | — | every hook inert |
| engineer session | — | — | claude never loads the file; codex hooks untrusted/inert |

- Claude loads the same `claude-settings.json` via `--settings` in every sail-launched session (dispatch, review, fix) — symmetric with codex.
- Deletes `claude-fix-settings.json`, `renderFixLane`, `FIX_SETTINGS_PATH`, and the setup probe line.
- Containers that already received the fix-lane file just stop referencing it; nothing else to migrate.

## Testing

Full `mvn clean verify` green including the JaCoCo gates. Runner tests now assert both lanes load the single layer and that the reviewer stays inert (no run id, no session file).