### PR TITLE
Presence through the whole spec lifecycle (decouple SAIL_SPEC_ID)

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -775,6 +775,16 @@ public final class RunStore implements ConflictResolver {
         this::mapRow);
   }
 
+  /**
+   * Every running run, review executions included — the presence lanes. Unlike {@link #running()},
+   * which the systemd reaper scopes to {@link #SESSION_ROLES}, presence covers a reviewer or fix
+   * agent too: they are agents at work and show a chip like any other run. Read-time presence still
+   * filters to the stamped rows; this only widens which running rows the emitter considers.
+   */
+  public List<RunRow> runningForPresence() {
+    return db.query("SELECT " + COLUMNS + " FROM runs WHERE status = 'running'", this::mapRow);
+  }
+
   /** Marks local review executions orphaned by a server restart failed. */
   public int failRunningReviewsOnNode(String localHandle) {
     var ids =

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -214,6 +214,15 @@ public final class RunStore implements ConflictResolver {
     }
 
     /**
+     * Whether this row is a review execution — the reviewer or its fix agent, which share the one
+     * review row. Their own stop must never re-enter the pipeline, so lane-aware reactors consult
+     * this as the fallback when a stop signal lost its role marker.
+     */
+    public boolean reviewRole() {
+      return "review".equals(role);
+    }
+
+    /**
      * Whether this row is an agent session the run-scoped machinery owns — a build attempt, an
      * ad-hoc run, or a room wake — as opposed to a pipeline-driven review execution. Session rows
      * are the ones the stop, status, log, reaper, and missed-stop lanes address; a room run joins

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -19,7 +19,9 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -484,6 +486,10 @@ class RunStoreTest {
     assertEquals(buildId, store.latestForProjectOnNode("backend", "node-a").orElseThrow().id());
     assertEquals(buildId, store.runningForProjectOnNode("backend", "node-a").orElseThrow().id());
     assertEquals(List.of(buildId), store.running().stream().map(RunStore.RunRow::id).toList());
+    assertEquals(
+        Set.of(buildId, reviewId),
+        store.runningForPresence().stream().map(RunStore.RunRow::id).collect(Collectors.toSet()),
+        "presence covers the review execution too — it is an agent at work");
     assertEquals(2, store.listForProject("backend").size(), "the aggregate still lists both roles");
   }
 

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/SailEventHelper.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/SailEventHelper.java
@@ -35,23 +35,24 @@ public final class SailEventHelper {
       #   Args: <event-type> [reason]
       # The optional reason lands in data.reason, sanitized to keep the
       # hand-built JSON valid (quotes, backslashes, control chars dropped).
-      # Spec attribution flows in via SAIL_SPEC_ID env var (set by sail at launch);
-      # absent or blank means an engineer-initiated session — skip silently so
-      # ad-hoc 'claude' invocations never pollute the spec event bus.
-      # The run credential (SAIL_RUN_CREDENTIAL, injected at launch) authenticates the
-      # request; the server stamps authorship from it, so the agent field here is advisory.
+      # The run credential (SAIL_RUN_CREDENTIAL, injected at launch) both authenticates the
+      # request and scopes it: the server stamps project/spec/run/author from the authenticated
+      # run and ignores the fields below. No credential means an untracked engineer session with
+      # no run to speak for — skip silently so ad-hoc 'claude' invocations never pollute the spec
+      # event bus. This is why a credentialed reviewer/fix run (no SAIL_SPEC_ID, no SAIL_RUN_ID)
+      # still emits and shows presence. SAIL_SPEC_ID rides along only as an advisory hint.
       set -eu
 
       EVENT_TYPE="${1:?event type required}"
       REASON="$(printf '%s' "${2:-}" | tr -d '\\\\"\\000-\\037')"
-      SPEC_ID="${SAIL_SPEC_ID:-}"
-      if [ -z "$SPEC_ID" ]; then
+      CREDENTIAL="${SAIL_RUN_CREDENTIAL:-}"
+      if [ -z "$CREDENTIAL" ]; then
         exit 0
       fi
+      SPEC_ID="${SAIL_SPEC_ID:-}"
       AGENT="${SAIL_AGENT:-claude-code}"
       RUN_ID="${SAIL_RUN_ID:-}"
       RUN_ROLE="${SAIL_RUN_ROLE:-}"
-      CREDENTIAL="${SAIL_RUN_CREDENTIAL:-}"
       PROJECT="$(hostname)"
       HOST="$(hostname)"
       TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/SailEventHelperTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/SailEventHelperTest.java
@@ -66,14 +66,17 @@ class SailEventHelperTest {
   }
 
   @Test
-  void scriptNoOpsWhenSpecIdMissing() {
+  void scriptNoOpsWhenRunCredentialMissing() {
     var content = SailEventHelper.scriptContent();
-    var idx = content.indexOf("if [ -z \"$SPEC_ID\" ]; then");
-    assertTrue(idx > 0, "must short-circuit when SAIL_SPEC_ID is unset");
+    var idx = content.indexOf("if [ -z \"$CREDENTIAL\" ]; then");
+    assertTrue(
+        idx > 0,
+        "must short-circuit when SAIL_RUN_CREDENTIAL is unset — an untracked engineer session has"
+            + " no run to authenticate as, and the credential is what scopes the event");
     var afterCheck = content.substring(idx);
     assertTrue(
         afterCheck.indexOf("exit 0") < afterCheck.indexOf("curl"),
-        "exit 0 must come before the curl call so engineer sessions skip the POST");
+        "exit 0 must come before the curl call so untracked sessions skip the POST");
   }
 
   @Test

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
@@ -181,6 +181,24 @@ public record Event(
     /** {@link #RUN_ROLE} value: a room wake — a chat that must never trigger a review. */
     public static final String RUN_ROLE_ROOM = "room";
 
+    /** {@link #RUN_ROLE} value: a reviewer run — its own stop must never re-enter the pipeline. */
+    public static final String RUN_ROLE_REVIEW = "review";
+
+    /** {@link #RUN_ROLE} value: a fix run — its own stop must never re-enter the pipeline. */
+    public static final String RUN_ROLE_FIX = "fix";
+
+    /**
+     * Whether a run role names a lane whose own stop must never drive the review pipeline: a {@link
+     * #RUN_ROLE_ROOM} chat, or the pipeline's own {@link #RUN_ROLE_REVIEW} / {@link #RUN_ROLE_FIX}
+     * run. Reactors on {@code agent_session_stopped} drop such stops by role so the loop can never
+     * re-enter on its own agents. Null (a role-less stop) is a normal build stop.
+     */
+    public static boolean nonTriggeringLane(String role) {
+      return RUN_ROLE_ROOM.equals(role)
+          || RUN_ROLE_REVIEW.equals(role)
+          || RUN_ROLE_FIX.equals(role);
+    }
+
     private WellKnownData() {}
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -262,7 +262,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
   }
 
   private void handleAgentStopped(Event event) {
-    if (roomStop(event)) return;
+    if (nonTriggeringLaneStop(event)) return;
 
     var specId = event.spec();
     var spec = specStore.findById(specId);
@@ -996,15 +996,25 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
   }
 
   /**
-   * Whether this stop belongs to a room wake — a chat-lane run that answers in the spec's room and
-   * must never trigger a review, structurally: an escalated spec parked in {@code review} is
-   * exactly where a human asks "what is it stuck on?", and reviewing that chat would re-enter the
-   * loop the human just took over. The role rides the stop signal itself (hook, watcher, and
-   * reconciler stops all carry it), with the run row consulted as the fallback for a signal that
-   * lost it.
+   * Whether this stop belongs to a lane the pipeline must never act on — so its own agents' stops
+   * can never re-enter the review loop:
+   *
+   * <ul>
+   *   <li>A <b>room</b> wake: a chat-lane run answering in the spec's room. An escalated spec
+   *       parked in {@code review} is exactly where a human asks "what is it stuck on?", and
+   *       reviewing that chat would re-enter the loop the human just took over.
+   *   <li>A <b>review</b> or <b>fix</b> run: the pipeline's own agents. Reviewing on their stop
+   *       would recurse the review loop forever. Their events carry a blank spec (they launch
+   *       without {@code SAIL_SPEC_ID}), so {@code filter()} already drops them — this is the
+   *       explicit, role-keyed backstop that holds even if such a run ever carried a spec id.
+   * </ul>
+   *
+   * <p>The role rides the stop signal itself (hook, watcher, and reconciler stops all carry it),
+   * with the run row consulted as the fallback for a signal that lost it.
    */
