### PR TITLE
Fix lane refinements: the reviewer's evidence travels, the author is honest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- A `still_open` ruling's evidence now travels with the finding instead of being discarded. The
+  carried row stores the ruling's evidence (`carry_evidence`, newest ruling wins; the
+  `carried_from` chain keeps the older ones), the next fix task renders it as a reproduction
+  claim the agent must answer — with code or a dispute argument, never a bare "already fixed" —
+  and the re-review prompt shows each carried finding alongside its own prior scenario. The
+  review prompt now asks `still_open` verdicts to describe the exact residual scenario.
+- Fix-lane room posts are attributed honestly. Rejoining a review run stamps the invocation's
+  own identity on the run row (`<agent>/fix-<reviewId>` for the fix lane,
+  `<reviewer>/review-<reviewId>` for a reviewer), journaled so it replicates — the room's audit
+  trail names the lane that wrote each post instead of crediting the fix agent's work to the
+  reviewer's principal.
+
 - Room messages now reach the live run. A new `sail-room-relay` PostToolUse hook delivers replies
   posted mid-run into the agent's context after its next tool call, on both Claude Code and Codex
   (both honor `additionalContext` injection). Each run keeps a `run_delivered_messages` ledger —

--- a/sail-core/src/main/java/ai/singlr/sail/engine/FixTaskBuilder.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/FixTaskBuilder.java
@@ -12,9 +12,12 @@ import java.util.List;
 /**
  * Generates a structured fix task from review findings for the coding agent. Each finding is
  * presented with its id, severity, category, file/line reference, evidence, and concrete
- * suggestion. The agent receives actionable instructions, not vague feedback — and a dispute lane:
- * a finding it believes is wrong is argued in the spec room for the re-review to rule on, never
- * coded around and never silently skipped.
+ * suggestion. A carried finding also presents the {@code still_open} ruling's evidence as a
+ * reproduction claim, so a fix agent that believes the finding already fixed must answer the
+ * reviewer's exact scenario — with code or a dispute argument, never a bare re-claim. The agent
+ * receives actionable instructions, not vague feedback — and a dispute lane: a finding it believes
+ * is wrong is argued in the spec room for the re-review to rule on, never coded around and never
+ * silently skipped.
  */
 public final class FixTaskBuilder {
 
@@ -95,6 +98,17 @@ public final class FixTaskBuilder {
 
       if (f.evidence() != null && !f.evidence().isEmpty()) {
         sb.append("Evidence: %s\n".formatted(f.evidence()));
+      }
+
+      if (f.carryEvidence() != null && !f.carryEvidence().isBlank()) {
+        sb.append(
+            """
+            Reviewer's evidence that this remains open: %s
+            Treat this as a reproduction claim — investigate this exact scenario before
+            re-claiming it fixed; if your investigation shows the scenario cannot occur,
+            dispute with that analysis.
+            """
+                .formatted(f.carryEvidence()));
       }
 
       if (f.suggestion() != null && !f.suggestion().rationale().isEmpty()) {

--- a/sail-core/src/main/java/ai/singlr/sail/engine/ReviewPromptBuilder.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/ReviewPromptBuilder.java
@@ -73,6 +73,8 @@ public final class ReviewPromptBuilder {
         - evidence: required for fixed (cite the commit or current code that resolves it) and
           for disputed (state why the finding is wrong; an argument posted in the conversation
           above counts). A fixed or disputed verdict without evidence is treated as still_open.
+          For still_open, describe the exact scenario that is still broken — the next fix
+          iteration reads it as its reproduction target.
         If no carried findings are listed above, "verdicts" must be an empty array.
 
         Each entry in "findings" reports a NEW issue (never repeat a carried finding) and must have:
@@ -102,8 +104,9 @@ public final class ReviewPromptBuilder {
 
   /**
    * The carry-forward contract: the previous review's open findings, each with the id the verdict
-   * must cite. Rendered before the response-format instructions so the reviewer reads what it must
-   * rule on before it reads how to answer.
+   * must cite and the evidence its carrying ruling rested on, so the re-review rules against its
+   * own prior scenario rather than rediscovering it. Rendered before the response-format
+   * instructions so the reviewer reads what it must rule on before it reads how to answer.
    */
   private static String carryForward(List<Finding> carried) {
     if (carried.isEmpty()) {
@@ -113,8 +116,8 @@ public final class ReviewPromptBuilder {
         carried.stream()
             .map(
                 f ->
-                    "- finding_id %s [%s] %s%s"
-                        .formatted(f.id(), f.severity(), f.title(), location(f)))
+                    "- finding_id %s [%s] %s%s%s"
+                        .formatted(f.id(), f.severity(), f.title(), location(f), carryEvidence(f)))
             .reduce((a, b) -> a + "\n" + b)
             .orElse("");
     return """
@@ -125,6 +128,13 @@ public final class ReviewPromptBuilder {
 
         """
         .formatted(lines);
+  }
+
+  private static String carryEvidence(Finding f) {
+    if (f.carryEvidence() == null || f.carryEvidence().isBlank()) {
+      return "";
+    }
+    return "\n  Prior ruling's evidence that it remains open: " + f.carryEvidence();
   }
 
   private static String location(Finding f) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/Finding.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/Finding.java
@@ -15,9 +15,12 @@ import java.util.Map;
  *
  * <p>A finding has identity across review iterations: when a re-review rules it {@code still_open},
  * a fresh row is attached to the new review with {@code carriedFrom} pointing at its predecessor,
- * so one finding aging across iterations is a single chain walk. A resolution that retires the
- * finding ({@code FIXED} by the reviewer's verdict, {@code DISPUTED} by a ruled argument) records
- * its {@code resolutionEvidence} — nothing resolves silently.
+ * so one finding aging across iterations is a single chain walk. The carried row also keeps the
+ * ruling that carried it: {@code carryEvidence} is the {@code still_open} verdict's evidence — the
+ * reviewer's sharpest explanation of what remains broken — which the next fix task and re-review
+ * render. A resolution that retires the finding ({@code FIXED} by the reviewer's verdict, {@code
+ * DISPUTED} by a ruled argument) records its {@code resolutionEvidence} — nothing resolves
+ * silently.
  */
 public record Finding(
     String id,
@@ -33,7 +36,8 @@ public record Finding(
     double confidence,
     Resolution resolution,
     String resolutionEvidence,
-    String carriedFrom) {
+    String carriedFrom,
+    String carryEvidence) {
 
   public enum Severity {
     CRITICAL,
@@ -120,15 +124,17 @@ public record Finding(
         confidence,
         Resolution.OPEN,
         null,
+        null,
         null);
   }
 
   /**
    * The open successor row a {@code still_open} verdict attaches to the next review: a fresh
    * identity linked to this finding through {@code carriedFrom}, so the chain records every
-   * iteration the finding survived.
+   * iteration the finding survived. {@code carryEvidence} is that verdict's evidence — each carry
+   * stores the latest ruling's explanation, the chain preserving the older ones.
    */
-  public Finding carriedCopy() {
+  public Finding carriedCopy(String carryEvidence) {
     return new Finding(
         DateTimeUtils.newId().toString(),
         severity,
@@ -143,7 +149,8 @@ public record Finding(
         confidence,
         Resolution.OPEN,
         null,
-        id);
+        id,
+        carryEvidence);
   }
 
   @SuppressWarnings("unchecked")
@@ -161,6 +168,7 @@ public record Finding(
         Suggestion.fromMap(map.get("suggestion")),
         doubleValue(map.getOrDefault("confidence", 0.5)),
         Resolution.OPEN,
+        null,
         null,
         null);
   }
@@ -183,6 +191,7 @@ public record Finding(
       m.put("resolution_evidence", resolutionEvidence);
     }
     if (carriedFrom != null) m.put("carried_from", carriedFrom);
+    if (carryEvidence != null && !carryEvidence.isEmpty()) m.put("carry_evidence", carryEvidence);
     return m;
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
@@ -280,11 +280,14 @@ public final class MessageStore {
     var ownsAuthor =
         peer.equals(author)
             || db.queryOne(
-                    "SELECT 1 FROM runs WHERE principal = ? AND owner = ? AND spec_id = ? LIMIT 1",
+                    "SELECT 1 FROM runs r WHERE r.owner = ? AND r.spec_id = ?"
+                        + " AND (r.principal = ? OR EXISTS (SELECT 1 FROM run_principals rp"
+                        + " WHERE rp.run_id = r.id AND rp.principal = ?)) LIMIT 1",
                     row -> true,
-                    author,
                     peer,
-                    specId)
+                    specId,
+                    author,
+                    author)
                 .orElse(false);
     if (!ownsAuthor) {
       return false;

--- a/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
@@ -321,10 +321,15 @@ public final class ReviewStore implements ConflictResolver {
    * whose {@code carried_from} points at its predecessor, storing the carrying ruling's evidence
    * with it, and returns the new row. The predecessor stays {@code OPEN} where it is — history is
    * never rewritten; the chain is the identity. Each re-carry stores the latest ruling's evidence —
-   * the newest explanation is the actionable one; the chain walk preserves the older ones.
+   * the newest explanation is the actionable one; the chain walk preserves the older ones. A blank
+   * ruling preserves the predecessor's evidence instead: fail-closed reconciliation synthesizes
+   * blank-evidence {@code still_open} rulings for omitted or unsupported verdicts, and defaulting
+   * must never erase the last actionable reproduction target.
    */
   public Finding carryForward(String stageId, Finding predecessor, String evidence) {
-    var carried = predecessor.carriedCopy(evidence);
+    var carried =
+        predecessor.carriedCopy(
+            Strings.isNotBlank(evidence) ? evidence : predecessor.carryEvidence());
     addFinding(stageId, carried);
     return carried;
   }

--- a/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
@@ -292,8 +292,8 @@ public final class ReviewStore implements ConflictResolver {
               INSERT INTO review_findings (id, stage_id, severity, category, file,
                   line_start, line_end, title, description, evidence,
                   suggestion_before, suggestion_after, suggestion_rationale,
-                  confidence, resolution, resolution_evidence, carried_from)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                  confidence, resolution, resolution_evidence, carried_from, carry_evidence)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
               finding.id(),
               stageId,
               finding.severity().name(),
@@ -310,18 +310,21 @@ public final class ReviewStore implements ConflictResolver {
               finding.confidence(),
               finding.resolution().name(),
               finding.resolutionEvidence(),
-              finding.carriedFrom());
+              finding.carriedFrom(),
+              finding.carryEvidence());
           journalForStage(stageId);
         });
   }
 
   /**
    * Re-attaches a still-open finding from the previous review to the given stage as a fresh row
-   * whose {@code carried_from} points at its predecessor, and returns the new row. The predecessor
-   * stays {@code OPEN} where it is — history is never rewritten; the chain is the identity.
+   * whose {@code carried_from} points at its predecessor, storing the carrying ruling's evidence
+   * with it, and returns the new row. The predecessor stays {@code OPEN} where it is — history is
+   * never rewritten; the chain is the identity. Each re-carry stores the latest ruling's evidence —
+   * the newest explanation is the actionable one; the chain walk preserves the older ones.
    */
-  public Finding carryForward(String stageId, Finding predecessor) {
-    var carried = predecessor.carriedCopy();
+  public Finding carryForward(String stageId, Finding predecessor, String evidence) {
+    var carried = predecessor.carriedCopy(evidence);
     addFinding(stageId, carried);
     return carried;
   }
@@ -342,7 +345,7 @@ public final class ReviewStore implements ConflictResolver {
         () -> {
           for (var ruling : rulings) {
             if (ruling.resolution() == Finding.Resolution.OPEN) {
-              carryForward(stageId, ruling.finding());
+              carryForward(stageId, ruling.finding(), ruling.evidence());
             } else {
               resolveFinding(ruling.finding().id(), ruling.resolution(), ruling.evidence());
             }
@@ -355,7 +358,7 @@ public final class ReviewStore implements ConflictResolver {
       "f.id, f.severity, f.category, f.file, f.line_start, f.line_end,"
           + " f.title, f.description, f.evidence, f.suggestion_before,"
           + " f.suggestion_after, f.suggestion_rationale, f.confidence, f.resolution,"
-          + " f.resolution_evidence, f.carried_from";
+          + " f.resolution_evidence, f.carried_from, f.carry_evidence";
 
   private static final String SEVERITY_ORDER =
       "CASE f.severity WHEN 'CRITICAL' THEN 0 WHEN 'HIGH' THEN 1"
@@ -960,6 +963,7 @@ public final class ReviewStore implements ConflictResolver {
         row.isNull(12) ? 0.0 : Double.parseDouble(row.text(12)),
         Finding.Resolution.valueOf(row.text(13)),
         row.text(14),
-        row.text(15));
+        row.text(15),
+        row.text(16));
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -221,14 +221,21 @@ public final class RunStore implements ConflictResolver {
   }
 
   /**
-   * Rotates the credential of a live run — the seam the review pipeline's fix lane uses to rejoin
-   * its review's identity after the reviewer invocation already created the run. The original
-   * plaintext is unrecoverable by design, so rejoining means a fresh credential; the run holds
-   * exactly one at a time (the schema enforces it), so rotation retires the previous invocation's
-   * credential in the same transaction. Fails loud on a missing or finished run — a dead run's
-   * identity is never resurrected.
+   * Rotates the credential of a live run — the seam the review pipeline's lanes use to rejoin the
+   * run after another invocation already created it (the fix lane rejoining its review's still-open
+   * negotiation, a later stage's reviewer rejoining after it). The original plaintext is
+   * unrecoverable by design, so rejoining means a fresh credential; the run holds exactly one at a
+   * time (the schema enforces it), so rotation retires the previous invocation's credential in the
+   * same transaction. The rejoining invocation also stamps its own identity: the run row's {@code
+   * agent} and {@code principal} become the invocation's ({@code <agent>/fix-<id>} for the fix
+   * lane, {@code <agent>/review-<id>} for a reviewer), journaled so the honest attribution
+   * replicates — rooms and run views read the principal, and the author must be the lane that
+   * wrote. Fails loud on a missing or finished run — a dead run's identity is never resurrected.
+   *
+   * @param lane {@code "fix"} or {@code "review"} — the invocation rejoining the run, which selects
+   *     the principal's marker; the run row's {@code role} stays {@code review}
    */
-  public String rotateCredential(String id) {
+  public String rotateCredential(String id, String agent, String lane) {
     return db.transaction(
         () -> {
           var run =
@@ -241,8 +248,15 @@ public final class RunStore implements ConflictResolver {
             throw new IllegalStateException(
                 "Run " + id + " is " + run.status() + "; only a running run can be credentialed.");
           }
+          db.execute(
+              "UPDATE runs SET agent = ?, principal = ? WHERE id = ?",
+              agent,
+              principalHandle(agent, lane, id),
+              id);
           revokeCredential(id);
-          return mintCredential(id, null);
+          var credential = mintCredential(id, null);
+          recordRevision(id, "local", false);
+          return credential;
         });
   }
 
@@ -425,17 +439,23 @@ public final class RunStore implements ConflictResolver {
 
   /**
    * The run's minted principal handle: the agent family (the yaml name up to its first dash) over
-   * the full run id, with review runs marked as such — {@code claude/<run-uuid>}, {@code
-   * claude/review-<run-uuid>}. The whole UUID, never a truncation: the handle is a security
-   * identity compared in ownership checks and audit rows, so it must be exactly as collision-proof
-   * as the run id itself.
+   * the full run id, with review and fix invocations marked as such — {@code claude/<run-uuid>},
+   * {@code claude/review-<run-uuid>}, {@code claude/fix-<run-uuid>}. The whole UUID, never a
+   * truncation: the handle is a security identity compared in ownership checks and audit rows, so
+   * it must be exactly as collision-proof as the run id itself.
    */
   private static String principalHandle(String agent, String role, String id) {
     var family = Objects.toString(agent, "");
     var dash = family.indexOf('-');
     var base = dash > 0 ? family.substring(0, dash) : family;
     var runId = Objects.requireNonNull(id, "run id");
-    return base + "/" + ("review".equals(role) ? "review-" + runId : runId);
+    var marker =
+        switch (Objects.toString(role, "")) {
+          case "review" -> "review-";
+          case "fix" -> "fix-";
+          default -> "";
+        };
+    return base + "/" + marker + runId;
   }
 
   private String mintCredential(String id, Duration maxDuration) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -188,6 +188,7 @@ public final class RunStore implements ConflictResolver {
               unit,
               principalHandle(agent, role, id),
               owner);
+          recordPrincipal(id, principalHandle(agent, role, id));
           var credential = mintCredential(id, null);
           recordRevision(id, "local", false);
           return credential;
@@ -253,6 +254,7 @@ public final class RunStore implements ConflictResolver {
               agent,
               principalHandle(agent, lane, id),
               id);
+          recordPrincipal(id, principalHandle(agent, lane, id));
           revokeCredential(id);
           var credential = mintCredential(id, null);
           recordRevision(id, "local", false);
@@ -359,6 +361,7 @@ public final class RunStore implements ConflictResolver {
               YamlUtil.dumpJson(reserved),
               principalHandle(agent, role, id),
               owner);
+          recordPrincipal(id, principalHandle(agent, role, id));
           var credential = mintCredential(id, maxDuration);
           recordRevision(id, "local", false);
           return new Reservation.Reserved(credential);
@@ -444,6 +447,33 @@ public final class RunStore implements ConflictResolver {
    * truncation: the handle is a security identity compared in ownership checks and audit rows, so
    * it must be exactly as collision-proof as the run id itself.
    */
+  /**
+   * The run's replicated, append-only principal history: every identity a legitimate invocation of
+   * this run has ever posted under. The runs row keeps only the current principal for honest live
+   * attribution; message authorization on main checks membership here, so a room message authored
+   * before a lane rotation still authenticates when it synchronizes late. Never pruned while the
+   * run exists; cascades away with it.
+   */
+  public List<String> principals(String id) {
+    return db.query(
+        "SELECT principal FROM run_principals WHERE run_id = ? ORDER BY principal",
+        row -> row.text(0),
+        id);
+  }
+
+  private void recordPrincipal(String id, String principal) {
+    if (Strings.isBlank(principal)) {
+      return;
+    }
+    db.execute(
+        "INSERT OR IGNORE INTO run_principals (run_id, principal) VALUES (?, ?)", id, principal);
+  }
+
+  private void recordPrincipals(String id, Map<String, Object> snapshot) {
+    stringList(snapshot, "principals").forEach(principal -> recordPrincipal(id, principal));
+    recordPrincipal(id, text(snapshot, "principal"));
+  }
+
   private static String principalHandle(String agent, String role, String id) {
     var family = Objects.toString(agent, "");
     var dash = family.indexOf('-');
@@ -749,7 +779,14 @@ public final class RunStore implements ConflictResolver {
   }
 
   public Map<String, Object> comparableSnapshot(String id) {
-    return findById(id).map(RunStore::comparable).orElse(null);
+    return findById(id)
+        .map(
+            run -> {
+              var map = snapshotMap(run);
+              map.put("principals", principals(id));
+              return comparable(map);
+            })
+        .orElse(null);
   }
 
   public Map<String, Object> comparableAtRev(String id, String rev) {
@@ -797,6 +834,7 @@ public final class RunStore implements ConflictResolver {
             adoptDeletion(id, rev);
           } else {
             writeRow(rowFrom(id, snapshot));
+            recordPrincipals(id, snapshot);
             recordRevision(id, rev, "sync", false, true);
           }
         });
@@ -819,6 +857,7 @@ public final class RunStore implements ConflictResolver {
             return new PushOutcome.Accepted(rev);
           }
           writeRow(rowFrom(id, snapshot));
+          recordPrincipals(id, snapshot);
           return new PushOutcome.Accepted(recordRevision(id, null, "sync", false, false));
         });
   }
@@ -845,6 +884,7 @@ public final class RunStore implements ConflictResolver {
       return adoptBaseDeletion(id);
     }
     writeRow(rowFrom(id, remote));
+    recordPrincipals(id, remote);
     return recordRevision(id, null, "sync", false, true);
   }
 
@@ -871,6 +911,7 @@ public final class RunStore implements ConflictResolver {
       return rev;
     }
     writeRow(rowFrom(id, chosen));
+    recordPrincipals(id, chosen);
     return recordRevision(id, null, "resolve", false, false);
   }
 
@@ -895,6 +936,7 @@ public final class RunStore implements ConflictResolver {
       return null;
     }
     var map = snapshotMap(run);
+    map.put("principals", principals(id));
     if (deleted) {
       map.put("_base_rev", rawBaseRev(id));
     }

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -148,7 +148,8 @@ public final class SchemaManager {
               run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
               message_id TEXT NOT NULL REFERENCES spec_messages(id) ON DELETE CASCADE,
               PRIMARY KEY (run_id, message_id)
-          )""");
+          )""",
+          "ALTER TABLE review_findings ADD COLUMN carry_evidence TEXT");
 
   /** The schema version this binary converges every database to. */
   static final int CURRENT_VERSION = V1_VERSION + MIGRATIONS.size();

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -144,6 +144,13 @@ public final class SchemaManager {
           "CREATE INDEX idx_review_findings_stage ON review_findings(stage_id)",
           "CREATE INDEX idx_review_findings_severity ON review_findings(severity)",
           """
+          CREATE TABLE run_principals (
+              run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+              principal TEXT NOT NULL,
+              PRIMARY KEY (run_id, principal)
+          )""",
+          "INSERT INTO run_principals SELECT id, principal FROM runs WHERE principal IS NOT NULL",
+          """
           CREATE TABLE run_delivered_messages (
               run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
               message_id TEXT NOT NULL REFERENCES spec_messages(id) ON DELETE CASCADE,

--- a/sail-core/src/test/java/ai/singlr/sail/config/ReviewPipelineConfigTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/ReviewPipelineConfigTest.java
@@ -178,6 +178,7 @@ class ReviewPipelineConfigTest {
             0.9,
             Finding.Resolution.DISMISSED,
             null,
+            null,
             null);
 
     assertTrue(Gate.NO_CRITICAL.passes(List.of(dismissed)));
@@ -200,6 +201,7 @@ class ReviewPipelineConfigTest {
             0.9,
             Finding.Resolution.DISPUTED,
             "the reviewer ruled the argument valid",
+            null,
             null);
 
     assertTrue(Gate.NO_CRITICAL.passes(List.of(disputed)));
@@ -289,6 +291,7 @@ class ReviewPipelineConfigTest {
             0.8,
             Finding.Resolution.FIXED,
             "commit abc",
+            null,
             null);
 
     assertTrue(Gate.ALL_CLEAR.passes(List.of(fixed)));

--- a/sail-core/src/test/java/ai/singlr/sail/engine/FixTaskBuilderTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/FixTaskBuilderTest.java
@@ -51,6 +51,54 @@ class FixTaskBuilderTest {
   }
 
   @Test
+  void aCarriedFindingRendersTheReviewersEvidenceAsAReproductionClaim() {
+    var carried =
+        Finding.create(
+                Finding.Severity.HIGH,
+                Finding.Category.CONCURRENCY,
+                "src/Dispatch.java",
+                10,
+                12,
+                "Seed-window race",
+                "Two dispatches can claim one seed.",
+                "Trace of the race",
+                null,
+                0.9)
+            .carriedCopy("restart between reserve and claim still double-seeds");
+
+    var task = FixTaskBuilder.build("auth", "OAuth flow", List.of(carried), List.of()).task();
+
+    assertTrue(
+        task.contains(
+            "Reviewer's evidence that this remains open: restart between reserve and claim"
+                + " still double-seeds"));
+    assertTrue(task.contains("Treat this as a reproduction claim"));
+    assertTrue(task.contains("investigate this exact scenario before"));
+    assertTrue(task.contains("dispute with that analysis"));
+  }
+
+  @Test
+  void aFindingWithoutCarryEvidenceRendersWithoutTheReproductionClaim() {
+    var fresh =
+        Finding.create(
+            Finding.Severity.HIGH,
+            Finding.Category.LOGIC,
+            "a.java",
+            1,
+            1,
+            "New issue",
+            "Desc",
+            "Evidence",
+            null,
+            0.8);
+
+    var task = FixTaskBuilder.build("auth", "OAuth flow", List.of(fresh), List.of()).task();
+
+    assertFalse(task.contains("Reviewer's evidence that this remains open"));
+    assertFalse(task.contains("reproduction claim"));
+  }
+
+  @Test
   void multiLineRangeShowsStartAndEnd() {
     var finding =
         Finding.create(

--- a/sail-core/src/test/java/ai/singlr/sail/engine/ReviewPromptBuilderTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/ReviewPromptBuilderTest.java
@@ -74,6 +74,60 @@ class ReviewPromptBuilderTest {
   }
 
   @Test
+  void carryForwardSectionRendersThePriorRulingsEvidence() {
+    var carried =
+        Finding.create(
+                Finding.Severity.HIGH,
+                Finding.Category.CONCURRENCY,
+                "src/Worker.java",
+                10,
+                14,
+                "Non-atomic target selection",
+                "d",
+                "e",
+                null,
+                0.9)
+            .carriedCopy("the seed window still races between reserve and claim");
+
+    var prompt =
+        ReviewPromptBuilder.build("main", List.of("app"), List.of(), List.of(), List.of(carried));
+
+    assertTrue(
+        prompt.contains(
+            "Prior ruling's evidence that it remains open: the seed window still races"
+                + " between reserve and claim"),
+        prompt);
+  }
+
+  @Test
+  void aCarriedFindingWithoutCarryEvidenceRendersItsLineAlone() {
+    var carried =
+        Finding.create(
+            Finding.Severity.HIGH,
+            Finding.Category.CONCURRENCY,
+            "src/Worker.java",
+            10,
+            14,
+            "Non-atomic target selection",
+            "d",
+            "e",
+            null,
+            0.9);
+
+    var prompt =
+        ReviewPromptBuilder.build("main", List.of("app"), List.of(), List.of(), List.of(carried));
+
+    assertTrue(!prompt.contains("Prior ruling's evidence"), prompt);
+  }
+
+  @Test
+  void asksForTheResidualScenarioOnStillOpenVerdicts() {
+    var prompt = ReviewPromptBuilder.build("main", List.of("app"), List.of());
+    assertTrue(prompt.contains("For still_open, describe the exact scenario"));
+    assertTrue(prompt.contains("reproduction target"));
+  }
+
+  @Test
   void carriedFindingWithoutFileRendersWithoutLocation() {
     var carried =
         Finding.create(

--- a/sail-core/src/test/java/ai/singlr/sail/store/FindingTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/FindingTest.java
@@ -156,6 +156,34 @@ class FindingTest {
   }
 
   @Test
+  void carriedCopyStoresTheCarryingRulingsEvidenceOnAFreshIdentity() {
+    var original =
+        Finding.create(
+            Finding.Severity.HIGH,
+            Finding.Category.CONCURRENCY,
+            "src/Dispatch.java",
+            10,
+            15,
+            "Seed-window race",
+            "Desc",
+            "Evidence",
+            null,
+            0.9);
+
+    var carried = original.carriedCopy("the seed window still races on restart");
+
+    assertNotEquals(original.id(), carried.id());
+    assertEquals(original.id(), carried.carriedFrom());
+    assertEquals("the seed window still races on restart", carried.carryEvidence());
+    assertNull(original.carryEvidence());
+    assertEquals(
+        "the seed window still races on restart",
+        carried.toMap().get("carry_evidence"),
+        "the carried evidence joins the serialized view");
+    assertFalse(original.toMap().containsKey("carry_evidence"));
+  }
+
+  @Test
   void severityParseCaseInsensitive() {
     assertEquals(Finding.Severity.CRITICAL, Finding.Severity.parse("critical"));
     assertEquals(Finding.Severity.HIGH, Finding.Severity.parse(" HIGH "));

--- a/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
@@ -533,13 +533,44 @@ class ReviewStoreTest {
     var r2 = store.createReview("auth", 2);
     var stage2 = store.createStage(r2, "security", "agent");
 
-    var carried = store.carryForward(stage2, original);
+    var carried = store.carryForward(stage2, original, "still repros via the seed window");
 
     assertEquals(original.id(), carried.carriedFrom());
     assertTrue(!carried.id().equals(original.id()), "a carried row is a fresh identity");
     assertEquals(
         Finding.Resolution.OPEN, store.findFinding(original.id()).orElseThrow().resolution());
-    assertEquals("Stubborn high", store.findingsForStage(stage2).getFirst().title());
+    var stored = store.findingsForStage(stage2).getFirst();
+    assertEquals("Stubborn high", stored.title());
+    assertEquals(
+        "still repros via the seed window",
+        stored.carryEvidence(),
+        "the ruling's evidence persists on the carried row");
+    assertNull(
+        store.findFinding(original.id()).orElseThrow().carryEvidence(),
+        "the predecessor is history and is never rewritten");
+  }
+
+  @Test
+  void eachReCarryStoresTheLatestRulingsEvidenceAndTheChainKeepsTheOlderOnes() {
+    var r1 = store.createReview("auth", 1);
+    var stage1 = store.createStage(r1, "security", "agent");
+    var original = addOpenFinding(stage1, Finding.Severity.HIGH, "Stubborn high");
+    var r2 = store.createReview("auth", 2);
+    var stage2 = store.createStage(r2, "security", "agent");
+    var second = store.carryForward(stage2, original, "first scenario");
+    var r3 = store.createReview("auth", 3);
+    var stage3 = store.createStage(r3, "security", "agent");
+
+    var third = store.carryForward(stage3, second, "sharper second scenario");
+
+    assertEquals(
+        "sharper second scenario",
+        store.findFinding(third.id()).orElseThrow().carryEvidence(),
+        "the newest ruling's explanation is the actionable one");
+    assertEquals(
+        "first scenario",
+        store.findFinding(second.id()).orElseThrow().carryEvidence(),
+        "the chain walk preserves every prior ruling's evidence");
   }
 
   @Test
@@ -549,10 +580,10 @@ class ReviewStoreTest {
     var original = addOpenFinding(stage1, Finding.Severity.HIGH, "Aging high");
     var r2 = store.createReview("auth", 2);
     var stage2 = store.createStage(r2, "security", "agent");
-    var second = store.carryForward(stage2, original);
+    var second = store.carryForward(stage2, original, null);
     var r3 = store.createReview("auth", 3);
     var stage3 = store.createStage(r3, "security", "agent");
-    var third = store.carryForward(stage3, second);
+    var third = store.carryForward(stage3, second, null);
 
     var chain = store.findingChain(third.id());
 
@@ -622,7 +653,7 @@ class ReviewStoreTest {
         store.carryForwardFindings("auth", r3, "security").stream().map(Finding::id).toList(),
         "an errored review has no verdict; the carry set comes from the last real one");
 
-    store.carryForward(stage3, open);
+    store.carryForward(stage3, open, null);
     assertTrue(
         store.carryForwardFindings("auth", r3, "security").isEmpty(),
         "a finding already re-attached to this review is not carried twice");
@@ -714,20 +745,23 @@ class ReviewStoreTest {
         stage2,
         List.of(
             new ReviewStore.StageRuling(fixed, Finding.Resolution.FIXED, "commit abc"),
-            new ReviewStore.StageRuling(stubborn, Finding.Resolution.OPEN, "")),
+            new ReviewStore.StageRuling(
+                stubborn, Finding.Resolution.OPEN, "the seed window still races")),
         List.of(fresh));
 
-    assertEquals(
-        Finding.Resolution.FIXED, store.findFinding(fixed.id()).orElseThrow().resolution());
+    var resolved = store.findFinding(fixed.id()).orElseThrow();
+    assertEquals(Finding.Resolution.FIXED, resolved.resolution());
+    assertEquals("commit abc", resolved.resolutionEvidence());
+    assertNull(resolved.carryEvidence(), "a resolving ruling stores its evidence as resolution");
     var stageFindings = store.findingsForStage(stage2);
     assertEquals(2, stageFindings.size());
+    var carried =
+        stageFindings.stream().filter(f -> f.carriedFrom() != null).findFirst().orElseThrow();
+    assertEquals(stubborn.id(), carried.carriedFrom());
     assertEquals(
-        stubborn.id(),
-        stageFindings.stream()
-            .filter(f -> f.carriedFrom() != null)
-            .findFirst()
-            .orElseThrow()
-            .carriedFrom());
+        "the seed window still races",
+        carried.carryEvidence(),
+        "the still_open ruling's evidence travels on the carried row");
   }
 
   @Test
@@ -753,6 +787,7 @@ class ReviewStoreTest {
             null,
             0.9,
             Finding.Resolution.OPEN,
+            null,
             null,
             null);
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
@@ -526,6 +526,31 @@ class ReviewStoreTest {
   }
 
   @Test
+  void aBlankRulingPreservesThePredecessorsCarryEvidence() {
+    var r1 = store.createReview("auth", 1);
+    var stage1 = store.createStage(r1, "security", "agent");
+    var original = addOpenFinding(stage1, Finding.Severity.HIGH, "Stubborn high");
+    var r2 = store.createReview("auth", 2);
+    var stage2 = store.createStage(r2, "security", "agent");
+    var carried = store.carryForward(stage2, original, "still repros via the seed window");
+    var r3 = store.createReview("auth", 3);
+    var stage3 = store.createStage(r3, "security", "agent");
+
+    var recarried = store.carryForward(stage3, carried, "");
+
+    assertEquals(
+        "still repros via the seed window",
+        recarried.carryEvidence(),
+        "fail-closed defaulting synthesizes blank-evidence still_open rulings — a blank ruling"
+            + " must preserve the last actionable reproduction target, never erase it");
+    var overwritten = store.carryForward(stage3, carried, "sharper scenario");
+    assertEquals(
+        "sharper scenario",
+        overwritten.carryEvidence(),
+        "a genuine newer explanation still replaces the previous one");
+  }
+
+  @Test
   void carryForwardCreatesALinkedRowAndLeavesThePredecessorOpen() {
     var r1 = store.createReview("auth", 1);
     var stage1 = store.createStage(r1, "security", "agent");

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -1400,6 +1400,41 @@ class RunStoreTest {
   }
 
   @Test
+  void rotationAppendsToTheReplicatedPrincipalHistory() {
+    var id = newRun("backend", "auth");
+    var first = store.findById(id).orElseThrow().principal();
+
+    store.rotateCredential(id, "claude-code", "fix");
+
+    var rotated = store.findById(id).orElseThrow().principal();
+    assertTrue(rotated.contains("fix"), "the live row shows the current lane's identity");
+    assertEquals(
+        List.of(first, rotated).stream().sorted().toList(),
+        store.principals(id),
+        "history is append-only: rotation never erases the identity earlier messages were"
+            + " authored under");
+    var snapshot = store.comparableSnapshot(id);
+    assertEquals(
+        store.principals(id),
+        snapshot.get("principals"),
+        "the history replicates with the run, so main can authenticate late-syncing messages");
+  }
+
+  @Test
+  void adoptingAnOldShapeSnapshotDerivesTheHistoryFromItsPrincipal() {
+    var id = newRun("backend", "auth");
+    var snapshot = new java.util.LinkedHashMap<>(store.comparableSnapshot(id));
+    var principal = (String) snapshot.get("principal");
+    snapshot.remove("principals");
+
+    store.applyRevision(id, snapshot, "2-remote");
+
+    assertTrue(
+        store.principals(id).contains(principal),
+        "a snapshot without a history list still records its current principal as a member");
+  }
+
+  @Test
   void seedingByExactIdentityNeverSweepsALateSyncingOlderMessage() {
     var id = newRun("backend", "auth");
     var messages = new MessageStore(db);

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -1153,7 +1153,7 @@ class RunStoreTest {
     var id = DateTimeUtils.newId().toString();
     var original = createReview(id);
 
-    var rotated = store.rotateCredential(id);
+    var rotated = store.rotateCredential(id, "claude-code", "fix");
 
     assertEquals(id, store.findByCredential(rotated).orElseThrow().id());
     assertTrue(
@@ -1168,8 +1168,32 @@ class RunStoreTest {
   }
 
   @Test
+  void rotateCredentialStampsTheRejoiningInvocationsIdentityAndJournalsIt() {
+    var id = DateTimeUtils.newId().toString();
+    createReview(id);
+
+    store.rotateCredential(id, "claude-code", "fix");
+
+    var asFix = store.findById(id).orElseThrow();
+    assertEquals("claude-code", asFix.agent());
+    assertEquals("claude/fix-" + id, asFix.principal());
+    assertEquals("review", asFix.role(), "the row stays a review run; only the identity changes");
+    assertEquals(
+        "claude/fix-" + id,
+        store.comparableSnapshot(id).get("principal"),
+        "the honest attribution joins the journaled snapshot and replicates");
+
+    store.rotateCredential(id, "codex", "review");
+
+    var asReviewer = store.findById(id).orElseThrow();
+    assertEquals("codex", asReviewer.agent());
+    assertEquals("codex/review-" + id, asReviewer.principal());
+  }
+
+  @Test
   void rotateCredentialRefusesAMissingOrFinishedRun() {
-    assertThrows(IllegalStateException.class, () -> store.rotateCredential("ghost"));
+    assertThrows(
+        IllegalStateException.class, () -> store.rotateCredential("ghost", "codex", "review"));
 
     var id = DateTimeUtils.newId().toString();
     createReview(id);
@@ -1177,7 +1201,7 @@ class RunStoreTest {
 
     assertThrows(
         IllegalStateException.class,
-        () -> store.rotateCredential(id),
+        () -> store.rotateCredential(id, "codex", "review"),
         "a dead run's identity is never resurrected");
   }
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -362,13 +362,17 @@ class SchemaManagerTest {
 
     var survived =
         db.queryOne(
-                "SELECT title, resolution, carried_from, resolution_evidence"
+                "SELECT title, resolution, carried_from, resolution_evidence, carry_evidence"
                     + " FROM review_findings WHERE id = 'f1'",
                 r ->
                     List.of(
-                        r.text(0), r.text(1), String.valueOf(r.text(2)), String.valueOf(r.text(3))))
+                        r.text(0),
+                        r.text(1),
+                        String.valueOf(r.text(2)),
+                        String.valueOf(r.text(3)),
+                        String.valueOf(r.text(4))))
             .orElseThrow();
-    assertEquals(List.of("Leak", "OPEN", "null", "null"), survived);
+    assertEquals(List.of("Leak", "OPEN", "null", "null", "null"), survived);
     assertEquals(
         1,
         (int)

--- a/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
@@ -105,6 +105,30 @@ class MessageSyncTest {
   }
 
   @Test
+  void aMessageAuthoredBeforePrincipalRotationStillSyncs() {
+    var reviewId = "019fee00-0000-7000-8000-0000000000aa";
+    main.db.execute("UPDATE specs SET assignee = 'node' WHERE id = 'room'");
+    var runs = new ai.singlr.sail.store.RunStore(main.db);
+    runs.createReview(reviewId, "acme", "room", "node", "node", "codex", "b", "t", "/log", "unit");
+    var reviewerPrincipal = runs.findById(reviewId).orElseThrow().principal();
+    runs.rotateCredential(reviewId, "claude-code", "fix");
+
+    var accepted =
+        SyncPeer.with(
+            "node",
+            () ->
+                main.messages.commitRevision(
+                    "019fee00-0000-7000-8000-0000000000ab",
+                    snapshot(reviewerPrincipal, "room"),
+                    null));
+
+    assertTrue(
+        accepted instanceof ai.singlr.sail.store.PushOutcome.Accepted,
+        "a reviewer-authored message that synchronizes after the fix lane rotated the run's"
+            + " principal authenticates against the replicated history, never wedging sync");
+  }
+
+  @Test
   void authenticatedPeerCannotForgeAnotherFdeAuthor() {
     var messageId = "00000000-0000-7000-8000-000000000001";
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -425,7 +425,8 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
           ReviewPromptBuilder.build(
               branch, repos, stageConfig.categories(), roomMessages(specId), carried);
 
-      var credential = startReviewRun(stage.reviewId(), project, specId, agent, branch, prompt);
+      var credential =
+          startReviewRun(stage.reviewId(), project, specId, agent, branch, prompt, "review");
       var effort = spec.map(SpecStore.SpecRow::reasoningEffort).orElse(null);
       var output =
           agentRunner.run(project, agent, prompt, stage.reviewId(), credential, null, effort);
@@ -602,11 +603,13 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
   }
 
   /**
-   * The fix agent runs under the failed review's identity, appending to that review's log. It runs
-   * with the stop-readiness gate armed ({@link ReviewAgentRunner#runFix}) so it cannot end its turn
-   * with a dirty tree, and {@link ReviewAgentRunner#ensureCommitted} stays as the deterministic
-   * backstop — otherwise the re-review judges a branch without the fixes and the shared clone
-   * carries the leftovers into the next dispatch.
+   * The fix agent rejoins the failed review's run, appending to that review's log, but acts as
+   * itself: the rejoin stamps {@code <agent>/fix-<reviewId>} on the run row, so the room's audit
+   * trail attributes its posts to the fix lane, never to the reviewer. It runs with the
+   * stop-readiness gate armed ({@link ReviewAgentRunner#runFix}) so it cannot end its turn with a
+   * dirty tree, and {@link ReviewAgentRunner#ensureCommitted} stays as the deterministic backstop —
+   * otherwise the re-review judges a branch without the fixes and the shared clone carries the
+   * leftovers into the next dispatch.
    */
   private void triggerFixIteration(
       String reviewId, String specId, List<Finding> findings, String project) {
@@ -622,7 +625,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     try {
       var agent = spec.get().agent() != null ? spec.get().agent() : "claude-code";
       var credential =
-          startReviewRun(reviewId, project, specId, agent, spec.get().branch(), fixTask);
+          startReviewRun(reviewId, project, specId, agent, spec.get().branch(), fixTask, "fix");
       seedRoomDelivery(reviewId, built.renderedMessages());
       agentRunner.runFix(
           project,
@@ -849,17 +852,28 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
 
   /**
    * Ensures the review run exists and returns a live plaintext credential for it — created with the
-   * row on the reviewer's first invocation, rotated when the fix lane rejoins the still-open
-   * negotiation (the original plaintext is hashed at rest and unrecoverable). Blank without a run
-   * store, launching the agent without an identity.
+   * row on the reviewer's first invocation, rotated when a later invocation rejoins the still-open
+   * negotiation (the original plaintext is hashed at rest and unrecoverable). The rejoin stamps the
+   * invocation's own identity on the run row — {@code <agent>/fix-<reviewId>} for the fix lane,
+   * {@code <agent>/review-<reviewId>} for a reviewer — so room posts and run views attribute each
+   * write to the lane that made it. Blank without a run store, launching the agent without an
+   * identity.
    */
   private String startReviewRun(
-      String reviewId, String project, String specId, String agent, String branch, String task) {
+      String reviewId,
+      String project,
+      String specId,
+      String agent,
+      String branch,
+      String task,
+      String lane) {
     if (runStore == null) {
       return "";
     }
     if (runStore.findById(reviewId).isPresent()) {
-      return runStore.rotateCredential(reviewId);
+      var credential = runStore.rotateCredential(reviewId, agent, lane);
+      syncTrigger.run();
+      return credential;
     }
     var unit = AgentUnit.forReview(reviewId);
     var owner =

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -1663,7 +1663,8 @@ class ReviewPipelineControllerTest {
     var credentials = new java.util.concurrent.CopyOnWriteArrayList<List<String>>();
     ReviewAgentRunner runner =
         (p, a, pr, rid, cred) -> {
-          credentials.add(List.of(rid, cred));
+          credentials.add(
+              List.of(rid, cred, runs.findByCredential(cred).orElseThrow().principal()));
           return calls.incrementAndGet() == 1 ? criticalOutput : fixAllCarried(pr);
         };
     var ctrl =
@@ -1681,20 +1682,119 @@ class ReviewPipelineControllerTest {
 
     ctrl.onEvent(agentStoppedEvent("auth"));
 
-    assertTrue(credentials.size() >= 2, "reviewer and fix agent both ran");
+    assertEquals(3, credentials.size(), "reviewer, fix agent, and re-reviewer all ran");
     for (var invocation : credentials) {
-      var reviewId = invocation.get(0);
-      var credential = invocation.get(1);
-      assertFalse(credential.isBlank(), "every review invocation carries a credential");
-      var resolvedAtCallTime = runs.findById(reviewId).orElseThrow();
-      assertEquals(
-          "codex/review-" + reviewId,
-          resolvedAtCallTime.principal(),
-          "the credential's run records the review principal the agent acts as");
+      assertFalse(invocation.get(1).isBlank(), "every review invocation carries a credential");
     }
-    var firstReview = credentials.getFirst();
-    var reviewerRun = runs.findById(firstReview.get(0)).orElseThrow();
-    assertEquals("review", reviewerRun.role());
+    var r1 = credentials.get(0).get(0);
+    var r2 = credentials.get(2).get(0);
+    assertEquals(
+        "codex/review-" + r1,
+        credentials.get(0).get(2),
+        "the reviewer invocation acts as the review principal");
+    assertEquals(
+        "claude/fix-" + r1,
+        credentials.get(1).get(2),
+        "the fix invocation acts as its own fix principal, never the reviewer's");
+    assertEquals("codex/review-" + r2, credentials.get(2).get(2));
+    assertEquals("review", runs.findById(r1).orElseThrow().role());
+  }
+
+  @Test
+  void eachInvocationStampsItsOwnIdentitySoRoomPostsCarryTheHonestAuthor() {
+    createSpec("auth", "in_progress");
+    var criticalOutput =
+        """
+        ```json
+        {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
+          "line_start": 1, "line_end": 1, "title": "Bad",
+          "description": "Very bad", "confidence": 0.9}]}
+        ```
+        """;
+    var runs = new RunStore(db);
+    var messages = new MessageStore(db);
+    var calls = new AtomicInteger();
+    var reviewIds = new java.util.concurrent.CopyOnWriteArrayList<String>();
+    ReviewAgentRunner runner =
+        (p, a, pr, rid, cred) -> {
+          reviewIds.add(rid);
+          var principal = runs.findByCredential(cred).orElseThrow().principal();
+          messages.append("auth", principal, "posted by " + principal, null);
+          return calls.incrementAndGet() == 1 ? criticalOutput : fixAllCarried(pr);
+        };
+    var ctrl =
+        new ReviewPipelineController(
+            specStore,
+            reviewStore,
+            p -> singleAgentStage("no_critical"),
+            p -> "codex",
+            runner,
+            null,
+            () -> {},
+            new DirectExecutorService(),
+            runs,
+            () -> "node-a");
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    var r1 = reviewIds.get(0);
+    var r2 = reviewIds.get(2);
+    assertEquals(
+        "claude/fix-" + r1,
+        runs.findById(r1).orElseThrow().principal(),
+        "after the fix rejoin the run row reads the fix lane's identity");
+    assertEquals(
+        "codex/review-" + r2,
+        runs.findById(r2).orElseThrow().principal(),
+        "the next reviewer invocation carries the reviewer identity");
+    assertEquals(
+        List.of("codex/review-" + r1, "claude/fix-" + r1, "codex/review-" + r2),
+        messages.listAfter("auth", null, 10).stream().map(MessageStore.MessageRow::author).toList(),
+        "each room post is attributed to the lane that wrote it");
+  }
+
+  @Test
+  void aStillOpenRulingsEvidenceReachesTheNextFixTaskAndTheReReview() {
+    createSpec("auth", "in_progress");
+    var criticalOutput =
+        """
+        ```json
+        {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "CONCURRENCY", "file": "Dispatch.java",
+          "line_start": 5, "line_end": 9, "title": "Seed-window race",
+          "description": "Two dispatches can claim one seed.", "confidence": 0.9}]}
+        ```
+        """;
+    var evidence = "the seed window in DispatchOperations still races between reserve and claim";
+    var prompts = new ArrayList<String>();
+    ReviewAgentRunner runner =
+        (p, a, pr, rid, cred) -> {
+          prompts.add(pr);
+          return switch (prompts.size()) {
+            case 1 -> criticalOutput;
+            case 3 -> ReviewScripts.stillOpenAllCarried(pr, evidence);
+            case 5 -> fixAllCarried(pr);
+            default -> "fix applied";
+          };
+        };
+    var ctrl = controller(singleAgentStage("no_critical"), runner);
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
+    assertEquals(5, prompts.size(), "three reviews with a fix iteration between each");
+    var firstFixTask = prompts.get(1);
+    assertFalse(
+        firstFixTask.contains("Reviewer's evidence that this remains open"),
+        "the first fix task predates any ruling and carries no reproduction claim");
+    var secondFixTask = prompts.get(3);
+    assertTrue(
+        secondFixTask.contains("Reviewer's evidence that this remains open: " + evidence),
+        secondFixTask);
+    assertTrue(secondFixTask.contains("Treat this as a reproduction claim"), secondFixTask);
+    var thirdReviewPrompt = prompts.get(4);
+    assertTrue(
+        thirdReviewPrompt.contains("Prior ruling's evidence that it remains open: " + evidence),
+        "the re-review rules against its own prior scenario");
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewScripts.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewScripts.java
@@ -50,6 +50,19 @@ final class ReviewScripts {
     return "{\"verdicts\": [" + verdicts + "], \"findings\": " + findingsJson + "}";
   }
 
+  /** An envelope ruling every carried finding {@code still_open} with the given evidence. */
+  static String stillOpenAllCarried(String prompt, String evidence) {
+    var verdicts =
+        carriedFromPrompt(prompt).keySet().stream()
+            .map(
+                id ->
+                    ("{\"finding_id\": \"%s\", \"verdict\": \"still_open\","
+                            + " \"evidence\": \"%s\"}")
+                        .formatted(id, evidence))
+            .collect(Collectors.joining(", "));
+    return "{\"verdicts\": [" + verdicts + "], \"findings\": []}";
+  }
+
   /** An envelope disputing every carried finding in the prompt, evidence included. */
   static String disputeAllCarried(String prompt) {
     var verdicts =


### PR DESCRIPTION
## Why

Two defects surfaced by the first stuck-finding escalation (sail-room-agent-loop dispatch, 2026-08-10):

1. **A `still_open` ruling's evidence was discarded.** `ReviewStore.applyStageResult` carried findings forward without the ruling's evidence, so the fix agent's task rendered only the original finding description. Starved of the reviewer's sharpest explanation (iteration 2's evidence named the exact residual seed-window race), it re-claimed "already fixed" twice and the loop escalated.
2. **Fix-lane room posts misattributed the author.** The fix lane rejoined the review run's identity via `rotateCredential`, whose row carried the reviewer's agent — a claude-code fix agent posted as `codex/review-<id>`. Rooms are the audit trail; the attribution must be honest.

## What

**Brick 1 — still_open evidence travels into the next fix task**
- `Finding` gains a nullable `carryEvidence` component (`carry_evidence` column, one append-only `ALTER TABLE ... ADD COLUMN` migration — same outcome as a rebuild, rows preserved with the column null). `carryForward` stores the carrying ruling's evidence; each re-carry overwrites with the newest ruling's, the `carried_from` chain preserving history.
- `FixTaskBuilder` renders it as a reproduction claim: the fix agent must investigate the reviewer's exact scenario before re-claiming it fixed, or dispute with its analysis — never a bare re-claim.
- `ReviewPromptBuilder`'s carry-forward section renders the same evidence so the re-review rules against its own prior scenario, and the verdict rules now ask `still_open` verdicts to describe the exact residual scenario.

**Brick 2 — the fix lane posts as itself**
- `RunStore.rotateCredential` gains the rejoining invocation's agent and lane, stamping the run row's `agent` and `principal` (`<agent>/fix-<reviewId>` for the fix lane, `<reviewer>/review-<reviewId>` for a reviewer) and journaling the revision so the honest attribution replicates. One run row, honest per-invocation identity; no new tables, no change to credential semantics.
- The controller's `startReviewRun` passes the lane from each call site; consumers (rooms, run views, Slack narration) read the stamped principal unchanged.

## Tests

- Store: carry evidence persists; a second carry overwrites with the newest while the chain keeps the older; resolving rulings store evidence as resolution, not carry; migration preserves existing rows with `carry_evidence` null.
- Builders: fix task renders the repro-claim framing only for carried evidence; review prompt renders the prior ruling's scenario; findings without carry evidence render as today.
- Controller: end-to-end loop test proving the ruling evidence flows from the FindingParser verdict through `applyStageResult` into the next iteration's fix task and the following review prompt.
- Identity: per-invocation principals captured at call time (`codex/review-r1` → `claude/fix-r1` → `codex/review-r2`) and room posts through the message store carry the matching author; rotation journals the stamped identity into the sync snapshot.
- `mvn clean verify` green (BUILD SUCCESS, exit 0), all jacoco coverage gates met.

## Non-goals

No new verdict verbs, no gate/escalation/delivery-ledger changes, no session capture or no-live-run wake (tracked by sail-session-identity / sail-room-wake).