### PR TITLE
Review findings get identity, verdicts, and a dispute lane

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -416,6 +416,19 @@ stage's gate fails, a fix agent addresses the open findings on the same branch a
 reviewer runs again, bounded by `max_iterations`, after which the spec `escalates` and parks
 in `review` for a human.
 
+Findings have identity across iterations. The re-review receives the previous review's open
+findings and must return a verdict envelope — `{"verdicts": [...], "findings": [...]}`, the
+only response shape the parser admits — ruling each carried finding `fixed`, `still_open`, or
+`disputed`, with evidence required for `fixed` and `disputed`. Fail-closed: an unmentioned
+carried finding defaults to `still_open` and re-attaches to the new review as a fresh row
+chained through `carried_from`, so the gate keeps failing on a high the reviewer stopped
+mentioning, and a passed review resolves nothing implicitly. The fix agent has a dispute lane:
+it argues a wrong finding in the spec room instead of coding around it, the re-review rules on
+the argument, and a `disputed` finding is excluded from the gate but listed in the room verdict
+for the human. A gate-blocking finding still open after `max_finding_age` fix iterations
+(default 2) escalates by name — a convergence measure that catches a stuck loop long before
+`max_iterations` burns down.
+
 A gate pass is not completion: the PR is still open on whatever forge hosts the repo, so the
 spec parks in `awaiting_merge`. Sail never talks to the forge — the FDE reviews and merges
 the PR there, then closes the loop with `sail spec update <id> --status done`. Deciding about

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## Unreleased
 
-No unreleased changes.
+- Review findings now have identity, verdicts, and a dispute lane. The re-review receives the
+  previous review's open findings and must rule on every one (`fixed`/`still_open`/`disputed`,
+  evidence required to resolve) inside a verdict envelope — the only reviewer output shape the
+  parser accepts; a bare findings array errors the stage. Unruled findings carry forward as the
+  same finding (a `carried_from` chain), keep failing the gate, and escalate by name once they
+  survive `max_finding_age` fix iterations (default 2). The fix agent disputes a wrong finding by
+  arguing it in the spec room instead of coding around it; the reviewer rules, disputed findings
+  skip the gate but surface in the room verdict for the human. "N open findings" after a pass now
+  means exactly N unresolved sub-gate findings.
 
 ## 0.17.3
 

