### PR TITLE
Flag mis-addressed reviewer verdicts in the room

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/FindingParser.java
@@ -157,6 +157,7 @@ public final class FindingParser {
    */
   public static Reconciled reconcile(List<Finding> carried, List<Verdict> verdicts) {
     var warnings = new ArrayList<String>();
+    var unmatched = new ArrayList<String>();
     var rulings = new LinkedHashMap<String, Verdict>();
     for (var finding : carried) {
       rulings.put(finding.id(), new Verdict(finding.id(), Ruling.STILL_OPEN, ""));
@@ -165,6 +166,7 @@ public final class FindingParser {
     for (var verdict : verdicts) {
       if (!rulings.containsKey(verdict.findingId())) {
         warnings.add("Verdict for unknown finding " + verdict.findingId() + " ignored.");
+        unmatched.add(verdict.findingId());
         continue;
       }
       if (!ruled.add(verdict.findingId())) {
@@ -184,11 +186,20 @@ public final class FindingParser {
       }
       rulings.put(verdict.findingId(), verdict);
     }
-    return new Reconciled(Map.copyOf(rulings), List.copyOf(warnings));
+    return new Reconciled(Map.copyOf(rulings), List.copyOf(warnings), List.copyOf(unmatched));
   }
 
-  /** The effective ruling per carried finding id, plus what fail-closed defaulting rejected. */
-  public record Reconciled(Map<String, Verdict> rulings, List<String> warnings) {}
+  /**
+   * The effective ruling per carried finding id, the freeform warnings fail-closed defaulting
+   * produced, and {@code unmatchedVerdictIds}: the ids the reviewer ruled on that matched no
+   * carried finding. A non-empty {@code unmatchedVerdictIds} is the mis-transcribed-id signature —
+   * the reviewer meant to rule but named the wrong id, so a finding that shows still-open may in
+   * fact have been addressed. It is called out separately from the other warnings (conflicting or
+   * evidence-free verdicts, which are legitimately still_open) so the pipeline can surface only the
+   * ambiguous case in the room.
+   */
+  public record Reconciled(
+      Map<String, Verdict> rulings, List<String> warnings, List<String> unmatchedVerdictIds) {}
 
   static List<String> extractJsonBlocks(String output) {
     if (Strings.isBlank(output)) return List.of();

--- a/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/FindingParserTest.java
@@ -466,6 +466,23 @@ class FindingParserTest {
     assertEquals(Ruling.STILL_OPEN, reconciled.rulings().get(carried.getFirst().id()).ruling());
     assertEquals(1, reconciled.warnings().size());
     assertTrue(reconciled.warnings().getFirst().contains("ghost"));
+    assertEquals(
+        List.of("ghost"),
+        reconciled.unmatchedVerdictIds(),
+        "a verdict naming an id no carried finding holds is the mis-transcribed-id signature —"
+            + " surfaced separately so the room can flag that an open finding may be addressed");
+  }
+
+  @Test
+  void reconcileReportsNoUnmatchedIdsWhenEveryVerdictMatches() {
+    var carried = List.of(finding("Old high"));
+    var verdicts = List.of(new Verdict(carried.getFirst().id(), Ruling.FIXED, "evidence"));
+
+    var reconciled = FindingParser.reconcile(carried, verdicts);
+
+    assertTrue(
+        reconciled.unmatchedVerdictIds().isEmpty(),
+        "a legitimately still_open finding (no verdict, or evidence-free) is not an unmatched id");
   }
 
   @Test

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -439,7 +439,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
         return new StageOutcome.Errored(message);
       }
       var parsed = (FindingParser.ParseResult.Parsed) parseResult;
-      applyStageResult(stage.id(), carried, parsed);
+      applyStageResult(specId, stage.id(), carried, parsed);
 
       var findings = reviewStore.findingsForStage(stage.id());
       var passed = stageConfig.gate().passes(findings);
@@ -474,9 +474,15 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
    * with every carried finding still {@code OPEN} instead of silently retired.
    */
   private void applyStageResult(
-      String stageId, List<Finding> carried, FindingParser.ParseResult.Parsed parsed) {
+      String specId,
+      String stageId,
+      List<Finding> carried,
+      FindingParser.ParseResult.Parsed parsed) {
     var reconciled = FindingParser.reconcile(carried, parsed.verdicts());
     warn(reconciled.warnings());
+    if (!reconciled.unmatchedVerdictIds().isEmpty()) {
+      postRoom(specId, misaddressedVerdictNote(reconciled.unmatchedVerdictIds().size()));
+    }
     var rulings =
         carried.stream()
             .map(
@@ -495,6 +501,22 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
       case DISPUTED -> Finding.Resolution.DISPUTED;
       case STILL_OPEN -> Finding.Resolution.OPEN;
     };
+  }
+
+  /**
+   * The room note for a reviewer that ruled on a finding id no carried finding holds — the
+   * mis-transcribed-id signature. The verdict was dropped fail-closed and the real finding shows
+   * still-open, which reads as unresolved; this says plainly that it may in fact have been
+   * addressed, so a human checks the review log rather than trusting the open count. Kept off the
+   * pass/fail verdict lines so it fires only when the ambiguity is real.
+   */
+  private static String misaddressedVerdictNote(int count) {
+    return "Note: the reviewer ruled on "
+        + count
+        + " finding id"
+        + (count == 1 ? "" : "s")
+        + " that match no open finding on this spec (a mis-transcribed id). A finding shown"
+        + " still-open below may already be addressed — check the review log before acting on it.";
   }
 
   private static void warn(List<String> warnings) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -855,6 +855,48 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
+  void aMisaddressedVerdictIsFlaggedInTheRoomNotSilentlyLeftOpen() {
+    createSpec("auth", "in_progress");
+    var messages = new MessageStore(db);
+    var highOutput =
+        """
+        ```json
+        {"verdicts": [], "findings": [{"severity": "HIGH", "category": "LOGIC", "file": "a.java",
+          "line_start": 1, "line_end": 1, "title": "Stubborn high",
+          "description": "d", "evidence": "e", "confidence": 0.9,
+          "suggestion": {"before": "old", "after": "new", "rationale": "r"}}]}
+        ```
+        """;
+    var ghostVerdict =
+        """
+        ```json
+        {"verdicts": [{"finding_id": "ghost-not-a-real-id", "verdict": "fixed",
+          "evidence": "commit abc"}], "findings": []}
+        ```
+        """;
+    var calls = new AtomicInteger();
+    ReviewAgentRunner runner =
+        (p, a, prompt, rid, cred) ->
+            switch (calls.incrementAndGet()) {
+              case 1 -> highOutput;
+              case 3 -> ghostVerdict;
+              case 2, 4 -> "fix applied";
+              default -> fixAllCarried(prompt);
+            };
+    var ctrl = controller(p -> singleAgentStage("no_critical_or_high"), p -> "codex", runner, null);
+    ctrl.useMessages(messages);
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    assertTrue(
+        messages.list("auth", null, 50).stream()
+            .anyMatch(m -> m.body().contains("match no open finding")),
+        "a verdict naming an id no carried finding holds must be flagged in the room — the finding"
+            + " reads still-open but the reviewer meant to rule it, so a human is told to check the"
+            + " log rather than trust the open count");
+  }
+
+  @Test
   void aHumanStageOpensWithTheRoomVerdictListingDisputedFindings() {
     createSpec("auth", "in_progress");
     var messages = new MessageStore(db);


### PR DESCRIPTION
## Why

On the `sail-fix-lane-refinements` review, a reviewer emitted a verdict whose `finding_id` was confabulated (spliced from the dispatch run id's suffix). `FindingParser.reconcile` correctly dropped it fail-closed and the real finding defaulted to `still_open` — but that only reached **stderr**. In the room the finding read as unresolved, so a human re-examined a finding the reviewer had actually meant to rule *fixed*, and the `done_open_findings` metric inflated on the false positive.

## What

- `FindingParser.Reconciled` gains `unmatchedVerdictIds` — the ids a reviewer ruled on that matched no carried finding, reported separately from the freeform warnings (so it's distinct from the legitimately-still_open conflicting/evidence-free cases).
- `ReviewPipelineController` posts a concise room note when it's non-empty: *"the reviewer ruled on N finding id(s) that match no open finding … a finding shown still-open below may already be addressed — check the review log."* Fires only on the ambiguous case; kept off the pass/fail verdict lines.

## Testing

`mvn clean verify` green (honest exit). Parser test asserts `unmatchedVerdictIds` is populated for a ghost id and empty when every verdict matches; controller test drives a re-review whose verdict cites a confabulated id and asserts the room note appears — **proven to fail without the fix** (reverted the post, watched it fail, restored).

Companion to the v0.21.1 hotfix work; both address "the metric lied to a human." No new dependencies.