### PR TITLE
A live run shows whether it's working: presence from existing events

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -67,6 +67,10 @@ public final class RunStore implements ConflictResolver {
    * <p>{@code sessionId}, {@code sessionSource}, and {@code transcriptPath} are the hook-reported
    * identity of the run's agent conversation — see {@link #recordSession}. All three are null until
    * a session reports; a run adopted from an old-shape snapshot derives nulls the same way.
+   *
+   * <p>{@code lastActivityAt} is when the run's agent last showed progress (a tool call or a log
+   * chunk) — see {@link #stampActivity}. Null until the first stamp, and on every row adopted from
+   * a pre-upgrade snapshot; presence readers treat null as "unknown", never as quiet.
    */
   public record RunRow(
       String id,
@@ -91,7 +95,60 @@ public final class RunStore implements ConflictResolver {
       String owner,
       String sessionId,
       String sessionSource,
-      String transcriptPath) {
+      String transcriptPath,
+      String lastActivityAt) {
+
+    /** A row without activity — the shape every run has until its first progress stamp. */
+    public RunRow(
+        String id,
+        String project,
+        String specId,
+        String node,
+        String role,
+        String agent,
+        String branch,
+        String task,
+        Integer pid,
+        Integer watcherPid,
+        String status,
+        Integer exitCode,
+        String logPath,
+        String unit,
+        String startedAt,
+        String completedAt,
+        List<String> repos,
+        Long pidTicks,
+        String principal,
+        String owner,
+        String sessionId,
+        String sessionSource,
+        String transcriptPath) {
+      this(
+          id,
+          project,
+          specId,
+          node,
+          role,
+          agent,
+          branch,
+          task,
+          pid,
+          watcherPid,
+          status,
+          exitCode,
+          logPath,
+          unit,
+          startedAt,
+          completedAt,
+          repos,
+          pidTicks,
+          principal,
+          owner,
+          sessionId,
+          sessionSource,
+          transcriptPath,
+          null);
+    }
 
     /** A row without session identity — the shape every run has until its first session report. */
     public RunRow(
@@ -173,7 +230,7 @@ public final class RunStore implements ConflictResolver {
   private static final String COLUMNS =
       "id, project, spec_id, node, role, agent, branch, task, pid, watcher_pid, status,"
           + " exit_code, log_path, unit, started_at, completed_at, repos, pid_ticks,"
-          + " principal, owner, session_id, session_source, transcript_path";
+          + " principal, owner, session_id, session_source, transcript_path, last_activity_at";
 
   /**
    * Records a new run in the {@code running} state, journaling a baseline revision so it
@@ -485,6 +542,28 @@ public final class RunStore implements ConflictResolver {
               id);
           recordRevision(id, "local", false);
         });
+  }
+
+  /**
+   * Stamps when the run's agent last showed progress, coalesced to at most one write per {@code
+   * floor} window: the write is skipped while the row's {@code last_activity_at} is still within
+   * {@code floor} of now, so a continuous {@code agent_log_chunk} stream costs one UPDATE per
+   * window instead of one per chunk. Deliberately journals <em>no</em> revision — presence needs
+   * ~minute granularity, and a revision per stamp would flood the ChangeLog and fire sync-on-write
+   * on every chunk; the value rides along on the run's next real revision instead, so a foreign
+   * box's copy is as fresh as the normal sync cadence. Only a {@code running} row is stamped: a
+   * late event must never dirty a terminal row whose final revision has already been journaled.
+   * Returns whether a write happened.
+   */
+  public boolean stampActivity(String id, Duration floor) {
+    var now = DateTimeUtils.now();
+    db.execute(
+        "UPDATE runs SET last_activity_at = ? WHERE id = ? AND status = 'running'"
+            + " AND (last_activity_at IS NULL OR last_activity_at < ?)",
+        now.toString(),
+        id,
+        now.minus(floor).toString());
+    return db.changes() > 0;
   }
 
   /**
@@ -1075,8 +1154,8 @@ public final class RunStore implements ConflictResolver {
         """
         INSERT INTO runs (id, project, spec_id, node, role, agent, branch, task, pid, watcher_pid,
             status, exit_code, log_path, unit, started_at, completed_at, repos, pid_ticks,
-            principal, owner, session_id, session_source, transcript_path)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            principal, owner, session_id, session_source, transcript_path, last_activity_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET project = excluded.project, spec_id = excluded.spec_id,
             node = excluded.node, role = excluded.role, agent = excluded.agent,
             branch = excluded.branch, task = excluded.task, pid = excluded.pid,
@@ -1086,7 +1165,8 @@ public final class RunStore implements ConflictResolver {
             repos = excluded.repos, pid_ticks = excluded.pid_ticks,
             principal = excluded.principal, owner = excluded.owner,
             session_id = excluded.session_id, session_source = excluded.session_source,
-            transcript_path = excluded.transcript_path""",
+            transcript_path = excluded.transcript_path,
+            last_activity_at = excluded.last_activity_at""",
         row.id(),
         row.project(),
         row.specId(),
@@ -1109,7 +1189,8 @@ public final class RunStore implements ConflictResolver {
         row.owner(),
         row.sessionId(),
         row.sessionSource(),
-        row.transcriptPath());
+        row.transcriptPath(),
+        row.lastActivityAt());
   }
 
   private static Map<String, Object> snapshotMap(RunRow run) {
@@ -1137,6 +1218,7 @@ public final class RunStore implements ConflictResolver {
     map.put("session_id", run.sessionId());
     map.put("session_source", run.sessionSource());
     map.put("transcript_path", run.transcriptPath());
+    map.put("last_activity_at", run.lastActivityAt());
     return map;
   }
 
@@ -1200,7 +1282,8 @@ public final class RunStore implements ConflictResolver {
         text(snapshot, "owner"),
         text(snapshot, "session_id"),
         text(snapshot, "session_source"),
-        text(snapshot, "transcript_path"));
+        text(snapshot, "transcript_path"),
+        text(snapshot, "last_activity_at"));
   }
 
   private static String text(Map<String, Object> map, String key) {
@@ -1258,6 +1341,7 @@ public final class RunStore implements ConflictResolver {
         row.text(19),
         row.text(20),
         row.text(21),
-        row.text(22));
+        row.text(22),
+        row.text(23));
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -217,7 +217,8 @@ public final class SchemaManager {
           CREATE TABLE room_guard (
               run_id TEXT PRIMARY KEY REFERENCES runs(id) ON DELETE CASCADE,
               baseline TEXT NOT NULL
-          )""");
+          )""",
+          "ALTER TABLE runs ADD COLUMN last_activity_at TEXT");
 
   /** The schema version this binary converges every database to. */
   static final int CURRENT_VERSION = V1_VERSION + MIGRATIONS.size();

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -606,6 +606,70 @@ class RunStoreTest {
   }
 
   @Test
+  void stampActivityCoalescesToOneWritePerFloorWindow() {
+    var id = newRun("backend", "auth");
+
+    assertTrue(store.stampActivity(id, Duration.ofSeconds(30)));
+    var first = store.findById(id).orElseThrow().lastActivityAt();
+    assertNotNull(first);
+    assertFalse(
+        store.stampActivity(id, Duration.ofSeconds(30)),
+        "a second stamp inside the floor window is skipped");
+    assertEquals(first, store.findById(id).orElseThrow().lastActivityAt());
+  }
+
+  @Test
+  void stampActivityRefreshesOncePastTheFloor() {
+    var id = newRun("backend", "auth");
+    assertTrue(store.stampActivity(id, Duration.ZERO));
+
+    assertTrue(
+        store.stampActivity(id, Duration.ZERO),
+        "a zero floor coalesces nothing — every stamp writes");
+  }
+
+  @Test
+  void stampActivityJournalsNoRevisionAndRidesTheNextRealOne() {
+    var id = newRun("backend", "auth");
+    var rev = store.latestRev(id);
+
+    store.stampActivity(id, Duration.ofSeconds(30));
+
+    assertEquals(rev, store.latestRev(id), "presence stamping never mints revisions of its own");
+    assertNull(store.comparableAtRev(id, rev).get("last_activity_at"));
+
+    store.complete(id, "completed", 0);
+
+    assertNotNull(
+        store.comparableSnapshot(id).get("last_activity_at"),
+        "the stamp rides along on the run's next real revision");
+  }
+
+  @Test
+  void stampActivityRefusesANonRunningRun() {
+    var id = newRun("backend", "auth");
+    store.complete(id, "completed", 0);
+
+    assertFalse(store.stampActivity(id, Duration.ofSeconds(30)));
+    assertNull(store.findById(id).orElseThrow().lastActivityAt());
+  }
+
+  @Test
+  void anOldShapeSnapshotDerivesANullActivityStamp() {
+    var id = newRun("backend", "auth");
+    var snapshot = store.comparableSnapshot(id);
+    snapshot.remove("last_activity_at");
+    var rev = store.latestRev(id);
+
+    var other = freshStore("old-shape.db");
+    other.applyRevision(id, snapshot, rev);
+
+    assertNull(
+        other.findById(id).orElseThrow().lastActivityAt(),
+        "a pre-upgrade snapshot must read as unknown activity, never as quiet");
+  }
+
+  @Test
   void mutationsJournalComparableRevisions() {
     var id = newRun("backend", "auth");
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -311,6 +311,11 @@ class SchemaManagerTest {
     assertEquals(
         "acme",
         db.queryOne("SELECT project FROM runs WHERE id = 'r1'", r -> r.text(0)).orElseThrow());
+    assertTrue(
+        db.queryOne("SELECT last_activity_at IS NULL FROM runs WHERE id = 'r1'", r -> r.integer(0))
+                .orElseThrow()
+            == 1,
+        "a pre-upgrade run derives a null activity stamp — presence readers must not guess");
   }
 
   @Test
@@ -404,7 +409,7 @@ class SchemaManagerTest {
   @Test
   void theRunsRebuildCarriesRowsAndChildLedgersForwardAndAdmitsRoomRuns() {
     stageAtBaseline();
-    var priorEntries = SchemaManager.MIGRATIONS.size() - 7;
+    var priorEntries = migrationIndex("CREATE TABLE runs_v5") + 1;
     db.execute("PRAGMA foreign_keys = OFF");
     SchemaManager.MIGRATIONS.subList(0, priorEntries).forEach(db::execute);
     db.execute("PRAGMA foreign_keys = ON");

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.store.ChangeLog;
 import ai.singlr.sail.store.MessageStore;
@@ -1076,7 +1077,9 @@ record RunView(
     String principal,
     String owner,
     String sessionId,
-    String sessionSource)
+    String sessionSource,
+    String lastActivityAt,
+    String presence)
     implements Mappable {
   static RunView from(RunStore.RunRow row) {
     return new RunView(
@@ -1096,7 +1099,9 @@ record RunView(
         row.principal(),
         row.owner(),
         row.sessionId(),
-        row.sessionSource());
+        row.sessionSource(),
+        row.lastActivityAt(),
+        RunPresence.of(row.status(), row.lastActivityAt(), DateTimeUtils.now()));
   }
 
   @Override
@@ -1119,6 +1124,8 @@ record RunView(
     if (owner != null) m.put("owner", owner);
     if (sessionId != null) m.put("session_id", sessionId);
     if (sessionSource != null) m.put("session_source", sessionSource);
+    if (lastActivityAt != null) m.put("last_activity_at", lastActivityAt);
+    if (presence != null) m.put("presence", presence);
     return m;
   }
 }
@@ -1179,7 +1186,9 @@ record RunSummary(
     String principal,
     String owner,
     String sessionId,
-    String sessionSource)
+    String sessionSource,
+    String lastActivityAt,
+    String presence)
     implements Mappable {
   static RunSummary from(RunStore.RunRow row) {
     return new RunSummary(
@@ -1190,7 +1199,9 @@ record RunSummary(
         row.principal(),
         row.owner(),
         row.sessionId(),
-        row.sessionSource());
+        row.sessionSource(),
+        row.lastActivityAt(),
+        RunPresence.of(row.status(), row.lastActivityAt(), DateTimeUtils.now()));
   }
 
   @Override
@@ -1204,6 +1215,8 @@ record RunSummary(
     if (owner != null) m.put("owner", owner);
     if (sessionId != null) m.put("session_id", sessionId);
     if (sessionSource != null) m.put("session_source", sessionSource);
+    if (lastActivityAt != null) m.put("last_activity_at", lastActivityAt);
+    if (presence != null) m.put("presence", presence);
     return m;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
@@ -114,6 +114,17 @@ public record Event(
       };
     }
 
+    /**
+     * Whether {@code type} is evidence the agent is actively working — the one definition of
+     * "progress", shared by the guardrail watcher's stall timer and the {@link RunActivityStamper}
+     * so the two can never disagree about what counts as liveness.
+     */
+    public static boolean progress(String type) {
+      return AGENT_TOOL_STARTED.equals(type)
+          || AGENT_TOOL_FINISHED.equals(type)
+          || AGENT_LOG_CHUNK.equals(type);
+    }
+
     private WellKnownTypes() {}
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RunActivityStamper.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RunActivityStamper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.store.RunStore;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * EventBus subscriber that stamps a run's {@code last_activity_at} whenever a progress event
+ * ({@link Event.WellKnownTypes#progress}) carries its {@code run_id} — the same event set the
+ * guardrail watcher's stall timer trusts, so "working" here and "not stalled" there can never
+ * disagree. Deliberately its own subscriber, not folded into {@link RunTracker}, whose contract is
+ * to stamp only the terminal status and exit code.
+ *
+ * <p>The stamp is a best-effort local column update: {@link RunStore#stampActivity} coalesces to
+ * one write per {@link #COALESCE_FLOOR} window and journals no revision, so a continuous {@code
+ * agent_log_chunk} stream can never flood the ChangeLog or fire sync-on-write per chunk. Progress
+ * events only ever originate on the executing box (the in-container hooks post to the local
+ * socket), so the run addressed here is always this box's own — no ownership guard needed.
+ */
+public final class RunActivityStamper implements EventSubscriber {
+
+  /**
+   * Minimum spacing between stamps for one run. Presence needs ~{@link RunPresence#THRESHOLD}
+   * granularity, so anything well under it keeps the chip honest while a chunk burst stays one
+   * write.
+   */
+  public static final Duration COALESCE_FLOOR = Duration.ofSeconds(30);
+
+  private final RunStore runStore;
+
+  public RunActivityStamper(RunStore runStore) {
+    this.runStore = runStore;
+  }
+
+  @Override
+  public String name() {
+    return "run-activity";
+  }
+
+  @Override
+  public Predicate<Event> filter() {
+    return event -> Event.WellKnownTypes.progress(event.type());
+  }
+
+  @Override
+  public void onEvent(Event event) {
+    var runId = Objects.toString(event.data().get(Event.WellKnownData.RUN_ID), null);
+    if (Strings.isBlank(runId)) {
+      return;
+    }
+    try {
+      runStore.stampActivity(runId, COALESCE_FLOOR);
+    } catch (Exception e) {
+      System.err.println("run-activity: failed to stamp run " + runId + ": " + e.getMessage());
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RunPresence.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RunPresence.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.common.Strings;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Derives a live run's presence at read time — never stored, so there is nothing to flap,
+ * arbitrate, or reconcile. A {@code running} run whose last recorded activity is within {@link
+ * #THRESHOLD} of now reads {@code working}; past it, {@code quiet}; any other status — or a run
+ * with no activity stamp at all (pre-upgrade rows, agents mid-flight during upgrade) — has no
+ * presence, and readers show the plain status rather than guessing.
+ */
+public final class RunPresence {
+
+  /** A run whose activity is fresher than this reads {@code working}. */
+  public static final String WORKING = "working";
+
+  /** A running run that has shown no progress for {@link #THRESHOLD} reads {@code quiet}. */
+  public static final String QUIET = "quiet";
+
+  /**
+   * How long a running run may go without progress before it reads {@code quiet}. Chosen to fire
+   * well before a run's {@code max_idle} stall guardrail (a per-run duration, typically tens of
+   * minutes, not a global constant) would kill it: presence is the early "look at me" signal, the
+   * guardrail is the late enforcement — the ordering only holds while this stays far under any
+   * sensible {@code max_idle}.
+   */
+  public static final Duration THRESHOLD = Duration.ofSeconds(120);
+
+  private RunPresence() {}
+
+  /**
+   * The presence of a run in {@code status} whose last activity was {@code lastActivityAt}
+   * (ISO-8601, nullable), against the reader's clock: {@link #WORKING}, {@link #QUIET}, or null
+   * when the run has none. An unparseable stamp reads as no presence — never guess. Foreign runs
+   * compare their synced stamp against the local clock, so their staleness is dominated by sync
+   * cadence, not clock skew — the same freshness contract the board already has.
+   */
+  public static String of(String status, String lastActivityAt, Instant now) {
+    if (!"running".equals(status) || Strings.isBlank(lastActivityAt)) {
+      return null;
+    }
+    Instant at;
+    try {
+      at = Instant.parse(lastActivityAt);
+    } catch (RuntimeException unparseable) {
+      return null;
+    }
+    return at.isBefore(now.minus(THRESHOLD)) ? QUIET : WORKING;
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RunPresenceEmitter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RunPresenceEmitter.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.engine.HostInfo;
+import ai.singlr.sail.store.RunStore;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Publishes one {@code agent_presence} event per presence <em>crossing</em> of a local running run
+ * — {@code quiet} when it goes silent past {@link RunPresence#THRESHOLD}, {@code working} once
+ * activity resumes — never a heartbeat stream. SSE clients get the edge without polling; between
+ * edges, presence is derived at read time from {@code last_activity_at}, so nothing here is ever
+ * authoritative state.
+ *
+ * <p>Edge detection holds each run's previously-emitted presence in memory only, consistent with
+ * "presence is never persisted": entries for runs no longer live are dropped each pass, and a
+ * daemon restart simply re-seeds from current state without replaying old edges. Only runs this
+ * node executed are considered — a foreign run's stamp is only as fresh as the last sync, and
+ * narrating quiet from stale data would be noise; its executing box owns its edges. A sibling of
+ * {@link MissedStopReconciler} / {@link WatcherRearmer} on the shared {@link PeriodicPass}
+ * discipline: passes never overlap, a throwing pass never cancels the schedule.
+ */
+public final class RunPresenceEmitter implements AutoCloseable {
+
+  /**
+   * Pass cadence: a fraction of {@link RunPresence#THRESHOLD}, so a crossing is narrated well
+   * within the granularity presence promises.
+   */
+  public static final Duration DEFAULT_INTERVAL = Duration.ofSeconds(15);
+
+  private final RunStore runStore;
+  private final EventBus bus;
+  private final Supplier<String> localHandle;
+  private final Supplier<Instant> clock;
+  private final PeriodicPass pass;
+  private final Map<String, String> lastEmitted = new HashMap<>();
+
+  public RunPresenceEmitter(
+      RunStore runStore, EventBus bus, Supplier<String> localHandle, Supplier<Instant> clock) {
+    this.runStore = runStore;
+    this.bus = bus;
+    this.localHandle = localHandle;
+    this.clock = clock;
+    this.pass = new PeriodicPass("presence", this::sweep);
+  }
+
+  /** Starts the periodic pass at the default cadence. */
+  public void start() {
+    start(DEFAULT_INTERVAL);
+  }
+
+  public void start(Duration interval) {
+    pass.start(interval);
+  }
+
+  /**
+   * Runs one pass and returns how many presence events were published. A run with no presence (no
+   * activity stamp yet) publishes nothing and holds no edge state, so its first stamp can never
+   * read as a resume.
+   */
+  public int sweep() {
+    var node = localHandle.get();
+    var now = clock.get();
+    var live = new HashSet<String>();
+    var emitted = 0;
+    for (var run : runStore.running()) {
+      if (!SailOperations.ownsRun(run.node(), node)) {
+        continue;
+      }
+      var presence = RunPresence.of(run.status(), run.lastActivityAt(), now);
+      if (presence == null) {
+        continue;
+      }
+      live.add(run.id());
+      var previous = lastEmitted.put(run.id(), presence);
+      if (presence.equals(previous) || (previous == null && RunPresence.WORKING.equals(presence))) {
+        continue;
+      }
+      bus.publish(presenceEvent(run, presence));
+      emitted++;
+    }
+    lastEmitted.keySet().retainAll(live);
+    return emitted;
+  }
+
+  private static Event presenceEvent(RunStore.RunRow run, String presence) {
+    var data = new LinkedHashMap<String, Object>();
+    data.put("presence", presence);
+    data.put(Event.WellKnownData.RUN_ID, run.id());
+    data.put(Event.WellKnownData.RUN_ROLE, run.role());
+    data.put("last_activity_at", run.lastActivityAt());
+    return Event.of(
+        run.project(),
+        run.specId(),
+        Event.WellKnownTypes.AGENT_PRESENCE,
+        Event.SAIL_AGENT,
+        HostInfo.hostname(),
+        data);
+  }
+
+  @Override
+  public void close() {
+    pass.close();
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
@@ -326,10 +326,7 @@ public final class AgentWatchCommand implements Runnable {
 
   /** Whether an event signals the agent is actively working — resets the stall timer. */
   static boolean isProgressEvent(Event event) {
-    var type = event.type();
-    return Event.WellKnownTypes.AGENT_TOOL_STARTED.equals(type)
-        || Event.WellKnownTypes.AGENT_TOOL_FINISHED.equals(type)
-        || Event.WellKnownTypes.AGENT_LOG_CHUNK.equals(type);
+    return Event.WellKnownTypes.progress(event.type());
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -11,6 +11,8 @@ import ai.singlr.sail.api.EventRetentionSweeper;
 import ai.singlr.sail.api.MissedStopReconciler;
 import ai.singlr.sail.api.ReviewWiring;
 import ai.singlr.sail.api.RoomWakeReactor;
+import ai.singlr.sail.api.RunActivityStamper;
+import ai.singlr.sail.api.RunPresenceEmitter;
 import ai.singlr.sail.api.RunTracker;
 import ai.singlr.sail.api.SailApiServer;
 import ai.singlr.sail.api.SailOperations;
@@ -222,6 +224,7 @@ public final class ServerStartCommand implements Runnable {
                 NodeIdentity::handle)
             .useMessages(messageStore);
     bus.subscribe(new RunTracker(runStore, syncScheduler, NodeIdentity::handle));
+    bus.subscribe(new RunActivityStamper(runStore));
     var roomWake =
         new RoomWakeReactor(
             specStore,
@@ -293,13 +296,16 @@ public final class ServerStartCommand implements Runnable {
             WatcherRearmer.livingProcess(),
             NodeIdentity::handle,
             operations::relaunchWatcher);
+    var presenceEmitter =
+        new RunPresenceEmitter(runStore, bus, NodeIdentity::handle, DateTimeUtils::now);
     shutdown
         .register(server)
         .register(sweeper)
         .register(eventSweeper)
         .register(reconciler)
         .register(missedStops)
-        .register(rearmer);
+        .register(rearmer)
+        .register(presenceEmitter);
     try {
       server.start();
       sweeper.start();
@@ -323,6 +329,7 @@ public final class ServerStartCommand implements Runnable {
       }
       var rearmed = rearmer.rearm();
       rearmer.start();
+      presenceEmitter.start();
       if (rearmed > 0) {
         System.out.println(
             Ansi.AUTO.string(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -1326,6 +1326,8 @@ class ApiRouterTest {
                   null,
                   null,
                   null,
+                  null,
+                  null,
                   null)));
     }
 
@@ -1405,7 +1407,8 @@ class ApiRouterTest {
               null,
               null,
               0,
-              new RunSummary("run-1", "node-a", "running", null, null, null, null, null)));
+              new RunSummary(
+                  "run-1", "node-a", "running", null, null, null, null, null, null, null)));
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EventTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EventTest.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.api;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -241,6 +242,16 @@ class EventTest {
     assertEquals(
         Event.RetentionClass.EPHEMERAL,
         Event.WellKnownTypes.retentionClass(Event.WellKnownTypes.HEARTBEAT));
+  }
+
+  @Test
+  void progressIsExactlyTheToolAndLogChunkSet() {
+    assertTrue(Event.WellKnownTypes.progress(Event.WellKnownTypes.AGENT_TOOL_STARTED));
+    assertTrue(Event.WellKnownTypes.progress(Event.WellKnownTypes.AGENT_TOOL_FINISHED));
+    assertTrue(Event.WellKnownTypes.progress(Event.WellKnownTypes.AGENT_LOG_CHUNK));
+    assertFalse(Event.WellKnownTypes.progress(Event.WellKnownTypes.AGENT_SESSION_STARTED));
+    assertFalse(Event.WellKnownTypes.progress(Event.WellKnownTypes.AGENT_PRESENCE));
+    assertFalse(Event.WellKnownTypes.progress(Event.WellKnownTypes.HEARTBEAT));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RunActivityStamperTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RunActivityStamperTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RunActivityStamperTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private RunStore runStore;
+  private RunActivityStamper stamper;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    runStore = new RunStore(db);
+    stamper = new RunActivityStamper(runStore);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  private String runningRun() {
+    var id = DateTimeUtils.newId().toString();
+    return runStore.create(
+        id,
+        "backend",
+        "auth",
+        "node-a",
+        "node-a",
+        "build",
+        "claude-code",
+        "feat/x",
+        "do it",
+        123,
+        null,
+        "/home/dev/.sail/runs/" + id + "/agent.log",
+        "sail-agent-" + id);
+  }
+
+  private static Event progress(String type, Map<String, Object> data) {
+    return Event.of("backend", "auth", type, "claude-code", "host", data);
+  }
+
+  private long journaledRevisions(String runId) {
+    return db.queryOne(
+            "SELECT COUNT(*) FROM change_log WHERE entity_type = 'run' AND entity_id = ?",
+            row -> row.integer(0),
+            runId)
+        .orElseThrow();
+  }
+
+  @Test
+  void nameReturnsRunActivity() {
+    assertEquals("run-activity", stamper.name());
+  }
+
+  @Test
+  void filterAcceptsExactlyTheWatcherProgressSet() {
+    assertTrue(stamper.filter().test(progress(Event.WellKnownTypes.AGENT_TOOL_STARTED, Map.of())));
+    assertTrue(stamper.filter().test(progress(Event.WellKnownTypes.AGENT_TOOL_FINISHED, Map.of())));
+    assertTrue(stamper.filter().test(progress(Event.WellKnownTypes.AGENT_LOG_CHUNK, Map.of())));
+    assertFalse(
+        stamper.filter().test(progress(Event.WellKnownTypes.AGENT_SESSION_STARTED, Map.of())),
+        "session lifecycle is not progress — the stall timer and presence must agree");
+    assertFalse(stamper.filter().test(progress(Event.WellKnownTypes.HEARTBEAT, Map.of())));
+  }
+
+  @Test
+  void aProgressEventStampsTheRunItAddresses() {
+    var id = runningRun();
+
+    stamper.onEvent(
+        progress(Event.WellKnownTypes.AGENT_TOOL_STARTED, Map.of(Event.WellKnownData.RUN_ID, id)));
+
+    assertNotNull(runStore.findById(id).orElseThrow().lastActivityAt());
+  }
+
+  @Test
+  void aChunkBurstYieldsOneWriteAndJournalsNothing() {
+    var id = runningRun();
+    var revisionsBefore = journaledRevisions(id);
+    var revBefore = runStore.latestRev(id);
+
+    stamper.onEvent(
+        progress(Event.WellKnownTypes.AGENT_LOG_CHUNK, Map.of(Event.WellKnownData.RUN_ID, id)));
+    var firstStamp = runStore.findById(id).orElseThrow().lastActivityAt();
+    for (var i = 0; i < 200; i++) {
+      stamper.onEvent(
+          progress(Event.WellKnownTypes.AGENT_LOG_CHUNK, Map.of(Event.WellKnownData.RUN_ID, id)));
+    }
+
+    assertEquals(
+        firstStamp,
+        runStore.findById(id).orElseThrow().lastActivityAt(),
+        "a burst inside the coalescing floor is one write, not one per chunk");
+    assertEquals(
+        revisionsBefore,
+        journaledRevisions(id),
+        "stamping must never mint revisions — a chunk stream would flood the ChangeLog");
+    assertEquals(revBefore, runStore.latestRev(id));
+  }
+
+  @Test
+  void anEventWithoutARunIdIsIgnored() {
+    var id = runningRun();
+
+    stamper.onEvent(progress(Event.WellKnownTypes.AGENT_TOOL_STARTED, Map.of()));
+
+    assertNull(runStore.findById(id).orElseThrow().lastActivityAt());
+  }
+
+  @Test
+  void aTerminalRunIsNeverStamped() {
+    var id = runningRun();
+    runStore.complete(id, "completed", 0);
+    var revisions = journaledRevisions(id);
+
+    stamper.onEvent(
+        progress(Event.WellKnownTypes.AGENT_TOOL_STARTED, Map.of(Event.WellKnownData.RUN_ID, id)));
+
+    assertNull(
+        runStore.findById(id).orElseThrow().lastActivityAt(),
+        "a late event must not dirty a row whose final revision is already journaled");
+    assertEquals(revisions, journaledRevisions(id));
+  }
+
+  @Test
+  void anUnknownRunIdIsANoOp() {
+    assertDoesNotThrow(
+        () ->
+            stamper.onEvent(
+                progress(
+                    Event.WellKnownTypes.AGENT_TOOL_STARTED,
+                    Map.of(Event.WellKnownData.RUN_ID, "ghost"))));
+  }
+
+  @Test
+  void aStoreFailureIsSwallowedSoTheBusDrainSurvives() {
+    var id = runningRun();
+    db.close();
+    var event =
+        progress(Event.WellKnownTypes.AGENT_TOOL_STARTED, Map.of(Event.WellKnownData.RUN_ID, id));
+
+    assertDoesNotThrow(() -> stamper.onEvent(event));
+    db = null;
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RunPresenceEmitterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RunPresenceEmitterTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RunPresenceEmitterTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private RunStore runStore;
+  private EventBus bus;
+  private final AtomicReference<Instant> clock =
+      new AtomicReference<>(Instant.parse("2026-08-13T12:00:00Z"));
+  private RunPresenceEmitter emitter;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    runStore = new RunStore(db);
+    bus = new EventBus();
+    emitter = new RunPresenceEmitter(runStore, bus, () -> "node-a", clock::get);
+  }
+
+  @AfterEach
+  void tearDown() {
+    emitter.close();
+    bus.close();
+    if (db != null) db.close();
+  }
+
+  private String runningRunOn(String node) {
+    var id = DateTimeUtils.newId().toString();
+    return runStore.create(
+        id,
+        "backend",
+        "auth",
+        node,
+        node,
+        "build",
+        "claude-code",
+        "feat/x",
+        "do it",
+        123,
+        null,
+        "/home/dev/.sail/runs/" + id + "/agent.log",
+        "sail-agent-" + id);
+  }
+
+  private void stampAt(String id, Instant at) {
+    db.execute("UPDATE runs SET last_activity_at = ? WHERE id = ?", at.toString(), id);
+  }
+
+  private Instant now() {
+    return clock.get();
+  }
+
+  @Test
+  void aRunWithNoActivityStampEmitsNothing() {
+    runningRunOn("node-a");
+
+    assertEquals(0, emitter.sweep(), "presence is never guessed for an unstamped run");
+  }
+
+  @Test
+  void aWorkingRunSeedsSilentlyAndOnlyTheQuietCrossingEmits() throws Exception {
+    var id = runningRunOn("node-a");
+    stampAt(id, now().minusSeconds(10));
+    var received = new ConcurrentLinkedQueue<Event>();
+    var delivered = new CountDownLatch(1);
+    bus.subscribe(
+        new EventSubscriber() {
+          @Override
+          public String name() {
+            return "recorder";
+          }
+
+          @Override
+          public Predicate<Event> filter() {
+            return e -> Event.WellKnownTypes.AGENT_PRESENCE.equals(e.type());
+          }
+
+          @Override
+          public void onEvent(Event event) {
+            received.add(event);
+            delivered.countDown();
+          }
+        });
+
+    assertEquals(0, emitter.sweep(), "working is the default assumption — no edge on first sight");
+    assertEquals(0, emitter.sweep());
+
+    clock.set(now().plus(RunPresence.THRESHOLD).plusSeconds(60));
+    assertEquals(1, emitter.sweep(), "the quiet crossing emits");
+    assertEquals(0, emitter.sweep(), "once per crossing, never per pass");
+
+    BusTesting.awaitDelivery(delivered);
+    var event = received.poll();
+    assertEquals("quiet", event.data().get("presence"));
+    assertEquals(id, event.data().get(Event.WellKnownData.RUN_ID));
+    assertEquals("build", event.data().get(Event.WellKnownData.RUN_ROLE));
+    assertEquals("backend", event.project());
+    assertEquals("auth", event.spec());
+  }
+
+  @Test
+  void resumedActivityEmitsWorkingExactlyOnce() {
+    var id = runningRunOn("node-a");
+    stampAt(id, now().minus(RunPresence.THRESHOLD).minusSeconds(60));
+    assertEquals(1, emitter.sweep(), "first sight already past the threshold narrates the alarm");
+
+    stampAt(id, now());
+    assertEquals(1, emitter.sweep(), "the resume crossing emits working");
+    assertEquals(0, emitter.sweep());
+    assertEquals(2, bus.publishedCount(), "quiet then working — transitions only, no heartbeats");
+  }
+
+  @Test
+  void aForeignRunsEdgesBelongToItsExecutingBox() {
+    var id = runningRunOn("node-b");
+    stampAt(id, now().minus(RunPresence.THRESHOLD).minusSeconds(60));
+
+    assertEquals(
+        0,
+        emitter.sweep(),
+        "a synced stamp is only as fresh as the last sync — narrating quiet from it would be"
+            + " noise");
+  }
+
+  @Test
+  void aFinishedRunDropsItsEdgeStateInsteadOfEmitting() {
+    var id = runningRunOn("node-a");
+    stampAt(id, now().minus(RunPresence.THRESHOLD).minusSeconds(60));
+    assertEquals(1, emitter.sweep());
+
+    runStore.complete(id, "completed", 0);
+
+    assertEquals(0, emitter.sweep(), "terminal runs have no presence and no edges");
+  }
+
+  @Test
+  void startAndCloseAreIdempotentLifecycle() {
+    emitter.start();
+    emitter.close();
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RunPresenceTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RunPresenceTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class RunPresenceTest {
+
+  private static final Instant NOW = Instant.parse("2026-08-13T12:00:00Z");
+
+  @Test
+  void aRunningRunWithFreshActivityIsWorking() {
+    assertEquals("working", RunPresence.of("running", "2026-08-13T11:59:00Z", NOW));
+  }
+
+  @Test
+  void activityExactlyAtTheThresholdIsStillWorking() {
+    assertEquals(
+        "working",
+        RunPresence.of("running", NOW.minus(RunPresence.THRESHOLD).toString(), NOW),
+        "the boundary reads working; quiet begins strictly past the threshold");
+  }
+
+  @Test
+  void aRunningRunSilentPastTheThresholdIsQuiet() {
+    assertEquals("quiet", RunPresence.of("running", "2026-08-13T11:57:59Z", NOW));
+  }
+
+  @Test
+  void aTerminalRunHasNoPresence() {
+    assertNull(RunPresence.of("completed", "2026-08-13T11:59:00Z", NOW));
+    assertNull(RunPresence.of("stopped", "2026-08-13T11:59:00Z", NOW));
+    assertNull(RunPresence.of("failed", "2026-08-13T11:59:00Z", NOW));
+  }
+
+  @Test
+  void aStoppingRunHasNoPresence() {
+    assertNull(
+        RunPresence.of("stopping", "2026-08-13T11:59:00Z", NOW),
+        "a run mid-stop is the stop lane's story, not a liveness question");
+  }
+
+  @Test
+  void aRunWithNoActivityStampHasNoPresence() {
+    assertNull(RunPresence.of("running", null, NOW), "pre-upgrade rows must never guess");
+    assertNull(RunPresence.of("running", "", NOW));
+  }
+
+  @Test
+  void anUnparseableStampHasNoPresence() {
+    assertNull(RunPresence.of("running", "not-a-timestamp", NOW));
+  }
+
+  @Test
+  void theThresholdFiresWellBeforeAnySensibleMaxIdle() {
+    assertTrue(
+        RunPresence.THRESHOLD.toMinutes() <= 5,
+        "presence is the early signal; it must cross long before a max_idle guardrail would kill"
+            + " the run");
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -154,6 +154,8 @@ class TestOperations implements Operations {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null)));
   }
 


### PR DESCRIPTION
## sail-run-presence (sail side)

A grinding agent and a silent one looked identical: run status was just `running`, and the only liveness signal was buried in telemetry the clients discard. Presence is now **derived, not stateful** — a timestamp and a read-time computation, no new hooks, no state machine.

- **`runs.last_activity_at`** (migration appended): `RunActivityStamper` — its own EventBus subscriber, not folded into `RunTracker` — stamps the row when a progress event carries its `run_id`. "Progress" is one definition, `Event.WellKnownTypes.progress`, shared with the watcher's stall timer (`AgentWatchCommand.isProgressEvent` now delegates).
- **Coalesced, revision-free stamping**: `RunStore.stampActivity` skips writes inside a 30s floor and never journals a revision — a continuous `agent_log_chunk` stream can't flood the ChangeLog or fire sync-on-write per chunk. The value rides along on the run's next real revision; foreign-run freshness is bounded by sync cadence, the board's existing contract. Only `running` rows are stamped, so a late event never dirties a journaled terminal row.
- **Read-time presence** (`RunPresence`, 120s threshold, documented to fire well under any `max_idle` guardrail): `working`/`quiet` on `RunView` (runs listings) and `RunSummary` (`latest_run`); absent for terminal runs and null stamps — never guessed.
- **`agent_presence` finally has an emitter**: `RunPresenceEmitter`, a `PeriodicPass` sibling of the reconciler/rearmer, publishes transitions only — one `quiet` on the crossing, one `working` on resume — with in-memory edge state, local runs only (a foreign run's stamp is sync-stale; its executing box owns its edges). Retention class was already `EPHEMERAL`.

Tests: coalescing floor (burst → one write, ChangeLog not journaled), presence table test, single-fire crossings, old-shape snapshots derive null, migration staging. `mvn clean verify` green including the api.* 100% JaCoCo gates.

Mast counterpart standardapplied/mast#39 consumes `last_activity_at`/`presence` + the events and deletes its 5s run-status poll.