--- a/sail-core/src/main/java/ai/singlr/sail/config/ReviewPipelineConfig.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/ReviewPipelineConfig.java
@@ -22,6 +22,14 @@ import java.util.Map;
  */
 public record ReviewPipelineConfig(int maxIterations, int maxFindingAge, List<StageConfig> stages) {
 
+  public ReviewPipelineConfig {
+    if (stages.stream().map(StageConfig::name).distinct().count() != stages.size()) {
+      throw new IllegalArgumentException(
+          "review_pipeline stage names must be unique — carry-forward is keyed by stage name;"
+              + " rename the duplicate stage in sail.yaml");
+    }
+  }
+
   public record StageConfig(
       String name, StageType type, String agent, List<String> categories, Gate gate) {
 

--- a/sail-core/src/main/java/ai/singlr/sail/config/ReviewPipelineConfig.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/ReviewPipelineConfig.java
@@ -14,8 +14,13 @@ import java.util.Map;
  * Configurable multi-stage review pipeline. Parsed from the {@code agent.review_pipeline} block in
  * {@code sail.yaml}. Stages execute sequentially; each agent stage produces structured findings
  * evaluated against its gate before advancing.
+ *
+ * @param maxFindingAge how many fix iterations a gate-blocking finding may survive before the loop
+ *     escalates it as stuck — a convergence measure, unlike {@code maxIterations}' blind budget: a
+ *     loop resolving old findings while new ones surface keeps running; a loop replaying the same
+ *     finding stops here
  */
-public record ReviewPipelineConfig(int maxIterations, List<StageConfig> stages) {
+public record ReviewPipelineConfig(int maxIterations, int maxFindingAge, List<StageConfig> stages) {
 
   public record StageConfig(
       String name, StageType type, String agent, List<String> categories, Gate gate) {
@@ -56,17 +61,21 @@ public record ReviewPipelineConfig(int maxIterations, List<StageConfig> stages) 
     }
 
     public boolean passes(List<Finding> findings) {
+      return findings.stream().noneMatch(this::blocks);
+    }
+
+    /**
+     * Whether this single finding trips the gate. Only {@code OPEN} findings block — a disputed
+     * finding is excluded from the gate and surfaces in the room verdict for the human instead.
+     */
+    public boolean blocks(Finding finding) {
+      if (finding.resolution() != Finding.Resolution.OPEN) {
+        return false;
+      }
       return switch (this) {
-        case NO_CRITICAL ->
-            findings.stream()
-                .filter(f -> f.resolution() == Finding.Resolution.OPEN)
-                .noneMatch(f -> f.severity() == Finding.Severity.CRITICAL);
-        case NO_CRITICAL_OR_HIGH ->
-            findings.stream()
-                .filter(f -> f.resolution() == Finding.Resolution.OPEN)
-                .noneMatch(f -> f.severity().isAtLeast(Finding.Severity.HIGH));
-        case ALL_CLEAR ->
-            findings.stream().noneMatch(f -> f.resolution() == Finding.Resolution.OPEN);
+        case NO_CRITICAL -> finding.severity() == Finding.Severity.CRITICAL;
+        case NO_CRITICAL_OR_HIGH -> finding.severity().isAtLeast(Finding.Severity.HIGH);
+        case ALL_CLEAR -> true;
       };
     }
   }
@@ -80,6 +89,7 @@ public record ReviewPipelineConfig(int maxIterations, List<StageConfig> stages) 
   public static ReviewPipelineConfig mandatoryDefault() {
     return new ReviewPipelineConfig(
         3,
+        2,
         List.of(
             new StageConfig(
                 "review",
@@ -93,9 +103,11 @@ public record ReviewPipelineConfig(int maxIterations, List<StageConfig> stages) 
   public static ReviewPipelineConfig fromMap(Map<String, Object> map) {
     var maxIterations =
         map.containsKey("max_iterations") ? ((Number) map.get("max_iterations")).intValue() : 3;
+    var maxFindingAge =
+        map.containsKey("max_finding_age") ? ((Number) map.get("max_finding_age")).intValue() : 2;
     var stagesList = (List<Map<String, Object>>) map.getOrDefault("stages", List.of());
     var stages = stagesList.stream().map(StageConfig::fromMap).toList();
-    return new ReviewPipelineConfig(maxIterations, stages);
+    return new ReviewPipelineConfig(maxIterations, maxFindingAge, stages);
   }
 
   public List<StageConfig> agentStages() {

--- a/sail-core/src/main/java/ai/singlr/sail/config/SailYaml.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/SailYaml.java
@@ -384,6 +384,7 @@ public record SailYaml(
             "review_pipeline",
             Map.of(
                 "max_iterations", reviewPipeline.maxIterations(),
+                "max_finding_age", reviewPipeline.maxFindingAge(),
                 "stages", reviewPipeline.stages()));
       return map;
     }

--- a/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
@@ -9,6 +9,7 @@ import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.store.Finding;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -21,13 +22,14 @@ import java.util.Objects;
  *
  * <pre>{@code {"verdicts": [...], "findings": [...]}}</pre>
  *
- * where each verdict rules on a finding carried forward from the previous review and each finding
- * is a newly discovered issue. Anything else — a bare findings array included — is unparseable
- * reviewer output: the reviewer and this parser ship in the same binary, so no legacy shape is
- * tolerated and an off-contract response errors the stage rather than passing as a clean review.
- * The same fail-closed rule applies inside the envelope: a single malformed entry rejects the whole
- * response, because an unreadable finding has unknown severity and cannot safely be dropped — the
- * gate must never rule on a result from which a reported issue was discarded.
+ * where each verdict rules on a finding carried forward from the previous review — exactly one
+ * verdict per finding — and each finding is a newly discovered issue. Anything else — a bare
+ * findings array included — is unparseable reviewer output: the reviewer and this parser ship in
+ * the same binary, so no legacy shape is tolerated and an off-contract response errors the stage
+ * rather than passing as a clean review. The same fail-closed rule applies inside the envelope: a
+ * single malformed entry — or a duplicate verdict, whose effective ruling would be ambiguous —
+ * rejects the whole response, because an unreadable finding has unknown severity and cannot safely
+ * be dropped — the gate must never rule on a result from which a reported issue was discarded.
  */
 public final class FindingParser {
 
@@ -66,26 +68,28 @@ public final class FindingParser {
   }
 
   /**
-   * Parses the verdict envelope out of a review agent's raw transcript. Transcripts are noisy: the
-   * agent may echo the prompt (which itself names the {@code ```json} convention) and may emit
-   * fenced blocks mid-reasoning, so candidates are tried <em>last to first</em> and the last block
-   * that parses as an envelope wins — the response convention puts the verdict at the end. Fenced
-   * blocks are tried first; when none parses, the transcript is scanned for an unfenced JSON object
-   * before giving up — the format instruction is a request, not a guarantee, and an envelope
-   * without its fence is still a verdict. The hardening locates the envelope in noisy output; it
-   * does not admit alternative formats.
+   * Parses the verdict envelope out of a review agent's raw transcript. The response convention
+   * puts the verdict at the end, so the last fenced JSON object is the response — and it is
+   * authoritative: when it is malformed the whole transcript is unparseable and the stage errors,
+   * never silently replaced by an earlier draft or echoed envelope that could retire a
+   * gate-blocking finding. Only when no fenced candidate exists is the transcript scanned for an
+   * unfenced JSON object before giving up — the format instruction is a request, not a guarantee,
+   * and an envelope without its fence is still a verdict. The hardening locates the envelope in
+   * noisy output; it does not admit alternative formats.
    */
   public static ParseResult parse(String agentOutput) {
+    var fenced = extractJsonBlocks(agentOutput);
+    if (!fenced.isEmpty()) {
+      return parseEnvelope(fenced.getLast());
+    }
     var warnings = new ArrayList<String>();
-    for (var candidates :
-        List.of(extractJsonBlocks(agentOutput), extractEmbeddedObjects(agentOutput))) {
-      for (var i = candidates.size() - 1; i >= 0; i--) {
-        switch (parseEnvelope(candidates.get(i))) {
-          case ParseResult.Parsed parsed -> {
-            return parsed;
-          }
-          case ParseResult.Unparseable rejected -> warnings.addAll(rejected.warnings());
+    var embedded = extractEmbeddedObjects(agentOutput);
+    for (var i = embedded.size() - 1; i >= 0; i--) {
+      switch (parseEnvelope(embedded.get(i))) {
+        case ParseResult.Parsed parsed -> {
+          return parsed;
         }
+        case ParseResult.Unparseable rejected -> warnings.addAll(rejected.warnings());
       }
     }
     if (warnings.isEmpty()) {
@@ -130,6 +134,12 @@ public final class FindingParser {
         warnings.add("Finding " + i + ": " + e.getMessage());
       }
     }
+    var ruledIds = new HashSet<String>();
+    for (var verdict : verdicts) {
+      if (!ruledIds.add(verdict.findingId())) {
+        warnings.add("Duplicate verdict for finding " + verdict.findingId() + ".");
+      }
+    }
     if (!warnings.isEmpty()) {
       return new ParseResult.Unparseable(List.copyOf(warnings));
     }
@@ -140,8 +150,10 @@ public final class FindingParser {
    * Fail-closed reconciliation of the reviewer's verdicts against the carried findings it was asked
    * to rule on: every carried finding gets exactly one effective ruling. A carried finding missing
    * from the verdicts defaults to {@code still_open}; {@code fixed} or {@code disputed} without
-   * evidence downgrades to {@code still_open}; a verdict naming an unknown finding is a warning,
-   * never a crash. Incomplete-answer semantics — a finding can never resolve by omission.
+   * evidence downgrades to {@code still_open}; duplicate verdicts for one finding are an ambiguous
+   * ruling and force {@code still_open} regardless of order; a verdict naming an unknown finding is
+   * a warning, never a crash. Incomplete-answer semantics — a finding can never resolve by
+   * omission, and never by the entry order of a malformed answer.
    */
   public static Reconciled reconcile(List<Finding> carried, List<Verdict> verdicts) {
     var warnings = new ArrayList<String>();
@@ -149,9 +161,16 @@ public final class FindingParser {
     for (var finding : carried) {
       rulings.put(finding.id(), new Verdict(finding.id(), Ruling.STILL_OPEN, ""));
     }
+    var ruled = new HashSet<String>();
     for (var verdict : verdicts) {
       if (!rulings.containsKey(verdict.findingId())) {
         warnings.add("Verdict for unknown finding " + verdict.findingId() + " ignored.");
+        continue;
+      }
+      if (!ruled.add(verdict.findingId())) {
+        rulings.put(verdict.findingId(), new Verdict(verdict.findingId(), Ruling.STILL_OPEN, ""));
+        warnings.add(
+            "Conflicting verdicts for finding " + verdict.findingId() + "; treated as still_open.");
         continue;
       }
       if (verdict.ruling() != Ruling.STILL_OPEN && Strings.isBlank(verdict.evidence())) {
@@ -189,8 +208,10 @@ public final class FindingParser {
   /**
    * Every marker occurrence starts an independent candidate (advancing past the marker, not the
    * closing fence): a prompt echo's mid-sentence marker would otherwise swallow the real block's
-   * opening fence as its terminator. Overlap is harmless — candidates are validated by parsing.
-   * Markers match case-insensitively, so a {@code ```JSON} fence is not mistaken for prose.
+   * opening fence as its terminator. A candidate that does not open a JSON object is extraction
+   * noise — a mid-sentence marker's trailing prose, not a response — and is dropped, so it can
+   * never stand in as the authoritative final block. Markers match case-insensitively, so a {@code
+   * ```JSON} fence is not mistaken for prose.
    */
   private static void collectBlocks(String output, String marker, List<String> blocks) {
     var haystack = output.toLowerCase(Locale.ROOT);
@@ -203,8 +224,11 @@ public final class FindingParser {
       if (contentStart < 0) return;
       contentStart++;
       var end = output.indexOf("```", contentStart);
-      blocks.add(
-          (end < 0 ? output.substring(contentStart) : output.substring(contentStart, end)).strip());
+      var candidate =
+          (end < 0 ? output.substring(contentStart) : output.substring(contentStart, end)).strip();
+      if (candidate.startsWith("{")) {
+        blocks.add(candidate);
+      }
     }
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
@@ -9,69 +9,168 @@ import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.store.Finding;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 
 /**
- * Parses structured JSON findings from review agent output. Extracts the JSON array between {@code
- * ```json} and {@code ```} markers. Tolerant of malformed output — unparseable entries are skipped
- * with a warning, never crashing the pipeline.
+ * Parses the verdict envelope from review agent output. The envelope is the review contract's only
+ * valid response shape, from iteration one:
+ *
+ * <pre>{@code {"verdicts": [...], "findings": [...]}}</pre>
+ *
+ * where each verdict rules on a finding carried forward from the previous review and each finding
+ * is a newly discovered issue. Anything else — a bare findings array included — is unparseable
+ * reviewer output: the reviewer and this parser ship in the same binary, so no legacy shape is
+ * tolerated and an off-contract response errors the stage rather than passing as a clean review.
+ * Within a valid envelope, malformed entries are skipped with a warning, never crashing the
+ * pipeline.
  */
 public final class FindingParser {
 
   private FindingParser() {}
 
-  public record ParseResult(List<Finding> findings, List<String> warnings) {}
+  /** How the reviewer ruled on a carried finding. */
+  public enum Ruling {
+    FIXED,
+    STILL_OPEN,
+    DISPUTED;
+
+    static Ruling parse(String value) {
+      return valueOf(value.strip().toUpperCase(Locale.ROOT));
+    }
+  }
+
+  /** One ruling on one carried finding, with the evidence the ruling rests on. */
+  public record Verdict(String findingId, Ruling ruling, String evidence) {
+
+    static Verdict fromMap(Map<String, Object> map) {
+      var findingId = (String) map.get("finding_id");
+      if (Strings.isBlank(findingId)) {
+        throw new IllegalArgumentException("verdict requires a finding_id");
+      }
+      var ruling = Ruling.parse((String) map.get("verdict"));
+      return new Verdict(findingId, ruling, Objects.toString(map.get("evidence"), "").strip());
+    }
+  }
+
+  /** A parsed envelope, or the proof that no candidate in the transcript was one. */
+  public sealed interface ParseResult {
+
+    record Parsed(List<Verdict> verdicts, List<Finding> findings, List<String> warnings)
+        implements ParseResult {}
+
+    record Unparseable(List<String> warnings) implements ParseResult {}
+  }
 
   /**
-   * Parses the findings array out of a review agent's raw transcript. Transcripts are noisy: the
+   * Parses the verdict envelope out of a review agent's raw transcript. Transcripts are noisy: the
    * agent may echo the prompt (which itself names the {@code ```json} convention) and may emit
    * fenced blocks mid-reasoning, so candidates are tried <em>last to first</em> and the last block
-   * that parses as a JSON array wins — the response convention puts the verdict at the end. Fenced
-   * blocks are tried first; when none parses, the transcript is scanned for an unfenced findings
-   * array (or a bare {@code []} verdict line) before giving up — the format instruction is a
-   * request, not a guarantee, and JSON without its fence is still a verdict. When nothing parses,
-   * the result carries warnings so the pipeline can refuse to treat an unreadable review as a clean
-   * pass.
+   * that parses as an envelope wins — the response convention puts the verdict at the end. Fenced
+   * blocks are tried first; when none parses, the transcript is scanned for an unfenced JSON object
+   * before giving up — the format instruction is a request, not a guarantee, and an envelope
+   * without its fence is still a verdict. The hardening locates the envelope in noisy output; it
+   * does not admit alternative formats.
    */
   public static ParseResult parse(String agentOutput) {
     var warnings = new ArrayList<String>();
     for (var candidates :
-        List.of(extractJsonBlocks(agentOutput), extractEmbeddedArrays(agentOutput))) {
+        List.of(extractJsonBlocks(agentOutput), extractEmbeddedObjects(agentOutput))) {
       for (var i = candidates.size() - 1; i >= 0; i--) {
-        var result = parseJsonArray(candidates.get(i));
-        if (result.findings().isEmpty() && !result.warnings().isEmpty()) {
-          warnings.addAll(result.warnings());
-          continue;
+        switch (parseEnvelope(candidates.get(i))) {
+          case ParseResult.Parsed parsed -> {
+            return parsed;
+          }
+          case ParseResult.Unparseable rejected -> warnings.addAll(rejected.warnings());
         }
-        return result;
       }
     }
     if (warnings.isEmpty()) {
       warnings.add("No JSON block found in agent output.");
     }
-    return new ParseResult(List.of(), List.copyOf(warnings));
+    return new ParseResult.Unparseable(List.copyOf(warnings));
   }
 
-  private static ParseResult parseJsonArray(String json) {
+  @SuppressWarnings("unchecked")
+  private static ParseResult parseEnvelope(String json) {
+    Map<String, Object> map;
     try {
-      var list = YamlUtil.parseList(json);
-      var findings = new ArrayList<Finding>();
-      var warnings = new ArrayList<String>();
-
-      for (var i = 0; i < list.size(); i++) {
-        try {
-          findings.add(Finding.fromMap(list.get(i)));
-        } catch (Exception e) {
-          warnings.add("Finding " + i + ": " + e.getMessage());
-        }
-      }
-
-      return new ParseResult(List.copyOf(findings), List.copyOf(warnings));
+      map = YamlUtil.parseMap(json);
     } catch (Exception e) {
-      return new ParseResult(List.of(), List.of("Failed to parse JSON: " + e.getMessage()));
+      return new ParseResult.Unparseable(List.of("Failed to parse JSON: " + e.getMessage()));
     }
+    var verdictsRaw = map.get("verdicts");
+    var findingsRaw = map.get("findings");
+    if (!(verdictsRaw instanceof List) && !(findingsRaw instanceof List)) {
+      return new ParseResult.Unparseable(
+          List.of(
+              "Not a verdict envelope — expected a JSON object with \"verdicts\" and"
+                  + " \"findings\" arrays."));
+    }
+
+    var warnings = new ArrayList<String>();
+    var verdicts = new ArrayList<Verdict>();
+    var verdictEntries = verdictsRaw instanceof List ? (List<Object>) verdictsRaw : List.of();
+    for (var i = 0; i < verdictEntries.size(); i++) {
+      try {
+        verdicts.add(Verdict.fromMap((Map<String, Object>) verdictEntries.get(i)));
+      } catch (Exception e) {
+        warnings.add("Verdict " + i + ": " + e.getMessage());
+      }
+    }
+    var findings = new ArrayList<Finding>();
+    var findingEntries = findingsRaw instanceof List ? (List<Object>) findingsRaw : List.of();
+    for (var i = 0; i < findingEntries.size(); i++) {
+      try {
+        findings.add(Finding.fromMap((Map<String, Object>) findingEntries.get(i)));
+      } catch (Exception e) {
+        warnings.add("Finding " + i + ": " + e.getMessage());
+      }
+    }
+    if (verdicts.isEmpty() && findings.isEmpty() && !warnings.isEmpty()) {
+      return new ParseResult.Unparseable(List.copyOf(warnings));
+    }
+    return new ParseResult.Parsed(
+        List.copyOf(verdicts), List.copyOf(findings), List.copyOf(warnings));
   }
+
+  /**
+   * Fail-closed reconciliation of the reviewer's verdicts against the carried findings it was asked
+   * to rule on: every carried finding gets exactly one effective ruling. A carried finding missing
+   * from the verdicts defaults to {@code still_open}; {@code fixed} or {@code disputed} without
+   * evidence downgrades to {@code still_open}; a verdict naming an unknown finding is a warning,
+   * never a crash. Incomplete-answer semantics — a finding can never resolve by omission.
+   */
+  public static Reconciled reconcile(List<Finding> carried, List<Verdict> verdicts) {
+    var warnings = new ArrayList<String>();
+    var rulings = new LinkedHashMap<String, Verdict>();
+    for (var finding : carried) {
+      rulings.put(finding.id(), new Verdict(finding.id(), Ruling.STILL_OPEN, ""));
+    }
+    for (var verdict : verdicts) {
+      if (!rulings.containsKey(verdict.findingId())) {
+        warnings.add("Verdict for unknown finding " + verdict.findingId() + " ignored.");
+        continue;
+      }
+      if (verdict.ruling() != Ruling.STILL_OPEN && Strings.isBlank(verdict.evidence())) {
+        warnings.add(
+            "Verdict '"
+                + verdict.ruling().name().toLowerCase(Locale.ROOT)
+                + "' on finding "
+                + verdict.findingId()
+                + " carries no evidence; treated as still_open.");
+        continue;
+      }
+      rulings.put(verdict.findingId(), verdict);
+    }
+    return new Reconciled(Map.copyOf(rulings), List.copyOf(warnings));
+  }
+
+  /** The effective ruling per carried finding id, plus what fail-closed defaulting rejected. */
+  public record Reconciled(Map<String, Verdict> rulings, List<String> warnings) {}
 
   static List<String> extractJsonBlocks(String output) {
     if (Strings.isBlank(output)) return List.of();
@@ -79,7 +178,7 @@ public final class FindingParser {
     var blocks = new ArrayList<String>();
     collectBlocks(output, "```json", blocks);
     if (blocks.isEmpty()) {
-      collectBlocks(output, "```\n[", blocks);
+      collectBlocks(output, "```\n{", blocks);
     }
     if (blocks.isEmpty()) {
       var bare = tryBareJson(output);
@@ -111,32 +210,29 @@ public final class FindingParser {
   }
 
   /**
-   * Last-resort candidates for a reviewer that dropped the fence: every {@code [{} …{@code }]} span
-   * (an array of objects — the findings shape, rare in prose), and failing that a line that is
-   * exactly {@code []}. A mid-sentence {@code []} (the prompt echo names one) never matches — only
-   * a line the agent wrote as its whole verdict does.
+   * Last-resort candidates for a reviewer that dropped the fence: every {@code {"} …{@code }} span
+   * (an object opening straight into a key — the envelope shape, rare in prose). Spans are greedy
+   * to the last closing brace and validated by parsing, so a prompt echo's inline placeholder
+   * envelope (which is not valid JSON by design) never counts as a verdict.
    */
-  static List<String> extractEmbeddedArrays(String output) {
+  static List<String> extractEmbeddedObjects(String output) {
     if (Strings.isBlank(output)) return List.of();
 
     var blocks = new ArrayList<String>();
-    var end = output.lastIndexOf("}]");
+    var end = output.lastIndexOf('}');
     var from = 0;
     while (end >= 0) {
-      var start = output.indexOf("[{", from);
+      var start = output.indexOf("{\"", from);
       if (start < 0 || start > end) break;
-      blocks.add(output.substring(start, end + 2));
+      blocks.add(output.substring(start, end + 1));
       from = start + 1;
-    }
-    if (blocks.isEmpty()) {
-      output.lines().map(String::strip).filter("[]"::equals).findFirst().ifPresent(blocks::add);
     }
     return List.copyOf(blocks);
   }
 
   private static String tryBareJson(String output) {
     var trimmed = output.strip();
-    if (trimmed.startsWith("[") && trimmed.endsWith("]")) return trimmed;
+    if (trimmed.startsWith("{") && trimmed.endsWith("}")) return trimmed;
     return null;
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
@@ -25,8 +25,9 @@ import java.util.Objects;
  * is a newly discovered issue. Anything else — a bare findings array included — is unparseable
  * reviewer output: the reviewer and this parser ship in the same binary, so no legacy shape is
  * tolerated and an off-contract response errors the stage rather than passing as a clean review.
- * Within a valid envelope, malformed entries are skipped with a warning, never crashing the
- * pipeline.
+ * The same fail-closed rule applies inside the envelope: a single malformed entry rejects the whole
+ * response, because an unreadable finding has unknown severity and cannot safely be dropped — the
+ * gate must never rule on a result from which a reported issue was discarded.
  */
 public final class FindingParser {
 
@@ -59,8 +60,7 @@ public final class FindingParser {
   /** A parsed envelope, or the proof that no candidate in the transcript was one. */
   public sealed interface ParseResult {
 
-    record Parsed(List<Verdict> verdicts, List<Finding> findings, List<String> warnings)
-        implements ParseResult {}
+    record Parsed(List<Verdict> verdicts, List<Finding> findings) implements ParseResult {}
 
     record Unparseable(List<String> warnings) implements ParseResult {}
   }
@@ -130,11 +130,10 @@ public final class FindingParser {
         warnings.add("Finding " + i + ": " + e.getMessage());
       }
     }
-    if (verdicts.isEmpty() && findings.isEmpty() && !warnings.isEmpty()) {
+    if (!warnings.isEmpty()) {
       return new ParseResult.Unparseable(List.copyOf(warnings));
     }
-    return new ParseResult.Parsed(
-        List.copyOf(verdicts), List.copyOf(findings), List.copyOf(warnings));
+    return new ParseResult.Parsed(List.copyOf(verdicts), List.copyOf(findings));
   }
 
   /**

--- a/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
@@ -104,16 +104,16 @@ public final class FindingParser {
     }
     var verdictsRaw = map.get("verdicts");
     var findingsRaw = map.get("findings");
-    if (!(verdictsRaw instanceof List) && !(findingsRaw instanceof List)) {
+    if (!(verdictsRaw instanceof List) || !(findingsRaw instanceof List)) {
       return new ParseResult.Unparseable(
           List.of(
-              "Not a verdict envelope — expected a JSON object with \"verdicts\" and"
+              "Not a verdict envelope — expected a JSON object with both \"verdicts\" and"
                   + " \"findings\" arrays."));
     }
 
     var warnings = new ArrayList<String>();
     var verdicts = new ArrayList<Verdict>();
-    var verdictEntries = verdictsRaw instanceof List ? (List<Object>) verdictsRaw : List.of();
+    var verdictEntries = (List<Object>) verdictsRaw;
     for (var i = 0; i < verdictEntries.size(); i++) {
       try {
         verdicts.add(Verdict.fromMap((Map<String, Object>) verdictEntries.get(i)));
@@ -122,7 +122,7 @@ public final class FindingParser {
       }
     }
     var findings = new ArrayList<Finding>();
-    var findingEntries = findingsRaw instanceof List ? (List<Object>) findingsRaw : List.of();
+    var findingEntries = (List<Object>) findingsRaw;
     for (var i = 0; i < findingEntries.size(); i++) {
       try {
         findings.add(Finding.fromMap((Map<String, Object>) findingEntries.get(i)));

--- a/sail-core/src/main/java/ai/singlr/sail/engine/FixTaskBuilder.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/FixTaskBuilder.java
@@ -10,8 +10,10 @@ import java.util.List;
 
 /**
  * Generates a structured fix task from review findings for the coding agent. Each finding is
- * presented with its severity, category, file/line reference, evidence, and concrete suggestion.
- * The agent receives actionable instructions, not vague feedback.
+ * presented with its id, severity, category, file/line reference, evidence, and concrete
+ * suggestion. The agent receives actionable instructions, not vague feedback — and a dispute lane:
+ * a finding it believes is wrong is argued in the spec room for the re-review to rule on, never
+ * coded around and never silently skipped.
  */
 public final class FixTaskBuilder {
 
@@ -34,7 +36,7 @@ public final class FixTaskBuilder {
     return body.isEmpty() ? subject : subject + "\n\n" + body;
   }
 
-  public static String build(String specTitle, List<Finding> findings) {
+  public static String build(String specId, String specTitle, List<Finding> findings) {
     if (findings.isEmpty()) {
       return "No review findings to address for spec \"%s\".".formatted(specTitle);
     }
@@ -43,11 +45,22 @@ public final class FixTaskBuilder {
     sb.append(
         "Your implementation for spec \"%s\" received %d review finding(s).%n"
             .formatted(specTitle, findings.size()));
-    sb.append("Address each finding below. The reviewer will re-check after you commit.\n\n");
+    sb.append("Address each finding below. The reviewer will re-check after you commit.\n");
+    sb.append(
+        """
+        Fix what is real. If you believe a finding is wrong, do NOT code around it and do NOT
+        silently skip it: post your argument to the spec room (spec comment %s --body "...")
+        naming the finding's id, and leave that code alone. The re-review reads the room and
+        rules fixed, still_open, or disputed with your argument as evidence — a finding is
+        retired by argument in the open, never by omission.
+
+        """
+            .formatted(specId));
 
     for (var i = 0; i < findings.size(); i++) {
       var f = findings.get(i);
       sb.append("--- Finding %d [%s] %s ---\n".formatted(i + 1, f.severity(), f.category()));
+      sb.append("Id: %s\n".formatted(f.id()));
       sb.append("Title: %s\n".formatted(f.title()));
 
       if (f.file() != null) {

--- a/sail-core/src/main/java/ai/singlr/sail/engine/ReviewPromptBuilder.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/ReviewPromptBuilder.java
@@ -5,13 +5,16 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.store.Finding;
 import ai.singlr.sail.store.MessageStore;
 import java.util.List;
 
 /**
- * Builds structured review prompts for review agents. The prompt instructs the agent to output
- * findings as a JSON array with severity, category, file/line references, evidence, and suggested
- * fixes. Every finding must include evidence — unsubstantiated reports are explicitly excluded.
+ * Builds structured review prompts for review agents. The prompt instructs the agent to respond
+ * with the verdict envelope — a ruling on every finding carried forward from the previous review,
+ * plus any newly discovered findings — as one JSON object. Every finding must include evidence;
+ * unsubstantiated reports are explicitly excluded, and a carried finding can only be retired by a
+ * verdict with evidence, never by omission.
  */
 public final class ReviewPromptBuilder {
 
@@ -23,7 +26,7 @@ public final class ReviewPromptBuilder {
    *     repos, and a wrong name sends the reviewer into an unrelated codebase)
    */
   public static String build(String branch, List<String> repos, List<String> categories) {
-    return build(branch, repos, categories, List.of());
+    return build(branch, repos, categories, List.of(), List.of());
   }
 
   public static String build(
@@ -31,6 +34,19 @@ public final class ReviewPromptBuilder {
       List<String> repos,
       List<String> categories,
       List<MessageStore.MessageRow> messages) {
+    return build(branch, repos, categories, messages, List.of());
+  }
+
+  /**
+   * @param carried the previous review's still-open findings, which the reviewer must rule on: one
+   *     verdict per carried finding, alongside (not instead of) any new findings
+   */
+  public static String build(
+      String branch,
+      List<String> repos,
+      List<String> categories,
+      List<MessageStore.MessageRow> messages,
+      List<Finding> carried) {
     var categoryList =
         categories.isEmpty() ? "any relevant category" : String.join(", ", categories);
     var repoList = repos.isEmpty() ? "the repository in the workspace" : String.join(", ", repos);
@@ -44,7 +60,22 @@ public final class ReviewPromptBuilder {
 
         Focus on these categories: %s
 
-        Output your findings as a JSON array. Each finding must have:
+        """
+            .formatted(branch, repos.size() == 1 ? "y" : "ies", repoList, categoryList)
+        + carryForward(carried)
+        + """
+        Respond with exactly one JSON object — the verdict envelope:
+        {"verdicts": [<one verdict per carried finding>], "findings": [<new findings only>]}
+
+        Each entry in "verdicts" rules on one carried finding listed above and must have:
+        - finding_id: the id exactly as listed above
+        - verdict: "fixed", "still_open", or "disputed"
+        - evidence: required for fixed (cite the commit or current code that resolves it) and
+          for disputed (state why the finding is wrong; an argument posted in the conversation
+          above counts). A fixed or disputed verdict without evidence is treated as still_open.
+        If no carried findings are listed above, "verdicts" must be an empty array.
+
+        Each entry in "findings" reports a NEW issue (never repeat a carried finding) and must have:
         - severity: CRITICAL, HIGH, MEDIUM, or LOW
         - category: one of SECURITY, LOGIC, EDGE_CASE, PERFORMANCE, ERROR_HANDLING, CONCURRENCY, RESOURCE_LEAK, API_CONTRACT
         - file: relative file path
@@ -61,11 +92,47 @@ public final class ReviewPromptBuilder {
         2. Every finding MUST include evidence. If you cannot prove it, do not report it.
         3. Every finding MUST include a concrete suggestion with before/after code.
         4. Focus on correctness, security, and reliability — not formatting.
-        5. If there are no issues, return an empty array: []
+        5. Rule on EVERY carried finding: a carried finding you do not mention is treated as
+           still_open, so silence never resolves anything.
+        6. If there are no new issues, "findings" must be an empty array.
 
-        Begin your response with ```json and end with ```.
+        Begin the JSON object with ```json and end with ```.
+        """;
+  }
+
+  /**
+   * The carry-forward contract: the previous review's open findings, each with the id the verdict
+   * must cite. Rendered before the response-format instructions so the reviewer reads what it must
+   * rule on before it reads how to answer.
+   */
+  private static String carryForward(List<Finding> carried) {
+    if (carried.isEmpty()) {
+      return "";
+    }
+    var lines =
+        carried.stream()
+            .map(
+                f ->
+                    "- finding_id %s [%s] %s%s"
+                        .formatted(f.id(), f.severity(), f.title(), location(f)))
+            .reduce((a, b) -> a + "\n" + b)
+            .orElse("");
+    return """
+        The previous review left these findings open. Re-examine each one against the current
+        state of the branch and include a verdict for every single one in "verdicts":
+
+        %s
+
         """
-            .formatted(branch, repos.size() == 1 ? "y" : "ies", repoList, categoryList);
+        .formatted(lines);
+  }
+
+  private static String location(Finding f) {
+    if (f.file() == null) {
+      return "";
+    }
+    var span = f.lineEnd() != f.lineStart() ? "-" + f.lineEnd() : "";
+    return " (" + f.file() + ":" + f.lineStart() + span + ")";
   }
 
   private static String conversation(List<MessageStore.MessageRow> messages) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/ChangeLog.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ChangeLog.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.store;
 import ai.singlr.sail.common.DateTimeUtils;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * Append-only revision journal for synced entities — the durability spine of the DB-sync design.
@@ -38,6 +39,15 @@ public final class ChangeLog {
       boolean deleted,
       String snapshot,
       String peer) {}
+
+  /**
+   * Runs {@code work} in one transaction on the journal's database, excluding every concurrent
+   * writer for the whole scope. The atomicity primitive behind {@code capture}/{@code
+   * adoptIfCurrent} in the sync replicas, which share this database with their stores.
+   */
+  public <T> T transaction(Supplier<T> work) {
+    return db.transaction(work);
+  }
 
   /** Appends a revision. {@code snapshot} is the entity's full state as JSON at this revision. */
   public void append(

--- a/sail-core/src/main/java/ai/singlr/sail/store/Finding.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/Finding.java
@@ -12,6 +12,12 @@ import java.util.Map;
 /**
  * A single reviewable issue discovered by a review agent. Immutable, evidence-based, and
  * actionable. Every finding cites specific code, explains why it matters, and suggests a fix.
+ *
+ * <p>A finding has identity across review iterations: when a re-review rules it {@code still_open},
+ * a fresh row is attached to the new review with {@code carriedFrom} pointing at its predecessor,
+ * so one finding aging across iterations is a single chain walk. A resolution that retires the
+ * finding ({@code FIXED} by the reviewer's verdict, {@code DISPUTED} by a ruled argument) records
+ * its {@code resolutionEvidence} — nothing resolves silently.
  */
 public record Finding(
     String id,
@@ -25,7 +31,9 @@ public record Finding(
     String evidence,
     Suggestion suggestion,
     double confidence,
-    Resolution resolution) {
+    Resolution resolution,
+    String resolutionEvidence,
+    String carriedFrom) {
 
   public enum Severity {
     CRITICAL,
@@ -60,7 +68,8 @@ public record Finding(
   public enum Resolution {
     OPEN,
     FIXED,
-    DISMISSED
+    DISMISSED,
+    DISPUTED
   }
 
   public record Suggestion(String before, String after, String rationale) {
@@ -109,7 +118,32 @@ public record Finding(
         evidence,
         suggestion,
         confidence,
-        Resolution.OPEN);
+        Resolution.OPEN,
+        null,
+        null);
+  }
+
+  /**
+   * The open successor row a {@code still_open} verdict attaches to the next review: a fresh
+   * identity linked to this finding through {@code carriedFrom}, so the chain records every
+   * iteration the finding survived.
+   */
+  public Finding carriedCopy() {
+    return new Finding(
+        DateTimeUtils.newId().toString(),
+        severity,
+        category,
+        file,
+        lineStart,
+        lineEnd,
+        title,
+        description,
+        evidence,
+        suggestion,
+        confidence,
+        Resolution.OPEN,
+        null,
+        id);
   }
 
   @SuppressWarnings("unchecked")
@@ -126,7 +160,9 @@ public record Finding(
         (String) map.getOrDefault("evidence", ""),
         Suggestion.fromMap(map.get("suggestion")),
         doubleValue(map.getOrDefault("confidence", 0.5)),
-        Resolution.OPEN);
+        Resolution.OPEN,
+        null,
+        null);
   }
 
   public Map<String, Object> toMap() {
@@ -143,6 +179,10 @@ public record Finding(
     if (suggestion != null) m.put("suggestion", suggestion.toMap());
     m.put("confidence", confidence);
     m.put("resolution", resolution.name());
+    if (resolutionEvidence != null && !resolutionEvidence.isEmpty()) {
+      m.put("resolution_evidence", resolutionEvidence);
+    }
+    if (carriedFrom != null) m.put("carried_from", carriedFrom);
     return m;
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
@@ -292,8 +292,8 @@ public final class ReviewStore implements ConflictResolver {
               INSERT INTO review_findings (id, stage_id, severity, category, file,
                   line_start, line_end, title, description, evidence,
                   suggestion_before, suggestion_after, suggestion_rationale,
-                  confidence, resolution)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                  confidence, resolution, resolution_evidence, carried_from)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
               finding.id(),
               stageId,
               finding.severity().name(),
@@ -308,20 +308,41 @@ public final class ReviewStore implements ConflictResolver {
               finding.suggestion() != null ? finding.suggestion().after() : null,
               finding.suggestion() != null ? finding.suggestion().rationale() : null,
               finding.confidence(),
-              finding.resolution().name());
+              finding.resolution().name(),
+              finding.resolutionEvidence(),
+              finding.carriedFrom());
           journalForStage(stageId);
         });
   }
 
+  /**
+   * Re-attaches a still-open finding from the previous review to the given stage as a fresh row
+   * whose {@code carried_from} points at its predecessor, and returns the new row. The predecessor
+   * stays {@code OPEN} where it is — history is never rewritten; the chain is the identity.
+   */
+  public Finding carryForward(String stageId, Finding predecessor) {
+    var carried = predecessor.carriedCopy();
+    addFinding(stageId, carried);
+    return carried;
+  }
+
+  private static final String FINDING_COLUMNS =
+      "f.id, f.severity, f.category, f.file, f.line_start, f.line_end,"
+          + " f.title, f.description, f.evidence, f.suggestion_before,"
+          + " f.suggestion_after, f.suggestion_rationale, f.confidence, f.resolution,"
+          + " f.resolution_evidence, f.carried_from";
+
+  private static final String SEVERITY_ORDER =
+      "CASE f.severity WHEN 'CRITICAL' THEN 0 WHEN 'HIGH' THEN 1"
+          + " WHEN 'MEDIUM' THEN 2 ELSE 3 END";
+
   public List<Finding> findingsForStage(String stageId) {
     return db.query(
         """
-        SELECT id, severity, category, file, line_start, line_end, title,
-            description, evidence, suggestion_before, suggestion_after,
-            suggestion_rationale, confidence, resolution
-        FROM review_findings WHERE stage_id = ? ORDER BY
-            CASE severity WHEN 'CRITICAL' THEN 0 WHEN 'HIGH' THEN 1
-            WHEN 'MEDIUM' THEN 2 ELSE 3 END""",
+        SELECT %s FROM review_findings f
+        WHERE f.stage_id = ?
+        ORDER BY %s"""
+            .formatted(FINDING_COLUMNS, SEVERITY_ORDER),
         this::mapFinding,
         stageId);
   }
@@ -329,14 +350,11 @@ public final class ReviewStore implements ConflictResolver {
   public List<Finding> findingsForReview(String reviewId) {
     return db.query(
         """
-        SELECT f.id, f.severity, f.category, f.file, f.line_start, f.line_end,
-            f.title, f.description, f.evidence, f.suggestion_before,
-            f.suggestion_after, f.suggestion_rationale, f.confidence, f.resolution
-        FROM review_findings f
+        SELECT %s FROM review_findings f
         JOIN review_stages s ON s.id = f.stage_id
         WHERE s.review_id = ?
-        ORDER BY CASE f.severity WHEN 'CRITICAL' THEN 0 WHEN 'HIGH' THEN 1
-            WHEN 'MEDIUM' THEN 2 ELSE 3 END""",
+        ORDER BY %s"""
+            .formatted(FINDING_COLUMNS, SEVERITY_ORDER),
         this::mapFinding,
         reviewId);
   }
@@ -344,24 +362,123 @@ public final class ReviewStore implements ConflictResolver {
   public List<Finding> openFindingsForReview(String reviewId) {
     return db.query(
         """
-        SELECT f.id, f.severity, f.category, f.file, f.line_start, f.line_end,
-            f.title, f.description, f.evidence, f.suggestion_before,
-            f.suggestion_after, f.suggestion_rationale, f.confidence, f.resolution
-        FROM review_findings f
+        SELECT %s FROM review_findings f
         JOIN review_stages s ON s.id = f.stage_id
         WHERE s.review_id = ? AND f.resolution = 'OPEN'
-        ORDER BY CASE f.severity WHEN 'CRITICAL' THEN 0 WHEN 'HIGH' THEN 1
-            WHEN 'MEDIUM' THEN 2 ELSE 3 END""",
+        ORDER BY %s"""
+            .formatted(FINDING_COLUMNS, SEVERITY_ORDER),
         this::mapFinding,
         reviewId);
   }
 
+  /**
+   * The findings the next review of the spec must rule on: the open findings of the current
+   * dispatch attempt's latest gate-failed review (errored reviews have no verdict and are skipped),
+   * excluding any already re-attached to {@code currentReviewId} — so a second agent stage in the
+   * same review rules only on what the first stage has not already carried or resolved.
+   */
+  public List<Finding> carryForwardFindings(String specId, String currentReviewId) {
+    return db.query(
+        """
+        SELECT %s FROM review_findings f
+        JOIN review_stages s ON s.id = f.stage_id
+        WHERE s.review_id = (
+            SELECT id FROM reviews
+            WHERE spec_id = ? AND superseded_at IS NULL AND status = 'failed'
+                AND error IS NULL AND id != ?
+            ORDER BY created_at DESC, rowid DESC LIMIT 1)
+        AND f.resolution = 'OPEN'
+        AND f.id NOT IN (
+            SELECT f2.carried_from FROM review_findings f2
+            JOIN review_stages s2 ON s2.id = f2.stage_id
+            WHERE s2.review_id = ? AND f2.carried_from IS NOT NULL)
+        ORDER BY %s"""
+            .formatted(FINDING_COLUMNS, SEVERITY_ORDER),
+        this::mapFinding,
+        specId,
+        currentReviewId,
+        currentReviewId);
+  }
+
+  /**
+   * Every finding of the current dispatch attempt a reviewer ruled {@code DISPUTED}, newest ruling
+   * first. Disputed findings are excluded from the gate, so the room verdict lists them for the
+   * human — an argument retires a finding only in the open.
+   */
+  public List<Finding> disputedFindings(String specId) {
+    return db.query(
+        """
+        SELECT %s FROM review_findings f
+        JOIN review_stages s ON s.id = f.stage_id
+        JOIN reviews r ON r.id = s.review_id
+        WHERE r.spec_id = ? AND r.superseded_at IS NULL AND f.resolution = 'DISPUTED'
+        ORDER BY r.created_at DESC, %s"""
+            .formatted(FINDING_COLUMNS, SEVERITY_ORDER),
+        this::mapFinding,
+        specId);
+  }
+
+  /**
+   * How many fix iterations the finding has survived: the number of {@code carried_from} hops back
+   * to its first sighting. A cycle (impossible by construction, since every carried row is fresh)
+   * terminates the walk instead of hanging it.
+   */
+  public int findingAge(String findingId) {
+    var visited = new LinkedHashSet<String>();
+    var current = findingId;
+    while (visited.add(current)) {
+      var parent =
+          db.queryOne(
+                  "SELECT COALESCE(carried_from, '') FROM review_findings WHERE id = ?",
+                  row -> row.text(0),
+                  current)
+              .orElse("");
+      if (parent.isBlank()) {
+        return visited.size() - 1;
+      }
+      current = parent;
+    }
+    return visited.size() - 1;
+  }
+
+  /** The finding's full lineage, newest first — the chain a persistent finding ages along. */
+  public List<Finding> findingChain(String findingId) {
+    var chain = new java.util.ArrayList<Finding>();
+    var visited = new LinkedHashSet<String>();
+    var current = findingId;
+    while (current != null && visited.add(current)) {
+      var finding = findFinding(current).orElse(null);
+      if (finding == null) {
+        break;
+      }
+      chain.add(finding);
+      current = finding.carriedFrom();
+    }
+    return List.copyOf(chain);
+  }
+
+  public Optional<Finding> findFinding(String findingId) {
+    return db.queryOne(
+        "SELECT " + FINDING_COLUMNS + " FROM review_findings f WHERE f.id = ?",
+        this::mapFinding,
+        findingId);
+  }
+
   public void resolveFinding(String findingId, Finding.Resolution resolution) {
+    resolveFinding(findingId, resolution, null);
+  }
+
+  /**
+   * Resolves a finding and records the evidence the resolution rests on — the reviewer's proof of
+   * the fix, or the ruled argument that retired a disputed finding.
+   */
+  public void resolveFinding(String findingId, Finding.Resolution resolution, String evidence) {
     db.transaction(
         () -> {
           db.execute(
-              "UPDATE review_findings SET resolution = ? WHERE id = ?",
+              "UPDATE review_findings SET resolution = ?, resolution_evidence = ? WHERE id = ?",
               resolution.name(),
+              evidence,
               findingId);
           var reviewId =
               db.queryOne(
@@ -796,6 +913,8 @@ public final class ReviewStore implements ConflictResolver {
         row.text(8),
         new Finding.Suggestion(row.text(9), row.text(10), row.text(11)),
         row.isNull(12) ? 0.0 : Double.parseDouble(row.text(12)),
-        Finding.Resolution.valueOf(row.text(13)));
+        Finding.Resolution.valueOf(row.text(13)),
+        row.text(14),
+        row.text(15));
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
@@ -372,12 +372,15 @@ public final class ReviewStore implements ConflictResolver {
   }
 
   /**
-   * The findings the next review of the spec must rule on: the open findings of the current
-   * dispatch attempt's latest gate-failed review (errored reviews have no verdict and are skipped),
-   * excluding any already re-attached to {@code currentReviewId} — so a second agent stage in the
-   * same review rules only on what the first stage has not already carried or resolved.
+   * The findings the same-named stage of the next review must rule on: the open findings that
+   * {@code stageName} emitted in the current dispatch attempt's latest gate-failed review (errored
+   * reviews have no verdict and are skipped), excluding any already re-attached to that stage of
+   * {@code currentReviewId}. Scoping by stage keeps every finding facing the categories and gate of
+   * the stage that raised it — a HIGH from a strict later stage can never be laundered through an
+   * earlier stage's looser gate.
    */
-  public List<Finding> carryForwardFindings(String specId, String currentReviewId) {
+  public List<Finding> carryForwardFindings(
+      String specId, String currentReviewId, String stageName) {
     return db.query(
         """
         SELECT %s FROM review_findings f
@@ -387,17 +390,20 @@ public final class ReviewStore implements ConflictResolver {
             WHERE spec_id = ? AND superseded_at IS NULL AND status = 'failed'
                 AND error IS NULL AND id != ?
             ORDER BY created_at DESC, rowid DESC LIMIT 1)
+        AND s.name = ?
         AND f.resolution = 'OPEN'
         AND f.id NOT IN (
             SELECT f2.carried_from FROM review_findings f2
             JOIN review_stages s2 ON s2.id = f2.stage_id
-            WHERE s2.review_id = ? AND f2.carried_from IS NOT NULL)
+            WHERE s2.review_id = ? AND s2.name = ? AND f2.carried_from IS NOT NULL)
         ORDER BY %s"""
             .formatted(FINDING_COLUMNS, SEVERITY_ORDER),
         this::mapFinding,
         specId,
         currentReviewId,
-        currentReviewId);
+        stageName,
+        currentReviewId,
+        stageName);
   }
 
   /**
@@ -597,14 +603,21 @@ public final class ReviewStore implements ConflictResolver {
     return baseRev == null ? null : baseRev.toString();
   }
 
-  /** Adopts main's authoritative aggregate at its exact rev as the new synced ancestor. */
+  /**
+   * Adopts main's authoritative aggregate at its exact rev as the new synced ancestor. When the
+   * adopted content already matches the local aggregate — the normal case on the executing node
+   * after its own successful push — only the revision is linked: rebuilding would delete the
+   * finding rows (which never replicate) that carry-forward and dispute resolution read.
+   */
   public void applyRevision(String id, Map<String, Object> snapshot, String rev) {
     db.transaction(
         () -> {
           if (snapshot == null) {
             adoptDeletion(id, rev);
           } else {
-            writeAggregate(id, snapshot);
+            if (!sameContent(aggregateMap(id), snapshot)) {
+              writeAggregate(id, snapshot);
+            }
             recordRevision(id, rev, "sync", false, true);
           }
         });

--- a/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
@@ -326,6 +326,31 @@ public final class ReviewStore implements ConflictResolver {
     return carried;
   }
 
+  /** One effective ruling on a carried finding: {@code OPEN} carries it forward, else resolves. */
+  public record StageRuling(Finding finding, Finding.Resolution resolution, String evidence) {}
+
+  /**
+   * Applies a reviewer's complete stage result as one atomic write: every ruling on the carried
+   * findings (resolving {@code FIXED}/{@code DISPUTED} predecessors, re-attaching {@code OPEN}
+   * ones) and every newly discovered finding. Any failure — a duplicate finding id, a constraint
+   * violation, a journaling error — rolls the whole result back, so a partially committed verdict
+   * can never retire a carried finding on behalf of a stage that subsequently errors: the retry
+   * still sees it {@code OPEN} and carries it.
+   */
+  public void applyStageResult(String stageId, List<StageRuling> rulings, List<Finding> findings) {
+    db.transaction(
+        () -> {
+          for (var ruling : rulings) {
+            if (ruling.resolution() == Finding.Resolution.OPEN) {
+              carryForward(stageId, ruling.finding());
+            } else {
+              resolveFinding(ruling.finding().id(), ruling.resolution(), ruling.evidence());
+            }
+          }
+          findings.forEach(finding -> addFinding(stageId, finding));
+        });
+  }
+
   private static final String FINDING_COLUMNS =
       "f.id, f.severity, f.category, f.file, f.line_start, f.line_end,"
           + " f.title, f.description, f.evidence, f.suggestion_before,"
@@ -373,11 +398,13 @@ public final class ReviewStore implements ConflictResolver {
 
   /**
    * The findings the same-named stage of the next review must rule on: the open findings that
-   * {@code stageName} emitted in the current dispatch attempt's latest gate-failed review (errored
-   * reviews have no verdict and are skipped), excluding any already re-attached to that stage of
-   * {@code currentReviewId}. Scoping by stage keeps every finding facing the categories and gate of
-   * the stage that raised it — a HIGH from a strict later stage can never be laundered through an
-   * earlier stage's looser gate.
+   * {@code stageName} emitted in the current dispatch attempt's latest gate-failed review <em>in
+   * which that stage actually executed</em> (errored reviews have no verdict and are skipped, and
+   * so is a review where an earlier stage failed before this one ran — its pending stage holds no
+   * rows, and picking it would silently drop the stage's still-open findings from an older review),
+   * excluding any already re-attached to that stage of {@code currentReviewId}. Scoping by stage
+   * keeps every finding facing the categories and gate of the stage that raised it — a HIGH from a
+   * strict later stage can never be laundered through an earlier stage's looser gate.
    */
   public List<Finding> carryForwardFindings(
       String specId, String currentReviewId, String stageName) {
@@ -386,10 +413,13 @@ public final class ReviewStore implements ConflictResolver {
         SELECT %s FROM review_findings f
         JOIN review_stages s ON s.id = f.stage_id
         WHERE s.review_id = (
-            SELECT id FROM reviews
-            WHERE spec_id = ? AND superseded_at IS NULL AND status = 'failed'
-                AND error IS NULL AND id != ?
-            ORDER BY created_at DESC, rowid DESC LIMIT 1)
+            SELECT r.id FROM reviews r
+            JOIN review_stages prior ON prior.review_id = r.id
+            WHERE r.spec_id = ? AND r.superseded_at IS NULL AND r.status = 'failed'
+                AND r.error IS NULL AND r.id != ?
+                AND prior.name = ? AND prior.status IN ('passed', 'failed')
+                AND prior.error IS NULL
+            ORDER BY r.created_at DESC, r.rowid DESC LIMIT 1)
         AND s.name = ?
         AND f.resolution = 'OPEN'
         AND f.id NOT IN (
@@ -401,6 +431,7 @@ public final class ReviewStore implements ConflictResolver {
         this::mapFinding,
         specId,
         currentReviewId,
+        stageName,
         stageName,
         currentReviewId,
         stageName);

--- a/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
@@ -398,13 +398,14 @@ public final class ReviewStore implements ConflictResolver {
 
   /**
    * The findings the same-named stage of the next review must rule on: the open findings that
-   * {@code stageName} emitted in the current dispatch attempt's latest gate-failed review <em>in
-   * which that stage actually executed</em> (errored reviews have no verdict and are skipped, and
-   * so is a review where an earlier stage failed before this one ran — its pending stage holds no
-   * rows, and picking it would silently drop the stage's still-open findings from an older review),
-   * excluding any already re-attached to that stage of {@code currentReviewId}. Scoping by stage
-   * keeps every finding facing the categories and gate of the stage that raised it — a HIGH from a
-   * strict later stage can never be laundered through an earlier stage's looser gate.
+   * {@code stageName} emitted in the current dispatch attempt's latest failed review <em>in which
+   * that stage actually executed</em>, excluding any already re-attached to that stage of {@code
+   * currentReviewId}. Validity is per stage, not per review: a stage that errored — or never ran
+   * because an earlier stage failed first — holds no verdict and is skipped, but a stage that
+   * completed cleanly before a <em>later</em> stage errored the review still carries its findings;
+   * skipping the whole review would silently drop them from the eventual passed review. Scoping by
+   * stage keeps every finding facing the categories and gate of the stage that raised it — a HIGH
+   * from a strict later stage can never be laundered through an earlier stage's looser gate.
    */
   public List<Finding> carryForwardFindings(
       String specId, String currentReviewId, String stageName) {
@@ -416,7 +417,7 @@ public final class ReviewStore implements ConflictResolver {
             SELECT r.id FROM reviews r
             JOIN review_stages prior ON prior.review_id = r.id
             WHERE r.spec_id = ? AND r.superseded_at IS NULL AND r.status = 'failed'
-                AND r.error IS NULL AND r.id != ?
+                AND r.id != ?
                 AND prior.name = ? AND prior.status IN ('passed', 'failed')
                 AND prior.error IS NULL
             ORDER BY r.created_at DESC, r.rowid DESC LIMIT 1)

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -108,7 +108,40 @@ public final class SchemaManager {
               handle TEXT NOT NULL,
               credential_hash TEXT NOT NULL UNIQUE,
               created_at TEXT NOT NULL
-          )""");
+          )""",
+          """
+          CREATE TABLE review_findings_v2 (
+              id TEXT PRIMARY KEY,
+              stage_id TEXT NOT NULL REFERENCES review_stages(id) ON DELETE CASCADE,
+              severity TEXT NOT NULL,
+              category TEXT NOT NULL,
+              file TEXT,
+              line_start INTEGER,
+              line_end INTEGER,
+              title TEXT NOT NULL,
+              description TEXT NOT NULL,
+              evidence TEXT,
+              suggestion_before TEXT,
+              suggestion_after TEXT,
+              suggestion_rationale TEXT,
+              confidence REAL NOT NULL DEFAULT 0.0,
+              resolution TEXT NOT NULL DEFAULT 'OPEN'
+                  CHECK (resolution IN ('OPEN', 'FIXED', 'DISMISSED', 'DISPUTED')),
+              resolution_evidence TEXT,
+              carried_from TEXT
+          )""",
+          """
+          INSERT INTO review_findings_v2 (id, stage_id, severity, category, file,
+                  line_start, line_end, title, description, evidence, suggestion_before,
+                  suggestion_after, suggestion_rationale, confidence, resolution)
+              SELECT id, stage_id, severity, category, file,
+                  line_start, line_end, title, description, evidence, suggestion_before,
+                  suggestion_after, suggestion_rationale, confidence, resolution
+              FROM review_findings""",
+          "DROP TABLE review_findings",
+          "ALTER TABLE review_findings_v2 RENAME TO review_findings",
+          "CREATE INDEX idx_review_findings_stage ON review_findings(stage_id)",
+          "CREATE INDEX idx_review_findings_severity ON review_findings(severity)");
 
   /** The schema version this binary converges every database to. */
   static final int CURRENT_VERSION = V1_VERSION + MIGRATIONS.size();
@@ -476,17 +509,29 @@ public final class SchemaManager {
   /**
    * Applies the post-baseline remainder incrementally: each migration commits with its own version
    * stamp, so an interruption resumes exactly where it left off and a database written by an older
-   * 1.x binary replays only the entries it has not seen.
+   * 1.x binary replays only the entries it has not seen. Foreign-key enforcement is suspended for
+   * the window, exactly as on the on-ramp: the chain contains a table rebuild whose {@code DROP
+   * TABLE} would otherwise fire an implicit delete and cascade child rows away. Integrity is
+   * verified before enforcement is restored.
    */
   private void postBaselineFrom(int current) {
-    for (var next = current + 1; next <= CURRENT_VERSION; next++) {
-      var version = next;
-      var statement = MIGRATIONS.get(version - V1_VERSION - 1);
-      db.transaction(
-          () -> {
-            db.execute(statement);
-            stamp(version);
-          });
+    if (current >= CURRENT_VERSION) {
+      return;
+    }
+    db.execute("PRAGMA foreign_keys = OFF");
+    try {
+      for (var next = current + 1; next <= CURRENT_VERSION; next++) {
+        var version = next;
+        var statement = MIGRATIONS.get(version - V1_VERSION - 1);
+        db.transaction(
+            () -> {
+              db.execute(statement);
+              stamp(version);
+            });
+      }
+      requireForeignKeysIntact();
+    } finally {
+      db.execute("PRAGMA foreign_keys = ON");
     }
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/sync/FileReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/FileReplica.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Adapts one box's {@link FileStore} to the sync roles, so the {@link SyncEngine} reconciles shared
@@ -53,6 +54,11 @@ public final class FileReplica implements LocalReplica, MainReplica {
   @Override
   public Set<String> entityIds() {
     return files.syncEntityIds();
+  }
+
+  @Override
+  public <T> T atomically(Supplier<T> work) {
+    return changeLog.transaction(work);
   }
 
   @Override

--- a/sail-core/src/main/java/ai/singlr/sail/sync/LocalReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/LocalReplica.java
@@ -7,7 +7,9 @@ package ai.singlr.sail.sync;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * The node (local replica) side of a sync round. Tracks the merge base it last synced from main,
@@ -29,6 +31,41 @@ public interface LocalReplica {
    */
   default boolean mayPush(String id) {
     return true;
+  }
+
+  /** A comparable snapshot paired with the exact revision it was read at. */
+  record Captured(Map<String, Object> snapshot, String rev) {}
+
+  /**
+   * Runs {@code work} in one atomic scope on the local store, excluding every concurrent local
+   * writer for the whole scope.
+   */
+  <T> T atomically(Supplier<T> work);
+
+  /**
+   * Samples the current snapshot and its revision as one atomic read, so a local write landing
+   * mid-sample can never pair an old snapshot with a newer revision — the torn pair that would
+   * later defeat the stale-adoption guard and overwrite the newer work.
+   */
+  default Captured capture(String id) {
+    return atomically(() -> new Captured(current(id), currentRev(id)));
+  }
+
+  /**
+   * Adopts an authoritative state only if the local row still sits at {@code expectedRev}. The
+   * check and the adoption are one atomic step, so a local write can never land between them and be
+   * overwritten. Returns {@code false} when the row moved; the caller re-reconciles instead.
+   */
+  default boolean adoptIfCurrent(
+      String id, String expectedRev, Map<String, Object> snapshot, String rev) {
+    return atomically(
+        () -> {
+          if (!Objects.equals(currentRev(id), expectedRev)) {
+            return false;
+          }
+          adopt(id, snapshot, rev);
+          return true;
+        });
   }
 
   /** Current comparable state; {@code null} if deleted or absent. */

--- a/sail-core/src/main/java/ai/singlr/sail/sync/MessageReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/MessageReplica.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /** Sync adapter for immutable, append-only spec messages. */
 public final class MessageReplica implements LocalReplica, MainReplica {
@@ -48,6 +49,11 @@ public final class MessageReplica implements LocalReplica, MainReplica {
   @Override
   public Set<String> entityIds() {
     return messages.syncEntityIds();
+  }
+
+  @Override
+  public <T> T atomically(Supplier<T> work) {
+    return changeLog.transaction(work);
   }
 
   @Override

--- a/sail-core/src/main/java/ai/singlr/sail/sync/ProjectReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/ProjectReplica.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Adapts a box's {@link ProjectStore} to the sync roles, exactly as {@link SpecReplica} does for
@@ -55,6 +56,11 @@ public final class ProjectReplica implements LocalReplica, MainReplica {
   @Override
   public Set<String> entityIds() {
     return projects.syncEntityIds();
+  }
+
+  @Override
+  public <T> T atomically(Supplier<T> work) {
+    return changeLog.transaction(work);
   }
 
   @Override

--- a/sail-core/src/main/java/ai/singlr/sail/sync/ReviewReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/ReviewReplica.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Adapts a box's {@link ReviewStore} to the sync roles, exactly as {@link RunReplica} does for
@@ -61,6 +62,11 @@ public final class ReviewReplica implements LocalReplica, MainReplica {
   @Override
   public Set<String> entityIds() {
     return reviews.syncEntityIds();
+  }
+
+  @Override
+  public <T> T atomically(Supplier<T> work) {
+    return changeLog.transaction(work);
   }
 
   @Override

--- a/sail-core/src/main/java/ai/singlr/sail/sync/RunReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/RunReplica.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Adapts a box's {@link RunStore} to the sync roles, exactly as {@link SpecReplica} does for specs:
@@ -87,6 +88,11 @@ public final class RunReplica implements LocalReplica, MainReplica {
     return runs.findById(entityId)
         .map(run -> run.node() == null || run.node().isBlank() || handle.equals(run.node()))
         .orElse(true);
+  }
+
+  @Override
+  public <T> T atomically(Supplier<T> work) {
+    return changeLog.transaction(work);
   }
 
   @Override

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SpecReplica.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SpecReplica.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Adapts a single box's spec stores to the sync roles. The same box can act as the node ({@link
@@ -55,6 +56,11 @@ public final class SpecReplica implements LocalReplica, MainReplica {
   @Override
   public Set<String> entityIds() {
     return specs.syncEntityIds();
+  }
+
+  @Override
+  public <T> T atomically(Supplier<T> work) {
+    return changeLog.transaction(work);
   }
 
   @Override

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncEngine.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncEngine.java
@@ -83,6 +83,7 @@ public final class SyncEngine {
       int redetectsLeft) {
     var base = local.base(id);
     var localSnap = local.current(id);
+    var localRev = local.currentRev(id);
     if (ProjectStore.isBlocksResurrectionMarker(remoteSnap)) {
       if (base == null) {
         var changed = localSnap != null || !Objects.equals(local.currentRev(id), remoteRev);
@@ -99,7 +100,7 @@ public final class SyncEngine {
             id, null, localSnap, remoteSnap, List.of(ConflictDetector.DELETED_FIELD));
         return Outcome.CONFLICT;
       }
-      return push(local, main, id, localSnap, remoteRev, Outcome.PUSHED, redetectsLeft);
+      return push(local, main, id, localSnap, localRev, remoteRev, Outcome.PUSHED, redetectsLeft);
     }
     return switch (ConflictDetector.detect(base, localSnap, remoteSnap)) {
       case ConflictDetector.Converged ignored -> {
@@ -112,11 +113,12 @@ public final class SyncEngine {
       }
       case ConflictDetector.KeepLocal ignored ->
           local.mayPush(id)
-              ? push(local, main, id, localSnap, remoteRev, Outcome.PUSHED, redetectsLeft)
+              ? push(local, main, id, localSnap, localRev, remoteRev, Outcome.PUSHED, redetectsLeft)
               : pullInsteadOfPush(local, id, remoteSnap, remoteRev);
       case ConflictDetector.Merged m ->
           local.mayPush(id)
-              ? push(local, main, id, m.result(), remoteRev, Outcome.MERGED, redetectsLeft)
+              ? push(
+                  local, main, id, m.result(), localRev, remoteRev, Outcome.MERGED, redetectsLeft)
               : pullInsteadOfPush(local, id, remoteSnap, remoteRev);
       case ConflictDetector.Conflict c -> {
         local.recordConflict(id, base, localSnap, remoteSnap, c.fields());
@@ -136,22 +138,36 @@ public final class SyncEngine {
     return Outcome.PULLED;
   }
 
+  /**
+   * Commits the offered snapshot to main and, on acceptance, adopts it locally — but only if the
+   * local store still sits at the revision the snapshot was captured from. A local write landing
+   * during the commit round makes the accepted snapshot stale; adopting it would overwrite (and,
+   * for aggregates, delete the non-replicated children of) the newer local state. Instead the
+   * entity is re-reconciled against main's fresh state, so the newer local work pushes, merges, or
+   * parks as a conflict — never silently vanishes.
+   */
   private Outcome push(
       LocalReplica local,
       MainReplica main,
       String id,
       Map<String, Object> snapshot,
+      String offeredLocalRev,
       String expectedRev,
       Outcome onAccepted,
       int redetectsLeft) {
     return switch (main.commit(id, snapshot, expectedRev)) {
       case CommitOutcome.Accepted a -> {
+        if (!Objects.equals(local.currentRev(id), offeredLocalRev)) {
+          yield redetectsLeft <= 0
+              ? recordStaleConflict(local, id, main.current(id))
+              : reconcileEntity(local, main, id, main.current(id), a.rev(), redetectsLeft - 1);
+        }
         local.adopt(id, snapshot, a.rev());
         yield onAccepted;
       }
       case CommitOutcome.Rejected r -> {
         if (redetectsLeft <= 0) {
-          yield recordStaleConflict(local, id, r);
+          yield recordStaleConflict(local, id, r.currentSnapshot());
         }
         yield reconcileEntity(
             local, main, id, r.currentSnapshot(), r.currentRev(), redetectsLeft - 1);
@@ -164,15 +180,14 @@ public final class SyncEngine {
    * the user decides, naming the clashing fields when there are any.
    */
   private static Outcome recordStaleConflict(
-      LocalReplica local, String id, CommitOutcome.Rejected rejected) {
+      LocalReplica local, String id, Map<String, Object> remoteSnap) {
     var base = local.base(id);
     var localSnap = local.current(id);
     var fields =
-        ConflictDetector.detect(base, localSnap, rejected.currentSnapshot())
-                instanceof ConflictDetector.Conflict c
+        ConflictDetector.detect(base, localSnap, remoteSnap) instanceof ConflictDetector.Conflict c
             ? c.fields()
             : List.of(STALE_FIELD);
-    local.recordConflict(id, base, localSnap, rejected.currentSnapshot(), fields);
+    local.recordConflict(id, base, localSnap, remoteSnap, fields);
     return Outcome.CONFLICT;
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncEngine.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncEngine.java
@@ -82,15 +82,16 @@ public final class SyncEngine {
       String remoteRev,
       int redetectsLeft) {
     var base = local.base(id);
-    var localSnap = local.current(id);
-    var localRev = local.currentRev(id);
+    var captured = local.capture(id);
+    var localSnap = captured.snapshot();
+    var localRev = captured.rev();
     if (ProjectStore.isBlocksResurrectionMarker(remoteSnap)) {
       if (base == null) {
-        var changed = localSnap != null || !Objects.equals(local.currentRev(id), remoteRev);
-        if (changed) {
-          local.adopt(id, null, remoteRev);
+        if (localSnap == null && Objects.equals(localRev, remoteRev)) {
+          return Outcome.CONVERGED;
         }
-        return changed ? Outcome.PULLED : Outcome.CONVERGED;
+        return adoptOrRedetect(
+            local, main, id, localRev, null, remoteRev, Outcome.PULLED, redetectsLeft);
       }
       remoteSnap = null;
     }
@@ -103,23 +104,32 @@ public final class SyncEngine {
       return push(local, main, id, localSnap, localRev, remoteRev, Outcome.PUSHED, redetectsLeft);
     }
     return switch (ConflictDetector.detect(base, localSnap, remoteSnap)) {
-      case ConflictDetector.Converged ignored -> {
-        linkSharedRevision(local, id, remoteSnap, remoteRev);
-        yield Outcome.CONVERGED;
-      }
-      case ConflictDetector.TakeRemote ignored -> {
-        local.adopt(id, remoteSnap, remoteRev);
-        yield Outcome.PULLED;
-      }
+      case ConflictDetector.Converged ignored ->
+          remoteRev == null || Objects.equals(localRev, remoteRev)
+              ? Outcome.CONVERGED
+              : adoptOrRedetect(
+                  local,
+                  main,
+                  id,
+                  localRev,
+                  remoteSnap,
+                  remoteRev,
+                  Outcome.CONVERGED,
+                  redetectsLeft);
+      case ConflictDetector.TakeRemote ignored ->
+          adoptOrRedetect(
+              local, main, id, localRev, remoteSnap, remoteRev, Outcome.PULLED, redetectsLeft);
       case ConflictDetector.KeepLocal ignored ->
           local.mayPush(id)
               ? push(local, main, id, localSnap, localRev, remoteRev, Outcome.PUSHED, redetectsLeft)
-              : pullInsteadOfPush(local, id, remoteSnap, remoteRev);
+              : adoptOrRedetect(
+                  local, main, id, localRev, remoteSnap, remoteRev, Outcome.PULLED, redetectsLeft);
       case ConflictDetector.Merged m ->
           local.mayPush(id)
               ? push(
                   local, main, id, m.result(), localRev, remoteRev, Outcome.MERGED, redetectsLeft)
-              : pullInsteadOfPush(local, id, remoteSnap, remoteRev);
+              : adoptOrRedetect(
+                  local, main, id, localRev, remoteSnap, remoteRev, Outcome.PULLED, redetectsLeft);
       case ConflictDetector.Conflict c -> {
         local.recordConflict(id, base, localSnap, remoteSnap, c.fields());
         yield Outcome.CONFLICT;
@@ -128,24 +138,33 @@ public final class SyncEngine {
   }
 
   /**
-   * The local diverged on an entity it may not push — a run it did not author. Discard the local
-   * divergence and adopt main's authoritative version, so a reader box converges instead of
-   * offering an un-owned push main would only reject.
-   */
-  private static Outcome pullInsteadOfPush(
-      LocalReplica local, String id, Map<String, Object> remoteSnap, String remoteRev) {
-    local.adopt(id, remoteSnap, remoteRev);
-    return Outcome.PULLED;
-  }
-
-  /**
-   * Commits the offered snapshot to main and, on acceptance, adopts it locally — but only if the
-   * local store still sits at the revision the snapshot was captured from. A local write landing
-   * during the commit round makes the accepted snapshot stale; adopting it would overwrite (and,
+   * Adopts an authoritative state, but only if the local row still sits at the revision the round's
+   * snapshot was captured from — check and adoption are one atomic replica operation. A local write
+   * landing anywhere in the round makes the adoption stale; adopting anyway would overwrite (and,
    * for aggregates, delete the non-replicated children of) the newer local state. Instead the
    * entity is re-reconciled against main's fresh state, so the newer local work pushes, merges, or
-   * parks as a conflict — never silently vanishes.
+   * parks as a conflict — never silently vanishes. The retry is bounded; past the budget the entity
+   * parks as a stale conflict with the local row untouched.
    */
+  private Outcome adoptOrRedetect(
+      LocalReplica local,
+      MainReplica main,
+      String id,
+      String expectedLocalRev,
+      Map<String, Object> snapshot,
+      String rev,
+      Outcome onAdopted,
+      int redetectsLeft) {
+    if (local.adoptIfCurrent(id, expectedLocalRev, snapshot, rev)) {
+      return onAdopted;
+    }
+    return redetectsLeft <= 0
+        ? recordStaleConflict(local, id, main.current(id))
+        : reconcileEntity(
+            local, main, id, main.current(id), main.currentRev(id), redetectsLeft - 1);
+  }
+
+  /** Commits the offered snapshot to main and, on acceptance, adopts it via the stale guard. */
   private Outcome push(
       LocalReplica local,
       MainReplica main,
@@ -156,15 +175,9 @@ public final class SyncEngine {
       Outcome onAccepted,
       int redetectsLeft) {
     return switch (main.commit(id, snapshot, expectedRev)) {
-      case CommitOutcome.Accepted a -> {
-        if (!Objects.equals(local.currentRev(id), offeredLocalRev)) {
-          yield redetectsLeft <= 0
-              ? recordStaleConflict(local, id, main.current(id))
-              : reconcileEntity(local, main, id, main.current(id), a.rev(), redetectsLeft - 1);
-        }
-        local.adopt(id, snapshot, a.rev());
-        yield onAccepted;
-      }
+      case CommitOutcome.Accepted a ->
+          adoptOrRedetect(
+              local, main, id, offeredLocalRev, snapshot, a.rev(), onAccepted, redetectsLeft);
       case CommitOutcome.Rejected r -> {
         if (redetectsLeft <= 0) {
           yield recordStaleConflict(local, id, r.currentSnapshot());
@@ -189,17 +202,5 @@ public final class SyncEngine {
             : List.of(STALE_FIELD);
     local.recordConflict(id, base, localSnap, remoteSnap, fields);
     return Outcome.CONFLICT;
-  }
-
-  /**
-   * When local and main already agree but local has not yet recorded main's revision (e.g. they
-   * independently reached identical content), adopt main's rev so both share a merge base going
-   * forward. A no-op once the revisions are linked, so it never churns.
-   */
-  private static void linkSharedRevision(
-      LocalReplica local, String id, Map<String, Object> remoteSnap, String remoteRev) {
-    if (remoteRev != null && !Objects.equals(local.currentRev(id), remoteRev)) {
-      local.adopt(id, remoteSnap, remoteRev);
-    }
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/config/ReviewPipelineConfigTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/ReviewPipelineConfigTest.java
@@ -35,6 +35,19 @@ class ReviewPipelineConfigTest {
   }
 
   @Test
+  void duplicateStageNamesAreRejected() {
+    var stages =
+        List.of(
+            Map.<String, Object>of("name", "review", "type", "agent"),
+            Map.<String, Object>of("name", "review", "type", "agent"));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ReviewPipelineConfig.fromMap(Map.of("stages", stages)),
+        "carry-forward is keyed by stage name; a duplicate would merge two stages' findings");
+  }
+
+  @Test
   void parseMaxFindingAge() {
     var config =
         ReviewPipelineConfig.fromMap(

--- a/sail-core/src/test/java/ai/singlr/sail/config/ReviewPipelineConfigTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/ReviewPipelineConfigTest.java
@@ -27,10 +27,24 @@ class ReviewPipelineConfigTest {
             Map.of("stages", List.of(Map.of("name", "security", "type", "agent"))));
 
     assertEquals(3, config.maxIterations());
+    assertEquals(2, config.maxFindingAge(), "a stuck finding escalates after 2 fix iterations");
     assertEquals(1, config.stages().size());
     assertEquals("security", config.stages().getFirst().name());
     assertEquals(StageType.AGENT, config.stages().getFirst().type());
     assertEquals(Gate.NO_CRITICAL, config.stages().getFirst().gate());
+  }
+
+  @Test
+  void parseMaxFindingAge() {
+    var config =
+        ReviewPipelineConfig.fromMap(
+            Map.of(
+                "max_finding_age",
+                4,
+                "stages",
+                List.of(Map.of("name", "security", "type", "agent"))));
+
+    assertEquals(4, config.maxFindingAge());
   }
 
   @Test
@@ -149,9 +163,38 @@ class ReviewPipelineConfigTest {
             "",
             null,
             0.9,
-            Finding.Resolution.DISMISSED);
+            Finding.Resolution.DISMISSED,
+            null,
+            null);
 
     assertTrue(Gate.NO_CRITICAL.passes(List.of(dismissed)));
+  }
+
+  @Test
+  void gateExcludesDisputedFindingsAtEverySeverity() {
+    var disputed =
+        new Finding(
+            "id",
+            Finding.Severity.CRITICAL,
+            Finding.Category.SECURITY,
+            "a.java",
+            1,
+            1,
+            "Disputed critical",
+            "",
+            "",
+            null,
+            0.9,
+            Finding.Resolution.DISPUTED,
+            "the reviewer ruled the argument valid",
+            null);
+
+    assertTrue(Gate.NO_CRITICAL.passes(List.of(disputed)));
+    assertTrue(Gate.NO_CRITICAL_OR_HIGH.passes(List.of(disputed)));
+    assertTrue(
+        Gate.ALL_CLEAR.passes(List.of(disputed)),
+        "a disputed finding never counts against any gate — it goes to the human instead");
+    assertFalse(Gate.NO_CRITICAL.blocks(disputed));
   }
 
   @Test
@@ -231,7 +274,9 @@ class ReviewPipelineConfigTest {
             "",
             null,
             0.8,
-            Finding.Resolution.FIXED);
+            Finding.Resolution.FIXED,
+            "commit abc",
+            null);
 
     assertTrue(Gate.ALL_CLEAR.passes(List.of(fixed)));
   }

--- a/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
@@ -365,6 +365,66 @@ class FindingParserTest {
   }
 
   @Test
+  void aMalformedFinalFencedEnvelopeIsNeverReplacedByAnEarlierCleanOne() {
+    var transcript =
+        """
+        ```json
+        {"verdicts": [], "findings": []}
+        ```
+        Refining my findings...
+        ```json
+        {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "SECURTY", "title": "Injection", "description": "D"}]}
+        ```
+        """;
+
+    var result = unparseable(transcript);
+
+    assertTrue(
+        result.warnings().getFirst().contains("Finding 0"),
+        "the final fenced response is authoritative: a malformed gate-blocking finding must"
+            + " error the stage, not vanish behind an earlier clean envelope");
+  }
+
+  @Test
+  void duplicateVerdictsForOneFindingRejectTheEnvelope() {
+    var output =
+        """
+        ```json
+        {"verdicts": [
+          {"finding_id": "f-1", "verdict": "still_open"},
+          {"finding_id": "f-1", "verdict": "fixed", "evidence": "commit abc"}],
+         "findings": []}
+        ```
+        """;
+
+    var result = unparseable(output);
+
+    assertTrue(
+        result.warnings().getFirst().contains("f-1"),
+        "one verdict per carried finding: conflicting duplicates are ambiguous and must reject"
+            + " the response instead of resolving by entry order");
+  }
+
+  @Test
+  void reconcileForcesConflictingDuplicateVerdictsToStillOpenInEitherOrder() {
+    var carried = List.of(finding("Old critical"));
+    var id = carried.getFirst().id();
+    var open = new Verdict(id, Ruling.STILL_OPEN, "");
+    var fixed = new Verdict(id, Ruling.FIXED, "commit abc");
+
+    for (var verdicts : List.of(List.of(open, fixed), List.of(fixed, open))) {
+      var reconciled = FindingParser.reconcile(carried, verdicts);
+
+      assertEquals(
+          Ruling.STILL_OPEN,
+          reconciled.rulings().get(id).ruling(),
+          "duplicate verdicts are an ambiguous ruling; the finding must stay open regardless"
+              + " of entry order");
+      assertFalse(reconciled.warnings().isEmpty());
+    }
+  }
+
+  @Test
   void reconcileDefaultsAnUnmentionedCarriedFindingToStillOpen() {
     var carried = List.of(finding("Old high"));
 

--- a/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
@@ -136,6 +136,25 @@ class FindingParserTest {
   }
 
   @Test
+  void anEnvelopeMissingVerdictsIsUnparseable() {
+    assertFalse(unparseable("{\"findings\": []}").warnings().isEmpty());
+  }
+
+  @Test
+  void anEnvelopeMissingFindingsIsUnparseable() {
+    assertFalse(unparseable("{\"verdicts\": []}").warnings().isEmpty());
+  }
+
+  @Test
+  void anEnvelopeWhereFindingsIsNotAnArrayIsUnparseable() {
+    var result = unparseable("{\"verdicts\": [], \"findings\": {\"severity\": \"CRITICAL\"}}");
+    assertFalse(
+        result.warnings().isEmpty(),
+        "a malformed findings member must ride the errored-retry lane — resolving carried"
+            + " findings while dropping new ones would launder the new issues");
+  }
+
+  @Test
   void handlesBareEnvelopeWithoutFence() {
     var output =
         """

--- a/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
@@ -7,21 +7,41 @@ package ai.singlr.sail.engine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.singlr.sail.engine.FindingParser.ParseResult;
+import ai.singlr.sail.engine.FindingParser.Ruling;
+import ai.singlr.sail.engine.FindingParser.Verdict;
 import ai.singlr.sail.store.Finding;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class FindingParserTest {
 
+  private static ParseResult.Parsed parsed(String output) {
+    var result = FindingParser.parse(output);
+    assertInstanceOf(
+        ParseResult.Parsed.class, result, "expected a parsed envelope, got: " + result);
+    return (ParseResult.Parsed) result;
+  }
+
+  private static ParseResult.Unparseable unparseable(String output) {
+    var result = FindingParser.parse(output);
+    assertInstanceOf(
+        ParseResult.Unparseable.class, result, "expected unparseable output, got: " + result);
+    return (ParseResult.Unparseable) result;
+  }
+
   @Test
-  void parsesJsonBlockWithFindings() {
+  void parsesAnEnvelopeWithFindings() {
     var output =
         """
         Here are my findings:
 
         ```json
-        [
+        {"verdicts": [],
+         "findings": [
           {
             "severity": "HIGH",
             "category": "SECURITY",
@@ -38,12 +58,13 @@ class FindingParserTest {
             },
             "confidence": 0.95
           }
-        ]
+        ]}
         ```
         """;
 
-    var result = FindingParser.parse(output);
+    var result = parsed(output);
     assertEquals(1, result.findings().size());
+    assertTrue(result.verdicts().isEmpty());
     assertTrue(result.warnings().isEmpty());
 
     var finding = result.findings().getFirst();
@@ -56,68 +77,89 @@ class FindingParserTest {
   }
 
   @Test
-  void parsesEmptyArray() {
+  void parsesVerdictsAlongsideNewFindings() {
+    var output =
+        """
+        ```json
+        {"verdicts": [
+          {"finding_id": "f-1", "verdict": "fixed", "evidence": "commit abc123 parameterizes the query"},
+          {"finding_id": "f-2", "verdict": "disputed", "evidence": "the cap is enforced upstream"},
+          {"finding_id": "f-3", "verdict": "still_open"}
+         ],
+         "findings": [
+          {"severity": "LOW", "category": "LOGIC", "title": "New issue", "description": "D"}
+        ]}
+        ```
+        """;
+
+    var result = parsed(output);
+    assertEquals(3, result.verdicts().size());
+    assertEquals(
+        new Verdict("f-1", Ruling.FIXED, "commit abc123 parameterizes the query"),
+        result.verdicts().get(0));
+    assertEquals(Ruling.DISPUTED, result.verdicts().get(1).ruling());
+    assertEquals(Ruling.STILL_OPEN, result.verdicts().get(2).ruling());
+    assertEquals("", result.verdicts().get(2).evidence());
+    assertEquals(1, result.findings().size());
+  }
+
+  @Test
+  void parsesAnEmptyEnvelope() {
     var output =
         """
         No issues found.
 
         ```json
-        []
+        {"verdicts": [], "findings": []}
         ```
         """;
 
-    var result = FindingParser.parse(output);
+    var result = parsed(output);
+    assertTrue(result.verdicts().isEmpty());
     assertTrue(result.findings().isEmpty());
     assertTrue(result.warnings().isEmpty());
   }
 
   @Test
-  void parsesMultipleFindings() {
+  void aBareFindingsArrayIsOffContractAndUnparseable() {
     var output =
         """
         ```json
-        [
-          {"severity": "CRITICAL", "category": "SECURITY", "title": "First", "description": "A"},
-          {"severity": "LOW", "category": "LOGIC", "title": "Second", "description": "B"}
-        ]
+        [{"severity": "MEDIUM", "category": "LOGIC", "title": "Issue", "description": "Desc"}]
         ```
         """;
 
-    var result = FindingParser.parse(output);
-    assertEquals(2, result.findings().size());
-    assertEquals(Finding.Severity.CRITICAL, result.findings().get(0).severity());
-    assertEquals(Finding.Severity.LOW, result.findings().get(1).severity());
+    var result = unparseable(output);
+    assertFalse(
+        result.warnings().isEmpty(),
+        "a bare findings array must error the stage, never silently pass or half-parse");
   }
 
   @Test
-  void handlesBareJsonArray() {
+  void handlesBareEnvelopeWithoutFence() {
     var output =
         """
-        [{"severity": "MEDIUM", "category": "LOGIC", "title": "Issue", "description": "Desc"}]
+        {"verdicts": [], "findings": [{"severity": "MEDIUM", "category": "LOGIC", "title": "Issue", "description": "Desc"}]}
         """;
 
-    var result = FindingParser.parse(output);
+    var result = parsed(output);
     assertEquals(1, result.findings().size());
   }
 
   @Test
   void handlesNullInput() {
-    var result = FindingParser.parse(null);
-    assertTrue(result.findings().isEmpty());
+    var result = unparseable(null);
     assertEquals(1, result.warnings().size());
   }
 
   @Test
   void handlesEmptyInput() {
-    var result = FindingParser.parse("");
-    assertTrue(result.findings().isEmpty());
-    assertFalse(result.warnings().isEmpty());
+    assertFalse(unparseable("").warnings().isEmpty());
   }
 
   @Test
   void handlesNoJsonBlock() {
-    var result = FindingParser.parse("Just some text without JSON.");
-    assertTrue(result.findings().isEmpty());
+    var result = unparseable("Just some text without JSON.");
     assertEquals(1, result.warnings().size());
     assertTrue(result.warnings().getFirst().contains("No JSON block"));
   }
@@ -127,31 +169,62 @@ class FindingParserTest {
     var output =
         """
         ```json
-        [{"severity": "HIGH", "category":
+        {"verdicts": [{"finding_id":
         ```
         """;
 
-    var result = FindingParser.parse(output);
-    assertTrue(result.findings().isEmpty());
-    assertFalse(result.warnings().isEmpty());
+    assertFalse(unparseable(output).warnings().isEmpty());
   }
 
   @Test
-  void handlesMalformedFindingInArray() {
+  void skipsAMalformedFindingAndKeepsTheRest() {
     var output =
         """
         ```json
-        [
+        {"verdicts": [],
+         "findings": [
           {"severity": "INVALID", "category": "SECURITY", "title": "Bad", "description": "X"},
           {"severity": "HIGH", "category": "LOGIC", "title": "Good", "description": "Y"}
-        ]
+        ]}
         ```
         """;
 
-    var result = FindingParser.parse(output);
+    var result = parsed(output);
     assertEquals(1, result.findings().size());
     assertEquals("Good", result.findings().getFirst().title());
     assertEquals(1, result.warnings().size());
+  }
+
+  @Test
+  void skipsAMalformedVerdictAndKeepsTheRest() {
+    var output =
+        """
+        ```json
+        {"verdicts": [
+          {"verdict": "fixed", "evidence": "no finding_id"},
+          {"finding_id": "f-9", "verdict": "banana"},
+          {"finding_id": "f-1", "verdict": "still_open"}
+         ],
+         "findings": []}
+        ```
+        """;
+
+    var result = parsed(output);
+    assertEquals(1, result.verdicts().size());
+    assertEquals("f-1", result.verdicts().getFirst().findingId());
+    assertEquals(2, result.warnings().size());
+  }
+
+  @Test
+  void anEnvelopeWhereNothingParsesIsUnparseableNotACleanPass() {
+    var output =
+        """
+        ```json
+        {"verdicts": [{"bogus": true}], "findings": [{"severity": "NOPE"}]}
+        ```
+        """;
+
+    assertFalse(unparseable(output).warnings().isEmpty());
   }
 
   @Test
@@ -159,12 +232,12 @@ class FindingParserTest {
     var output =
         """
         ```json
-        [{"severity": "LOW", "category": "LOGIC", "title": "Open", "description": "D"}]
+        {"verdicts": [], "findings": []}
         """;
 
     var json = FindingParser.extractJsonBlocks(output);
     assertEquals(1, json.size());
-    assertTrue(json.getFirst().startsWith("["));
+    assertTrue(json.getFirst().startsWith("{"));
   }
 
   @Test
@@ -172,7 +245,7 @@ class FindingParserTest {
     var output =
         """
         ```
-        [{"severity": "LOW", "category": "LOGIC", "title": "Fence", "description": "D"}]
+        {"verdicts": [], "findings": []}
         ```
         """;
 
@@ -181,29 +254,26 @@ class FindingParserTest {
   }
 
   @Test
-  void parsesTheFindingsWhenTheTranscriptEchoesThePromptFence() {
+  void parsesTheEnvelopeWhenTheTranscriptEchoesThePromptFence() {
     var transcript =
         """
-        Rules:
-        5. If there are no issues, return an empty array: []
+        Respond with exactly one JSON object — the verdict envelope:
+        {"verdicts": [<one verdict per carried finding>], "findings": [<new findings only>]}
 
-        Begin your response with ```json and end with ```.
+        Begin the JSON object with ```json and end with ```.
         codex
         I inspected the diff and found one issue.
 
         ```json
-        [{"severity": "MEDIUM", "category": "LOGIC", "file": "a.ts",
+        {"verdicts": [],
+         "findings": [{"severity": "MEDIUM", "category": "LOGIC", "file": "a.ts",
           "line_start": 5, "line_end": 5, "title": "Leaked body",
-          "description": "Response not cancelled.", "confidence": 0.86}]
+          "description": "Response not cancelled.", "confidence": 0.86}]}
         ```
         """;
 
-    var result = FindingParser.parse(transcript);
-
-    assertEquals(
-        1,
-        result.findings().size(),
-        "the prompt echo's fence must not shadow the real findings block: " + result.warnings());
+    var result = parsed(transcript);
+    assertEquals(1, result.findings().size());
     assertEquals("Leaked body", result.findings().getFirst().title());
   }
 
@@ -216,16 +286,13 @@ class FindingParserTest {
         ```
         thinking...
         ```json
-        []
+        {"verdicts": [], "findings": []}
         ```
         """;
 
-    var result = FindingParser.parse(transcript);
-
-    assertEquals(0, result.findings().size());
-    assertTrue(
-        result.warnings().isEmpty(),
-        "a clean empty array is a valid verdict: " + result.warnings());
+    var result = parsed(transcript);
+    assertTrue(result.findings().isEmpty());
+    assertTrue(result.warnings().isEmpty(), "a clean empty envelope is a valid verdict");
   }
 
   @Test
@@ -233,79 +300,118 @@ class FindingParserTest {
     var output =
         """
         ```JSON
-        [{"severity": "LOW", "category": "LOGIC", "title": "Case", "description": "D"}]
+        {"verdicts": [], "findings": [{"severity": "LOW", "category": "LOGIC", "title": "Case", "description": "D"}]}
         ```
         """;
 
-    var result = FindingParser.parse(output);
-
-    assertEquals(
-        1, result.findings().size(), "fence casing is not a verdict: " + result.warnings());
+    var result = parsed(output);
     assertEquals("Case", result.findings().getFirst().title());
   }
 
   @Test
-  void findsTheArrayEmbeddedInProseWithoutAFence() {
+  void findsTheEnvelopeEmbeddedInProseWithoutAFence() {
     var output =
         """
         I reviewed the branch and found one issue.
-        [{"severity": "HIGH", "category": "SECURITY", "title": "Leak", "description": "D"}]
+        {"verdicts": [], "findings": [{"severity": "HIGH", "category": "SECURITY", "title": "Leak", "description": "D"}]}
         Let me know if you need more detail.
         """;
 
-    var result = FindingParser.parse(output);
-
-    assertEquals(1, result.findings().size(), "unfenced JSON is still JSON: " + result.warnings());
+    var result = parsed(output);
+    assertEquals(1, result.findings().size());
     assertEquals("Leak", result.findings().getFirst().title());
   }
 
   @Test
-  void fallsThroughToAnEmbeddedArrayWhenTheOnlyFenceIsThePromptEcho() {
+  void fallsThroughToAnEmbeddedEnvelopeWhenTheOnlyFenceIsThePromptEcho() {
     var output =
         """
-        Begin your response with ```json and end with ```.
+        Begin the JSON object with ```json and end with ```.
         I inspected the diff and found one issue.
-        [{"severity": "MEDIUM", "category": "LOGIC", "title": "Bug", "description": "D"}]
+        {"verdicts": [], "findings": [{"severity": "MEDIUM", "category": "LOGIC", "title": "Bug", "description": "D"}]}
         """;
 
-    var result = FindingParser.parse(output);
-
-    assertEquals(
-        1,
-        result.findings().size(),
-        "an unparseable prompt-echo fence must not hide real findings: " + result.warnings());
+    var result = parsed(output);
+    assertEquals(1, result.findings().size());
     assertEquals("Bug", result.findings().getFirst().title());
   }
 
   @Test
-  void aBareEmptyArrayLineInProseIsACleanVerdict() {
-    var output =
-        """
-        I examined every change on the branch.
-        []
-        No issues worth reporting.
-        """;
+  void thePromptEchoesPlaceholderEnvelopeIsNeverACleanPass() {
+    var result =
+        FindingParser.parse(
+            "Respond with exactly one JSON object — the verdict envelope:\n"
+                + "{\"verdicts\": [<one verdict per carried finding>], \"findings\":"
+                + " [<new findings only>]}");
 
-    var result = FindingParser.parse(output);
-
-    assertTrue(result.findings().isEmpty());
-    assertTrue(result.warnings().isEmpty(), "a bare [] is a verdict: " + result.warnings());
+    assertInstanceOf(
+        ParseResult.Unparseable.class,
+        result,
+        "an echoed placeholder envelope must never count as an empty verdict");
   }
 
   @Test
-  void proseMentioningAnEmptyArrayMidSentenceIsNotAVerdict() {
-    var result = FindingParser.parse("If there are no issues, return an empty array: []");
+  void reconcileDefaultsAnUnmentionedCarriedFindingToStillOpen() {
+    var carried = List.of(finding("Old high"));
 
-    assertTrue(result.findings().isEmpty());
-    assertFalse(result.warnings().isEmpty(), "a prompt echo must never count as a clean pass");
+    var reconciled = FindingParser.reconcile(carried, List.of());
+
+    assertEquals(Ruling.STILL_OPEN, reconciled.rulings().get(carried.getFirst().id()).ruling());
+    assertTrue(reconciled.warnings().isEmpty(), "silence is still_open, not an error");
   }
 
   @Test
-  void reportsAWarningWhenNoBlockParses() {
-    var result = FindingParser.parse("Begin your response with ```json and end with ```.");
+  void reconcileDowngradesFixedWithoutEvidenceToStillOpen() {
+    var carried = List.of(finding("Old high"));
+    var verdicts = List.of(new Verdict(carried.getFirst().id(), Ruling.FIXED, " "));
 
-    assertTrue(result.findings().isEmpty());
-    assertTrue(
-        !result.warnings().isEmpty(), "an unparseable review must say so, never pass silently");
+    var reconciled = FindingParser.reconcile(carried, verdicts);
+
+    assertEquals(Ruling.STILL_OPEN, reconciled.rulings().get(carried.getFirst().id()).ruling());
+    assertEquals(1, reconciled.warnings().size());
+    assertTrue(reconciled.warnings().getFirst().contains("no evidence"));
+  }
+
+  @Test
+  void reconcileDowngradesDisputedWithoutEvidenceToStillOpen() {
+    var carried = List.of(finding("Old high"));
+    var verdicts = List.of(new Verdict(carried.getFirst().id(), Ruling.DISPUTED, ""));
+
+    var reconciled = FindingParser.reconcile(carried, verdicts);
+
+    assertEquals(Ruling.STILL_OPEN, reconciled.rulings().get(carried.getFirst().id()).ruling());
+  }
+
+  @Test
+  void reconcileWarnsOnAnUnknownFindingIdInsteadOfCrashing() {
+    var carried = List.of(finding("Old high"));
+    var verdicts = List.of(new Verdict("ghost", Ruling.FIXED, "evidence"));
+
+    var reconciled = FindingParser.reconcile(carried, verdicts);
+
+    assertEquals(Ruling.STILL_OPEN, reconciled.rulings().get(carried.getFirst().id()).ruling());
+    assertEquals(1, reconciled.warnings().size());
+    assertTrue(reconciled.warnings().getFirst().contains("ghost"));
+  }
+
+  @Test
+  void reconcileAppliesEvidenceBackedRulings() {
+    var fixed = finding("Fixed one");
+    var disputed = finding("Disputed one");
+    var verdicts =
+        List.of(
+            new Verdict(fixed.id(), Ruling.FIXED, "commit abc"),
+            new Verdict(disputed.id(), Ruling.DISPUTED, "wrong assumption"));
+
+    var reconciled = FindingParser.reconcile(List.of(fixed, disputed), verdicts);
+
+    assertEquals(Ruling.FIXED, reconciled.rulings().get(fixed.id()).ruling());
+    assertEquals("commit abc", reconciled.rulings().get(fixed.id()).evidence());
+    assertEquals(Ruling.DISPUTED, reconciled.rulings().get(disputed.id()).ruling());
+  }
+
+  private static Finding finding(String title) {
+    return Finding.create(
+        Finding.Severity.HIGH, Finding.Category.LOGIC, "a.java", 1, 1, title, "d", "e", null, 0.9);
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
@@ -65,7 +65,6 @@ class FindingParserTest {
     var result = parsed(output);
     assertEquals(1, result.findings().size());
     assertTrue(result.verdicts().isEmpty());
-    assertTrue(result.warnings().isEmpty());
 
     var finding = result.findings().getFirst();
     assertEquals(Finding.Severity.HIGH, finding.severity());
@@ -117,7 +116,6 @@ class FindingParserTest {
     var result = parsed(output);
     assertTrue(result.verdicts().isEmpty());
     assertTrue(result.findings().isEmpty());
-    assertTrue(result.warnings().isEmpty());
   }
 
   @Test
@@ -196,42 +194,39 @@ class FindingParserTest {
   }
 
   @Test
-  void skipsAMalformedFindingAndKeepsTheRest() {
+  void aMalformedFindingEntryRejectsTheWholeEnvelope() {
     var output =
         """
         ```json
-        {"verdicts": [],
+        {"verdicts": [{"finding_id": "f-1", "verdict": "fixed", "evidence": "commit abc"}],
          "findings": [
-          {"severity": "INVALID", "category": "SECURITY", "title": "Bad", "description": "X"},
+          {"severity": "CRITICAL", "category": "SECURTY", "title": "Bad", "description": "X"},
           {"severity": "HIGH", "category": "LOGIC", "title": "Good", "description": "Y"}
         ]}
         ```
         """;
 
-    var result = parsed(output);
-    assertEquals(1, result.findings().size());
-    assertEquals("Good", result.findings().getFirst().title());
-    assertEquals(1, result.warnings().size());
+    var result = unparseable(output);
+    assertFalse(
+        result.warnings().isEmpty(),
+        "an unreadable finding has unknown severity; accepting the rest would resolve the"
+            + " carried blocker while silently dropping a reported issue from the gate");
   }
 
   @Test
-  void skipsAMalformedVerdictAndKeepsTheRest() {
+  void aMalformedVerdictEntryRejectsTheWholeEnvelope() {
     var output =
         """
         ```json
         {"verdicts": [
           {"verdict": "fixed", "evidence": "no finding_id"},
-          {"finding_id": "f-9", "verdict": "banana"},
           {"finding_id": "f-1", "verdict": "still_open"}
          ],
          "findings": []}
         ```
         """;
 
-    var result = parsed(output);
-    assertEquals(1, result.verdicts().size());
-    assertEquals("f-1", result.verdicts().getFirst().findingId());
-    assertEquals(2, result.warnings().size());
+    assertFalse(unparseable(output).warnings().isEmpty());
   }
 
   @Test
@@ -311,7 +306,7 @@ class FindingParserTest {
 
     var result = parsed(transcript);
     assertTrue(result.findings().isEmpty());
-    assertTrue(result.warnings().isEmpty(), "a clean empty envelope is a valid verdict");
+    assertTrue(result.verdicts().isEmpty(), "a clean empty envelope is a valid verdict");
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/engine/FixTaskBuilderTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/FixTaskBuilderTest.java
@@ -16,7 +16,7 @@ class FixTaskBuilderTest {
 
   @Test
   void emptyFindingsReturnsNoActionMessage() {
-    var task = FixTaskBuilder.build("OAuth flow", List.of());
+    var task = FixTaskBuilder.build("auth", "OAuth flow", List.of());
     assertTrue(task.contains("No review findings"));
     assertTrue(task.contains("OAuth flow"));
   }
@@ -37,7 +37,7 @@ class FixTaskBuilderTest {
                 "db.exec(sql + id)", "db.exec(sql, id)", "Use parameterized queries"),
             0.95);
 
-    var task = FixTaskBuilder.build("OAuth flow", List.of(finding));
+    var task = FixTaskBuilder.build("auth", "OAuth flow", List.of(finding));
 
     assertTrue(task.contains("1 review finding(s)"));
     assertTrue(task.contains("[CRITICAL] SECURITY"));
@@ -64,7 +64,7 @@ class FixTaskBuilderTest {
             new Finding.Suggestion("", "", "Fix the loop bound"),
             0.8);
 
-    var task = FixTaskBuilder.build("Payment", List.of(finding));
+    var task = FixTaskBuilder.build("pay", "Payment", List.of(finding));
     assertTrue(task.contains("Service.java:10-25"));
   }
 
@@ -95,7 +95,7 @@ class FixTaskBuilderTest {
             null,
             0.7);
 
-    var task = FixTaskBuilder.build("Spec", List.of(f1, f2));
+    var task = FixTaskBuilder.build("spec-1", "Spec", List.of(f1, f2));
     assertTrue(task.contains("Finding 1"));
     assertTrue(task.contains("Finding 2"));
     assertTrue(task.contains("2 review finding(s)"));
@@ -116,7 +116,7 @@ class FixTaskBuilderTest {
             null,
             0.5);
 
-    var task = FixTaskBuilder.build("Spec", List.of(finding));
+    var task = FixTaskBuilder.build("spec-1", "Spec", List.of(finding));
     assertFalse(task.contains("File:"));
   }
 
@@ -135,7 +135,7 @@ class FixTaskBuilderTest {
             null,
             0.7);
 
-    var task = FixTaskBuilder.build("Spec", List.of(finding));
+    var task = FixTaskBuilder.build("spec-1", "Spec", List.of(finding));
     assertFalse(task.contains("Fix:"));
   }
 
@@ -154,7 +154,7 @@ class FixTaskBuilderTest {
             null,
             0.9);
 
-    var task = FixTaskBuilder.build("Spec", List.of(finding));
+    var task = FixTaskBuilder.build("spec-1", "Spec", List.of(finding));
 
     assertTrue(task.contains("commit"), "the fix agent must be told to commit, not just hinted");
     assertTrue(task.contains("push"));
@@ -176,8 +176,36 @@ class FixTaskBuilderTest {
             null,
             0.3);
 
-    var task = FixTaskBuilder.build("Payment Integration", List.of(finding));
+    var task = FixTaskBuilder.build("pay", "Payment Integration", List.of(finding));
     assertTrue(task.contains("\"Payment Integration\""));
+  }
+
+  @Test
+  void taskOpensTheDisputeLaneInsteadOfDemandingBlindCompliance() {
+    var finding =
+        Finding.create(
+            Finding.Severity.HIGH,
+            Finding.Category.LOGIC,
+            "a.java",
+            1,
+            1,
+            "Maybe wrong",
+            "Desc",
+            "",
+            null,
+            0.9);
+
+    var task = FixTaskBuilder.build("auth-spec", "Spec", List.of(finding));
+
+    assertTrue(
+        task.contains("spec comment auth-spec"),
+        "the agent is told exactly how to argue a false positive in the open");
+    assertTrue(task.contains("do NOT code around it"));
+    assertTrue(
+        task.contains("never by omission"),
+        "the lane is argue-then-leave-alone, not silently skip");
+    assertTrue(
+        task.contains("Id: " + finding.id()), "each finding carries the id a dispute must cite");
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/engine/ReviewPromptBuilderTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/ReviewPromptBuilderTest.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.engine;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.singlr.sail.store.Finding;
 import ai.singlr.sail.store.MessageStore;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -34,10 +35,77 @@ class ReviewPromptBuilderTest {
   }
 
   @Test
-  void instructsJsonOutput() {
+  void instructsTheVerdictEnvelopeFromIterationOne() {
     var prompt = ReviewPromptBuilder.build("main", List.of("app"), List.of());
     assertTrue(prompt.contains("```json"));
-    assertTrue(prompt.contains("JSON array"));
+    assertTrue(prompt.contains("\"verdicts\""));
+    assertTrue(prompt.contains("\"findings\""));
+    assertTrue(
+        prompt.contains("\"verdicts\" must be an empty array"),
+        "the envelope is the only contract even when nothing is carried");
+  }
+
+  @Test
+  void carryForwardSectionRendersIdsSeveritiesAndLocations() {
+    var carried =
+        Finding.create(
+            Finding.Severity.HIGH,
+            Finding.Category.CONCURRENCY,
+            "src/Worker.java",
+            10,
+            14,
+            "Non-atomic target selection",
+            "d",
+            "e",
+            null,
+            0.9);
+
+    var prompt =
+        ReviewPromptBuilder.build("main", List.of("app"), List.of(), List.of(), List.of(carried));
+
+    assertTrue(prompt.contains("finding_id " + carried.id()), prompt);
+    assertTrue(prompt.contains("[HIGH] Non-atomic target selection"), prompt);
+    assertTrue(prompt.contains("(src/Worker.java:10-14)"), prompt);
+    assertTrue(
+        prompt.contains("include a verdict for every single one"),
+        "every carried finding demands a ruling");
+    assertTrue(
+        prompt.contains("treated as still_open"), "the reviewer is told silence resolves nothing");
+  }
+
+  @Test
+  void carriedFindingWithoutFileRendersWithoutLocation() {
+    var carried =
+        Finding.create(
+            Finding.Severity.LOW,
+            Finding.Category.API_CONTRACT,
+            null,
+            0,
+            0,
+            "Contract drift",
+            "d",
+            "e",
+            null,
+            0.4);
+
+    var prompt =
+        ReviewPromptBuilder.build("main", List.of("app"), List.of(), List.of(), List.of(carried));
+
+    assertTrue(prompt.contains("[LOW] Contract drift\n"), prompt);
+  }
+
+  @Test
+  void noCarriedFindingsRendersNoCarrySection() {
+    var prompt = ReviewPromptBuilder.build("main", List.of("app"), List.of());
+    assertTrue(!prompt.contains("The previous review left these findings open"));
+  }
+
+  @Test
+  void demandsEvidenceForFixedAndDisputedVerdicts() {
+    var prompt = ReviewPromptBuilder.build("main", List.of("app"), List.of());
+    assertTrue(prompt.contains("required for fixed"));
+    assertTrue(prompt.contains("for disputed"));
+    assertTrue(prompt.contains("without evidence is treated as still_open"));
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.store;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.config.SpecStatus;
@@ -571,6 +572,7 @@ class ReviewStoreTest {
     var open = addOpenFinding(stage1, Finding.Severity.HIGH, "Open high");
     var fixed = addOpenFinding(stage1, Finding.Severity.MEDIUM, "Already fixed");
     store.resolveFinding(fixed.id(), Finding.Resolution.FIXED, "commit abc");
+    store.completeStage(stage1, "failed");
     store.updateReviewStatus(r1, "failed");
     var r2 = store.createReview("auth", 2);
     store.createStage(r2, "security", "agent");
@@ -587,6 +589,8 @@ class ReviewStoreTest {
     var correctness = store.createStage(r1, "correctness", "agent");
     var securityFinding = addOpenFinding(security, Finding.Severity.HIGH, "Token leak");
     var correctnessFinding = addOpenFinding(correctness, Finding.Severity.HIGH, "Off by one");
+    store.completeStage(security, "failed");
+    store.completeStage(correctness, "failed");
     store.updateReviewStatus(r1, "failed");
     var r2 = store.createReview("auth", 2);
     store.createStage(r2, "security", "agent");
@@ -606,6 +610,7 @@ class ReviewStoreTest {
     var r1 = store.createReview("auth", 1);
     var stage1 = store.createStage(r1, "security", "agent");
     var open = addOpenFinding(stage1, Finding.Severity.HIGH, "Open high");
+    store.completeStage(stage1, "failed");
     store.updateReviewStatus(r1, "failed");
     var errored = store.createReview("auth", 2);
     store.failReviewWithError(errored, "quota exceeded");
@@ -624,11 +629,130 @@ class ReviewStoreTest {
   }
 
   @Test
+  void carryForwardReachesPastAReviewWhereAnEarlierStageFailedBeforeThisOneRan() {
+    var r1 = store.createReview("auth", 1);
+    var security1 = store.createStage(r1, "security", "agent");
+    store.completeStage(security1, "passed");
+    var correctness1 = store.createStage(r1, "correctness", "agent");
+    var blocker = addOpenFinding(correctness1, Finding.Severity.HIGH, "Off by one");
+    store.completeStage(correctness1, "failed");
+    store.updateReviewStatus(r1, "failed");
+
+    var r2 = store.createReview("auth", 2);
+    var security2 = store.createStage(r2, "security", "agent");
+    var securityBlocker = addOpenFinding(security2, Finding.Severity.CRITICAL, "Token leak");
+    store.completeStage(security2, "failed");
+    store.createStage(r2, "correctness", "agent");
+    store.updateReviewStatus(r2, "failed");
+
+    var r3 = store.createReview("auth", 3);
+    store.createStage(r3, "security", "agent");
+    store.createStage(r3, "correctness", "agent");
+
+    assertEquals(
+        List.of(blocker.id()),
+        store.carryForwardFindings("auth", r3, "correctness").stream().map(Finding::id).toList(),
+        "a stage that never ran in the latest failed review still carries its open findings"
+            + " from the last review where it did run");
+    assertEquals(
+        List.of(securityBlocker.id()),
+        store.carryForwardFindings("auth", r3, "security").stream().map(Finding::id).toList());
+  }
+
+  @Test
   void carryForwardFindingsIsEmptyWhenNoPriorFailedReviewExists() {
     var r1 = store.createReview("auth", 1);
     store.createStage(r1, "security", "agent");
 
     assertTrue(store.carryForwardFindings("auth", r1, "security").isEmpty());
+  }
+
+  @Test
+  void applyStageResultAppliesRulingsAndNewFindingsTogether() {
+    var r1 = store.createReview("auth", 1);
+    var stage1 = store.createStage(r1, "security", "agent");
+    var fixed = addOpenFinding(stage1, Finding.Severity.HIGH, "Now fixed");
+    var stubborn = addOpenFinding(stage1, Finding.Severity.MEDIUM, "Still there");
+    store.completeStage(stage1, "failed");
+    store.updateReviewStatus(r1, "failed");
+    var r2 = store.createReview("auth", 2);
+    var stage2 = store.createStage(r2, "security", "agent");
+    var fresh =
+        Finding.create(
+            Finding.Severity.LOW,
+            Finding.Category.LOGIC,
+            "b.java",
+            1,
+            1,
+            "New issue",
+            "",
+            "",
+            null,
+            0.6);
+
+    store.applyStageResult(
+        stage2,
+        List.of(
+            new ReviewStore.StageRuling(fixed, Finding.Resolution.FIXED, "commit abc"),
+            new ReviewStore.StageRuling(stubborn, Finding.Resolution.OPEN, "")),
+        List.of(fresh));
+
+    assertEquals(
+        Finding.Resolution.FIXED, store.findFinding(fixed.id()).orElseThrow().resolution());
+    var stageFindings = store.findingsForStage(stage2);
+    assertEquals(2, stageFindings.size());
+    assertEquals(
+        stubborn.id(),
+        stageFindings.stream()
+            .filter(f -> f.carriedFrom() != null)
+            .findFirst()
+            .orElseThrow()
+            .carriedFrom());
+  }
+
+  @Test
+  void applyStageResultRollsBackRulingsWhenAFindingInsertFails() {
+    var r1 = store.createReview("auth", 1);
+    var stage1 = store.createStage(r1, "security", "agent");
+    var blocker = addOpenFinding(stage1, Finding.Severity.HIGH, "Blocker");
+    store.completeStage(stage1, "failed");
+    store.updateReviewStatus(r1, "failed");
+    var r2 = store.createReview("auth", 2);
+    var stage2 = store.createStage(r2, "security", "agent");
+    var colliding =
+        new Finding(
+            blocker.id(),
+            Finding.Severity.CRITICAL,
+            Finding.Category.SECURITY,
+            "b.java",
+            1,
+            1,
+            "Colliding id",
+            "",
+            "",
+            null,
+            0.9,
+            Finding.Resolution.OPEN,
+            null,
+            null);
+
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            store.applyStageResult(
+                stage2,
+                List.of(new ReviewStore.StageRuling(blocker, Finding.Resolution.FIXED, "claimed")),
+                List.of(colliding)));
+
+    assertEquals(
+        Finding.Resolution.OPEN,
+        store.findFinding(blocker.id()).orElseThrow().resolution(),
+        "a stage result that fails to commit fully must not retire any carried finding");
+    assertTrue(store.findingsForStage(stage2).isEmpty());
+    assertEquals(
+        List.of(blocker.id()),
+        store.carryForwardFindings("auth", r2, "security").stream().map(Finding::id).toList(),
+        "the retry still sees the finding open and carries it");
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
@@ -575,9 +575,30 @@ class ReviewStoreTest {
     var r2 = store.createReview("auth", 2);
     store.createStage(r2, "security", "agent");
 
-    var carryable = store.carryForwardFindings("auth", r2);
+    var carryable = store.carryForwardFindings("auth", r2, "security");
 
     assertEquals(List.of(open.id()), carryable.stream().map(Finding::id).toList());
+  }
+
+  @Test
+  void carryForwardIsScopedToTheStageThatEmittedTheFinding() {
+    var r1 = store.createReview("auth", 1);
+    var security = store.createStage(r1, "security", "agent");
+    var correctness = store.createStage(r1, "correctness", "agent");
+    var securityFinding = addOpenFinding(security, Finding.Severity.HIGH, "Token leak");
+    var correctnessFinding = addOpenFinding(correctness, Finding.Severity.HIGH, "Off by one");
+    store.updateReviewStatus(r1, "failed");
+    var r2 = store.createReview("auth", 2);
+    store.createStage(r2, "security", "agent");
+    store.createStage(r2, "correctness", "agent");
+
+    assertEquals(
+        List.of(securityFinding.id()),
+        store.carryForwardFindings("auth", r2, "security").stream().map(Finding::id).toList(),
+        "each stage re-judges only its own findings, under its own gate");
+    assertEquals(
+        List.of(correctnessFinding.id()),
+        store.carryForwardFindings("auth", r2, "correctness").stream().map(Finding::id).toList());
   }
 
   @Test
@@ -593,12 +614,12 @@ class ReviewStoreTest {
 
     assertEquals(
         List.of(open.id()),
-        store.carryForwardFindings("auth", r3).stream().map(Finding::id).toList(),
+        store.carryForwardFindings("auth", r3, "security").stream().map(Finding::id).toList(),
         "an errored review has no verdict; the carry set comes from the last real one");
 
     store.carryForward(stage3, open);
     assertTrue(
-        store.carryForwardFindings("auth", r3).isEmpty(),
+        store.carryForwardFindings("auth", r3, "security").isEmpty(),
         "a finding already re-attached to this review is not carried twice");
   }
 
@@ -607,7 +628,7 @@ class ReviewStoreTest {
     var r1 = store.createReview("auth", 1);
     store.createStage(r1, "security", "agent");
 
-    assertTrue(store.carryForwardFindings("auth", r1).isEmpty());
+    assertTrue(store.carryForwardFindings("auth", r1, "security").isEmpty());
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
@@ -629,6 +629,26 @@ class ReviewStoreTest {
   }
 
   @Test
+  void aStageCompletedBeforeALaterStageErroredStillCarriesItsFindings() {
+    var r1 = store.createReview("auth", 1);
+    var security1 = store.createStage(r1, "security", "agent");
+    var blocker = addOpenFinding(security1, Finding.Severity.HIGH, "Token leak");
+    store.completeStage(security1, "failed");
+    var correctness1 = store.createStage(r1, "correctness", "agent");
+    store.completeStage(correctness1, "failed", "agent runner crashed");
+    store.failReviewWithError(r1, "agent runner crashed");
+
+    var r2 = store.createReview("auth", 1);
+    store.createStage(r2, "security", "agent");
+
+    assertEquals(
+        List.of(blocker.id()),
+        store.carryForwardFindings("auth", r2, "security").stream().map(Finding::id).toList(),
+        "validity is per stage: a stage that completed before a later stage errored the review"
+            + " keeps its findings in the carry set");
+  }
+
+  @Test
   void carryForwardReachesPastAReviewWhereAnEarlierStageFailedBeforeThisOneRan() {
     var r1 = store.createReview("auth", 1);
     var security1 = store.createStage(r1, "security", "agent");

--- a/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
@@ -525,6 +525,142 @@ class ReviewStoreTest {
   }
 
   @Test
+  void carryForwardCreatesALinkedRowAndLeavesThePredecessorOpen() {
+    var r1 = store.createReview("auth", 1);
+    var stage1 = store.createStage(r1, "security", "agent");
+    var original = addOpenFinding(stage1, Finding.Severity.HIGH, "Stubborn high");
+    var r2 = store.createReview("auth", 2);
+    var stage2 = store.createStage(r2, "security", "agent");
+
+    var carried = store.carryForward(stage2, original);
+
+    assertEquals(original.id(), carried.carriedFrom());
+    assertTrue(!carried.id().equals(original.id()), "a carried row is a fresh identity");
+    assertEquals(
+        Finding.Resolution.OPEN, store.findFinding(original.id()).orElseThrow().resolution());
+    assertEquals("Stubborn high", store.findingsForStage(stage2).getFirst().title());
+  }
+
+  @Test
+  void findingChainWalksTheWholeLineageNewestFirst() {
+    var r1 = store.createReview("auth", 1);
+    var stage1 = store.createStage(r1, "security", "agent");
+    var original = addOpenFinding(stage1, Finding.Severity.HIGH, "Aging high");
+    var r2 = store.createReview("auth", 2);
+    var stage2 = store.createStage(r2, "security", "agent");
+    var second = store.carryForward(stage2, original);
+    var r3 = store.createReview("auth", 3);
+    var stage3 = store.createStage(r3, "security", "agent");
+    var third = store.carryForward(stage3, second);
+
+    var chain = store.findingChain(third.id());
+
+    assertEquals(
+        List.of(third.id(), second.id(), original.id()),
+        chain.stream().map(Finding::id).toList(),
+        "one finding aging across iterations is one chain walk");
+    assertEquals(2, store.findingAge(third.id()));
+    assertEquals(1, store.findingAge(second.id()));
+    assertEquals(0, store.findingAge(original.id()));
+  }
+
+  @Test
+  void carryForwardFindingsReturnsThePreviousFailedReviewsOpenFindings() {
+    var r1 = store.createReview("auth", 1);
+    var stage1 = store.createStage(r1, "security", "agent");
+    var open = addOpenFinding(stage1, Finding.Severity.HIGH, "Open high");
+    var fixed = addOpenFinding(stage1, Finding.Severity.MEDIUM, "Already fixed");
+    store.resolveFinding(fixed.id(), Finding.Resolution.FIXED, "commit abc");
+    store.updateReviewStatus(r1, "failed");
+    var r2 = store.createReview("auth", 2);
+    store.createStage(r2, "security", "agent");
+
+    var carryable = store.carryForwardFindings("auth", r2);
+
+    assertEquals(List.of(open.id()), carryable.stream().map(Finding::id).toList());
+  }
+
+  @Test
+  void carryForwardFindingsSkipsErroredReviewsAndAlreadyCarriedRows() {
+    var r1 = store.createReview("auth", 1);
+    var stage1 = store.createStage(r1, "security", "agent");
+    var open = addOpenFinding(stage1, Finding.Severity.HIGH, "Open high");
+    store.updateReviewStatus(r1, "failed");
+    var errored = store.createReview("auth", 2);
+    store.failReviewWithError(errored, "quota exceeded");
+    var r3 = store.createReview("auth", 2);
+    var stage3 = store.createStage(r3, "security", "agent");
+
+    assertEquals(
+        List.of(open.id()),
+        store.carryForwardFindings("auth", r3).stream().map(Finding::id).toList(),
+        "an errored review has no verdict; the carry set comes from the last real one");
+
+    store.carryForward(stage3, open);
+    assertTrue(
+        store.carryForwardFindings("auth", r3).isEmpty(),
+        "a finding already re-attached to this review is not carried twice");
+  }
+
+  @Test
+  void carryForwardFindingsIsEmptyWhenNoPriorFailedReviewExists() {
+    var r1 = store.createReview("auth", 1);
+    store.createStage(r1, "security", "agent");
+
+    assertTrue(store.carryForwardFindings("auth", r1).isEmpty());
+  }
+
+  @Test
+  void resolveFindingRecordsEvidenceForTheResolution() {
+    var reviewId = store.createReview("auth", 1);
+    var stageId = store.createStage(reviewId, "security", "agent");
+    var finding = addOpenFinding(stageId, Finding.Severity.HIGH, "Ruled fixed");
+
+    store.resolveFinding(finding.id(), Finding.Resolution.FIXED, "commit abc parameterizes it");
+
+    var resolved = store.findFinding(finding.id()).orElseThrow();
+    assertEquals(Finding.Resolution.FIXED, resolved.resolution());
+    assertEquals("commit abc parameterizes it", resolved.resolutionEvidence());
+  }
+
+  @Test
+  void disputedFindingsSpansTheAttemptAndIgnoresSupersededHistory() {
+    var stale = store.createReview("auth", 1);
+    var staleStage = store.createStage(stale, "security", "agent");
+    var oldDispute = addOpenFinding(staleStage, Finding.Severity.HIGH, "Old attempt dispute");
+    store.resolveFinding(oldDispute.id(), Finding.Resolution.DISPUTED, "old argument");
+    store.supersedeForSpec("auth");
+
+    var r1 = store.createReview("auth", 1);
+    var stage1 = store.createStage(r1, "security", "agent");
+    var disputed = addOpenFinding(stage1, Finding.Severity.HIGH, "Wrong finding");
+    store.resolveFinding(disputed.id(), Finding.Resolution.DISPUTED, "cap enforced upstream");
+    addOpenFinding(stage1, Finding.Severity.LOW, "Still open");
+
+    var found = store.disputedFindings("auth");
+
+    assertEquals(List.of(disputed.id()), found.stream().map(Finding::id).toList());
+    assertEquals("cap enforced upstream", found.getFirst().resolutionEvidence());
+  }
+
+  @Test
+  void openFindingsAfterPassIgnoresFixedAndDisputed() {
+    var reviewId = store.createReview("auth", 1);
+    var stageId = store.createStage(reviewId, "security", "agent");
+    var open = addOpenFinding(stageId, Finding.Severity.LOW, "Genuinely open");
+    var fixed = addOpenFinding(stageId, Finding.Severity.HIGH, "Fixed");
+    var disputed = addOpenFinding(stageId, Finding.Severity.MEDIUM, "Disputed");
+    store.resolveFinding(fixed.id(), Finding.Resolution.FIXED, "commit abc");
+    store.resolveFinding(disputed.id(), Finding.Resolution.DISPUTED, "argued");
+    store.updateReviewStatus(reviewId, "passed");
+
+    assertEquals(
+        List.of(open.id()),
+        store.openFindingsAfterPass("auth").stream().map(Finding::id).toList(),
+        "open-after-pass means genuinely unresolved, not accumulated history");
+  }
+
+  @Test
   void anErroredReviewRecordsWhyAndIsDistinguishableFromAVerdict() {
     var review = store.createReview("auth", 1);
     var stage = store.createStage(review, "security", "agent");

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -333,4 +333,48 @@ class SchemaManagerTest {
         "INSERT INTO schema_version (version, applied_at) VALUES (?, 'staged')",
         SchemaManager.V1_VERSION);
   }
+
+  @Test
+  void theFindingsRebuildCarriesRowsAndSourceLinksForwardAndAdmitsDisputed() {
+    stageAtBaseline();
+    db.execute(
+        "INSERT INTO specs (id, title, status, created_at, updated_at)"
+            + " VALUES ('auth', 'T', 'done', 't0', 't0')");
+    db.execute(
+        "INSERT INTO reviews (id, spec_id, iteration, status, created_at)"
+            + " VALUES ('r1', 'auth', 1, 'failed', 't0')");
+    db.execute(
+        "INSERT INTO review_stages (id, review_id, name, stage_type, status)"
+            + " VALUES ('s1', 'r1', 'security', 'agent', 'failed')");
+    db.execute(
+        "INSERT INTO review_findings (id, stage_id, severity, category, title, description,"
+            + " confidence, resolution) VALUES ('f1', 's1', 'HIGH', 'SECURITY', 'Leak', 'D',"
+            + " 0.9, 'OPEN')");
+    db.execute("INSERT INTO spec_source_findings (spec_id, finding_id) VALUES ('auth', 'f1')");
+
+    new SchemaManager(db).migrate();
+
+    var survived =
+        db.queryOne(
+                "SELECT title, resolution, carried_from, resolution_evidence"
+                    + " FROM review_findings WHERE id = 'f1'",
+                r ->
+                    List.of(
+                        r.text(0), r.text(1), String.valueOf(r.text(2)), String.valueOf(r.text(3))))
+            .orElseThrow();
+    assertEquals(List.of("Leak", "OPEN", "null", "null"), survived);
+    assertEquals(
+        1,
+        (int)
+            db.queryOne(
+                    "SELECT COUNT(*) FROM spec_source_findings WHERE finding_id = 'f1'",
+                    r -> (int) r.integer(0))
+                .orElseThrow(),
+        "the rebuild must never cascade the follow-up links away");
+    db.execute("UPDATE review_findings SET resolution = 'DISPUTED' WHERE id = 'f1'");
+    assertEquals(
+        "DISPUTED",
+        db.queryOne("SELECT resolution FROM review_findings WHERE id = 'f1'", r -> r.text(0))
+            .orElseThrow());
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/sync/ConcurrentReconcileTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/ConcurrentReconcileTest.java
@@ -39,6 +39,7 @@ class ConcurrentReconcileTest {
     final Map<String, Map<String, Object>> snapshots = new LinkedHashMap<>();
     final Map<String, String> revs = new LinkedHashMap<>();
     final Deque<CommitOutcome> script = new ArrayDeque<>();
+    Runnable onFirstCommit;
     int minted = 1;
 
     @Override
@@ -68,6 +69,11 @@ class ConcurrentReconcileTest {
 
     @Override
     public CommitOutcome commit(String id, Map<String, Object> snapshot, String expectedRev) {
+      if (onFirstCommit != null) {
+        var hook = onFirstCommit;
+        onFirstCommit = null;
+        hook.run();
+      }
       var outcome = script.isEmpty() ? new CommitOutcome.Accepted("m-" + minted++) : script.poll();
       if (outcome instanceof CommitOutcome.Accepted accepted) {
         snapshots.put(id, snapshot);
@@ -123,6 +129,35 @@ class ConcurrentReconcileTest {
     assertEquals(1, report.conflicts());
     assertEquals(List.of("<stale>"), node.conflicts.pending().getFirst().fields());
     assertEquals("Title from node", node.specs.findById("auth").orElseThrow().title());
+  }
+
+  @Test
+  void aDisjointLocalWriteDuringTheCommitRoundIsReOfferedAndLands() {
+    node.specs.update(SyncBox.spec("auth", "Title from node", "pending"));
+    main.onFirstCommit =
+        () -> node.specs.update(SyncBox.spec("auth", "Title from node", "in_progress"));
+
+    engine.reconcile(node.replica, main);
+
+    assertEquals(
+        "in_progress",
+        node.specs.findById("auth").orElseThrow().status().wire(),
+        "a write landing while the push was in flight must not be overwritten by the"
+            + " accepted-but-stale snapshot");
+    assertEquals("in_progress", main.snapshots.get("auth").get("status"));
+    assertTrue(node.conflicts.pending().isEmpty());
+  }
+
+  @Test
+  void anOverlappingLocalWriteDuringTheCommitRoundParksAConflictAndKeepsLocalWork() {
+    node.specs.update(SyncBox.spec("auth", "Title from node", "pending"));
+    main.onFirstCommit =
+        () -> node.specs.update(SyncBox.spec("auth", "Title during round", "pending"));
+
+    var report = engine.reconcile(node.replica, main);
+
+    assertEquals(1, report.conflicts());
+    assertEquals("Title during round", node.specs.findById("auth").orElseThrow().title());
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/sync/ReviewSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/ReviewSyncTest.java
@@ -116,6 +116,25 @@ class ReviewSyncTest {
   }
 
   @Test
+  void aSuccessfulPushLeavesTheExecutingNodesFindingRowsIntact() {
+    var reviewId = node.reviews.createReview("auth", 1);
+    var stageId = node.reviews.createStage(reviewId, "security", "agent");
+    node.reviews.startStage(stageId, "codex");
+    node.reviews.addFinding(stageId, finding(Finding.Severity.HIGH));
+    node.reviews.completeStage(stageId, "failed");
+    node.reviews.updateReviewStatus(reviewId, "failed");
+
+    sync(node);
+
+    assertEquals(
+        1,
+        node.reviews.findingsForStage(stageId).size(),
+        "adopting main's identical aggregate after a push must link the revision without"
+            + " rebuilding — the rebuild deletes the finding rows that carry-forward and"
+            + " dispute resolution read");
+  }
+
+  @Test
   void aLaterTransitionOnTheOwningNodePropagates() {
     var reviewId = node.reviews.createReview("auth", 1);
     sync(node);

--- a/sail-core/src/test/java/ai/singlr/sail/sync/ReviewSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/ReviewSyncTest.java
@@ -154,6 +154,31 @@ class ReviewSyncTest {
             + " aggregate — the rebuild deletes the non-replicated finding rows");
   }
 
+  @Test
+  void syncRoundsRacingAConcurrentLocalWriterNeverLoseFindingRows() throws InterruptedException {
+    var reviewId = node.reviews.createReview("auth", 1);
+    var stageId = node.reviews.createStage(reviewId, "security", "agent");
+    node.reviews.startStage(stageId, "codex");
+    node.reviews.addFinding(stageId, finding(Finding.Severity.HIGH));
+
+    var rounds = 25;
+    for (var round = 0; round < rounds; round++) {
+      var writer =
+          new Thread(() -> node.reviews.addFinding(stageId, finding(Finding.Severity.CRITICAL)));
+      writer.start();
+      sync(node);
+      writer.join();
+    }
+    sync(node);
+
+    assertEquals(
+        1 + rounds,
+        node.reviews.findingsForStage(stageId).size(),
+        "snapshot capture and adoption must be atomic against concurrent local writes — a torn"
+            + " snapshot/revision pair or a write between the revision check and adoption"
+            + " rebuilds the aggregate and deletes the non-replicated finding rows");
+  }
+
   private MainReplica racingMain(Runnable onFirstCommit) {
     return new MainReplica() {
       private Runnable pending = onFirstCommit;

--- a/sail-core/src/test/java/ai/singlr/sail/sync/ReviewSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/ReviewSyncTest.java
@@ -16,6 +16,8 @@ import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.SyncConflicts;
 import ai.singlr.sail.store.SyncState;
 import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -132,6 +134,66 @@ class ReviewSyncTest {
         "adopting main's identical aggregate after a push must link the revision without"
             + " rebuilding — the rebuild deletes the finding rows that carry-forward and"
             + " dispute resolution read");
+  }
+
+  @Test
+  void aFindingAddedWhileThePushIsInFlightSurvivesTheAcceptedSnapshot() {
+    var reviewId = node.reviews.createReview("auth", 1);
+    var stageId = node.reviews.createStage(reviewId, "security", "agent");
+    node.reviews.startStage(stageId, "codex");
+    node.reviews.addFinding(stageId, finding(Finding.Severity.HIGH));
+
+    var racing =
+        racingMain(() -> node.reviews.addFinding(stageId, finding(Finding.Severity.CRITICAL)));
+    engine.reconcile(node.replica, racing);
+
+    assertEquals(
+        2,
+        node.reviews.findingsForStage(stageId).size(),
+        "adopting a snapshot accepted while a local write landed must never rebuild the"
+            + " aggregate — the rebuild deletes the non-replicated finding rows");
+  }
+
+  private MainReplica racingMain(Runnable onFirstCommit) {
+    return new MainReplica() {
+      private Runnable pending = onFirstCommit;
+
+      @Override
+      public String id() {
+        return main.replica.id();
+      }
+
+      @Override
+      public Set<String> entityIds() {
+        return main.replica.entityIds();
+      }
+
+      @Override
+      public Map<String, Object> current(String entityId) {
+        return main.replica.current(entityId);
+      }
+
+      @Override
+      public String currentRev(String entityId) {
+        return main.replica.currentRev(entityId);
+      }
+
+      @Override
+      public long maxSeq() {
+        return main.replica.maxSeq();
+      }
+
+      @Override
+      public CommitOutcome commit(
+          String entityId, Map<String, Object> snapshot, String expectedRev) {
+        if (pending != null) {
+          var hook = pending;
+          pending = null;
+          hook.run();
+        }
+        return main.replica.commit(entityId, snapshot, expectedRev);
+      }
+    };
   }
 
   @Test

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -361,6 +361,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
         if (stageConfig.type() == StageType.HUMAN) {
           reviewStore.startStage(stage.id(), "human");
           publishEvent(project, specId, "review_stage_started", stage.name());
+          postRoom(specId, humanVerdict(specId));
           return;
         }
 
@@ -419,7 +420,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       var spec = specStore.findById(specId);
       var branch = spec.map(SpecStore.SpecRow::branch).orElse("main");
       var repos = spec.map(SpecStore.SpecRow::repos).orElse(List.of());
-      var carried = reviewStore.carryForwardFindings(specId, stage.reviewId());
+      var carried = reviewStore.carryForwardFindings(specId, stage.reviewId(), stage.name());
       var prompt =
           ReviewPromptBuilder.build(
               branch, repos, stageConfig.categories(), roomMessages(specId), carried);
@@ -716,6 +717,17 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
         + findingLines(open)
         + disputed
         + "\nAwaiting merge.";
+  }
+
+  /**
+   * The room verdict a human stage opens with: the automated stages before it passed, and every
+   * disputed finding the gate excluded is surfaced — argument included — before the human rules.
+   * Deliberately not the passed verdict: the pipeline has not passed, so no "Awaiting merge".
+   */
+  private String humanVerdict(String specId) {
+    return "Automated review stages passed."
+        + disputedLines(reviewStore.disputedFindings(specId))
+        + "\nAwaiting human approval.";
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -372,7 +372,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
           return;
         }
         if (outcome instanceof StageOutcome.GateFailed) {
-          handleStageFailure(reviewId, config, stageConfig.gate(), project, specId);
+          handleStageFailure(reviewId, config, stage.id(), stageConfig.gate(), project, specId);
           return;
         }
       }
@@ -436,12 +436,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
         return new StageOutcome.Errored(message);
       }
       var parsed = (FindingParser.ParseResult.Parsed) parseResult;
-      warn(parsed.warnings());
-      applyVerdicts(stage.id(), carried, parsed.verdicts());
-
-      for (var finding : parsed.findings()) {
-        reviewStore.addFinding(stage.id(), finding);
-      }
+      applyStageResult(stage.id(), carried, parsed);
 
       var findings = reviewStore.findingsForStage(stage.id());
       var passed = stageConfig.gate().passes(findings);
@@ -466,28 +461,37 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
   }
 
   /**
-   * Applies the reviewer's verdicts to the carried findings, fail-closed: {@code fixed} and {@code
-   * disputed} (both evidence-backed, enforced by {@link FindingParser#reconcile}) resolve the
-   * predecessor row with the evidence recorded; everything else — {@code still_open}, a missing
-   * verdict, a ruling without evidence — re-attaches the finding to this stage as a carried row, so
-   * it keeps aging and keeps facing the gate. A reviewer that stops mentioning last iteration's
-   * finding launders nothing.
+   * Applies the reviewer's complete result — verdicts and new findings — as one atomic write,
+   * fail-closed on both axes. Verdicts: {@code fixed} and {@code disputed} (both evidence-backed,
+   * enforced by {@link FindingParser#reconcile}) resolve the predecessor row with the evidence
+   * recorded; everything else — {@code still_open}, a missing verdict, a ruling without evidence —
+   * re-attaches the finding to this stage as a carried row, so it keeps aging and keeps facing the
+   * gate. A reviewer that stops mentioning last iteration's finding launders nothing. Atomicity: if
+   * any new finding fails to insert, the resolutions roll back too, so an errored stage retries
+   * with every carried finding still {@code OPEN} instead of silently retired.
    */
-  private void applyVerdicts(
-      String stageId, List<Finding> carried, List<FindingParser.Verdict> verdicts) {
-    var reconciled = FindingParser.reconcile(carried, verdicts);
+  private void applyStageResult(
+      String stageId, List<Finding> carried, FindingParser.ParseResult.Parsed parsed) {
+    var reconciled = FindingParser.reconcile(carried, parsed.verdicts());
     warn(reconciled.warnings());
-    for (var finding : carried) {
-      var verdict = reconciled.rulings().get(finding.id());
-      switch (verdict.ruling()) {
-        case FIXED ->
-            reviewStore.resolveFinding(finding.id(), Finding.Resolution.FIXED, verdict.evidence());
-        case DISPUTED ->
-            reviewStore.resolveFinding(
-                finding.id(), Finding.Resolution.DISPUTED, verdict.evidence());
-        case STILL_OPEN -> reviewStore.carryForward(stageId, finding);
-      }
-    }
+    var rulings =
+        carried.stream()
+            .map(
+                finding -> {
+                  var verdict = reconciled.rulings().get(finding.id());
+                  return new ReviewStore.StageRuling(
+                      finding, resolutionOf(verdict.ruling()), verdict.evidence());
+                })
+            .toList();
+    reviewStore.applyStageResult(stageId, rulings, parsed.findings());
+  }
+
+  private static Finding.Resolution resolutionOf(FindingParser.Ruling ruling) {
+    return switch (ruling) {
+      case FIXED -> Finding.Resolution.FIXED;
+      case DISPUTED -> Finding.Resolution.DISPUTED;
+      case STILL_OPEN -> Finding.Resolution.OPEN;
+    };
   }
 
   private static void warn(List<String> warnings) {
@@ -523,6 +527,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
   private void handleStageFailure(
       String reviewId,
       ReviewPipelineConfig config,
+      String failedStageId,
       ReviewPipelineConfig.Gate gate,
       String project,
       String specId) {
@@ -537,7 +542,8 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
         failedVerdict(
             review.get().iteration(), openFindings, reviewStore.disputedFindings(specId)));
 
-    var stuck = stuckFinding(gate, openFindings, config.maxFindingAge());
+    var stuck =
+        stuckFinding(gate, reviewStore.findingsForStage(failedStageId), config.maxFindingAge());
     if (stuck != null) {
       escalate(
           project,
@@ -570,11 +576,13 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
    * The convergence check: a gate-blocking finding whose {@code carried_from} chain shows it has
    * already survived {@code maxFindingAge} fix iterations. Sub-gate findings may age freely — they
    * do not drive the loop — and a loop resolving old blockers while new ones surface never trips
-   * this: that loop is converging and runs to {@code max_iterations} as before.
+   * this: that loop is converging and runs to {@code max_iterations} as before. Scoped to the
+   * failed stage's own findings: a finding is gate-blocking only under the gate of the stage that
+   * owns it, so an aged finding another stage's gate permits never counts as this stage's blocker.
    */
   private Finding stuckFinding(
-      ReviewPipelineConfig.Gate gate, List<Finding> openFindings, int maxFindingAge) {
-    return openFindings.stream()
+      ReviewPipelineConfig.Gate gate, List<Finding> stageFindings, int maxFindingAge) {
+    return stageFindings.stream()
         .filter(gate::blocks)
         .filter(finding -> reviewStore.findingAge(finding.id()) >= maxFindingAge)
         .findFirst()
@@ -732,8 +740,9 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
 
   /**
    * The disputed findings section of a room verdict: excluded from the gate by a reviewer-ruled
-   * argument, so they are surfaced — argument included — for the human to confirm or overrule. An
-   * agent can silence a finding only by arguing it in the open, never by omission.
+   * argument, so every one is surfaced — argument included, never truncated — for the human to
+   * confirm or overrule. An agent can silence a finding only by arguing it in the open, never by
+   * omission, and a dispute the human cannot see is an omission.
    */
   private static String disputedLines(List<Finding> disputed) {
     if (disputed.isEmpty()) {
@@ -741,7 +750,6 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     }
     var shown =
         disputed.stream()
-            .limit(10)
             .map(
                 f ->
                     "- ["
@@ -753,10 +761,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
                             ? ""
                             : " — " + f.resolutionEvidence()))
             .collect(Collectors.joining("\n"));
-    var more = disputed.size() - Math.min(disputed.size(), 10);
-    return "\nDisputed (excluded from the gate — needs your ruling):\n"
-        + shown
-        + (more > 0 ? "\n- +" + more + " more" : "");
+    return "\nDisputed (excluded from the gate — needs your ruling):\n" + shown;
   }
 
   /** {@code "2 high, 1 low"} in severity order, or {@code "no findings"}. */

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.ReviewPipelineConfig;
 import ai.singlr.sail.config.ReviewPipelineConfig.StageConfig;
 import ai.singlr.sail.config.ReviewPipelineConfig.StageType;
@@ -35,6 +36,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Orchestrates the review pipeline when an agent completes a spec. Subscribes to the event bus,
@@ -369,14 +371,14 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
           return;
         }
         if (outcome instanceof StageOutcome.GateFailed) {
-          handleStageFailure(reviewId, config, project, specId);
+          handleStageFailure(reviewId, config, stageConfig.gate(), project, specId);
           return;
         }
       }
 
       reviewStore.updateReviewStatus(reviewId, "passed");
       advanceSpec(specId, SpecStatus.AWAITING_MERGE);
-      postRoom(specId, passedVerdict(reviewId));
+      postRoom(specId, passedVerdict(reviewId, specId));
       publishEvent(project, specId, "review_completed", null);
 
     } catch (Exception e) {
@@ -417,21 +419,26 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       var spec = specStore.findById(specId);
       var branch = spec.map(SpecStore.SpecRow::branch).orElse("main");
       var repos = spec.map(SpecStore.SpecRow::repos).orElse(List.of());
+      var carried = reviewStore.carryForwardFindings(specId, stage.reviewId());
       var prompt =
-          ReviewPromptBuilder.build(branch, repos, stageConfig.categories(), roomMessages(specId));
+          ReviewPromptBuilder.build(
+              branch, repos, stageConfig.categories(), roomMessages(specId), carried);
 
       var credential = startReviewRun(stage.reviewId(), project, specId, agent, branch, prompt);
       var effort = spec.map(SpecStore.SpecRow::reasoningEffort).orElse(null);
       var output =
           agentRunner.run(project, agent, prompt, stage.reviewId(), credential, null, effort);
       var parseResult = FindingParser.parse(output);
-      if (parseResult.findings().isEmpty() && !parseResult.warnings().isEmpty()) {
-        var message = "reviewer output unparseable: " + String.join("; ", parseResult.warnings());
+      if (parseResult instanceof FindingParser.ParseResult.Unparseable unparseable) {
+        var message = "reviewer output unparseable: " + String.join("; ", unparseable.warnings());
         reviewStore.completeStage(stage.id(), "failed", message);
         return new StageOutcome.Errored(message);
       }
+      var parsed = (FindingParser.ParseResult.Parsed) parseResult;
+      warn(parsed.warnings());
+      applyVerdicts(stage.id(), carried, parsed.verdicts());
 
-      for (var finding : parseResult.findings()) {
+      for (var finding : parsed.findings()) {
         reviewStore.addFinding(stage.id(), finding);
       }
 
@@ -455,6 +462,35 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       failReviewRun(stage.reviewId(), e);
       return new StageOutcome.Errored(e.getMessage());
     }
+  }
+
+  /**
+   * Applies the reviewer's verdicts to the carried findings, fail-closed: {@code fixed} and {@code
+   * disputed} (both evidence-backed, enforced by {@link FindingParser#reconcile}) resolve the
+   * predecessor row with the evidence recorded; everything else — {@code still_open}, a missing
+   * verdict, a ruling without evidence — re-attaches the finding to this stage as a carried row, so
+   * it keeps aging and keeps facing the gate. A reviewer that stops mentioning last iteration's
+   * finding launders nothing.
+   */
+  private void applyVerdicts(
+      String stageId, List<Finding> carried, List<FindingParser.Verdict> verdicts) {
+    var reconciled = FindingParser.reconcile(carried, verdicts);
+    warn(reconciled.warnings());
+    for (var finding : carried) {
+      var verdict = reconciled.rulings().get(finding.id());
+      switch (verdict.ruling()) {
+        case FIXED ->
+            reviewStore.resolveFinding(finding.id(), Finding.Resolution.FIXED, verdict.evidence());
+        case DISPUTED ->
+            reviewStore.resolveFinding(
+                finding.id(), Finding.Resolution.DISPUTED, verdict.evidence());
+        case STILL_OPEN -> reviewStore.carryForward(stageId, finding);
+      }
+    }
+  }
+
+  private static void warn(List<String> warnings) {
+    warnings.forEach(warning -> System.err.println("review-pipeline: " + warning));
   }
 
   /**
@@ -484,14 +520,35 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
   }
 
   private void handleStageFailure(
-      String reviewId, ReviewPipelineConfig config, String project, String specId) {
+      String reviewId,
+      ReviewPipelineConfig config,
+      ReviewPipelineConfig.Gate gate,
+      String project,
+      String specId) {
     reviewStore.updateReviewStatus(reviewId, "failed");
 
     var review = reviewStore.findReview(reviewId);
     if (review.isEmpty()) return;
 
     var openFindings = reviewStore.openFindingsForReview(reviewId);
-    postRoom(specId, failedVerdict(review.get().iteration(), openFindings));
+    postRoom(
+        specId,
+        failedVerdict(
+            review.get().iteration(), openFindings, reviewStore.disputedFindings(specId)));
+
+    var stuck = stuckFinding(gate, openFindings, config.maxFindingAge());
+    if (stuck != null) {
+      escalate(
+          project,
+          specId,
+          reviewId,
+          "finding \""
+              + stuck.title()
+              + "\" survived "
+              + reviewStore.findingAge(stuck.id())
+              + " fix iterations; the loop is stuck on it — fix or dismiss it, then re-dispatch");
+      return;
+    }
 
     if (review.get().iteration() >= config.maxIterations()) {
       escalate(
@@ -506,6 +563,21 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
 
     triggerFixIteration(reviewId, specId, openFindings, project);
     reReview(config, project, specId, review.get().iteration() + 1);
+  }
+
+  /**
+   * The convergence check: a gate-blocking finding whose {@code carried_from} chain shows it has
+   * already survived {@code maxFindingAge} fix iterations. Sub-gate findings may age freely — they
+   * do not drive the loop — and a loop resolving old blockers while new ones surface never trips
+   * this: that loop is converging and runs to {@code max_iterations} as before.
+   */
+  private Finding stuckFinding(
+      ReviewPipelineConfig.Gate gate, List<Finding> openFindings, int maxFindingAge) {
+    return openFindings.stream()
+        .filter(gate::blocks)
+        .filter(finding -> reviewStore.findingAge(finding.id()) >= maxFindingAge)
+        .findFirst()
+        .orElse(null);
   }
 
   /**
@@ -532,7 +604,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     var spec = specStore.findById(specId);
     if (spec.isEmpty()) return;
 
-    var fixTask = FixTaskBuilder.build(spec.get().title(), findings);
+    var fixTask = FixTaskBuilder.build(specId, spec.get().title(), findings);
     advanceSpec(specId, SpecStatus.IN_PROGRESS);
     publishEvent(project, specId, "review_iteration_started", null);
 
@@ -614,24 +686,27 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     }
   }
 
-  private static String failedVerdict(int iteration, List<Finding> findings) {
+  private static String failedVerdict(
+      int iteration, List<Finding> findings, List<Finding> disputed) {
     return "Review failed (iteration "
         + iteration
         + "): "
         + severitySummary(findings)
         + "."
-        + findingLines(findings);
+        + findingLines(findings)
+        + disputedLines(disputed);
   }
 
-  private String passedVerdict(String reviewId) {
+  private String passedVerdict(String reviewId, String specId) {
     var iteration =
         reviewStore.findReview(reviewId).map(ReviewStore.ReviewRow::iteration).orElse(0);
     var open =
         reviewStore.findingsForReview(reviewId).stream()
             .filter(f -> f.resolution() == Finding.Resolution.OPEN)
             .toList();
+    var disputed = disputedLines(reviewStore.disputedFindings(specId));
     if (open.isEmpty()) {
-      return "Review passed (iteration " + iteration + "). Awaiting merge.";
+      return "Review passed (iteration " + iteration + ")." + disputed + "\nAwaiting merge.";
     }
     return "Review passed (iteration "
         + iteration
@@ -639,7 +714,37 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
         + severitySummary(open)
         + " below the gate — worth a look before merge."
         + findingLines(open)
+        + disputed
         + "\nAwaiting merge.";
+  }
+
+  /**
+   * The disputed findings section of a room verdict: excluded from the gate by a reviewer-ruled
+   * argument, so they are surfaced — argument included — for the human to confirm or overrule. An
+   * agent can silence a finding only by arguing it in the open, never by omission.
+   */
+  private static String disputedLines(List<Finding> disputed) {
+    if (disputed.isEmpty()) {
+      return "";
+    }
+    var shown =
+        disputed.stream()
+            .limit(10)
+            .map(
+                f ->
+                    "- ["
+                        + f.severity()
+                        + "] "
+                        + f.title()
+                        + (f.file() == null ? "" : " (" + f.file() + ":" + f.lineStart() + ")")
+                        + (Strings.isBlank(f.resolutionEvidence())
+                            ? ""
+                            : " — " + f.resolutionEvidence()))
+            .collect(Collectors.joining("\n"));
+    var more = disputed.size() - Math.min(disputed.size(), 10);
+    return "\nDisputed (excluded from the gate — needs your ruling):\n"
+        + shown
+        + (more > 0 ? "\n- +" + more + " more" : "");
   }
 
   /** {@code "2 high, 1 low"} in severity order, or {@code "no findings"}. */

--- a/sail-infra/src/test/java/ai/singlr/sail/api/Fleet.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/Fleet.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import static ai.singlr.sail.api.ReviewScripts.CLEAN_REVIEW;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -264,7 +265,7 @@ public final class Fleet implements AutoCloseable {
               reviews,
               project -> REVIEW,
               project -> "codex",
-              (project, agent, prompt, reviewId, credential) -> "[]",
+              (project, agent, prompt, reviewId, credential) -> CLEAN_REVIEW,
               bus,
               () -> {},
               new DirectExecutorService());

--- a/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/MissedStopReconcilerTest.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import static ai.singlr.sail.api.ReviewScripts.CLEAN_REVIEW;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -581,7 +582,7 @@ class MissedStopReconcilerTest {
             reviewStore,
             p -> config,
             p -> "codex",
-            (p, a, pr, rid, cred) -> "[]",
+            (p, a, pr, rid, cred) -> CLEAN_REVIEW,
             bus,
             () -> {},
             new DirectExecutorService());

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopIT.java
@@ -55,14 +55,18 @@ class ReviewAgentLoopIT extends AbstractIncusIT {
         while [ -f "$HOME/.sail/review-hold" ]; do sleep 0.1; done
       fi
       case "$*" in
-        *"Output your findings"*)
+        *"Review the changes on branch"*)
           n_file="$HOME/.sail/review-count"
           n=$(( $(cat "$n_file" 2>/dev/null || echo 0) + 1 ))
           printf '%s' "$n" > "$n_file"
           if [ "$n" -eq 1 ]; then
-            printf '```json\\n[{"severity":"CRITICAL","category":"SECURITY","file":"a.java","line_start":1,"line_end":1,"title":"Bad","description":"Very bad","evidence":"trace","confidence":0.95}]\\n```\\n'
+            printf '```json\\n{"verdicts": [], "findings": [{"severity":"CRITICAL","category":"SECURITY","file":"a.java","line_start":1,"line_end":1,"title":"Bad","description":"Very bad","evidence":"trace","confidence":0.95}]}\\n```\\n'
           else
-            printf '[]\\n'
+            v=""
+            for id in $(printf '%s' "$*" | grep -o 'finding_id [^ ]*' | cut -d' ' -f2); do
+              v="$v{\\"finding_id\\": \\"$id\\", \\"verdict\\": \\"fixed\\", \\"evidence\\": \\"commit abc\\"},"
+            done
+            printf '```json\\n{"verdicts": [%s], "findings": []}\\n```\\n' "${v%,}"
           fi
           ;;
         *)
@@ -108,11 +112,12 @@ class ReviewAgentLoopIT extends AbstractIncusIT {
                 ai.singlr.sail.common.DateTimeUtils.newId().toString(),
                 "sailrun_it");
 
-    var parsed = FindingParser.parse(output);
-    assertEquals(
-        1,
-        parsed.findings().size(),
-        "findings must be parsed from real container output: " + output);
+    var result = FindingParser.parse(output);
+    assertTrue(
+        result instanceof FindingParser.ParseResult.Parsed,
+        "the envelope must be parsed from real container output: " + output);
+    var parsed = (FindingParser.ParseResult.Parsed) result;
+    assertEquals(1, parsed.findings().size());
     assertEquals(Finding.Severity.CRITICAL, parsed.findings().getFirst().severity());
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewAgentLoopTest.java
@@ -39,9 +39,9 @@ class ReviewAgentLoopTest {
   private static final String CRITICAL_FINDING =
       """
       ```json
-      [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
+      {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
         "line_start": 1, "line_end": 1, "title": "Bad",
-        "description": "Very bad", "confidence": 0.95}]
+        "description": "Very bad", "confidence": 0.95}]}
       ```
       """;
 
@@ -183,9 +183,14 @@ class ReviewAgentLoopTest {
         return new Result(0, "", "");
       }
       if (joined.contains("tail -c")) {
-        if (lastPrompt.contains("Output your findings")) {
+        if (lastPrompt.contains("Review the changes on branch")) {
           var i = reviewCall++;
-          return new Result(0, i < reviewOutputs.size() ? reviewOutputs.get(i) : "[]", "");
+          return new Result(
+              0,
+              i < reviewOutputs.size()
+                  ? reviewOutputs.get(i)
+                  : ReviewScripts.fixAllCarried(lastPrompt),
+              "");
         }
         return new Result(0, "fix applied", "");
       }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewLoopIntegrationTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewLoopIntegrationTest.java
@@ -5,6 +5,8 @@
 
 package ai.singlr.sail.api;
 
+import static ai.singlr.sail.api.ReviewScripts.CLEAN_REVIEW;
+import static ai.singlr.sail.api.ReviewScripts.fixAllCarried;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -92,9 +94,9 @@ class ReviewLoopIntegrationTest {
   private static final String CRITICAL_FINDING =
       """
       ```json
-      [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
+      {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
         "line_start": 1, "line_end": 1, "title": "Bad",
-        "description": "Very bad", "confidence": 0.95}]
+        "description": "Very bad", "confidence": 0.95}]}
       ```
       """;
 
@@ -106,9 +108,9 @@ class ReviewLoopIntegrationTest {
   private static ReviewAgentRunner cyclingRunner(java.util.List<String> reviewOutputs) {
     var reviewCall = new AtomicInteger();
     return (project, agent, prompt, reviewId, credential) -> {
-      if (prompt.contains("Output your findings")) {
+      if (prompt.contains("Review the changes on branch")) {
         var i = reviewCall.getAndIncrement();
-        return i < reviewOutputs.size() ? reviewOutputs.get(i) : "[]";
+        return i < reviewOutputs.size() ? reviewOutputs.get(i) : fixAllCarried(prompt);
       }
       return "fix applied";
     };
@@ -162,7 +164,7 @@ class ReviewLoopIntegrationTest {
   void aCleanStopPublishedToTheBusAdvancesTheSpecToAwaitingMerge() throws Exception {
     createSpec("auth");
     var latch = new CountDownLatch(1);
-    subscribe(singleStage("no_critical"), (p, a, pr, rid, cred) -> "[]", latch);
+    subscribe(singleStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW, latch);
 
     bus.publish(stop("auth"));
 
@@ -175,7 +177,7 @@ class ReviewLoopIntegrationTest {
   void aHookTurnEndStopThroughTheBusDoesNotTriggerReview() throws Exception {
     createSpec("auth");
     var latch = new CountDownLatch(1);
-    subscribe(singleStage("no_critical"), (p, a, pr, rid, cred) -> "[]", latch);
+    subscribe(singleStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW, latch);
 
     bus.publish(hookTurnEndStop("auth"));
 
@@ -220,7 +222,7 @@ class ReviewLoopIntegrationTest {
   void aNonZeroExitPublishedToTheBusSkipsReview() throws Exception {
     createSpec("auth");
     var latch = new CountDownLatch(1);
-    subscribe(singleStage("no_critical"), (p, a, pr, rid, cred) -> "[]", latch);
+    subscribe(singleStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW, latch);
 
     bus.publish(stop("auth", 137));
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -23,6 +23,8 @@ import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -674,6 +676,121 @@ class ReviewPipelineControllerTest {
     assertEquals(2, stages.size());
     assertEquals("passed", stages.get(0).status());
     assertEquals("passed", stages.get(1).status());
+  }
+
+  @Test
+  void aCarriedFindingReturnsToItsOwnStageAndFacesItsOwnGate() {
+    createSpec("auth", "in_progress");
+    var config =
+        ReviewPipelineConfig.fromMap(
+            Map.of(
+                "stages",
+                List.of(
+                    Map.of(
+                        "name",
+                        "security",
+                        "type",
+                        "agent",
+                        "agent",
+                        "codex",
+                        "gate",
+                        "no_critical"),
+                    Map.of(
+                        "name",
+                        "correctness",
+                        "type",
+                        "agent",
+                        "agent",
+                        "claude",
+                        "gate",
+                        "no_critical_or_high"))));
+    var highOutput =
+        """
+        ```json
+        {"verdicts": [], "findings": [{"severity": "HIGH", "category": "LOGIC", "file": "Pager.java",
+          "line_start": 3, "line_end": 3, "title": "Persistent high",
+          "description": "d", "evidence": "e", "confidence": 0.9,
+          "suggestion": {"before": "old", "after": "new", "rationale": "r"}}]}
+        ```
+        """;
+    var promptsByAgent = new HashMap<String, List<String>>();
+    ReviewAgentRunner runner =
+        (p, agent, prompt, rid, cred) -> {
+          var prompts = promptsByAgent.computeIfAbsent(agent, k -> new ArrayList<>());
+          prompts.add(prompt);
+          if (agent.equals("claude")) {
+            return prompts.size() == 1 ? highOutput : fixAllCarried(prompt);
+          }
+          return agent.equals("codex") ? CLEAN_REVIEW : "fix applied";
+        };
+    var ctrl = controller(config, runner);
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
+    var codexPrompts = promptsByAgent.get("codex");
+    assertEquals(2, codexPrompts.size());
+    assertTrue(
+        codexPrompts.stream().allMatch(prompt -> ReviewScripts.carriedFromPrompt(prompt).isEmpty()),
+        "a HIGH from the strict later stage must never be re-judged under the first stage's"
+            + " looser gate");
+    var claudePrompts = promptsByAgent.get("claude");
+    assertEquals(2, claudePrompts.size());
+    assertTrue(
+        claudePrompts.get(1).contains("Persistent high"),
+        "the finding returns to the stage that emitted it");
+  }
+
+  @Test
+  void aHumanStageOpensWithTheRoomVerdictListingDisputedFindings() {
+    createSpec("auth", "in_progress");
+    var messages = new MessageStore(db);
+    var config =
+        ReviewPipelineConfig.fromMap(
+            Map.of(
+                "stages",
+                List.of(
+                    Map.of(
+                        "name",
+                        "security",
+                        "type",
+                        "agent",
+                        "agent",
+                        "codex",
+                        "gate",
+                        "no_critical_or_high"),
+                    Map.of("name", "human", "type", "human"))));
+    var highOutput =
+        """
+        ```json
+        {"verdicts": [], "findings": [{"severity": "HIGH", "category": "SECURITY", "file": "Auth.java",
+          "line_start": 7, "line_end": 7, "title": "Unvalidated input",
+          "description": "d", "evidence": "e", "confidence": 0.9,
+          "suggestion": {"before": "old", "after": "new", "rationale": "r"}}]}
+        ```
+        """;
+    var calls = new AtomicInteger();
+    ReviewAgentRunner runner =
+        (p, a, prompt, rid, cred) ->
+            switch (calls.incrementAndGet()) {
+              case 1 -> highOutput;
+              case 2 -> "fix applied";
+              default -> ReviewScripts.disputeAllCarried(prompt);
+            };
+    var ctrl = controller(config, runner);
+    ctrl.useMessages(messages);
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    var review = reviewStore.latestReviewForSpec("auth").orElseThrow();
+    assertEquals("running", review.status());
+    assertEquals("running", reviewStore.stagesForReview(review.id()).get(1).status());
+    var verdict = messages.list("auth", null, 50).getLast();
+    assertTrue(verdict.body().contains("Awaiting human approval"), verdict.body());
+    assertTrue(
+        verdict.body().contains("Unvalidated input"),
+        "the disputed finding the gate excluded must face the human before approval");
+    assertTrue(verdict.body().contains("input is validated upstream"), verdict.body());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -33,6 +33,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -791,6 +793,62 @@ class ReviewPipelineControllerTest {
         verdict.body().contains("Unvalidated input"),
         "the disputed finding the gate excluded must face the human before approval");
     assertTrue(verdict.body().contains("input is validated upstream"), verdict.body());
+  }
+
+  @Test
+  void everyDisputedFindingReachesTheHumanVerdictUntruncated() {
+    createSpec("auth", "in_progress");
+    var messages = new MessageStore(db);
+    var config =
+        ReviewPipelineConfig.fromMap(
+            Map.of(
+                "stages",
+                List.of(
+                    Map.of(
+                        "name",
+                        "security",
+                        "type",
+                        "agent",
+                        "agent",
+                        "codex",
+                        "gate",
+                        "no_critical_or_high"),
+                    Map.of("name", "human", "type", "human"))));
+    var elevenHighs =
+        IntStream.rangeClosed(1, 11)
+            .mapToObj(
+                i ->
+                    ("{\"severity\": \"HIGH\", \"category\": \"LOGIC\", \"file\": \"a.java\","
+                            + " \"line_start\": %d, \"line_end\": %d, \"title\": \"Wrong claim"
+                            + " %d\", \"description\": \"d\", \"confidence\": 0.8}")
+                        .formatted(i, i, i))
+            .collect(Collectors.joining(", "));
+    var calls = new AtomicInteger();
+    ReviewAgentRunner runner =
+        (p, a, prompt, rid, cred) ->
+            switch (calls.incrementAndGet()) {
+              case 1 -> "{\"verdicts\": [], \"findings\": [" + elevenHighs + "]}";
+              case 2 -> "fix applied";
+              default -> ReviewScripts.disputeAllCarried(prompt);
+            };
+    var ctrl = controller(config, runner);
+    ctrl.useMessages(messages);
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    var verdict = messages.list("auth", null, 50).getLast().body();
+    assertTrue(verdict.contains("Awaiting human approval"), verdict);
+    IntStream.rangeClosed(1, 11)
+        .forEach(
+            i ->
+                assertTrue(
+                    verdict.contains("Wrong claim " + i),
+                    "every gate-excluded dispute must face the human with its identity and"
+                        + " argument, never as a count: missing 'Wrong claim "
+                        + i
+                        + "' in: "
+                        + verdict));
+    assertFalse(verdict.contains("more"), verdict);
   }
 
   @Test
@@ -1846,6 +1904,84 @@ class ReviewPipelineControllerTest {
           java.util.Objects.toString(captured.events().getFirst().data().get("detail"), "");
       assertTrue(detail.contains("Sticky high"), "escalation names the stuck finding: " + detail);
       assertTrue(detail.contains("survived 2 fix iterations"), detail);
+    }
+  }
+
+  @Test
+  void anotherStagesAgedSubGateFindingNeverTripsTheFailingStagesConvergenceCheck()
+      throws Exception {
+    createSpec("auth", "in_progress");
+    var config =
+        ReviewPipelineConfig.fromMap(
+            Map.of(
+                "max_iterations",
+                3,
+                "stages",
+                List.of(
+                    Map.of(
+                        "name",
+                        "security",
+                        "type",
+                        "agent",
+                        "agent",
+                        "codex",
+                        "gate",
+                        "no_critical"),
+                    Map.of(
+                        "name",
+                        "correctness",
+                        "type",
+                        "agent",
+                        "agent",
+                        "claude",
+                        "gate",
+                        "all_clear"))));
+    var toleratedHigh =
+        """
+        ```json
+        {"verdicts": [], "findings": [{"severity": "HIGH", "category": "SECURITY", "file": "a.java",
+          "line_start": 1, "line_end": 1, "title": "Tolerated high",
+          "description": "d", "confidence": 0.9}]}
+        ```
+        """;
+    var codexCalls = new AtomicInteger();
+    var claudeCalls = new AtomicInteger();
+    ReviewAgentRunner runner =
+        (p, agent, prompt, rid, cred) ->
+            switch (agent) {
+              case "codex" -> codexCalls.incrementAndGet() == 1 ? toleratedHigh : CLEAN_REVIEW;
+              case "claude" ->
+                  ReviewScripts.fixAllCarried(
+                      prompt,
+                      ("[{\"severity\": \"LOW\", \"category\": \"LOGIC\", \"file\": \"b.java\","
+                              + " \"line_start\": 1, \"line_end\": 1, \"title\": \"Fresh low %d\","
+                              + " \"description\": \"d\", \"confidence\": 0.4}]")
+                          .formatted(claudeCalls.incrementAndGet()));
+              default -> "fix applied";
+            };
+
+    try (var bus = new EventBus()) {
+      var captured = captureEvents(bus, Set.of("review_escalated"), 1);
+      var ctrl = controller(p -> config, p -> "codex", runner, bus);
+
+      ctrl.onEvent(agentStoppedEvent("auth"));
+      BusTesting.awaitDelivery(captured.latch());
+
+      assertEquals(
+          3,
+          reviewStore.reviewsForSpec("auth").size(),
+          "a converging loop — new blocker each round — runs to max_iterations");
+      var detail =
+          java.util.Objects.toString(captured.events().getFirst().data().get("detail"), "");
+      assertTrue(
+          detail.contains("review iterations exhausted"),
+          "the loop exhausts its budget instead of escalating a foreign stage's finding: "
+              + detail);
+      assertFalse(
+          detail.contains("Tolerated high"),
+          "the security stage's aged HIGH passes its own gate; the correctness gate must never"
+              + " judge it: "
+              + detail);
     }
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -5,6 +5,8 @@
 
 package ai.singlr.sail.api;
 
+import static ai.singlr.sail.api.ReviewScripts.CLEAN_REVIEW;
+import static ai.singlr.sail.api.ReviewScripts.fixAllCarried;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -221,7 +223,7 @@ class ReviewPipelineControllerTest {
             reviewStore,
             p -> singleAgentStage("no_critical"),
             p -> "codex",
-            (p, a, pr, rid, cred) -> "[]",
+            (p, a, pr, rid, cred) -> CLEAN_REVIEW,
             null,
             syncs::incrementAndGet,
             new DirectExecutorService());
@@ -235,7 +237,7 @@ class ReviewPipelineControllerTest {
   @Test
   void aSyncDerivedStopNeverStartsAPipelineTheWorkLivesOnAnotherBox() {
     createSpec("auth", "in_progress");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(
         Event.of(
@@ -253,7 +255,7 @@ class ReviewPipelineControllerTest {
   @Test
   void anAuthoritativeStopStillKicksOffReviewWhenStatusWasClobberedToReview() {
     createSpec("auth", "review");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -266,7 +268,7 @@ class ReviewPipelineControllerTest {
 
   @Test
   void messageStoreWiringIsFluent() {
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     assertEquals(ctrl, ctrl.useMessages(new MessageStore(db)));
   }
@@ -276,7 +278,7 @@ class ReviewPipelineControllerTest {
     createSpec("auth", "review");
     var reviewId = reviewStore.createReview("auth", 1);
     reviewStore.updateReviewStatus(reviewId, "running");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -286,7 +288,7 @@ class ReviewPipelineControllerTest {
   @Test
   void aTerminalSpecStatusIgnoresTheStop() {
     createSpec("auth", "awaiting_merge");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -296,7 +298,7 @@ class ReviewPipelineControllerTest {
 
   @Test
   void skipsAnUnknownSpec() {
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("ghost"));
 
@@ -310,7 +312,7 @@ class ReviewPipelineControllerTest {
     ReviewAgentRunner capturing =
         (p, a, prompt, rid, cred) -> {
           capturedAgent.set(a);
-          return "[]";
+          return CLEAN_REVIEW;
         };
     var ctrl =
         controller(p -> singleStageNoAgent("no_critical"), p -> "claude-code", capturing, null);
@@ -325,7 +327,10 @@ class ReviewPipelineControllerTest {
     createSpec("auth", "in_progress");
     var ctrl =
         controller(
-            p -> singleStageNoAgent("no_critical"), p -> null, (p, a, pr, rid, cred) -> "[]", null);
+            p -> singleStageNoAgent("no_critical"),
+            p -> null,
+            (p, a, pr, rid, cred) -> CLEAN_REVIEW,
+            null);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -335,7 +340,7 @@ class ReviewPipelineControllerTest {
 
   @Test
   void reusesOneExecutorAcrossEventsAndShutsItDownOnClose() {
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
     createSpec("auth", "in_progress");
     createSpec("billing", "in_progress");
 
@@ -350,21 +355,21 @@ class ReviewPipelineControllerTest {
 
   @Test
   void filterAcceptsAgentSessionStoppedWithSpec() {
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
     var event = agentStoppedEvent("auth");
     assertTrue(ctrl.filter().test(event));
   }
 
   @Test
   void filterRejectsEventsWithoutSpec() {
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
     var event = Event.of("proj", null, Event.WellKnownTypes.AGENT_SESSION_STOPPED, "sail", "h");
     assertFalse(ctrl.filter().test(event));
   }
 
   @Test
   void filterRejectsUnrelatedEventTypes() {
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
     var event = Event.of("proj", "spec", "spec_dispatched", "sail", "h");
     assertFalse(ctrl.filter().test(event));
   }
@@ -372,7 +377,7 @@ class ReviewPipelineControllerTest {
   @Test
   void skipsSpecNotInProgress() {
     createSpec("auth", "pending");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -382,7 +387,7 @@ class ReviewPipelineControllerTest {
 
   @Test
   void skipsUnknownSpec() {
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
     ctrl.onEvent(agentStoppedEvent("nonexistent"));
 
     assertTrue(reviewStore.reviewsForSpec("nonexistent").isEmpty());
@@ -391,7 +396,7 @@ class ReviewPipelineControllerTest {
   @Test
   void aStopArrivingAfterAnOperatorCancelNeverKicksAReview() {
     createSpec("auth", "cancelled");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -402,7 +407,7 @@ class ReviewPipelineControllerTest {
   @Test
   void ignoresAStopForASpecAlreadyAwaitingMerge() {
     createSpec("auth", "awaiting_merge");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -413,7 +418,7 @@ class ReviewPipelineControllerTest {
   @Test
   void transitionsSpecToReview() {
     createSpec("auth", "in_progress");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -424,7 +429,7 @@ class ReviewPipelineControllerTest {
   @Test
   void cleanReviewPassesAndParksSpecAwaitingMerge() {
     createSpec("auth", "in_progress");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -445,7 +450,7 @@ class ReviewPipelineControllerTest {
             singleAgentStage("no_critical"),
             (p, a, pr, rid, cred) -> {
               specStore.updateStatus("auth", SpecStatus.CANCELLED);
-              return "[]";
+              return CLEAN_REVIEW;
             });
 
     ctrl.onEvent(agentStoppedEvent("auth"));
@@ -459,7 +464,7 @@ class ReviewPipelineControllerTest {
   @Test
   void aWatcherStopAndAReconcilerReplayBackToBackProduceExactlyOneReview() {
     createSpec("auth", "in_progress");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
     ctrl.onEvent(reconcilerStoppedEvent("auth"));
@@ -477,7 +482,7 @@ class ReviewPipelineControllerTest {
             singleAgentStage("no_critical"),
             (p, a, pr, rid, cred) -> {
               ctrl.get().onEvent(reconcilerStoppedEvent("auth"));
-              return "[]";
+              return CLEAN_REVIEW;
             }));
 
     ctrl.get().onEvent(agentStoppedEvent("auth"));
@@ -502,9 +507,9 @@ class ReviewPipelineControllerTest {
     var agentOutput =
         """
         ```json
-        [{"severity": "HIGH", "category": "SECURITY", "file": "Auth.java",
+        {"verdicts": [], "findings": [{"severity": "HIGH", "category": "SECURITY", "file": "Auth.java",
           "line_start": 42, "line_end": 42, "title": "SQL injection",
-          "description": "User input in query", "confidence": 0.9}]
+          "description": "User input in query", "confidence": 0.9}]}
         ```
         """;
     var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> agentOutput);
@@ -569,7 +574,8 @@ class ReviewPipelineControllerTest {
     assertEquals(1, reviewStore.latestReviewForSpec("auth").orElseThrow().iteration());
 
     specStore.updateStatus("auth", SpecStatus.IN_PROGRESS);
-    var healthy = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var healthy =
+        controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
     healthy.onEvent(agentStoppedEvent("auth"));
 
     var review = reviewStore.latestReviewForSpec("auth").orElseThrow();
@@ -588,9 +594,9 @@ class ReviewPipelineControllerTest {
     var agentOutput =
         """
         ```json
-        [{"severity": "CRITICAL", "category": "SECURITY", "file": "Auth.java",
+        {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "SECURITY", "file": "Auth.java",
           "line_start": 1, "line_end": 1, "title": "Critical issue",
-          "description": "Very bad", "confidence": 0.95}]
+          "description": "Very bad", "confidence": 0.95}]}
         ```
         """;
     var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> agentOutput);
@@ -607,7 +613,7 @@ class ReviewPipelineControllerTest {
     var exhausted = reviewStore.createReview("auth", 3);
     reviewStore.updateReviewStatus(exhausted, "escalated");
     reviewStore.supersedeForSpec("auth");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -623,7 +629,7 @@ class ReviewPipelineControllerTest {
     var interrupted = reviewStore.createReview("auth", 1);
     reviewStore.updateReviewStatus(interrupted, "running");
     reviewStore.supersedeForSpec("auth");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -639,9 +645,9 @@ class ReviewPipelineControllerTest {
     var agentOutput =
         """
         ```json
-        [{"severity": "MEDIUM", "category": "LOGIC", "file": "a.java",
+        {"verdicts": [], "findings": [{"severity": "MEDIUM", "category": "LOGIC", "file": "a.java",
           "line_start": 1, "line_end": 1, "title": "Minor issue",
-          "description": "Not great", "confidence": 0.5}]
+          "description": "Not great", "confidence": 0.5}]}
         ```
         """;
     var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> agentOutput);
@@ -655,7 +661,9 @@ class ReviewPipelineControllerTest {
   @Test
   void twoStagesPipelineBothPass() {
     createSpec("auth", "in_progress");
-    var ctrl = controller(p -> twoAgentStages(), p -> "codex", (p, a, pr, rid, cred) -> "[]", null);
+    var ctrl =
+        controller(
+            p -> twoAgentStages(), p -> "codex", (p, a, pr, rid, cred) -> CLEAN_REVIEW, null);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -671,7 +679,9 @@ class ReviewPipelineControllerTest {
   @Test
   void humanStageStopsAndWaits() {
     createSpec("auth", "in_progress");
-    var ctrl = controller(p -> agentThenHuman(), p -> "codex", (p, a, pr, rid, cred) -> "[]", null);
+    var ctrl =
+        controller(
+            p -> agentThenHuman(), p -> "codex", (p, a, pr, rid, cred) -> CLEAN_REVIEW, null);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -688,7 +698,7 @@ class ReviewPipelineControllerTest {
   @Test
   void noPipelineConfigSkipsReview() {
     createSpec("auth", "in_progress");
-    var ctrl = controller(p -> null, p -> "codex", (p, a, pr, rid, cred) -> "[]", null);
+    var ctrl = controller(p -> null, p -> "codex", (p, a, pr, rid, cred) -> CLEAN_REVIEW, null);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -700,7 +710,7 @@ class ReviewPipelineControllerTest {
   void emptyPipelineConfigSkipsReview() {
     createSpec("auth", "in_progress");
     var emptyConfig = ReviewPipelineConfig.fromMap(Map.of());
-    var ctrl = controller(emptyConfig, (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(emptyConfig, (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -725,7 +735,7 @@ class ReviewPipelineControllerTest {
 
   @Test
   void subscriberNameIsReviewPipeline() {
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
     assertEquals("review-pipeline", ctrl.name());
   }
 
@@ -736,7 +746,7 @@ class ReviewPipelineControllerTest {
     ReviewAgentRunner capturing =
         (p, a, prompt, rid, cred) -> {
           capturedPrompt.set(prompt);
-          return "[]";
+          return CLEAN_REVIEW;
         };
     var ctrl = controller(singleAgentStage("no_critical"), capturing);
 
@@ -752,17 +762,17 @@ class ReviewPipelineControllerTest {
     var criticalOutput =
         """
         ```json
-        [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
+        {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
           "line_start": 1, "line_end": 1, "title": "Bad",
           "description": "Very bad", "confidence": 0.9,
-          "suggestion": {"before": "old", "after": "new", "rationale": "fix it"}}]
+          "suggestion": {"before": "old", "after": "new", "rationale": "fix it"}}]}
         ```
         """;
     var callCount = new AtomicInteger(0);
     ReviewAgentRunner runner =
         (p, a, prompt, rid, cred) -> {
           var call = callCount.incrementAndGet();
-          return call == 1 ? criticalOutput : "[]";
+          return call == 1 ? criticalOutput : fixAllCarried(prompt);
         };
     var ctrl = controller(singleAgentStage("no_critical"), runner);
 
@@ -779,17 +789,17 @@ class ReviewPipelineControllerTest {
     var criticalOutput =
         """
         ```json
-        [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
+        {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
           "line_start": 1, "line_end": 1, "title": "Bad",
           "description": "Very bad", "confidence": 0.9,
-          "suggestion": {"before": "old", "after": "new", "rationale": "fix it"}}]
+          "suggestion": {"before": "old", "after": "new", "rationale": "fix it"}}]}
         ```
         """;
     var reviewIds = new java.util.ArrayList<String>();
     ReviewAgentRunner runner =
         (p, a, prompt, rid, cred) -> {
           reviewIds.add(rid);
-          return reviewIds.size() == 1 ? criticalOutput : "[]";
+          return reviewIds.size() == 1 ? criticalOutput : fixAllCarried(prompt);
         };
     var ctrl = controller(singleAgentStage("no_critical"), runner);
 
@@ -816,9 +826,9 @@ class ReviewPipelineControllerTest {
     var criticalOutput =
         """
         ```json
-        [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
+        {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
           "line_start": 1, "line_end": 1, "title": "Persistent issue",
-          "description": "Cannot fix", "confidence": 0.95}]
+          "description": "Cannot fix", "confidence": 0.95}]}
         ```
         """;
     var config =
@@ -914,9 +924,9 @@ class ReviewPipelineControllerTest {
     var criticalOutput =
         """
         ```json
-        [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
+        {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
           "line_start": 1, "line_end": 1, "title": "Bad",
-          "description": "Very bad", "confidence": 0.9}]
+          "description": "Very bad", "confidence": 0.9}]}
         ```
         """;
     var ensured = new AtomicReference<List<Object>>();
@@ -925,7 +935,7 @@ class ReviewPipelineControllerTest {
         new ReviewAgentRunner() {
           @Override
           public String run(String p, String a, String prompt, String rid, String cred) {
-            return calls.incrementAndGet() == 1 ? criticalOutput : "[]";
+            return calls.incrementAndGet() == 1 ? criticalOutput : fixAllCarried(prompt);
           }
 
           @Override
@@ -971,9 +981,9 @@ class ReviewPipelineControllerTest {
     var criticalOutput =
         """
         ```json
-        [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
+        {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
           "line_start": 1, "line_end": 1, "title": "Bad",
-          "description": "Very bad", "confidence": 0.9}]
+          "description": "Very bad", "confidence": 0.9}]}
         ```
         """;
     var fixLaunch = new AtomicReference<List<Object>>();
@@ -983,7 +993,7 @@ class ReviewPipelineControllerTest {
         new ReviewAgentRunner() {
           @Override
           public String run(String p, String a, String prompt, String rid, String cred) {
-            return calls.incrementAndGet() == 1 ? criticalOutput : "[]";
+            return calls.incrementAndGet() == 1 ? criticalOutput : fixAllCarried(prompt);
           }
 
           @Override
@@ -1042,22 +1052,22 @@ class ReviewPipelineControllerTest {
     var failedOutput =
         """
         ```json
-        [{"severity": "CRITICAL", "category": "SECURITY", "file": "Auth.java",
+        {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "SECURITY", "file": "Auth.java",
           "line_start": 7, "line_end": 7, "title": "Token logged in plaintext",
-          "description": "d", "confidence": 0.9}]
+          "description": "d", "confidence": 0.9}]}
         ```
         """;
-    var passedOutput =
+    var lowFinding =
         """
-        ```json
         [{"severity": "LOW", "category": "LOGIC", "file": "Pager.java",
           "line_start": 3, "line_end": 3, "title": "Off-by-one in pager",
-          "description": "d", "confidence": 0.6}]
-        ```
-        """;
+          "description": "d", "confidence": 0.6}]""";
     var calls = new AtomicInteger();
     ReviewAgentRunner runner =
-        (p, a, pr, rid, cred) -> calls.incrementAndGet() == 1 ? failedOutput : passedOutput;
+        (p, a, pr, rid, cred) ->
+            calls.incrementAndGet() == 1
+                ? failedOutput
+                : ReviewScripts.fixAllCarried(pr, lowFinding);
 
     try (var bus = new EventBus()) {
       var captured = captureEvents(bus, Set.of("review_completed"), 1);
@@ -1097,7 +1107,7 @@ class ReviewPipelineControllerTest {
     var brokenMessages = new MessageStore(brokenDb);
     brokenDb.close();
 
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
     ctrl.useMessages(brokenMessages);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
@@ -1121,7 +1131,7 @@ class ReviewPipelineControllerTest {
           controller(
               p -> singleAgentStage("no_critical"),
               p -> "codex",
-              (p, a, pr, rid, cred) -> "[]",
+              (p, a, pr, rid, cred) -> CLEAN_REVIEW,
               bus);
 
       ctrl.executePipeline(reviewId, singleAgentStage("no_critical"), "test-project", "auth");
@@ -1136,7 +1146,7 @@ class ReviewPipelineControllerTest {
     var agentOutput =
         """
         ```json
-        [{"severity": "HIGH", "category": "SECURITY", "file": "Auth.java",
+        {"verdicts": [], "findings": [{"severity": "HIGH", "category": "SECURITY", "file": "Auth.java",
           "line_start": 1, "line_end": 1, "title": "SQL injection",
           "description": "d", "confidence": 0.9},
          {"severity": "HIGH", "category": "SECURITY", "file": "Auth.java",
@@ -1144,7 +1154,7 @@ class ReviewPipelineControllerTest {
           "description": "d", "confidence": 0.9},
          {"severity": "LOW", "category": "LOGIC", "file": "Auth.java",
           "line_start": 3, "line_end": 3, "title": "Naming",
-          "description": "d", "confidence": 0.9}]
+          "description": "d", "confidence": 0.9}]}
         ```
         """;
 
@@ -1176,7 +1186,7 @@ class ReviewPipelineControllerTest {
           controller(
               p -> singleAgentStage("no_critical"),
               p -> "codex",
-              (p, a, pr, rid, cred) -> "[]",
+              (p, a, pr, rid, cred) -> CLEAN_REVIEW,
               bus);
 
       ctrl.onEvent(agentStoppedEvent("auth"));
@@ -1246,7 +1256,7 @@ class ReviewPipelineControllerTest {
           controller(
               p -> singleAgentStage("no_critical"),
               p -> "codex",
-              (p, a, pr, rid, cred) -> "[]",
+              (p, a, pr, rid, cred) -> CLEAN_REVIEW,
               bus);
       db.close();
 
@@ -1264,7 +1274,7 @@ class ReviewPipelineControllerTest {
     createSpec("auth", "in_progress");
     var reviewId = reviewStore.createReview("auth", 1);
     reviewStore.updateReviewStatus(reviewId, "running");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -1280,7 +1290,7 @@ class ReviewPipelineControllerTest {
         (p, a, pr, rid, cred) -> {
           started.countDown();
           await(release);
-          return "[]";
+          return CLEAN_REVIEW;
         };
     var ctrl =
         new ReviewPipelineController(
@@ -1310,7 +1320,7 @@ class ReviewPipelineControllerTest {
         (p, a, pr, rid, cred) -> {
           started.countDown();
           await(release);
-          return "[]";
+          return CLEAN_REVIEW;
         };
     var runs = new RunStore(db);
     var ctrl =
@@ -1380,10 +1390,10 @@ class ReviewPipelineControllerTest {
     var criticalOutput =
         """
         ```json
-        [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
+        {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
           "line_start": 1, "line_end": 1, "title": "Bad",
           "description": "Very bad", "confidence": 0.9,
-          "suggestion": {"before": "old", "after": "new", "rationale": "fix it"}}]
+          "suggestion": {"before": "old", "after": "new", "rationale": "fix it"}}]}
         ```
         """;
     var runs = new RunStore(db);
@@ -1392,7 +1402,7 @@ class ReviewPipelineControllerTest {
     ReviewAgentRunner runner =
         (p, a, pr, rid, cred) -> {
           credentials.add(List.of(rid, cred));
-          return calls.incrementAndGet() == 1 ? criticalOutput : "[]";
+          return calls.incrementAndGet() == 1 ? criticalOutput : fixAllCarried(pr);
         };
     var ctrl =
         new ReviewPipelineController(
@@ -1431,9 +1441,9 @@ class ReviewPipelineControllerTest {
     var criticalOutput =
         """
         ```json
-        [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
+        {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
           "line_start": 1, "line_end": 1, "title": "Bad",
-          "description": "Very bad", "confidence": 0.9}]
+          "description": "Very bad", "confidence": 0.9}]}
         ```
         """;
     var runs = new RunStore(db);
@@ -1444,7 +1454,7 @@ class ReviewPipelineControllerTest {
           if (calls.incrementAndGet() == 2) {
             fixResolved.set(runs.findByCredential(cred).orElse(null));
           }
-          return calls.get() == 1 ? criticalOutput : "[]";
+          return calls.get() == 1 ? criticalOutput : fixAllCarried(pr);
         };
     var ctrl =
         new ReviewPipelineController(
@@ -1472,7 +1482,7 @@ class ReviewPipelineControllerTest {
   @Test
   void closeAwaitsInFlightPipelines() {
     createSpec("auth", "in_progress");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
     ctrl.close();
@@ -1483,7 +1493,7 @@ class ReviewPipelineControllerTest {
 
   @Test
   void awaitCompletionWithNoInFlightReturnsImmediately() throws Exception {
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
     ctrl.awaitCompletion(1000);
   }
 
@@ -1516,7 +1526,7 @@ class ReviewPipelineControllerTest {
             new ReviewStore(errDb),
             p -> singleAgentStage("no_critical"),
             p -> "codex",
-            (p, a, pr, rid, cred) -> "[]",
+            (p, a, pr, rid, cred) -> CLEAN_REVIEW,
             null,
             () -> {},
             new DirectExecutorService());
@@ -1528,7 +1538,7 @@ class ReviewPipelineControllerTest {
   @Test
   void aHookTurnEndStopIsIgnoredUntilTheAuthoritativeStopArrives() {
     createSpec("auth", "in_progress");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(hookTurnEndEvent("auth"));
 
@@ -1539,7 +1549,7 @@ class ReviewPipelineControllerTest {
   @Test
   void nonZeroExitSkipsReviewAndLeavesSpecInProgress() {
     createSpec("auth", "in_progress");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth", 137));
 
@@ -1555,7 +1565,7 @@ class ReviewPipelineControllerTest {
           controller(
               p -> singleAgentStage("no_critical"),
               p -> "codex",
-              (p, a, pr, rid, cred) -> "[]",
+              (p, a, pr, rid, cred) -> CLEAN_REVIEW,
               bus);
 
       ctrl.onEvent(agentStoppedEvent("auth", 1));
@@ -1567,7 +1577,7 @@ class ReviewPipelineControllerTest {
   @Test
   void zeroExitStillRunsReview() {
     createSpec("auth", "in_progress");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth", 0));
 
@@ -1579,7 +1589,7 @@ class ReviewPipelineControllerTest {
     createSpec("auth", "in_progress");
     var reviewId = reviewStore.createReview("auth", 3);
     reviewStore.updateReviewStatus(reviewId, "failed");
-    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> "[]");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
@@ -1592,9 +1602,9 @@ class ReviewPipelineControllerTest {
     var criticalOutput =
         """
         ```json
-        [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
+        {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
           "line_start": 1, "line_end": 1, "title": "Bad",
-          "description": "Very bad", "confidence": 0.9}]
+          "description": "Very bad", "confidence": 0.9}]}
         ```
         """;
     var calls = new AtomicInteger(0);
@@ -1614,6 +1624,284 @@ class ReviewPipelineControllerTest {
       latch.await();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
+    }
+  }
+
+  private ReviewPipelineConfig noHighGate(int maxIterations) {
+    return ReviewPipelineConfig.fromMap(
+        Map.of(
+            "max_iterations",
+            maxIterations,
+            "stages",
+            List.of(
+                Map.of(
+                    "name",
+                    "security",
+                    "type",
+                    "agent",
+                    "agent",
+                    "codex",
+                    "gate",
+                    "no_critical_or_high"))));
+  }
+
+  private static final String HIGH_FINDING =
+      """
+      ```json
+      {"verdicts": [], "findings": [{"severity": "HIGH", "category": "CONCURRENCY", "file": "Worker.java",
+        "line_start": 9, "line_end": 9, "title": "Sticky high",
+        "description": "d", "confidence": 0.9}]}
+      ```
+      """;
+
+  @Test
+  void aBareFindingsArrayIsOffContractAndErrorsTheStage() {
+    createSpec("auth", "in_progress");
+    var legacyArray =
+        """
+        ```json
+        [{"severity": "HIGH", "category": "SECURITY", "file": "a.java",
+          "line_start": 1, "line_end": 1, "title": "Bad", "description": "d", "confidence": 0.9}]
+        ```
+        """;
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> legacyArray);
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    var review = reviewStore.latestReviewForSpec("auth").orElseThrow();
+    assertEquals("failed", review.status());
+    assertTrue(
+        review.errored(),
+        "a bare findings array is off-contract reviewer output — it rides the errored-retry"
+            + " lane, never burning an iteration and never passing as a verdict");
+    assertTrue(review.error().contains("unparseable"), review.error());
+  }
+
+  @Test
+  void aCarriedOpenHighFailsTheGateEvenWhenTheNewFindingsListIsClean() {
+    createSpec("auth", "in_progress");
+    var calls = new AtomicInteger();
+    ReviewAgentRunner runner =
+        (p, a, pr, rid, cred) -> calls.incrementAndGet() == 1 ? HIGH_FINDING : CLEAN_REVIEW;
+    var ctrl = controller(p -> noHighGate(2), p -> "codex", runner, null);
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    var reviews = reviewStore.reviewsForSpec("auth");
+    assertEquals(2, reviews.size());
+    var carried = reviewStore.findingsForReview(reviews.get(1).id());
+    assertEquals(1, carried.size(), "the unruled high re-attaches to the re-review");
+    assertEquals("Sticky high", carried.getFirst().title());
+    assertEquals(
+        reviewStore.findingsForReview(reviews.get(0).id()).getFirst().id(),
+        carried.getFirst().carriedFrom(),
+        "the carried row chains to its predecessor — one finding, one lineage");
+    assertEquals(
+        "escalated",
+        reviews.get(1).status(),
+        "a reviewer that stops mentioning last iteration's high launders nothing — the high"
+            + " stays open and keeps failing the gate");
+    assertEquals(
+        Finding.Resolution.OPEN,
+        reviewStore.findingsForReview(reviews.get(0).id()).getFirst().resolution(),
+        "history is never rewritten; the predecessor row stays open where it was found");
+  }
+
+  @Test
+  void aGateBlockingFindingStillOpenTwiceEscalatesWithTheFindingNamed() throws Exception {
+    createSpec("auth", "in_progress");
+    var calls = new AtomicInteger();
+    ReviewAgentRunner runner =
+        (p, a, pr, rid, cred) -> calls.incrementAndGet() == 1 ? HIGH_FINDING : CLEAN_REVIEW;
+
+    try (var bus = new EventBus()) {
+      var captured = captureEvents(bus, Set.of("review_escalated"), 1);
+      var ctrl = controller(p -> noHighGate(5), p -> "codex", runner, bus);
+
+      ctrl.onEvent(agentStoppedEvent("auth"));
+      BusTesting.awaitDelivery(captured.latch());
+
+      assertEquals(
+          3,
+          reviewStore.reviewsForSpec("auth").size(),
+          "the stuck loop is caught after 2 fix iterations, not after max_iterations=5");
+      var detail =
+          java.util.Objects.toString(captured.events().getFirst().data().get("detail"), "");
+      assertTrue(detail.contains("Sticky high"), "escalation names the stuck finding: " + detail);
+      assertTrue(detail.contains("survived 2 fix iterations"), detail);
+    }
+  }
+
+  @Test
+  void subGateFindingsMayAgeFreelyWithoutTrippingTheConvergenceEscalation() {
+    createSpec("auth", "in_progress");
+    var lowOutput =
+        """
+        ```json
+        {"verdicts": [], "findings": [{"severity": "LOW", "category": "LOGIC", "file": "a.java",
+          "line_start": 1, "line_end": 1, "title": "Aging low",
+          "description": "d", "confidence": 0.4}]}
+        ```
+        """;
+    var calls = new AtomicInteger();
+    ReviewAgentRunner runner =
+        (p, a, pr, rid, cred) -> calls.incrementAndGet() == 1 ? lowOutput : CLEAN_REVIEW;
+    var ctrl = controller(p -> noHighGate(3), p -> "codex", runner, null);
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    assertEquals(
+        "passed",
+        reviewStore.latestReviewForSpec("auth").orElseThrow().status(),
+        "a sub-gate low never fails the gate, so it ages without escalating anything");
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void passWithExplicitFixedVerdictsResolvesExactlyThoseAndToleratesUnknownIds() {
+    createSpec("auth", "in_progress");
+    var firstOutput =
+        """
+        ```json
+        {"verdicts": [], "findings": [
+          {"severity": "HIGH", "category": "SECURITY", "file": "a.java",
+           "line_start": 1, "line_end": 1, "title": "Real bug", "description": "d", "confidence": 0.9},
+          {"severity": "LOW", "category": "LOGIC", "file": "b.java",
+           "line_start": 2, "line_end": 2, "title": "Nit", "description": "d", "confidence": 0.4}]}
+        ```
+        """;
+    var calls = new AtomicInteger();
+    ReviewAgentRunner runner =
+        (p, a, pr, rid, cred) -> {
+          if (calls.incrementAndGet() == 1) {
+            return firstOutput;
+          }
+          if (!pr.contains("Review the changes on branch")) {
+            return "fix applied";
+          }
+          return """
+              {"verdicts": [
+                {"finding_id": "%s", "verdict": "fixed", "evidence": "commit abc removes the leak"},
+                {"finding_id": "ghost", "verdict": "fixed", "evidence": "e"}
+              ], "findings": []}"""
+              .formatted(ReviewScripts.carriedId(pr, "Real bug"));
+        };
+    var ctrl = controller(p -> noHighGate(3), p -> "codex", runner, null);
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    var reviews = reviewStore.reviewsForSpec("auth");
+    assertEquals("passed", reviews.get(1).status());
+    var firstReviewFindings = reviewStore.findingsForReview(reviews.get(0).id());
+    var realBug =
+        firstReviewFindings.stream()
+            .filter(f -> f.title().equals("Real bug"))
+            .findFirst()
+            .orElseThrow();
+    var nit =
+        firstReviewFindings.stream().filter(f -> f.title().equals("Nit")).findFirst().orElseThrow();
+    assertEquals(Finding.Resolution.FIXED, realBug.resolution());
+    assertEquals("commit abc removes the leak", realBug.resolutionEvidence());
+    assertEquals(Finding.Resolution.OPEN, nit.resolution(), "only explicit fixed verdicts resolve");
+    var openAfterPass = reviewStore.openFindingsAfterPass("auth");
+    assertEquals(
+        List.of("Nit"),
+        openAfterPass.stream().map(Finding::title).toList(),
+        "open-after-pass counts exactly the unresolved sub-gate findings, not history");
+    assertEquals(
+        nit.id(),
+        openAfterPass.getFirst().carriedFrom(),
+        "the surviving nit is the same finding aging across iterations, visible as a chain");
+  }
+
+  @Test
+  void theDisputeNegotiationRetiresAFalsePositiveInTheOpenAndPassesTheGate() throws Exception {
+    createSpec("auth", "in_progress", List.of("api"));
+    var messages = new MessageStore(db);
+    var argument = "Worker cap is enforced upstream in Dispatcher.acquire; the finding is wrong";
+    var firstOutput =
+        """
+        ```json
+        {"verdicts": [], "findings": [
+          {"severity": "HIGH", "category": "CONCURRENCY", "file": "Worker.java",
+           "line_start": 4, "line_end": 4, "title": "Worker cap ignored", "description": "d", "confidence": 0.8},
+          {"severity": "HIGH", "category": "LOGIC", "file": "Snapshot.java",
+           "line_start": 8, "line_end": 8, "title": "Snapshot race", "description": "d", "confidence": 0.9}]}
+        ```
+        """;
+    var reReviewPrompt = new AtomicReference<String>();
+    var calls = new AtomicInteger();
+    var runner =
+        new ReviewAgentRunner() {
+          @Override
+          public String run(String p, String a, String pr, String rid, String cred) {
+            if (calls.incrementAndGet() == 1) {
+              return firstOutput;
+            }
+            reReviewPrompt.set(pr);
+            return """
+                {"verdicts": [
+                  {"finding_id": "%s", "verdict": "disputed", "evidence": "%s"},
+                  {"finding_id": "%s", "verdict": "fixed", "evidence": "commit def serializes the snapshot"}
+                ], "findings": []}"""
+                .formatted(
+                    ReviewScripts.carriedId(pr, "Worker cap ignored"),
+                    argument,
+                    ReviewScripts.carriedId(pr, "Snapshot race"));
+          }
+
+          @Override
+          public String runFix(
+              String p,
+              String a,
+              String prompt,
+              String rid,
+              String cred,
+              String branch,
+              List<String> repos,
+              String model,
+              String effort) {
+            messages.append("auth", "codex/fix", argument, null);
+            return "fixed the race, disputed the cap";
+          }
+        };
+
+    try (var bus = new EventBus()) {
+      var captured = captureEvents(bus, Set.of("review_completed"), 1);
+      var ctrl = controller(p -> noHighGate(3), p -> "codex", runner, bus);
+      ctrl.useMessages(messages);
+
+      ctrl.onEvent(agentStoppedEvent("auth"));
+      BusTesting.awaitDelivery(captured.latch());
+
+      var reviews = reviewStore.reviewsForSpec("auth");
+      assertEquals("passed", reviews.get(1).status(), "the negotiation converges in one round");
+      assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
+
+      var disputed = reviewStore.disputedFindings("auth");
+      assertEquals(List.of("Worker cap ignored"), disputed.stream().map(Finding::title).toList());
+      assertEquals(argument, disputed.getFirst().resolutionEvidence());
+      assertTrue(
+          reReviewPrompt.get().contains(argument),
+          "the re-review sees the fix agent's argument — the room rides the prompt");
+
+      var room = messages.list("auth", null, 50);
+      assertEquals(3, room.size(), "failed verdict, the dispute argument, passed verdict");
+      assertTrue(room.get(0).body().contains("Review failed"), room.get(0).body());
+      assertEquals(argument, room.get(1).body());
+      var passedBody = room.get(2).body();
+      assertTrue(passedBody.contains("Review passed"), passedBody);
+      assertTrue(
+          passedBody.contains("Disputed"),
+          "disputed findings are listed in the pass verdict for the human to confirm: "
+              + passedBody);
+      assertTrue(passedBody.contains("Worker cap ignored"), passedBody);
+      assertTrue(
+          passedBody.contains(argument),
+          "the ruled argument travels with the verdict so the human sees both sides");
+      assertTrue(
+          reviewStore.openFindingsAfterPass("auth").isEmpty(),
+          "a false positive retired by argument leaves nothing open — without a human dismiss");
     }
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewScripts.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewScripts.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Scripted reviewer responses for review-loop tests, all speaking the verdict envelope — the only
+ * response shape the parser admits. The helpers read the carried-finding ids straight out of the
+ * review prompt's carry-forward section, exactly as a real reviewer would, so a scripted re-review
+ * can rule on findings whose ids were minted at parse time.
+ */
+final class ReviewScripts {
+
+  static final String CLEAN_REVIEW = "{\"verdicts\": [], \"findings\": []}";
+
+  private ReviewScripts() {}
+
+  /** The carried findings listed in a review prompt, id → title, in listed order. */
+  static Map<String, String> carriedFromPrompt(String prompt) {
+    return prompt
+        .lines()
+        .filter(line -> line.startsWith("- finding_id "))
+        .collect(
+            Collectors.toMap(
+                line -> line.split(" ")[2],
+                line -> line.substring(line.indexOf("] ") + 2).split(" \\(")[0],
+                (a, b) -> a,
+                LinkedHashMap::new));
+  }
+
+  /** An envelope ruling every carried finding in the prompt {@code fixed} with evidence. */
+  static String fixAllCarried(String prompt) {
+    return fixAllCarried(prompt, "[]");
+  }
+
+  static String fixAllCarried(String prompt, String findingsJson) {
+    var verdicts =
+        carriedFromPrompt(prompt).keySet().stream()
+            .map(
+                id ->
+                    "{\"finding_id\": \"%s\", \"verdict\": \"fixed\", \"evidence\": \"commit abc\"}"
+                        .formatted(id))
+            .collect(Collectors.joining(", "));
+    return "{\"verdicts\": [" + verdicts + "], \"findings\": " + findingsJson + "}";
+  }
+
+  /** The id of the carried finding with this title, from the prompt's carry-forward section. */
+  static String carriedId(String prompt, String title) {
+    return carriedFromPrompt(prompt).entrySet().stream()
+        .filter(entry -> entry.getValue().equals(title))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("finding '" + title + "' not carried in prompt"))
+        .getKey();
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewScripts.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewScripts.java
@@ -50,6 +50,19 @@ final class ReviewScripts {
     return "{\"verdicts\": [" + verdicts + "], \"findings\": " + findingsJson + "}";
   }
 
+  /** An envelope disputing every carried finding in the prompt, evidence included. */
+  static String disputeAllCarried(String prompt) {
+    var verdicts =
+        carriedFromPrompt(prompt).keySet().stream()
+            .map(
+                id ->
+                    ("{\"finding_id\": \"%s\", \"verdict\": \"disputed\","
+                            + " \"evidence\": \"input is validated upstream\"}")
+                        .formatted(id))
+            .collect(Collectors.joining(", "));
+    return "{\"verdicts\": [" + verdicts + "], \"findings\": []}";
+  }
+
   /** The id of the carried finding with this title, from the prompt's carry-forward section. */
   static String carriedId(String prompt, String title) {
     return carriedFromPrompt(prompt).entrySet().stream()


### PR DESCRIPTION
Implements spec `sail-review-finding-identity`.

## Problem

Each review iteration was a fresh full-branch LLM scan with no memory of the previous one (field-verified on linkedin-bulk-capture-campaign, 2026-08-07): finding sets oscillated 4 → 3 → 5 → 3 with different "2 high" every time, nothing ever marked a finding FIXED (29 open findings on 16 done specs), the fix agent had no way to dispute a false positive, and escalation was a blind iteration counter that cannot tell a converging loop from a stuck one.

## Design

**One contract, from iteration 1.** The reviewer must respond with the verdict envelope — `{"verdicts": [...], "findings": [...]}` — and `FindingParser` admits nothing else: a bare findings array (or any off-contract output) errors the stage and rides the existing errored-retry lane (bounded by `MAX_ERRORED_RETRIES`, never burning an iteration). The transcript hardening (fence extraction, prompt-echo skipping, last-block-wins) is preserved; it locates the envelope in noisy output, it does not admit alternative formats.

**Carry-forward with fail-closed verdicts.** The re-review prompt lists the previous review's open findings (id, severity, title, file:line) and demands a ruling on every one. A carried finding missing from the verdicts defaults to `still_open`; `fixed`/`disputed` without evidence downgrade to `still_open`. `still_open` re-attaches the finding to the new review as a fresh row linked via the new `carried_from` column — one finding aging across iterations is one chain walk, and `Gate.passes` evaluates carried + new findings, so a reviewer that stops mentioning last iteration's high launders nothing.

**Evidence-bearing resolutions.** `fixed` and `disputed` resolve the predecessor row with the evidence recorded (`resolution_evidence` column, new `DISPUTED` resolution). A passed review auto-resolves nothing; only explicit fixed verdicts resolve, so `openFindingsAfterPass` reports exactly the unresolved sub-gate findings.

**Dispute lane.** `FixTaskBuilder` tells the fix agent: fix what is real; for a finding you believe is wrong, post your argument to the spec room (`spec comment`) and leave the code alone. The re-review sees the room and rules; disputed findings skip the gate but are listed in the room verdict — argument included — for the human. An agent can silence a finding only by arguing it in the open, never by omission.

**Convergence escalation.** A gate-blocking finding still open after `max_finding_age` fix iterations (default 2, configurable in `review_pipeline`) escalates with "finding <title> survived N fix iterations" — catching a stuck loop in 2 iterations instead of burning `max_iterations`. Oscillation (new highs while old ones resolve) keeps running to `max_iterations` as before: that loop is converging.

**Schema.** `review_findings` is rebuilt through the append-only migration chain (CHECK now admits `DISPUTED`; adds `resolution_evidence`, `carried_from`). The post-baseline chain now runs with foreign keys suspended and integrity verified, exactly like the on-ramp — otherwise the rebuild's `DROP TABLE` would cascade `spec_source_findings` links away. A migration test seeds a baseline database and asserts rows and links survive.

## Tests

`mvn clean verify` green (2600+ tests, spotless, jacoco gates incl. 100% line/method on `ai.singlr.sail.api.*`). New coverage: envelope parser (bare array off-contract, fail-closed reconcile, unknown-id warning), store chain walk / carry queries / disputed queries, prompt carry-forward rendering, fix-task dispute lane, controller carried-gate failure, stuck-finding escalation naming the finding, sub-gate findings aging freely, explicit-fixed resolution, and an end-to-end dispute negotiation (R1 two highs → fix disputes one + fixes one → R2 rules → gate passes; room shows the full negotiation).