### PR TITLE
An agent's question is a flag, not a hope: --question + derived needs_reply

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/AgentContextGenerator.java
@@ -243,7 +243,8 @@ public final class AgentContextGenerator {
         ### Working with specs
         - `spec board` — kanban summary; `spec list [--status pending] [--assignee me]`
         - `spec comment <id> --body <text>|-` — post progress, a question, or a final summary;
-          `spec comments <id>` — read the room
+          add `--question` when you are blocked and need a human reply (it pages the engineer
+          on the board until someone answers); `spec comments <id>` — read the room
         - `spec show <id>` — metadata, dependencies, and the full body
         - `spec create --id <id> --title "<title>" --body-file <file>` — create one; add
           `--depends-on a,b`, `--repos api,web`, `--agent codex|claude-code`, `--model <id>`,

--- a/sail-core/src/main/java/ai/singlr/sail/gen/SpecSkillGenerator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/gen/SpecSkillGenerator.java
@@ -92,7 +92,9 @@ public final class SpecSkillGenerator {
         `--status pending` or `--assignee me` to filter). Render the result as status columns:
 
         Use `spec comment <id> --body <text>|-` to post progress, questions, and summaries in the
-        spec's conversation; use `spec comments <id>` to read it.
+        spec's conversation; add `--question` when you are blocked and need a human reply — it
+        pages the engineer on the board until someone answers. Use `spec comments <id>` to read
+        the room.
 
         ```
         ┌─────────────┬─────────────────┬──────────────┬────────────────────┬──────────────┐

--- a/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
@@ -184,6 +184,15 @@ public final class MessageStore {
    * room; the author classes are structural, mirroring {@code RoomWakePolicy.humanAuthor}: an agent
    * principal always carries a {@code /}, the orchestrator posts as the literal {@code sail}, and
    * FDE handles contain neither.
+   *
+   * <p>"Later" is message-id order, which is origin-mint order, so this is content-deterministic
+   * and consistent across boxes at sync-freshness. Known edge: a human message posted in the room
+   * during the sync lag <em>before</em> a question arrives has a higher id and reads as answering
+   * it, so the chip and notification will not fire for that question. This never breaks the loop —
+   * {@code RoomWakeReactor} resumes the agent on any human reply regardless of this flag, and the
+   * question stays visible in the room. A robust fix needs per-box arrival order (which breaks
+   * cross-box determinism) or delivery receipts (a deliberate non-goal), so it stays a documented
+   * edge.
    */
   public Map<String, String> openQuestions() {
     var open = new LinkedHashMap<String, String>();

--- a/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
@@ -26,7 +26,7 @@ public final class MessageStore {
   public static final int MAX_BODY_BYTES = 64 * 1024;
   private static final String ENTITY = "message";
   private static final String COLUMNS =
-      "id, spec_id, author, body, reply_to, created_at, rev, base_rev";
+      "id, spec_id, author, body, reply_to, created_at, rev, base_rev, question";
 
   private final Sqlite db;
   private final ChangeLog changeLog;
@@ -44,9 +44,15 @@ public final class MessageStore {
       String replyTo,
       String createdAt,
       String rev,
-      String baseRev) {}
+      String baseRev,
+      boolean question) {}
 
   public MessageRow append(String specId, String author, String body, String replyTo) {
+    return append(specId, author, body, replyTo, false);
+  }
+
+  public MessageRow append(
+      String specId, String author, String body, String replyTo, boolean question) {
     requireBody(body);
     if (Strings.isBlank(author)) {
       throw new IllegalArgumentException("message author is required");
@@ -66,7 +72,8 @@ public final class MessageStore {
                   replyTo,
                   DateTimeUtils.now().toString(),
                   null,
-                  null);
+                  null,
+                  question);
           requireReplyTarget(row);
           var snapshot = snapshot(row);
           var rev = Revisions.next(null, YamlUtil.dumpJson(snapshot));
@@ -169,6 +176,29 @@ public final class MessageStore {
         "SELECT id FROM spec_messages WHERE spec_id = ? ORDER BY id DESC LIMIT 1",
         row -> row.text(0),
         specId);
+  }
+
+  /**
+   * Each spec whose latest agent-authored question is still unanswered, mapped to that question's
+   * message id — one aggregate query. A question is answered by any later human message in the
+   * room; the author classes are structural, mirroring {@code RoomWakePolicy.humanAuthor}: an agent
+   * principal always carries a {@code /}, the orchestrator posts as the literal {@code sail}, and
+   * FDE handles contain neither.
+   */
+  public Map<String, String> openQuestions() {
+    var open = new LinkedHashMap<String, String>();
+    for (var entry :
+        db.query(
+            "SELECT q.spec_id, MAX(q.id) FROM spec_messages q"
+                + " WHERE q.question != 0 AND q.author LIKE '%/%'"
+                + " AND NOT EXISTS (SELECT 1 FROM spec_messages h"
+                + " WHERE h.spec_id = q.spec_id AND h.id > q.id"
+                + " AND h.author NOT LIKE '%/%' AND h.author != 'sail')"
+                + " GROUP BY q.spec_id",
+            row -> Map.entry(row.text(0), row.text(1)))) {
+      open.put(entry.getKey(), entry.getValue());
+    }
+    return open;
   }
 
   /** Each room's newest message timestamp — one aggregate query, keyed by spec id. */
@@ -309,8 +339,8 @@ public final class MessageStore {
     db.execute(
         """
         INSERT INTO spec_messages
-            (id, spec_id, author, body, reply_to, created_at, rev, base_rev)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            (id, spec_id, author, body, reply_to, created_at, rev, base_rev, question)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET rev = excluded.rev, base_rev = excluded.base_rev""",
         row.id(),
         row.specId(),
@@ -319,7 +349,8 @@ public final class MessageStore {
         row.replyTo(),
         row.createdAt(),
         rev,
-        baseRev);
+        baseRev,
+        row.question() ? 1 : 0);
   }
 
   private void requireReplyTarget(MessageRow row) {
@@ -352,7 +383,8 @@ public final class MessageStore {
         replyTo,
         required(snapshot, "created_at"),
         null,
-        null);
+        null,
+        Boolean.parseBoolean(Objects.toString(snapshot.get("question"), "false")));
   }
 
   private static Map<String, Object> snapshot(MessageRow row) {
@@ -364,6 +396,9 @@ public final class MessageStore {
       map.put("reply_to", row.replyTo());
     }
     map.put("created_at", row.createdAt());
+    if (row.question()) {
+      map.put("question", true);
+    }
     return map;
   }
 
@@ -376,7 +411,8 @@ public final class MessageStore {
         row.text(4),
         row.text(5),
         row.text(6),
-        row.text(7));
+        row.text(7),
+        row.integer(8) != 0);
   }
 
   private static void requireBody(String body) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -218,7 +218,8 @@ public final class SchemaManager {
               run_id TEXT PRIMARY KEY REFERENCES runs(id) ON DELETE CASCADE,
               baseline TEXT NOT NULL
           )""",
-          "ALTER TABLE runs ADD COLUMN last_activity_at TEXT");
+          "ALTER TABLE runs ADD COLUMN last_activity_at TEXT",
+          "ALTER TABLE spec_messages ADD COLUMN question INTEGER NOT NULL DEFAULT 0");
 
   /** The schema version this binary converges every database to. */
   static final int CURRENT_VERSION = V1_VERSION + MIGRATIONS.size();

--- a/sail-core/src/test/java/ai/singlr/sail/engine/FixTaskBuilderTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/FixTaskBuilderTest.java
@@ -338,7 +338,8 @@ class FixTaskBuilderTest {
                 null,
                 "2026-08-10T00:00:00Z",
                 "1-a",
-                null));
+                null,
+                false));
 
     var task = FixTaskBuilder.build("auth-spec", "Spec", List.of(finding), messages).task();
 

--- a/sail-core/src/test/java/ai/singlr/sail/engine/ReviewPromptBuilderTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/ReviewPromptBuilderTest.java
@@ -209,7 +209,8 @@ class ReviewPromptBuilderTest {
             null,
             "2026-07-28T00:00:00Z",
             "1-a",
-            null);
+            null,
+            false);
 
     var prompt = ReviewPromptBuilder.build("main", List.of("app"), List.of(), List.of(message));
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/MessageStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/MessageStoreTest.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -165,6 +166,45 @@ class MessageStoreTest {
         "a run is never told its own story");
     assertThrows(
         IllegalArgumentException.class, () -> messages.listUndelivered("room", runId, "x", 0));
+  }
+
+  @Test
+  void questionFlagRoundTripsAndStaysOutOfPlainSnapshots() {
+    var question = messages.append("room", "claude/run-1", "Which auth flow?", null, true);
+    assertTrue(question.question());
+    assertTrue(messages.findById(question.id()).orElseThrow().question());
+    assertEquals(Boolean.TRUE, messages.comparableSnapshot(question.id()).get("question"));
+
+    var plain = messages.append("room", "claude/run-1", "progress", null);
+    assertFalse(plain.question());
+    assertFalse(messages.comparableSnapshot(plain.id()).containsKey("question"));
+  }
+
+  @Test
+  void openQuestionsFlagsTheLatestAgentQuestionUntilAHumanReplies() {
+    assertEquals(Map.of(), messages.openQuestions());
+
+    var first = messages.append("room", "claude/run-1", "Which db?", null, true);
+    assertEquals(Map.of("room", first.id()), messages.openQuestions());
+
+    var second = messages.append("room", "claude/run-1", "And which cache?", null, true);
+    assertEquals(Map.of("room", second.id()), messages.openQuestions());
+
+    messages.append("room", "codex/run-2", "agent chatter", null);
+    messages.append("room", "sail", "Review passed.", null);
+    assertEquals(
+        Map.of("room", second.id()),
+        messages.openQuestions(),
+        "neither an agent nor the orchestrator answers a question");
+
+    messages.append("room", "ada", "use redis and postgres", null);
+    assertEquals(Map.of(), messages.openQuestions());
+  }
+
+  @Test
+  void aHumanQuestionNeverNeedsAReply() {
+    messages.append("room", "ada", "what did you ship?", null, true);
+    assertEquals(Map.of(), messages.openQuestions());
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -479,6 +479,38 @@ class SchemaManagerTest {
   }
 
   @Test
+  void theQuestionColumnArrivesDefaultedOnPreUpgradeMessages() {
+    stageAtBaseline();
+    var priorEntries = migrationIndex("ADD COLUMN question");
+    db.execute("PRAGMA foreign_keys = OFF");
+    SchemaManager.MIGRATIONS.subList(0, priorEntries).forEach(db::execute);
+    db.execute("PRAGMA foreign_keys = ON");
+    db.execute(
+        "INSERT INTO schema_version (version, applied_at) VALUES (?, 'staged')",
+        SchemaManager.V1_VERSION + priorEntries);
+    db.execute(
+        "INSERT INTO specs (id, title, status, created_at, updated_at)"
+            + " VALUES ('auth', 'T', 'pending', 't0', 't0')");
+    db.execute(
+        "INSERT INTO spec_messages (id, spec_id, author, body, created_at, rev)"
+            + " VALUES ('0195a2f0-0000-7000-8000-000000000002', 'auth', 'uday', 'hi', 't0',"
+            + " '1-a')");
+
+    new SchemaManager(db).migrate();
+
+    assertEquals(
+        0L,
+        (long)
+            db.queryOne(
+                    "SELECT question FROM spec_messages"
+                        + " WHERE id = '0195a2f0-0000-7000-8000-000000000002'",
+                    r -> r.integer(0))
+                .orElseThrow(),
+        "a pre-upgrade message was never a question");
+    assertTrue(new MessageStore(db).append("auth", "claude/r1", "stuck?", null, true).question());
+  }
+
+  @Test
   void theWakeColumnAdmitsItsThreeModesAndRejectsGarbage() {
     new SchemaManager(db).migrate();
     db.execute(

--- a/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
@@ -89,6 +89,28 @@ class MessageSyncTest {
   }
 
   @Test
+  void theQuestionFlagSurvivesSyncAndDerivesTheSameAnswerEverywhere() {
+    var runId = "019fee00-0000-7000-8000-0000000000bb";
+    main.db.execute("UPDATE specs SET assignee = 'node' WHERE id = 'room'");
+    var runs = new ai.singlr.sail.store.RunStore(main.db);
+    runs.createReview(runId, "acme", "room", "node", "node", "codex", "b", "t", "/log", "unit");
+    var principal = runs.findById(runId).orElseThrow().principal();
+    var question = node.messages.append("room", principal, "Which flow?", null, true);
+    var engine = new SyncEngine();
+
+    SyncPeer.with("node", () -> engine.reconcile(node.replica, main.replica));
+
+    var synced = main.messages.findById(question.id()).orElseThrow();
+    assertTrue(synced.question(), "the flag is message data and rides the snapshot");
+    assertEquals(Map.of("room", question.id()), main.messages.openQuestions());
+
+    main.messages.append("room", "node", "answered", null);
+    SyncPeer.with("node", () -> engine.reconcile(node.replica, main.replica));
+    assertEquals(Map.of(), main.messages.openQuestions());
+    assertEquals(Map.of(), node.messages.openQuestions());
+  }
+
+  @Test
   void syncedMessagesCannotBeChangedOrDeleted() {
     main.db.execute("UPDATE specs SET assignee = 'node' WHERE id = 'room'");
     var row = node.messages.append("room", "node", "original", null);

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/SailStopGate.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/SailStopGate.java
@@ -271,7 +271,7 @@ public final class SailStopGate {
         fi
         REASON="$REASON Address or acknowledge them (reply with spec comment) before ending the turn."
       fi
-      REASON="$REASON If you are genuinely blocked, say so explicitly and stop again."
+      REASON="$REASON If you are genuinely blocked, post the question with spec comment <spec-id> --question --body <text> and stop again."
       publish agent_stop_nudged "$(printf '%.2000s' "$REASON")"
       printf '%s' "$REASON" | python3 -c 'import json, sys; print(json.dumps({"decision": "block", "reason": sys.stdin.read()}))'
       exit 0

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/SpecCliHelper.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/SpecCliHelper.java
@@ -105,7 +105,8 @@ public final class SpecCliHelper {
         spec update <id> [--status S] [--title T] [--assignee H] [--wake on|mention|off]
                     [--force] [...]  (alias: edit)
         spec content <id> --body-file F [--plan-file F]   revise the body
-        spec comment <id> --body <text>|- [--reply-to <message-id>]
+        spec comment <id> --body <text>|- [--reply-to <message-id>] [--question]
+                    (--question flags a blocking question so the board pages the engineer)
         spec comments <id> [--before <message-id>] [--limit N]
         spec archive <id>
         spec whoami                        show this run's principal identity
@@ -146,10 +147,13 @@ public final class SpecCliHelper {
           else
             FIELDS=(--data-urlencode "body=$body")
           fi
-          if [ $# -gt 0 ]; then
-            [ "$1" = "--reply-to" ] && [ $# -eq 2 ] || die "comment accepts only --reply-to <message-id>"
-            FIELDS+=(--data-urlencode "reply_to=$2")
-          fi
+          while [ $# -gt 0 ]; do
+            case "$1" in
+              --reply-to) [ $# -ge 2 ] || die "--reply-to needs a message id"; FIELDS+=(--data-urlencode "reply_to=$2"); shift 2;;
+              --question) FIELDS+=(--data-urlencode "question=true"); shift;;
+              *) die "comment accepts only --reply-to <message-id> and --question";;
+            esac
+          done
           api -X POST "${FIELDS[@]}" "$BASE/$id/messages";;
         comments)
           [ $# -ge 1 ] || die "comments needs a spec id"

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/SailStopGateTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/SailStopGateTest.java
@@ -74,6 +74,9 @@ class SailStopGateTest {
     assertEquals(0, result.exitCode(), result.stderr());
     var reason = blockReason(result);
     assertTrue(reason.contains("commit your work in sail"), reason);
+    assertTrue(
+        reason.contains("spec comment <spec-id> --question --body <text>"),
+        "a genuinely blocked agent must be told the question verb, not just to say so: " + reason);
     assertTrue(Files.exists(marker()), "the first block must drop the one-nudge-per-run marker");
   }
 

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/SpecCliHelperTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/SpecCliHelperTest.java
@@ -63,6 +63,18 @@ class SpecCliHelperTest {
   }
 
   @Test
+  void commentAcceptsTheQuestionFlagInAnyOrder() {
+    var content = SpecCliHelper.scriptContent();
+    assertTrue(content.contains("--question) FIELDS+=(--data-urlencode \"question=true\")"));
+    assertTrue(
+        content.contains("comment accepts only --reply-to <message-id> and --question"),
+        "unknown comment options must still die loudly");
+    assertTrue(
+        content.contains("[--reply-to <message-id>] [--question]"),
+        "the usage text teaches the flag");
+  }
+
+  @Test
   void createPostsAndUpdateAndArchivePut() {
     var content = SpecCliHelper.scriptContent();
     assertTrue(content.contains("-X POST --data-urlencode \"project=$PROJECT\""));

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -15,6 +15,7 @@ import ai.singlr.sail.store.SpecStore;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 record HealthResponse(String status) implements Mappable {
   @Override
@@ -739,17 +740,26 @@ record GlobalSpecView(
 }
 
 record GlobalSpecsListResponse(
-    List<GlobalSpecView> specs, int total, Map<String, String> latestMessageAt)
+    List<GlobalSpecView> specs,
+    int total,
+    Map<String, String> latestMessageAt,
+    Map<String, String> openQuestions)
     implements Mappable {
 
+  GlobalSpecsListResponse {
+    openQuestions = openQuestions == null ? Map.of() : openQuestions;
+  }
+
   GlobalSpecsListResponse(List<GlobalSpecView> specs, int total) {
-    this(specs, total, null);
+    this(specs, total, null, null);
   }
 
   /**
    * Each spec's {@code last_activity_at} = max(updated_at, its room's newest message) — the one
-   * activity source {@code updated_at} cannot see. Emitted only when the serving box has the
-   * message store, so a skewed client can detect absence and fall back.
+   * activity source {@code updated_at} cannot see. A spec whose latest agent question is still
+   * unanswered additionally carries {@code needs_reply} plus that question's message id. Both are
+   * emitted only when the serving box has the message store, so a skewed client can detect absence
+   * and fall back.
    */
   @Override
   public Map<String, Object> toMap() {
@@ -768,6 +778,11 @@ record GlobalSpecsListResponse(
                     spec.put(
                         "last_activity_at",
                         message != null && message.compareTo(updated) > 0 ? message : updated);
+                    var question = openQuestions.get(view.id());
+                    if (question != null) {
+                      spec.put("needs_reply", true);
+                      spec.put("question_message_id", question);
+                    }
                     return spec;
                   })
               .toList());
@@ -778,12 +793,28 @@ record GlobalSpecsListResponse(
 }
 
 record GlobalSpecDetailResponse(
-    GlobalSpecView spec, String body, String plan, int openFindings, RunSummary latestRun)
+    GlobalSpecView spec,
+    String body,
+    String plan,
+    int openFindings,
+    RunSummary latestRun,
+    String questionMessageId)
     implements Mappable {
+
+  GlobalSpecDetailResponse(
+      GlobalSpecView spec, String body, String plan, int openFindings, RunSummary latestRun) {
+    this(spec, body, plan, openFindings, latestRun, null);
+  }
+
   @Override
   public Map<String, Object> toMap() {
     var m = new LinkedHashMap<String, Object>();
-    m.put("spec", spec.toMap());
+    var specMap = spec.toMap();
+    if (questionMessageId != null) {
+      specMap.put("needs_reply", true);
+      specMap.put("question_message_id", questionMessageId);
+    }
+    m.put("spec", specMap);
     if (body != null) m.put("body", body);
     if (plan != null) m.put("plan", plan);
     if (openFindings > 0) m.put("open_findings", openFindings);
@@ -831,20 +862,33 @@ record GlobalSpecContentResponse(String specId, String body, String plan) implem
   }
 }
 
-record SpecMessageRequest(String body, String replyTo) {
+record SpecMessageRequest(String body, String replyTo, boolean question) {
   static SpecMessageRequest fromMap(Map<String, Object> map) {
     return new SpecMessageRequest(
         map.get("body") == null ? null : map.get("body").toString(),
-        map.get("reply_to") == null ? null : map.get("reply_to").toString());
+        map.get("reply_to") == null ? null : map.get("reply_to").toString(),
+        Boolean.parseBoolean(Objects.toString(map.get("question"), "false")));
   }
 }
 
 record SpecMessageView(
-    String id, String specId, String author, String body, String replyTo, String createdAt)
+    String id,
+    String specId,
+    String author,
+    String body,
+    String replyTo,
+    String createdAt,
+    boolean question)
     implements Mappable {
   static SpecMessageView from(MessageStore.MessageRow row) {
     return new SpecMessageView(
-        row.id(), row.specId(), row.author(), row.body(), row.replyTo(), row.createdAt());
+        row.id(),
+        row.specId(),
+        row.author(),
+        row.body(),
+        row.replyTo(),
+        row.createdAt(),
+        row.question());
   }
 
   @Override
@@ -856,6 +900,7 @@ record SpecMessageView(
     map.put("body", body);
     if (replyTo != null) map.put("reply_to", replyTo);
     map.put("created_at", createdAt);
+    if (question) map.put("question", true);
     return map;
   }
 }
@@ -918,7 +963,13 @@ record RunSessionResponse(String runId, String sessionId, String sessionSource)
   }
 }
 
-record GlobalBoardResponse(SpecStore.BoardSummary board, int doneOpenFindings) implements Mappable {
+record GlobalBoardResponse(SpecStore.BoardSummary board, int doneOpenFindings, int needsReply)
+    implements Mappable {
+
+  GlobalBoardResponse(SpecStore.BoardSummary board, int doneOpenFindings) {
+    this(board, doneOpenFindings, 0);
+  }
+
   @Override
   public Map<String, Object> toMap() {
     var m = new LinkedHashMap<String, Object>();
@@ -932,6 +983,7 @@ record GlobalBoardResponse(SpecStore.BoardSummary board, int doneOpenFindings) i
     m.put("archived", board.archived());
     m.put("next_ready_id", board.nextReadyId());
     m.put("done_open_findings", doneOpenFindings);
+    m.put("needs_reply", needsReply);
     return m;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
@@ -297,7 +297,10 @@ final class LocalApiRouter implements LocalApiHandler {
         yield ApiResponse.fromCreated(
             operations.postSpecMessage(
                 id,
-                new SpecMessageRequest(form.get("body"), form.get("reply_to")),
+                new SpecMessageRequest(
+                    form.get("body"),
+                    form.get("reply_to"),
+                    Boolean.parseBoolean(form.get("question"))),
                 caller.actor(),
                 caller.author()));
       }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -30,6 +30,7 @@ import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1063,13 +1064,29 @@ public final class SailOperations implements Operations {
             return listed;
           }
           return new GlobalSpecsListResponse(
-              listed.specs(), listed.total(), messageStore.latestBySpec());
+              listed.specs(),
+              listed.total(),
+              messageStore.latestBySpec(),
+              messageStore.openQuestions());
         });
   }
 
   @Override
   public Result<GlobalSpecDetailResponse> globalSpec(String specId) {
-    return safeRead(() -> globalSpecOps.get(specId));
+    return safeRead(
+        () -> {
+          var detail = globalSpecOps.get(specId);
+          if (messageStore == null) {
+            return detail;
+          }
+          return new GlobalSpecDetailResponse(
+              detail.spec(),
+              detail.body(),
+              detail.plan(),
+              detail.openFindings(),
+              detail.latestRun(),
+              messageStore.openQuestions().get(specId));
+        });
   }
 
   @Override
@@ -1121,9 +1138,16 @@ public final class SailOperations implements Operations {
           SpecPolicy.post(actor, spec.id(), spec.assignee(), spec.createdBy()).enforce();
           MessageStore.MessageRow row;
           try {
-            row = store.append(specId, author, request.body(), request.replyTo());
+            row =
+                store.append(specId, author, request.body(), request.replyTo(), request.question());
           } catch (IllegalArgumentException invalid) {
             throw new ApiException(ErrorCode.BAD_REQUEST, invalid.getMessage());
+          }
+          var data = new LinkedHashMap<String, Object>();
+          data.put("message_id", row.id());
+          data.put("preview", preview(row.body()));
+          if (row.question()) {
+            data.put("question", true);
           }
           publishOnBus(
               Event.of(
@@ -1132,7 +1156,7 @@ public final class SailOperations implements Operations {
                   Event.WellKnownTypes.SPEC_MESSAGE_POSTED,
                   author,
                   HostInfo.hostname(),
-                  Map.of("message_id", row.id(), "preview", preview(row.body()))));
+                  data));
           return new SpecMessageResponse(SpecMessageView.from(row));
         });
   }
@@ -1273,7 +1297,19 @@ public final class SailOperations implements Operations {
 
   @Override
   public Result<GlobalBoardResponse> globalBoard(String project) {
-    return safeRead(() -> globalSpecOps.board(project));
+    return safeRead(
+        () -> {
+          var board = globalSpecOps.board(project);
+          if (messageStore == null) {
+            return board;
+          }
+          var open = messageStore.openQuestions().keySet();
+          var count =
+              specStore.list(new SpecStore.SpecFilter(project, null, null, null, null)).stream()
+                  .filter(row -> open.contains(row.id()))
+                  .count();
+          return new GlobalBoardResponse(board.board(), board.doneOpenFindings(), (int) count);
+        });
   }
 
   @Override

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SyncTransitionEvents.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SyncTransitionEvents.java
@@ -205,9 +205,17 @@ public final class SyncTransitionEvents {
     if (located == null || author == null || body == null || !"posted".equals(transition.to())) {
       return List.of();
     }
+    var question =
+        Boolean.parseBoolean(Objects.toString(transition.snapshot().get("question"), "false"));
     return List.of(
         messagePosted(
-            located.project(), located.specId(), transition.entityId(), author, body, host));
+            located.project(),
+            located.specId(),
+            transition.entityId(),
+            author,
+            body,
+            question,
+            host));
   }
 
   /**
@@ -217,14 +225,20 @@ public final class SyncTransitionEvents {
    * wake reactor above all — as one posted locally.
    */
   public static Event messagePosted(
-      String project, String specId, String messageId, String author, String body, String host) {
-    return event(
-        project,
-        specId,
-        Event.WellKnownTypes.SPEC_MESSAGE_POSTED,
-        author,
-        host,
-        Map.of("message_id", messageId, "preview", preview(body)));
+      String project,
+      String specId,
+      String messageId,
+      String author,
+      String body,
+      boolean question,
+      String host) {
+    var data = new LinkedHashMap<String, Object>();
+    data.put("message_id", messageId);
+    data.put("preview", preview(body));
+    if (question) {
+      data.put("question", true);
+    }
+    return event(project, specId, Event.WellKnownTypes.SPEC_MESSAGE_POSTED, author, host, data);
   }
 
   /** A review-side transition addressed to its spec and project, or null when unresolvable. */

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecBoardCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecBoardCommand.java
@@ -76,6 +76,11 @@ public final class ApiSpecBoardCommand implements Runnable {
       System.out.println(
           Ansi.AUTO.string("    @|red Cancelled:|@       " + result.get("cancelled")));
 
+      var needsReply = result.get("needs_reply");
+      if (needsReply instanceof Number n && n.intValue() > 0) {
+        System.out.println(Ansi.AUTO.string("    @|bold,red Needs reply:|@     " + n.intValue()));
+      }
+
       var nextReady = result.get("next_ready_id");
       if (nextReady != null) {
         System.out.println();

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCommentCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCommentCommand.java
@@ -33,6 +33,9 @@ public final class ApiSpecCommentCommand implements Runnable {
   @Option(names = "--reply-to", description = "Message ID to reply to.")
   private String replyTo;
 
+  @Option(names = "--question", description = "Mark this message as a question that needs a reply.")
+  private boolean question;
+
   @Mixin private SyncOptions syncOptions;
   @Mixin private ConnectionOptions connection;
   @Spec private CommandSpec commandSpec;
@@ -50,6 +53,9 @@ public final class ApiSpecCommentCommand implements Runnable {
     request.put("body", text);
     if (replyTo != null) {
       request.put("reply_to", replyTo);
+    }
+    if (question) {
+      request.put("question", true);
     }
     var config = connection.resolve();
     try (var client = new SailApiClient(config.serverUrl(), config.token(), syncOptions.noSync())) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecListCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecListCommand.java
@@ -172,9 +172,18 @@ public final class ApiSpecListCommand implements Runnable {
                   : " @|magenta @" + assignee + "|@";
           var depsStr = deps.isEmpty() ? "" : " @|faint ← " + String.join(", ", deps) + "|@";
           var reposStr = repos.isEmpty() ? "" : " @|faint [" + String.join(", ", repos) + "]|@";
+          var needsReply =
+              Boolean.TRUE.equals(spec.get("needs_reply")) ? " @|bold,red ? needs reply|@" : "";
           System.out.println(
               Ansi.AUTO.string(
-                  "    • @|bold " + id + "|@  " + title + assigneeStr + reposStr + depsStr));
+                  "    • @|bold "
+                      + id
+                      + "|@  "
+                      + title
+                      + assigneeStr
+                      + reposStr
+                      + depsStr
+                      + needsReply));
         }
       }
       System.out.println();

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecShowCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecShowCommand.java
@@ -85,6 +85,12 @@ public final class ApiSpecShowCommand implements Runnable {
       if (spec.get("wake") != null) {
         System.out.println(Ansi.AUTO.string("  @|bold Wake:|@ " + spec.get("wake")));
       }
+      if (Boolean.TRUE.equals(spec.get("needs_reply"))) {
+        System.out.println(
+            Ansi.AUTO.string(
+                "  @|bold,red Needs reply:|@ unanswered question "
+                    + spec.get("question_message_id")));
+      }
 
       var body = (String) result.get("body");
       if (Strings.isNotBlank(body)) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
@@ -295,6 +295,7 @@ public final class SyncCommand implements Callable<Integer> {
                                 row.id(),
                                 row.author(),
                                 row.body(),
+                                row.question(),
                                 host))
                     .orElse(null))
         .filter(Objects::nonNull)

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/AgentTaskPrompt.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/AgentTaskPrompt.java
@@ -102,8 +102,11 @@ public final class AgentTaskPrompt {
         The room is a live channel, not a log: replies posted while you work are delivered into
         your context automatically after a tool call finishes, and unread messages block your
         first attempt to stop. When you are blocked on a decision, read the room with
-        `spec comments <id>` rather than guessing; read it once more before posting your final
-        summary, and acknowledge in that summary any guidance it carried.
+        `spec comments <id>` rather than guessing; if the room does not resolve it, post the
+        question with `spec comment <id> --question --body <text>` — the flag pages the
+        engineer on the board, and their reply clears it and wakes you. Read the room once more
+        before posting your final summary, and acknowledge in that summary any guidance it
+        carried.
 
         The spec is not complete until CI is green: after opening the pull request, watch its
         checks with the CLI of the forge hosting the repo (e.g. `gh pr checks <number> --watch`

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/RoomWakePrompt.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/RoomWakePrompt.java
@@ -70,12 +70,15 @@ public final class RoomWakePrompt {
         Grep tools for files. Do not fight a denial; work within the lane. If the
         conversation asks for code changes, answer that dispatch is the lane that changes
         code — describe what a re-dispatch (`sail spec dispatch %s --restart`) or a
-        follow-up spec should do instead of doing it here.
+        follow-up spec should do instead of doing it here. If the conversation asks
+        something you cannot answer or decide alone, post it back with
+        `spec comment %s --question --body <text>` — the flag pages the engineer on the
+        board until a human replies.
 
         The room stays live while you work: replies posted in the meantime are delivered
         into your context automatically after a tool call finishes, and unread messages
         block your first attempt to stop. When you have answered, stop.
         """
-        .formatted(specId, specId);
+        .formatted(specId, specId, specId);
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -787,6 +787,16 @@ class ApiRouterTest {
       assertEquals(Role.ADMIN, ops.actor.role());
       assertEquals(Actor.Lane.API, ops.actor.lane());
       assertEquals("ada", ops.author);
+      assertFalse(ops.question);
+
+      var asked =
+          post(
+              server,
+              "/v1/specs/auth-flow/messages",
+              "token",
+              "{\"body\":\"which flow?\",\"question\":true}");
+      assertEquals(201, asked.statusCode());
+      assertTrue(ops.question, "the JSON flag reaches the request");
 
       var listed = get(server, "/v1/specs/auth-flow/messages?limit=999", "token");
       assertEquals(200, listed.statusCode());
@@ -1117,6 +1127,7 @@ class ApiRouterTest {
     private Actor actor;
     private String author;
     private String body;
+    private boolean question;
 
     @Override
     public Result<SpecMessageResponse> postSpecMessage(
@@ -1124,6 +1135,7 @@ class ApiRouterTest {
       this.actor = actor;
       this.author = author;
       this.body = request.body();
+      this.question = request.question();
       return super.postSpecMessage(specId, request, actor, author);
     }
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/Fleet.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/Fleet.java
@@ -419,7 +419,7 @@ public final class Fleet implements AutoCloseable {
     public SpecMessageView postMessage(String specId, String body) {
       return operations
           .postSpecMessage(
-              specId, new SpecMessageRequest(body, null), Actor.cliOperator(handle), handle)
+              specId, new SpecMessageRequest(body, null, false), Actor.cliOperator(handle), handle)
           .orThrow()
           .message();
     }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/LocalApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/LocalApiRouterTest.java
@@ -290,10 +290,17 @@ class LocalApiRouterTest {
                 "body=Progress%20update&reply_to=01900000-0000-7000-8000-000000000001"));
     assertEquals(201, posted.status());
     assertEquals("Progress update", ops.lastMessage.body());
+    assertFalse(ops.lastMessage.question());
     assertEquals(TestOperations.PRINCIPAL, ops.lastMessageAuthor);
     assertEquals(TestOperations.PRINCIPAL, ops.lastActor.handle());
     assertEquals(TestOperations.OWNER, ops.lastActor.owner());
     assertTrue(ops.lastActor.agentLane());
+
+    var asked =
+        router.handle(
+            form("POST", "/v1/specs/oauth/messages", "body=Which%20flow%3F&question=true"));
+    assertEquals(201, asked.status());
+    assertTrue(ops.lastMessage.question(), "the form flag reaches the request");
 
     assertEquals(
         200,

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -1595,7 +1595,7 @@ class SailOperationsTest {
     var result =
         operations.postSpecMessage(
             "auth",
-            new SpecMessageRequest("Ready", null),
+            new SpecMessageRequest("Ready", null, false),
             new Actor("sail", Role.ADMIN, Actor.Lane.API),
             "sail");
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SpecMessageOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SpecMessageOperationsTest.java
@@ -87,7 +87,10 @@ class SpecMessageOperationsTest {
     var posted =
         operations
             .postSpecMessage(
-                "room", new SpecMessageRequest("Progress\n  update", null), member("ada"), "ada")
+                "room",
+                new SpecMessageRequest("Progress\n  update", null, false),
+                member("ada"),
+                "ada")
             .orThrow();
 
     assertEquals("ada", posted.message().author());
@@ -108,13 +111,14 @@ class SpecMessageOperationsTest {
     assertEquals(
         ErrorCode.SPEC_NOT_FOUND,
         operations
-            .postSpecMessage("missing", new SpecMessageRequest("body", null), member("ada"), "ada")
+            .postSpecMessage(
+                "missing", new SpecMessageRequest("body", null, false), member("ada"), "ada")
             .asFailure()
             .errorCode());
     assertEquals(
         ErrorCode.BAD_REQUEST,
         operations
-            .postSpecMessage("room", new SpecMessageRequest(" ", null), member("ada"), "ada")
+            .postSpecMessage("room", new SpecMessageRequest(" ", null, false), member("ada"), "ada")
             .asFailure()
             .errorCode());
     assertEquals(
@@ -126,7 +130,8 @@ class SpecMessageOperationsTest {
 
     var longMessage = "x".repeat(200);
     operations
-        .postSpecMessage("room", new SpecMessageRequest(longMessage, null), member("ada"), "ada")
+        .postSpecMessage(
+            "room", new SpecMessageRequest(longMessage, null, false), member("ada"), "ada")
         .orThrow();
     assertEquals(1, operations.specMessages("room", null, null, 50).orThrow().messages().size());
   }
@@ -137,7 +142,7 @@ class SpecMessageOperationsTest {
         operations
             .postSpecMessage(
                 "room",
-                new SpecMessageRequest("foreign instruction", null),
+                new SpecMessageRequest("foreign instruction", null, false),
                 member("mallory"),
                 "mallory")
             .asFailure();
@@ -149,7 +154,7 @@ class SpecMessageOperationsTest {
     var posted =
         operations
             .postSpecMessage(
-                "room", new SpecMessageRequest("owner update", null), agent, agent.handle())
+                "room", new SpecMessageRequest("owner update", null, false), agent, agent.handle())
             .orThrow();
     assertEquals(agent.handle(), posted.message().author());
   }
@@ -164,7 +169,8 @@ class SpecMessageOperationsTest {
     db.execute("UPDATE specs SET updated_at = '2026-07-01T00:00:00Z' WHERE id = 'room'");
     var posted =
         operations
-            .postSpecMessage("room", new SpecMessageRequest("activity", null), member("ada"), "ada")
+            .postSpecMessage(
+                "room", new SpecMessageRequest("activity", null, false), member("ada"), "ada")
             .orThrow();
 
     var listed = operations.globalSpecs(new SpecStore.SpecFilter(null, null, null, null, null));
@@ -182,17 +188,91 @@ class SpecMessageOperationsTest {
     var emptyRequest = SpecMessageRequest.fromMap(Map.of());
     assertEquals(null, emptyRequest.body());
     assertEquals(null, emptyRequest.replyTo());
+    assertFalse(emptyRequest.question());
     var request = SpecMessageRequest.fromMap(Map.of("body", 42, "reply_to", 7));
     assertEquals("42", request.body());
     assertEquals("7", request.replyTo());
+    assertTrue(SpecMessageRequest.fromMap(Map.of("question", true)).question());
+    assertTrue(SpecMessageRequest.fromMap(Map.of("question", "true")).question());
+    assertFalse(SpecMessageRequest.fromMap(Map.of("question", "nonsense")).question());
 
-    var view = new SpecMessageView("id", "room", "ada", "body", "parent", "2026-07-28T00:00:00Z");
+    var view =
+        new SpecMessageView("id", "room", "ada", "body", "parent", "2026-07-28T00:00:00Z", false);
     assertEquals("parent", view.toMap().get("reply_to"));
+    assertFalse(view.toMap().containsKey("question"));
     var withoutReply =
-        new SpecMessageView("id", "room", "ada", "body", null, "2026-07-28T00:00:00Z");
+        new SpecMessageView("id", "room", "ada", "body", null, "2026-07-28T00:00:00Z", false);
     assertFalse(withoutReply.toMap().containsKey("reply_to"));
+    var asQuestion =
+        new SpecMessageView(
+            "id", "room", "claude/r1", "stuck?", null, "2026-07-28T00:00:00Z", true);
+    assertEquals(Boolean.TRUE, asQuestion.toMap().get("question"));
     assertTrue(new SpecMessageResponse(view).toMap().containsKey("message"));
     assertEquals(1, new SpecMessagesResponse("room", List.of(view)).toMap().get("total"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void aQuestionPagesListShowAndBoardUntilAHumanReplies() throws Exception {
+    var event = new AtomicReference<Event>();
+    var delivered = new CountDownLatch(1);
+    bus.subscribe(
+        BusTesting.latching(
+            new EventSubscriber() {
+              @Override
+              public String name() {
+                return "question-capture";
+              }
+
+              @Override
+              public Predicate<Event> filter() {
+                return posted -> Event.WellKnownTypes.SPEC_MESSAGE_POSTED.equals(posted.type());
+              }
+
+              @Override
+              public void onEvent(Event posted) {
+                event.set(posted);
+              }
+            },
+            delivered));
+    var agent = Actor.agentPrincipal("claude/run-1", "ada");
+    var posted =
+        operations
+            .postSpecMessage(
+                "room", new SpecMessageRequest("Which flow?", null, true), agent, agent.handle())
+            .orThrow();
+
+    assertTrue(posted.message().question());
+    BusTesting.awaitDelivery(delivered);
+    assertEquals(Boolean.TRUE, event.get().data().get("question"));
+
+    var listed =
+        operations.globalSpecs(new SpecStore.SpecFilter(null, null, null, null, null)).orThrow();
+    var maps = (List<Map<String, Object>>) listed.toMap().get("specs");
+    var room = maps.stream().filter(m -> "room".equals(m.get("id"))).findFirst().orElseThrow();
+    assertEquals(Boolean.TRUE, room.get("needs_reply"));
+    assertEquals(posted.message().id(), room.get("question_message_id"));
+
+    var shown = (Map<String, Object>) operations.globalSpec("room").orThrow().toMap().get("spec");
+    assertEquals(Boolean.TRUE, shown.get("needs_reply"));
+    assertEquals(posted.message().id(), shown.get("question_message_id"));
+    assertEquals(1, operations.globalBoard("acme").orThrow().toMap().get("needs_reply"));
+
+    operations
+        .postSpecMessage(
+            "room", new SpecMessageRequest("use PKCE", null, false), member("ada"), "ada")
+        .orThrow();
+
+    var answeredList =
+        operations.globalSpecs(new SpecStore.SpecFilter(null, null, null, null, null)).orThrow();
+    var answeredMaps = (List<Map<String, Object>>) answeredList.toMap().get("specs");
+    var answeredRoom =
+        answeredMaps.stream().filter(m -> "room".equals(m.get("id"))).findFirst().orElseThrow();
+    assertFalse(answeredRoom.containsKey("needs_reply"));
+    var answeredShown =
+        (Map<String, Object>) operations.globalSpec("room").orThrow().toMap().get("spec");
+    assertFalse(answeredShown.containsKey("needs_reply"));
+    assertEquals(0, operations.globalBoard("acme").orThrow().toMap().get("needs_reply"));
   }
 
   private static Actor member(String handle) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SyncTransitionEventsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SyncTransitionEventsTest.java
@@ -229,6 +229,31 @@ class SyncTransitionEventsTest {
   }
 
   @Test
+  void aSyncedQuestionCarriesItsFlag() {
+    var snapshot =
+        Map.<String, Object>of(
+            "spec_id", "auth", "author", "codex/abc", "body", "Which region?", "question", true);
+
+    var event = map(new SyncTransition("message", "m1", null, "posted", snapshot)).getFirst();
+
+    assertEquals(
+        Boolean.TRUE,
+        event.data().get("question"),
+        "a synced question must carry its flag so consumers derive needs-reply like a local post");
+  }
+
+  @Test
+  void aSyncedPlainMessageOmitsTheQuestionFlag() {
+    var snapshot = Map.<String, Object>of("spec_id", "auth", "author", "ada", "body", "ok");
+
+    var event = map(new SyncTransition("message", "m1", null, "posted", snapshot)).getFirst();
+
+    assertNull(
+        event.data().get("question"),
+        "a plain message carries no flag — the local post omits it too");
+  }
+
+  @Test
   void aMessageForAnUnknownSpecIsSilent() {
     var snapshot =
         Map.<String, Object>of("spec_id", "ghost", "author", "ada", "body", "Progress update");

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -344,7 +344,8 @@ class TestOperations implements Operations {
                     request.replyTo(),
                     "2026-07-28T00:00:00Z",
                     "1-a",
-                    null))));
+                    null,
+                    request.question()))));
   }
 
   @Override
@@ -360,7 +361,8 @@ class TestOperations implements Operations {
                     PRINCIPAL,
                     "hello",
                     null,
-                    "2026-07-28T00:00:00Z"))));
+                    "2026-07-28T00:00:00Z",
+                    false))));
   }
 
   @Override
@@ -376,7 +378,8 @@ class TestOperations implements Operations {
                     "uday",
                     "please also update the docs",
                     null,
-                    "2026-07-28T00:01:00Z")),
+                    "2026-07-28T00:01:00Z",
+                    false)),
             false));
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ApiSpecCommandsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ApiSpecCommandsTest.java
@@ -208,6 +208,17 @@ class ApiSpecCommandsTest {
   }
 
   @Test
+  void commentQuestionFlagRidesTheRequestAndReturnsOnTheMessage() {
+    run("create", "--id", "asking", "--title", "Asking");
+
+    var posted = run("comment", "asking", "--body", "Which flow?", "--question");
+    assertTrue(posted.contains("\"question\": true"));
+
+    var listed = run("comments", "asking");
+    assertTrue(listed.contains("\"question\": true"));
+  }
+
+  @Test
   void commentReadsBodyFromStdin() {
     run("create", "--id", "stdin-room", "--title", "Room");
     var original = System.in;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandTest.java
@@ -207,6 +207,9 @@ class DispatchCommandTest {
     assertTrue(
         prompt.contains("read the room with\n`spec comments <id>`"),
         "the read verb is the portable floor: check when blocked, and before the final summary");
+    assertTrue(
+        prompt.contains("spec comment <id> --question --body <text>"),
+        "a blocked agent must know the question verb — the flag that pages the engineer");
     assertTrue(prompt.contains("unread messages block your\nfirst attempt to stop"));
   }
 
@@ -222,7 +225,8 @@ class DispatchCommandTest {
             null,
             "2026-07-28T00:00:00Z",
             "1-a",
-            null);
+            null,
+            false);
 
     var prompt = AgentTaskPrompt.build(spec, "Implement the flow", List.of(message)).prompt();
 

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/RoomWakePromptTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/RoomWakePromptTest.java
@@ -39,7 +39,7 @@ class RoomWakePromptTest {
 
   private static MessageStore.MessageRow message(String id, String author, String body) {
     return new MessageStore.MessageRow(
-        id, "auth", author, body, null, "2026-08-11T12:00:00Z", "1-a", null);
+        id, "auth", author, body, null, "2026-08-11T12:00:00Z", "1-a", null, false);
   }
 
   @Test
@@ -57,6 +57,9 @@ class RoomWakePromptTest {
     assertTrue(built.prompt().contains("spec comment auth --body"));
     assertTrue(built.prompt().contains("read-only chat session, and the harness enforces it"));
     assertTrue(built.prompt().contains("sail spec dispatch auth --restart"));
+    assertTrue(
+        built.prompt().contains("spec comment auth --question --body"),
+        "the wake lane teaches the question verb for what it cannot answer alone");
     assertEquals(List.of(question), built.renderedMessages());
   }
 


### PR DESCRIPTION
Implements `sail-room-needs-reply`: a blocked agent's question becomes a flag beside the status, not prose that drowns.

## What changed

**The flag.** `spec comment <id> --question --body <text>` marks a room message as a question — supported on the host CLI, the in-container `spec` script (url-encoded form), and the JSON message POST. The flag is part of the message row (`spec_messages.question`, one appended migration), rides the sync snapshot, and lands in the `spec_message_posted` event payload so clients can react without a refetch.

**Sync safety.** The snapshot key is omitted when false, mirroring `reply_to` — existing messages' snapshots and revs are byte-identical across old and new binaries, so the immutability guard never trips on pre-upgrade rooms.

**Derived `needs_reply`, zero new state.** A spec needs a reply when its latest agent-authored question (`author LIKE '%/%'`, mirroring `RoomWakePolicy.humanAuthor`) has no later human message. One aggregate query (`MessageStore.openQuestions()`), no clearing logic — any human reply anywhere in the room clears it by definition. Surfaced on:
- `spec list` — `needs_reply` + `question_message_id` per spec (store-present-gated, like `last_activity_at`), red `? needs reply` marker in the CLI render
- `spec show` — same fields on the spec map + a `Needs reply:` line
- board payload — `needs_reply` count + a board line

**Teaching the lane.** The dispatch prompt's blocked paragraph, the stop gate's "genuinely blocked" nudge, the room-wake duty text, and the generated agent context / spec skill all now name `--question` as the verb.

## Tests

- Store: flag round-trip through append/snapshot/read; `openQuestions()` table-tested (unanswered / human reply / agent+orchestrator reply only / human question / no questions)
- Sync: the flag survives box-to-box reconcile and derives the same answer on both ends
- Schema: seeded pre-upgrade database migrates forward with the column defaulted
- API: ops test walks question → list/show/board and back to cleared; event payload asserted; both routers (JSON + form) round-trip the flag; model mapping edge cases
- CLI: `--question` round-trips through the picocli command and the container script accepts the flag in any order
- Prompts: dispatch/stop-gate/room-wake texts asserted

`mvn clean verify` green (all modules, JaCoCo `api.*` gate included).

Mast counterpart: standardapplied/mast PR with the board chip, room mark, timeline marker, and the pure notification policy.

**Field flow after merge+release:** dispatch a spec whose task requires asking; the agent posts `--question` and stops; board shows the chip and Mast toasts; reply in the room; the chip clears and room-wake resumes the agent.