-  private boolean roomStop(Event event) {
-    if (Event.WellKnownData.RUN_ROLE_ROOM.equals(event.data().get(Event.WellKnownData.RUN_ROLE))) {
+  private boolean nonTriggeringLaneStop(Event event) {
+    var role = Objects.toString(event.data().get(Event.WellKnownData.RUN_ROLE), null);
+    if (Event.WellKnownData.nonTriggeringLane(role)) {
       return true;
     }
     if (runStore == null) {
@@ -1013,7 +1023,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     var runId = Objects.toString(event.data().get(Event.WellKnownData.RUN_ID), null);
     return runId != null
         && !runId.isBlank()
-        && runStore.findById(runId).map(RunStore.RunRow::roomRole).orElse(false);
+        && runStore.findById(runId).map(row -> row.roomRole() || row.reviewRole()).orElse(false);
   }
 
   private static Integer exitCodeOf(Event event) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -1004,9 +1004,10 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
    *       parked in {@code review} is exactly where a human asks "what is it stuck on?", and
    *       reviewing that chat would re-enter the loop the human just took over.
    *   <li>A <b>review</b> or <b>fix</b> run: the pipeline's own agents. Reviewing on their stop
-   *       would recurse the review loop forever. Their events carry a blank spec (they launch
-   *       without {@code SAIL_SPEC_ID}), so {@code filter()} already drops them — this is the
-   *       explicit, role-keyed backstop that holds even if such a run ever carried a spec id.
+   *       would recurse the review loop forever. Their own stop hooks are already refused at the
+   *       API layer (the terminal session types are watcher-and-reconciler-only), so in practice
+   *       only a watcher- or reconciler-derived stop could ever carry a review/fix role — this is
+   *       the explicit, role-keyed backstop that drops it regardless.
    * </ul>
    *
    * <p>The role rides the stop signal itself (hook, watcher, and reconciler stops all carry it),

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RunPresenceEmitter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RunPresenceEmitter.java
@@ -73,7 +73,7 @@ public final class RunPresenceEmitter implements AutoCloseable {
     var now = clock.get();
     var live = new HashSet<String>();
     var emitted = 0;
-    for (var run : runStore.running()) {
+    for (var run : runStore.runningForPresence()) {
       if (!SailOperations.ownsRun(run.node(), node)) {
         continue;
       }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SpecLifecycleReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SpecLifecycleReactor.java
@@ -46,8 +46,8 @@ public final class SpecLifecycleReactor implements EventSubscriber {
         HANDLED_TYPES.contains(e.type())
             && e.spec() != null
             && !e.spec().isBlank()
-            && !Event.WellKnownData.RUN_ROLE_ROOM.equals(
-                e.data().get(Event.WellKnownData.RUN_ROLE));
+            && !Event.WellKnownData.nonTriggeringLane(
+                Objects.toString(e.data().get(Event.WellKnownData.RUN_ROLE), null));
   }
 
   @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EventEmissionDeliveryIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EventEmissionDeliveryIT.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.engine.SailEventHelper;
+import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.store.MessageStore;
+import ai.singlr.sail.store.ProjectStore;
+import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Proves the emission gate behaviorally: the generated {@code sail-event.sh} runs against the real
+ * {@link LocalApiSocket} and either delivers or stays silent. The credential — not {@code
+ * SAIL_SPEC_ID} — is what lets a run emit and what scopes the event, which is exactly why a
+ * reviewer or fix agent (credentialed, but with no spec id and no run id) shows presence.
+ */
+class EventEmissionDeliveryIT {
+
+  @TempDir Path root;
+  private Sqlite db;
+  private EventBus bus;
+  private RunStore runStore;
+  private LocalApiSocket listener;
+  private Path home;
+  private String runId;
+  private String credential;
+
+  @BeforeEach
+  void bootFakeRunAgainstTheProductionApi() throws Exception {
+    home = root.resolve("home");
+    Files.createDirectories(home);
+    db = Sqlite.open(root.resolve("session.db"));
+    new SchemaManager(db).migrate();
+    db.execute(
+        """
+        INSERT INTO specs
+            (id, title, project, assignee, created_by, created_at, updated_at)
+        VALUES ('auth', 'Auth', 'acme', 'ada', 'ada', 'now', 'now')""");
+    bus = new EventBus();
+    runStore = new RunStore(db);
+    var operations =
+        new SailOperations(
+                new ShellExecutor(false),
+                "sail.yaml",
+                bus,
+                null,
+                new SpecStore(db),
+                new ReviewStore(db),
+                runStore,
+                new ProjectStore(db),
+                SyncScheduler.disabled(),
+                null)
+            .useMessages(new MessageStore(db));
+    runId = DateTimeUtils.newId().toString();
+    var reservation =
+        (RunStore.Reservation.Reserved)
+            runStore.reserveDispatch(
+                runId,
+                "acme",
+                "auth",
+                "node-a",
+                "ada",
+                "build",
+                List.of(),
+                "claude-code",
+                "b",
+                "t",
+                "l",
+                "u");
+    credential = reservation.credential();
+    listener = new LocalApiSocket(bus, operations, root.resolve("api.sock"));
+    listener.start();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (listener != null) {
+      listener.close();
+    }
+    bus.close();
+    db.close();
+  }
+
+  private CountDownLatch captureToolStarts(CopyOnWriteArrayList<Event> sink) {
+    var latch = new CountDownLatch(1);
+    bus.subscribe(
+        new EventSubscriber() {
+          @Override
+          public String name() {
+            return "capture";
+          }
+
+          @Override
+          public Predicate<Event> filter() {
+            return e -> Event.WellKnownTypes.AGENT_TOOL_STARTED.equals(e.type());
+          }
+
+          @Override
+          public void onEvent(Event event) {
+            sink.add(event);
+            latch.countDown();
+          }
+        });
+    return latch;
+  }
+
+  @Test
+  void aCredentialedRunEmitsAndTheServerScopesItToTheRunSpec() throws Exception {
+    var captured = new CopyOnWriteArrayList<Event>();
+    var latch = captureToolStarts(captured);
+
+    var result = runEvent("agent_tool_started", true);
+
+    assertEquals(0, result, "a best-effort emit never fails the hook");
+    assertTrue(latch.await(30, TimeUnit.SECONDS), "the credentialed tool-start must be delivered");
+    var event = captured.get(0);
+    assertEquals(
+        "auth",
+        event.spec(),
+        "the server scopes the event to the run's spec, not the client's blank SAIL_SPEC_ID");
+    assertEquals(runId, event.data().get(Event.WellKnownData.RUN_ID));
+  }
+
+  @Test
+  void anUncredentialedSessionEmitsNothing() throws Exception {
+    var captured = new CopyOnWriteArrayList<Event>();
+    var latch = captureToolStarts(captured);
+
+    runEvent("agent_tool_started", false);
+    runEvent("agent_tool_started", true);
+
+    assertTrue(latch.await(30, TimeUnit.SECONDS), "the credentialed control must land");
+    assertEquals(
+        1,
+        captured.size(),
+        "the un-credentialed call emitted nothing; only the credentialed control landed");
+  }
+
+  private int runEvent(String eventType, boolean withCredential) throws Exception {
+    var script = writeScript();
+    var pb = new ProcessBuilder("/bin/sh", script.toString(), eventType);
+    var env = pb.environment();
+    env.put("HOME", home.toString());
+    env.remove("SAIL_SPEC_ID");
+    env.remove("SAIL_RUN_ID");
+    if (withCredential) {
+      env.put("SAIL_RUN_CREDENTIAL", credential);
+    } else {
+      env.remove("SAIL_RUN_CREDENTIAL");
+    }
+    var process = pb.start();
+    assertTrue(process.waitFor(30, TimeUnit.SECONDS), "the emit must finish inside its timeout");
+    return process.exitValue();
+  }
+
+  private Path writeScript() throws IOException {
+    var path = home.resolve("sail-event.sh");
+    Files.writeString(
+        path,
+        SailEventHelper.scriptContent()
+            .replace(
+                SailPaths.apiSocketContainerPath().toString(),
+                root.resolve("api.sock").toString()));
+    Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rwxr-xr-x"));
+    return path;
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -269,6 +269,51 @@ class ReviewPipelineControllerTest {
     assertEquals(SpecStatus.REVIEW, specStore.findById("auth").orElseThrow().status());
   }
 
+  private Event laneStopEvent(String specId, String role, String runId) {
+    var data = new java.util.LinkedHashMap<String, Object>();
+    data.put(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_WATCHER);
+    data.put(Event.WellKnownData.EXIT_CODE, 0);
+    if (role != null) {
+      data.put(Event.WellKnownData.RUN_ROLE, role);
+    }
+    if (runId != null) {
+      data.put(Event.WellKnownData.RUN_ID, runId);
+    }
+    return Event.of(
+        "test-project",
+        specId,
+        Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+        "claude-code",
+        "host",
+        data);
+  }
+
+  @Test
+  void aReviewLaneStopNeverTriggersAReview() {
+    createSpec("auth", "in_progress");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
+
+    ctrl.onEvent(laneStopEvent("auth", Event.WellKnownData.RUN_ROLE_REVIEW, null));
+
+    assertTrue(
+        reviewStore.reviewsForSpec("auth").isEmpty(),
+        "a reviewer's own stop — even carrying the spec id — must never re-enter the pipeline");
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void aFixLaneStopNeverTriggersAReview() {
+    createSpec("auth", "in_progress");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
+
+    ctrl.onEvent(laneStopEvent("auth", Event.WellKnownData.RUN_ROLE_FIX, null));
+
+    assertTrue(
+        reviewStore.reviewsForSpec("auth").isEmpty(),
+        "a fix agent's own stop must never re-enter the pipeline");
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+  }
+
   @Test
   void aRoomStopOnADoneSpecTriggersNothing() {
     createSpec("auth", "done");

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RunPresenceEmitterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RunPresenceEmitterTest.java
@@ -49,6 +49,10 @@ class RunPresenceEmitterTest {
   }
 
   private String runningRunOn(String node) {
+    return runningRunOn(node, "build");
+  }
+
+  private String runningRunOn(String node, String role) {
     var id = DateTimeUtils.newId().toString();
     return runStore.create(
         id,
@@ -56,7 +60,7 @@ class RunPresenceEmitterTest {
         "auth",
         node,
         node,
-        "build",
+        role,
         "claude-code",
         "feat/x",
         "do it",
@@ -132,6 +136,18 @@ class RunPresenceEmitterTest {
     assertEquals(1, emitter.sweep(), "the resume crossing emits working");
     assertEquals(0, emitter.sweep());
     assertEquals(2, bus.publishedCount(), "quiet then working — transitions only, no heartbeats");
+  }
+
+  @Test
+  void aReviewRunGetsPresenceEdgesToo() {
+    var id = runningRunOn("node-a", "review");
+    stampAt(id, now().minus(RunPresence.THRESHOLD).minusSeconds(60));
+
+    assertEquals(
+        1,
+        emitter.sweep(),
+        "a review execution is an agent at work — its quiet crossing must narrate, even though"
+            + " running() excludes review rows for the reaper");
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SpecLifecycleReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SpecLifecycleReactorTest.java
@@ -89,6 +89,25 @@ class SpecLifecycleReactorTest {
   }
 
   @Test
+  void aReviewOrFixStopNeverAdvancesTheSpec() {
+    seed("auth", "in_progress");
+    for (var role :
+        List.of(Event.WellKnownData.RUN_ROLE_REVIEW, Event.WellKnownData.RUN_ROLE_FIX)) {
+      var laneStop =
+          Event.of(
+              "acme",
+              "auth",
+              Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+              "claude-code",
+              "host",
+              java.util.Map.of(Event.WellKnownData.RUN_ROLE, role));
+      assertFalse(
+          reactor.filter().test(laneStop),
+          "the pipeline's own " + role + " run must never flip the spec to review");
+    }
+  }
+
+  @Test
   void nameIsSpecLifecycle() {
     assertEquals("spec-lifecycle", reactor.name());
   }


### PR DESCRIPTION
Implements `sail-review-fix-presence`. The presence chip pulsed while a spec was *coded* but went dark through **review** and **fix** — even though an agent works the whole time, and a fix iteration puts the spec back in `in_progress`, identical on the board to a fresh dispatch but with no pulse.

Root cause: `SAIL_SPEC_ID` did three jobs at once — spec attribution, the event-emission master switch, and (by accident) the review re-entry guard. Review/fix agents launch without it, so their hooks emitted nothing and never stamped `last_activity_at`.

### What reading the ingest path changed
`LocalApiRouter.events` already **scopes every event from the credential's run** (not the client's `SAIL_SPEC_ID`) and already **refuses the terminal stop types** (`agent_session_stopped/completed` are `403`ed). So a reviewer's/fix agent's own stop can never reach the bus, and the credential already carries spec scope. That collapsed the design: gate emission on the **credential** (which the reviewer already has) and nothing else moves — no `SAIL_RUN_ID` for the reviewer, so its stop gate never arms, so **no `SailStopGate` change at all**.

### The three commits
1. **Explicit role guard** — `review`/`fix` run-role constants + a shared `Event.WellKnownData.nonTriggeringLane` helper; both stop reactors (`ReviewPipelineController`, `SpecLifecycleReactor`) drop review/fix stops by role, with a run-row `role()` fallback. Proven **red first** (a review/fix authoritative stop *did* trigger a review on the old code). This is defense-in-depth behind the ingest refusal.
2. **Credential-gated emission** — `sail-event.sh` gates on `SAIL_RUN_CREDENTIAL`. Reviewer and fix agents (already credentialed) now emit `agent_tool_*`; the server scopes to their spec, `RunActivityStamper` stamps by `run_id`, presence lights up through the read-time path that already computes for every role. Untracked human sessions have no credential → still silent. Behavioral IT drives the real script against a live `LocalApiSocket`.
3. **Presence edges for review/fix** — `RunStore.runningForPresence()` (all running rows) so `RunPresenceEmitter` fires server-authoritative quiet crossings for review/fix too, leaving `running()`/`SESSION_ROLES` untouched for the reaper.

### Verification
- `mvn clean verify`: **2733 tests, 0 failures, all coverage checks met** (incl. `api.*` 100% on touched classes).
- Every behavior change proven red→green. No `Thread.sleep`. No new dependencies.

Mast needs no functional change — the chip already renders for `in_progress`/`review` cards and the room header, and labels non-build lanes by role. (A one-line comment correction rides in a small mast PR.)