### PR TITLE
Invite an agent into the room: one checkbox, read-only or full

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/engine/AgentCli.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/AgentCli.java
@@ -170,13 +170,21 @@ public enum AgentCli {
   private static final String ROOM_ISOLATION = " --setting-sources \"\" --strict-mcp-config";
 
   /**
-   * Whether this CLI can run the room lane's read-only chat session with the restriction enforced
-   * by the harness rather than promised by the prompt. Claude Code can: {@code --print} without
-   * {@code --dangerously-skip-permissions} denies every tool call not covered by an allow rule, and
-   * {@link #ROOM_TOOLS} removes the mutating tools from the set entirely. Codex cannot: its only
-   * enforcement layer is the bubblewrap sandbox, which needs user namespaces — blocked inside incus
-   * containers ({@code bwrap: setting up uid map: Permission denied}) — so the sole mode that
-   * executes commands at all is the full bypass flag, exactly what the room contract forbids.
+   * Whether this CLI can run the room lane's read-only chat session with the write restriction
+   * enforced by the harness rather than promised by the prompt. Claude Code can: {@code --print}
+   * without {@code --dangerously-skip-permissions} refuses every <em>mutating</em> tool call —
+   * {@link #ROOM_TOOLS} removes {@code Write}/{@code Edit} from the set entirely, Bash write
+   * commands and arbitrary interpreters are denied, so no session-driven code change can happen.
+   * Reads are scoped, not broad: Claude Code auto-approves read commands ({@code cat}/{@code
+   * head}/{@code tail}/{@code grep}) only <em>within the working directory</em> (the workspace the
+   * session launches in, {@code ~/workspace}), and refuses them for paths outside it (verified
+   * empirically) — so the container's secrets, all of which live outside the workspace ({@code
+   * ~/.ssh}, {@code ~/.sail}, {@code ~/.claude}, {@code /var/lib/sail}), are unreadable by default.
+   * Explicit {@code Read}-deny rules ({@link ClaudeCodeHookConfig#roomReadDenyRules})
+   * belt-and-brace the highest-value credentials on top of that — see {@link #roomInvocation}.
+   * Codex cannot run this lane at all: its only enforcement layer is the bubblewrap sandbox, which
+   * needs user namespaces — blocked inside incus containers ({@code bwrap: setting up uid map:
+   * Permission denied}) — so its sole executing mode is the full bypass flag the room forbids.
    */
   public boolean supportsRoomLane() {
     return this == CLAUDE_CODE;
@@ -213,29 +221,41 @@ public enum AgentCli {
    * The room lane's headless command: like {@link #headlessCommand} but harness-restricted instead
    * of full-permission. The tool set is cut to {@code Bash,Read,Grep,Glob} — {@code Write} and
    * {@code Edit} do not exist in the session, and the {@code --tools} cut is CLI-authoritative, so
-   * no on-disk settings file can re-add them. The only auto-approved commands are {@code spec} (the
+   * no on-disk settings file can re-add them. The explicit allow-rules cover {@code spec} (the
    * lane's one write — posting the answer, and the room credential is viewer-role so even {@code
-   * spec} cannot mutate a spec) and {@code cd} (navigation, no write). Reading the workspace is
-   * {@code Read}/{@code Grep}/{@code Glob}, which have no write flag. Git is deliberately absent:
-   * {@code git diff --output=<path>} writes through a prefix allow-rule, and git's external-diff
-   * and pager config are command-execution surfaces — a read-only lane must not expose them.
+   * spec} cannot mutate a spec) and {@code cd}. Beyond those, {@code --print} refuses every
+   * <em>mutating</em> Bash command and every arbitrary interpreter, and it auto-permits recognized
+   * <em>read</em> commands ({@code cat}/{@code head}/{@code tail}/{@code grep}) only for paths
+   * <em>inside the working directory</em> — a read of a path outside {@code ~/workspace} is refused
+   * (verified empirically). So the session reads the code it is consulting on and nothing else:
+   * every container secret lives outside the workspace ({@code ~/.ssh}, {@code ~/.sail}, {@code
+   * ~/.claude}, {@code /var/lib/sail}) and is unreadable by default. The {@code Read}-deny rules in
+   * {@link ClaudeCodeHookConfig#roomReadDenyRules} — which Claude applies to a Bash read of a
+   * denied path too — belt-and-suspenders the highest-value credentials on top of that, they are
+   * not the primary boundary. Git is deliberately absent: {@code git diff --output=<path>} writes
+   * through a prefix allow-rule, and git's external-diff and pager config are command-execution
+   * surfaces — a read-only lane must not expose them.
    *
    * <p>The invocation is pinned closed against ambient configuration: {@code --setting-sources ""}
    * excludes every user/project/local settings file, so a {@code .claude/settings.json} in the
    * workspace or home directory cannot merge an additional {@code Bash(...)} allow-rule into the
    * session (Claude Code merges permission rules additively across settings sources; the flag
-   * removes those sources while the sail-owned {@code --settings} file — hooks plus the {@code
-   * box.credential} read-deny — still applies), and {@code --strict-mcp-config} keeps a workspace
+   * removes those sources while the sail-owned {@code --settings} file — hooks plus the
+   * credential/key read-denies — still applies), and {@code --strict-mcp-config} keeps a workspace
    * {@code .mcp.json} from launching MCP server processes into the session.
    *
    * <p>This is the harness-enforced boundary the platform can express, not a kernel one. It is
-   * exact about what it is: {@code Write}/{@code Edit} are structurally gone; the Bash allowlist is
-   * two non-writing commands; ambient settings and MCP configs are excluded; the room credential is
-   * viewer-role; and a host-side content guard ({@code DispatchOperations#guardRoomRun}) surfaces
-   * any worktree change as a loud guardrail event. What it is not: hermetic against a kernel-level
-   * escape or a harness-enforcement bug — that boundary is owned by the room-lane hardening
-   * follow-up spec (a sidecar container with a read-only disk device), which incus does not give a
-   * same-container process.
+   * exact about what it is: {@code Write}/{@code Edit} are structurally gone and Bash writes and
+   * interpreters are refused, so the session cannot change code; reads are auto-approved only
+   * inside the workspace, so out-of-tree secrets ({@code box.credential}, {@code ~/.ssh}, {@code
+   * ~/.sail}, {@code ~/.claude}) are unreadable by default, with {@code Read}-denies
+   * belt-and-bracing the top credentials; ambient settings and MCP configs are excluded; the room
+   * credential is viewer-role; and a host-side content guard ({@code
+   * DispatchOperations#guardRoomRun}) surfaces any worktree change as a loud guardrail event. What
+   * it is not: hermetic against a kernel-level escape, a harness-enforcement bug, or a secret
+   * committed <em>inside</em> the workspace (which the consultant reads by design, as any build
+   * agent does) — that boundary is owned by the room-lane hardening follow-up spec (a sidecar
+   * container with a read-only disk device), which incus does not give a same-container process.
    */
   public String headlessRoomCommand(
       String taskFile, String model, String claudeSettingsPath, boolean stream) {

--- a/sail-core/src/main/java/ai/singlr/sail/engine/AgentCli.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/AgentCli.java
@@ -181,6 +181,33 @@ public enum AgentCli {
   }
 
   /**
+   * Whether this CLI can run an invite's read-only mode. The read-only invite is the room lane's
+   * contract verbatim — viewer credential, harness tool cut, no reservation — so support is exactly
+   * {@link #supportsRoomLane}: offered only where the harness can enforce it, never where
+   * enforcement would be a promise. Every agent supports the full mode; it buys its authority with
+   * the pre-launch snapshot and the repo reservation, not a sandbox.
+   */
+  public boolean supportsReadOnlyInvite() {
+    return supportsRoomLane();
+  }
+
+  /**
+   * Why the read-only invite mode is unavailable for this CLI, or null when it is supported.
+   * Declared here, at the agent seam, so the API reports the same reason the launch gate refuses
+   * with and clients can grey the option out honestly.
+   */
+  public String readOnlyInviteRefusal() {
+    if (supportsReadOnlyInvite()) {
+      return null;
+    }
+    return displayName()
+        + " has no harness-enforced read-only session inside a sail container: its bubblewrap"
+        + " sandbox needs user namespaces, which incus containers block, so its only working mode"
+        + " bypasses all restrictions. Invite it with full access instead — a pre-launch snapshot"
+        + " and the repo reservation guard that lane.";
+  }
+
+  /**
    * The room lane's headless command: like {@link #headlessCommand} but harness-restricted instead
    * of full-permission. The tool set is cut to {@code Bash,Read,Grep,Glob} — {@code Write} and
    * {@code Edit} do not exist in the session, and the {@code --tools} cut is CLI-authoritative, so

--- a/sail-core/src/main/java/ai/singlr/sail/engine/AgentCli.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/AgentCli.java
@@ -167,6 +167,8 @@ public enum AgentCli {
   private static final String ROOM_ALLOWED_TOOLS =
       " --allowedTools \"Bash(spec:*)\" \"Bash(cd:*)\"";
 
+  private static final String ROOM_ISOLATION = " --setting-sources \"\" --strict-mcp-config";
+
   /**
    * Whether this CLI can run the room lane's read-only chat session with the restriction enforced
    * by the harness rather than promised by the prompt. Claude Code can: {@code --print} without
@@ -218,15 +220,22 @@ public enum AgentCli {
    * {@code git diff --output=<path>} writes through a prefix allow-rule, and git's external-diff
    * and pager config are command-execution surfaces — a read-only lane must not expose them.
    *
+   * <p>The invocation is pinned closed against ambient configuration: {@code --setting-sources ""}
+   * excludes every user/project/local settings file, so a {@code .claude/settings.json} in the
+   * workspace or home directory cannot merge an additional {@code Bash(...)} allow-rule into the
+   * session (Claude Code merges permission rules additively across settings sources; the flag
+   * removes those sources while the sail-owned {@code --settings} file — hooks plus the {@code
+   * box.credential} read-deny — still applies), and {@code --strict-mcp-config} keeps a workspace
+   * {@code .mcp.json} from launching MCP server processes into the session.
+   *
    * <p>This is the harness-enforced boundary the platform can express, not a kernel one. It is
    * exact about what it is: {@code Write}/{@code Edit} are structurally gone; the Bash allowlist is
-   * two non-writing commands; the room credential is viewer-role; and a host-side content guard
-   * ({@code DispatchOperations#guardRoomRun}) surfaces any worktree change as a loud guardrail
-   * event. What it is not: hermetic against an ambient {@code .claude/settings.json} that merges an
-   * additional {@code Bash(...)} allow-rule (Claude Code merges permission rules across settings
-   * sources), nor against a kernel-level escape — both are owned by the room-lane hardening
-   * follow-up spec (managed-policy settings and/or a sidecar container with a read-only disk
-   * device), the boundaries incus does not give a same-container process.
+   * two non-writing commands; ambient settings and MCP configs are excluded; the room credential is
+   * viewer-role; and a host-side content guard ({@code DispatchOperations#guardRoomRun}) surfaces
+   * any worktree change as a loud guardrail event. What it is not: hermetic against a kernel-level
+   * escape or a harness-enforcement bug — that boundary is owned by the room-lane hardening
+   * follow-up spec (a sidecar container with a read-only disk device), which incus does not give a
+   * same-container process.
    */
   public String headlessRoomCommand(
       String taskFile, String model, String claudeSettingsPath, boolean stream) {
@@ -261,6 +270,7 @@ public enum AgentCli {
         + " --print"
         + streamFormat
         + settings
+        + ROOM_ISOLATION
         + ROOM_TOOLS
         + ROOM_ALLOWED_TOOLS
         + claudeModelOptions(model);

--- a/sail-core/src/main/java/ai/singlr/sail/store/DispatchGate.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/DispatchGate.java
@@ -34,6 +34,18 @@ public final class DispatchGate {
   public static final String ROOM_ROLE = "room";
 
   /**
+   * The read-only invite lane: a consultant a human explicitly invited into the room. It reserves
+   * no repos and holds no write authority, so it conflicts with nothing at all — not even a live
+   * run of its own spec, because "a read-only consultant alongside the live build" is exactly the
+   * lane's purpose. The same-spec backstop stays for {@link #ROOM_ROLE} wakes, which fire
+   * automatically and must never race a live run.
+   */
+  public static final String READ_ONLY_INVITE_ROLE = "invite";
+
+  /** The full invite lane: reserves like a build, so one writer per repo always holds. */
+  public static final String FULL_INVITE_ROLE = "invite-full";
+
+  /**
    * One running local run of the project: its id, the spec it works, its role, and its reserved
    * repos.
    */
@@ -46,7 +58,9 @@ public final class DispatchGate {
   public record Conflict(RunningRun run, List<String> overlap) {}
 
   /**
-   * The first running run that blocks the dispatch, or empty to allow. A run of {@code
+   * The first running run that blocks the dispatch, or empty to allow. A {@link
+   * #READ_ONLY_INVITE_ROLE} run on either side conflicts with nothing — a read-only consultant runs
+   * alongside anything, including its own spec's live build. Otherwise a run of {@code
    * targetSpecId} itself always blocks, even on disjoint repos: a spec has one lifecycle and one
    * review pipeline, so a second live execution — reachable via restart with a repo override —
    * would race the first over shared spec state. Any other run blocks only on repo overlap, and a
@@ -56,7 +70,11 @@ public final class DispatchGate {
    */
   public static Optional<Conflict> decide(
       String targetSpecId, String targetRole, List<String> targetRepos, List<RunningRun> running) {
+    if (READ_ONLY_INVITE_ROLE.equals(targetRole)) {
+      return Optional.empty();
+    }
     return running.stream()
+        .filter(run -> !READ_ONLY_INVITE_ROLE.equals(run.role()))
         .map(
             run ->
                 sameSpec(run.specId(), targetSpecId)

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -214,6 +214,25 @@ public final class RunStore implements ConflictResolver {
     }
 
     /**
+     * Whether this row is an invited agent session, either mode: a human explicitly invited this
+     * agent into the spec's room. Invite stops never trigger the review pipeline — the review loop
+     * stays anchored to dispatch.
+     */
+    public boolean inviteRole() {
+      return "invite".equals(role) || "invite-full".equals(role);
+    }
+
+    /**
+     * Whether this row runs under the read-only room contract — a room wake or a read-only invite:
+     * viewer-tier credential, harness tool cut, no repo reservation, worktree-digest guard. The API
+     * boundary derives the credential tier from this predicate, never from anything the session
+     * says.
+     */
+    public boolean readOnlyLane() {
+      return roomRole() || "invite".equals(role);
+    }
+
+    /**
      * Whether this row is a review execution — the reviewer or its fix agent, which share the one
      * review row. Their own stop must never re-enter the pipeline, so lane-aware reactors consult
      * this as the fallback when a stop signal lost its role marker.
@@ -224,17 +243,18 @@ public final class RunStore implements ConflictResolver {
 
     /**
      * Whether this row is an agent session the run-scoped machinery owns — a build attempt, an
-     * ad-hoc run, or a room wake — as opposed to a pipeline-driven review execution. Session rows
-     * are the ones the stop, status, log, reaper, and missed-stop lanes address; a room run joins
-     * them because it launches through the same systemd unit and must be reaped and stoppable like
-     * any other.
+     * ad-hoc run, a room wake, or an invite — as opposed to a pipeline-driven review execution.
+     * Session rows are the ones the stop, status, log, reaper, and missed-stop lanes address; room
+     * and invite runs join them because they launch through the same systemd unit and must be
+     * reaped and stoppable like any other.
      */
     public boolean sessionRole() {
-      return buildRole() || adhocRole() || roomRole();
+      return buildRole() || adhocRole() || roomRole() || inviteRole();
     }
   }
 
-  private static final String SESSION_ROLES = "role IN ('build', 'adhoc', 'room')";
+  private static final String SESSION_ROLES =
+      "role IN ('build', 'adhoc', 'room', 'invite', 'invite-full')";
 
   private static final String COLUMNS =
       "id, project, spec_id, node, role, agent, branch, task, pid, watcher_pid, status,"
@@ -688,6 +708,7 @@ public final class RunStore implements ConflictResolver {
           case "review" -> "review-";
           case "fix" -> "fix-";
           case "room" -> "room-";
+          case "invite", "invite-full" -> "invite-";
           default -> "";
         };
     return base + "/" + marker + runId;

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -256,6 +256,8 @@ public final class RunStore implements ConflictResolver {
   private static final String SESSION_ROLES =
       "role IN ('build', 'adhoc', 'room', 'invite', 'invite-full')";
 
+  private static final String PROJECT_SESSION_ROLES = "role IN ('build', 'adhoc', 'room')";
+
   private static final String COLUMNS =
       "id, project, spec_id, node, role, agent, branch, task, pid, watcher_pid, status,"
           + " exit_code, log_path, unit, started_at, completed_at, repos, pid_ticks,"
@@ -738,9 +740,11 @@ public final class RunStore implements ConflictResolver {
   /**
    * The latest agent session (build or ad-hoc) of {@code project} that executed on this box, or
    * empty. Review runs remain in the aggregate but do not replace the session used by agent status,
-   * log, and report commands. Ownership is by node: a box with a handle owns exactly the runs
-   * stamped with it; a box with no handle owns exactly its own blank-node runs and never a run
-   * adopted from another box via sync.
+   * log, and report commands. Invites are excluded too ({@link #PROJECT_SESSION_ROLES}): a
+   * read-only invite runs alongside a live build by design, so a newer invite must not shadow the
+   * build a project-level status or log addresses. Ownership is by node: a box with a handle owns
+   * exactly the runs stamped with it; a box with no handle owns exactly its own blank-node runs and
+   * never a run adopted from another box via sync.
    */
   public Optional<RunRow> latestForProjectOnNode(String project, String localHandle) {
     return db.queryOne(
@@ -748,7 +752,7 @@ public final class RunStore implements ConflictResolver {
             + COLUMNS
             + " FROM runs WHERE project = ? AND IFNULL(node, '') = ?"
             + " AND "
-            + SESSION_ROLES
+            + PROJECT_SESSION_ROLES
             + " ORDER BY started_at DESC"
             + " LIMIT 1",
         this::mapRow,
@@ -759,7 +763,9 @@ public final class RunStore implements ConflictResolver {
   /**
    * The active agent session (build or ad-hoc) of {@code project} that executed on this box, or
    * empty. {@code stopping} counts as active: an interrupted stop's claim must stay addressable so
-   * a project-targeted stop retry resumes it. Node-scoped like {@link #latestForProjectOnNode}.
+   * a project-targeted stop retry resumes it. Invites are excluded ({@link #PROJECT_SESSION_ROLES})
+   * so a project-level stop halts the build, not a consultant running beside it; an invite is
+   * stopped by its own run id. Node-scoped like {@link #latestForProjectOnNode}.
    */
   public Optional<RunRow> runningForProjectOnNode(String project, String localHandle) {
     return db.queryOne(
@@ -767,7 +773,7 @@ public final class RunStore implements ConflictResolver {
             + COLUMNS
             + " FROM runs WHERE project = ? AND status IN ('running', 'stopping')"
             + " AND IFNULL(node, '') = ? AND "
-            + SESSION_ROLES
+            + PROJECT_SESSION_ROLES
             + " ORDER BY started_at DESC LIMIT 1",
         this::mapRow,
         project,

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -219,7 +219,51 @@ public final class SchemaManager {
               baseline TEXT NOT NULL
           )""",
           "ALTER TABLE runs ADD COLUMN last_activity_at TEXT",
-          "ALTER TABLE spec_messages ADD COLUMN question INTEGER NOT NULL DEFAULT 0");
+          "ALTER TABLE spec_messages ADD COLUMN question INTEGER NOT NULL DEFAULT 0",
+          """
+          CREATE TABLE runs_v6 (
+              id TEXT PRIMARY KEY,
+              project TEXT NOT NULL,
+              spec_id TEXT,
+              agent TEXT NOT NULL,
+              branch TEXT,
+              task TEXT,
+              pid INTEGER,
+              status TEXT NOT NULL DEFAULT 'running'
+                  CHECK (status IN ('running', 'stopping', 'completed', 'stopped', 'failed')),
+              started_at TEXT NOT NULL,
+              completed_at TEXT,
+              exit_code INTEGER,
+              watcher_pid INTEGER,
+              node TEXT,
+              role TEXT NOT NULL DEFAULT 'build'
+                  CHECK (role IN ('build', 'adhoc', 'review', 'room', 'invite', 'invite-full')),
+              log_path TEXT,
+              rev TEXT,
+              base_rev TEXT,
+              unit TEXT,
+              repos TEXT,
+              pid_ticks INTEGER,
+              principal TEXT,
+              owner TEXT,
+              session_id TEXT,
+              session_source TEXT,
+              transcript_path TEXT,
+              last_activity_at TEXT
+          )""",
+          """
+          INSERT INTO runs_v6 (id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos, pid_ticks, principal, owner, session_id,
+                  session_source, transcript_path, last_activity_at)
+              SELECT id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos, pid_ticks, principal, owner, session_id,
+                  session_source, transcript_path, last_activity_at FROM runs""",
+          "DROP TABLE runs",
+          "ALTER TABLE runs_v6 RENAME TO runs",
+          "CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project)",
+          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)");
 
   /** The schema version this binary converges every database to. */
   static final int CURRENT_VERSION = V1_VERSION + MIGRATIONS.size();

--- a/sail-core/src/test/java/ai/singlr/sail/engine/AgentCliTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/AgentCliTest.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.engine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -312,5 +313,19 @@ class AgentCliTest {
     assertThrows(
         IllegalStateException.class,
         () -> AgentCli.CODEX.headlessRoomResumeCommand("sess-42", TASK, null, null, true));
+  }
+
+  @Test
+  void readOnlyInviteSupportMatchesTheRoomLaneBoundary() {
+    assertTrue(AgentCli.CLAUDE_CODE.supportsReadOnlyInvite());
+    assertFalse(AgentCli.CODEX.supportsReadOnlyInvite());
+  }
+
+  @Test
+  void readOnlyInviteRefusalNamesTheFullLaneAsTheAlternative() {
+    assertNull(AgentCli.CLAUDE_CODE.readOnlyInviteRefusal());
+    var reason = AgentCli.CODEX.readOnlyInviteRefusal();
+    assertTrue(reason.contains("Codex CLI"), reason);
+    assertTrue(reason.contains("full access"), reason);
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/engine/AgentCliTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/AgentCliTest.java
@@ -288,11 +288,32 @@ class AgentCliTest {
   }
 
   @Test
+  void roomCommandExcludesAmbientSettingsSoNoWorkspaceFileCanWidenPermissions() {
+    var cmd =
+        AgentCli.CLAUDE_CODE.headlessRoomCommand(
+            TASK, null, "/home/dev/.sail/claude-settings.json", true);
+
+    assertTrue(
+        cmd.contains("--setting-sources \"\""),
+        "ambient user/project/local settings merge permission allow-rules additively; the room"
+            + " lane must exclude every settings source except the sail-owned --settings file."
+            + " Command: "
+            + cmd);
+    assertTrue(
+        cmd.contains("--strict-mcp-config"),
+        "a workspace .mcp.json launches MCP server processes into the session; the room lane"
+            + " must ignore every ambient MCP configuration. Command: "
+            + cmd);
+  }
+
+  @Test
   void headlessRoomResumeCommandKeepsTheRestrictionsOnTheRecordedSession() {
     var cmd = AgentCli.CLAUDE_CODE.headlessRoomResumeCommand("sess-42", TASK, "opus", null, true);
 
     assertFalse(cmd.contains("--dangerously-skip-permissions"), cmd);
     assertTrue(cmd.contains("--tools \"Bash,Read,Grep,Glob\""), cmd);
+    assertTrue(cmd.contains("--setting-sources \"\""), cmd);
+    assertTrue(cmd.contains("--strict-mcp-config"), cmd);
     assertTrue(cmd.contains("--model opus"), cmd);
     assertTrue(cmd.contains("--resume sess-42 -p \"$(cat " + TASK + ")\""), cmd);
   }

--- a/sail-core/src/test/java/ai/singlr/sail/store/DispatchGateTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/DispatchGateTest.java
@@ -153,4 +153,55 @@ class DispatchGateTest {
 
     assertTrue(DispatchGate.decide("", "adhoc", List.of(), running).isEmpty());
   }
+
+  @Test
+  void aReadOnlyInviteTargetConflictsWithNothingNotEvenItsOwnSpecsBuild() {
+    var running = List.of(running("auth", "build", List.of("app")));
+
+    assertTrue(DispatchGate.decide("auth", "invite", List.of(), running).isEmpty());
+  }
+
+  @Test
+  void aReadOnlyInviteTargetIgnoresAWholeContainerAdhocClaim() {
+    var running = List.of(running("", "adhoc", List.of()));
+
+    assertTrue(DispatchGate.decide("auth", "invite", List.of(), running).isEmpty());
+  }
+
+  @Test
+  void aLiveReadOnlyInviteBlocksNothingItsOwnSpecsBuildIncluded() {
+    var running = List.of(running("auth", "invite", List.of()));
+
+    assertTrue(DispatchGate.decide("auth", "build", List.of("app"), running).isEmpty());
+    assertTrue(DispatchGate.decide("auth", "invite-full", List.of("app"), running).isEmpty());
+    assertTrue(DispatchGate.decide("", "adhoc", List.of(), running).isEmpty());
+  }
+
+  @Test
+  void aFullInviteTargetConflictsLikeABuildOnRepoOverlap() {
+    var running = List.of(running("other", "build", List.of("app")));
+
+    var conflict =
+        DispatchGate.decide("auth", "invite-full", List.of("app"), running).orElseThrow();
+
+    assertEquals(List.of("app"), conflict.overlap());
+    assertTrue(DispatchGate.decide("auth", "invite-full", List.of("web"), running).isEmpty());
+  }
+
+  @Test
+  void aFullInviteTargetConflictsWithItsOwnSpecsLiveRun() {
+    var running = List.of(running("auth", "build", List.of("web")));
+
+    assertTrue(DispatchGate.decide("auth", "invite-full", List.of("app"), running).isPresent());
+  }
+
+  @Test
+  void aLiveFullInviteBlocksAnOverlappingBuildLikeAnyWriter() {
+    var running = List.of(running("auth", "invite-full", List.of("app")));
+
+    var conflict = DispatchGate.decide("other", "build", List.of("app"), running).orElseThrow();
+
+    assertEquals(RUN, conflict.run().runId());
+    assertTrue(DispatchGate.decide("other", "build", List.of("web"), running).isEmpty());
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -913,6 +913,54 @@ class RunStoreTest {
   }
 
   @Test
+  void inviteRolesMintTheInvitePrincipalAndJoinTheLanePredicates() {
+    var readOnly = DateTimeUtils.newId().toString();
+    var full = DateTimeUtils.newId().toString();
+    store.create(
+        readOnly,
+        "backend",
+        "auth",
+        "node-a",
+        "node-a",
+        "invite",
+        "claude-code",
+        null,
+        "consult",
+        null,
+        null,
+        null,
+        "sail-agent-" + readOnly);
+    store.create(
+        full,
+        "backend",
+        "auth",
+        "node-a",
+        "node-a",
+        "invite-full",
+        "codex",
+        null,
+        "pitch in",
+        null,
+        null,
+        null,
+        "sail-agent-" + full);
+
+    var readOnlyRun = store.findById(readOnly).orElseThrow();
+    var fullRun = store.findById(full).orElseThrow();
+    assertEquals("claude/invite-" + readOnly, readOnlyRun.principal());
+    assertEquals("codex/invite-" + full, fullRun.principal());
+    assertTrue(readOnlyRun.inviteRole());
+    assertTrue(fullRun.inviteRole());
+    assertTrue(readOnlyRun.readOnlyLane(), "a read-only invite carries the room contract");
+    assertFalse(fullRun.readOnlyLane(), "a full invite is member-tier, never viewer");
+    assertTrue(readOnlyRun.sessionRole(), "invites join the stop/status/reaper lanes");
+    assertTrue(fullRun.sessionRole());
+    assertFalse(readOnlyRun.buildRole());
+    assertTrue(store.running().stream().map(RunStore.RunRow::id).toList().contains(readOnly));
+    assertTrue(store.running().stream().map(RunStore.RunRow::id).toList().contains(full));
+  }
+
+  @Test
   void aRoomReservationNeverBlocksADisjointSpecsDispatchAndViceVersa() {
     reserveRoom(DateTimeUtils.newId().toString(), "auth", "node-a");
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -961,6 +961,38 @@ class RunStoreTest {
   }
 
   @Test
+  void aConcurrentInviteNeverShadowsTheBuildForProjectLevelCommands() {
+    var build = newRun("backend", "auth");
+    var invite = DateTimeUtils.newId().toString();
+    store.create(
+        invite,
+        "backend",
+        "auth",
+        "node-a",
+        "node-a",
+        "invite",
+        "claude-code",
+        null,
+        "consult",
+        null,
+        null,
+        null,
+        "sail-agent-" + invite);
+
+    assertEquals(
+        build,
+        store.latestForProjectOnNode("backend", "node-a").orElseThrow().id(),
+        "project-level status/log addresses the build, not a newer consultant beside it");
+    assertEquals(
+        build,
+        store.runningForProjectOnNode("backend", "node-a").orElseThrow().id(),
+        "a project-level stop halts the build, not the invite running alongside it");
+    assertTrue(
+        store.running().stream().map(RunStore.RunRow::id).toList().contains(invite),
+        "the reaper still owns the invite — it is addressable and stoppable by its run id");
+  }
+
+  @Test
   void aRoomReservationNeverBlocksADisjointSpecsDispatchAndViceVersa() {
     reserveRoom(DateTimeUtils.newId().toString(), "auth", "node-a");
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -463,6 +463,31 @@ class SchemaManagerTest {
   }
 
   @Test
+  void theRunsRoleCheckAdmitsBothInviteLanesAndRefusesUnknownRoles() {
+    new SchemaManager(db).migrate();
+
+    db.execute(
+        "INSERT INTO runs (id, project, agent, status, started_at, role)"
+            + " VALUES ('i1', 'acme', 'claude-code', 'running', 't1', 'invite')");
+    db.execute(
+        "INSERT INTO runs (id, project, agent, status, started_at, role)"
+            + " VALUES ('i2', 'acme', 'codex', 'running', 't1', 'invite-full')");
+
+    assertEquals(
+        "invite",
+        db.queryOne("SELECT role FROM runs WHERE id = 'i1'", r -> r.text(0)).orElseThrow());
+    assertEquals(
+        "invite-full",
+        db.queryOne("SELECT role FROM runs WHERE id = 'i2'", r -> r.text(0)).orElseThrow());
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            db.execute(
+                "INSERT INTO runs (id, project, agent, status, started_at, role)"
+                    + " VALUES ('i3', 'acme', 'claude-code', 'running', 't1', 'bogus')"));
+  }
+
+  @Test
   void theRoomGuardTableExistsAndCascadesWithItsRun() {
     new SchemaManager(db).migrate();
     db.execute(

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/AgentSession.java
@@ -536,11 +536,12 @@ public final class AgentSession {
   }
 
   /**
-   * The headless invocation for the run's lane. A {@code room} run gets the harness-restricted chat
-   * command — no mutating tools, print-mode default-deny, only the {@code spec} CLI and read-only
-   * git auto-approved — regardless of {@code fullPermissions}, so no caller can launch a
-   * full-permission chat by mispassing a flag. Every other lane keeps the full-permission dispatch
-   * command.
+   * The headless invocation for the run's lane. A {@code room} run — and a read-only {@code invite}
+   * run, which is the same contract under an explicit human invitation — gets the
+   * harness-restricted chat command — no mutating tools, print-mode default-deny, only the {@code
+   * spec} CLI and read-only git auto-approved — regardless of {@code fullPermissions}, so no caller
+   * can launch a full-permission chat by mispassing a flag. Every other lane, {@code invite-full}
+   * included, keeps the full-permission dispatch command.
    */
   private static String agentCommand(
       AgentCli cli,
@@ -551,7 +552,7 @@ public final class AgentSession {
       String role,
       String resumeSessionId,
       AgentUnit unit) {
-    if ("room".equals(role)) {
+    if ("room".equals(role) || "invite".equals(role)) {
       return resumeSessionId == null
           ? cli.headlessRoomCommand(unit.taskPath(), model, settingsPath, true)
           : cli.headlessRoomResumeCommand(

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/ClaudeCodeHookConfig.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/ClaudeCodeHookConfig.java
@@ -19,9 +19,10 @@ import java.util.concurrent.TimeoutException;
  * sessions that run bare {@code claude} never see these hooks, so their {@code Stop} events do not
  * leak into the spec event bus.
  *
- * <p>Besides hooks, the file carries the {@link #boxCredentialReadDeny} permission rule, so every
- * sail-launched session — most critically the room lane, whose whole file surface is the {@code
- * Read} tool — is denied tool-level reads of the ambient box credential.
+ * <p>Besides hooks, the file carries the {@link #roomReadDenyRules} permission rules — a
+ * belt-and-suspenders Read-deny on the container's top secrets (box credential, SSH identity, git
+ * credential) for the room / read-only-invite lane, whose primary read boundary is Claude's
+ * cwd-scoped approval (see {@link #roomReadDenyRules}).
  *
  * <p>Hooks wired:
  *
@@ -94,24 +95,43 @@ public final class ClaudeCodeHookConfig {
 
     var root = new LinkedHashMap<String, Object>();
     root.put("includeCoAuthoredBy", false);
-    root.put("permissions", Map.of("deny", List.of(boxCredentialReadDeny())));
+    root.put("permissions", Map.of("deny", roomReadDenyRules()));
     root.put("hooks", hooks);
     return YamlUtil.dumpJson(root);
   }
 
   /**
-   * The deny rule keeping the {@code Read} tool away from the ambient box credential. The file is
-   * world-readable by design (it rides the socket bind-mount, inside the box owner's SSH trust
-   * boundary), but it resolves to the box FDE's identity — a higher tier than the viewer credential
-   * a room or read-only-invite session holds — so the one lane whose only file access is the {@code
-   * Read} tool must not be able to lift it. Deny rules outrank every allow rule, and the room
-   * invocation pins {@code --setting-sources ""} so no ambient settings file can shadow this one.
-   * Spec-CLI authentication is untouched: the helper script reads the file at the OS level, not
-   * through the tool.
+   * The Read-deny rules that belt-and-suspenders the room / read-only-invite lane's highest-value
+   * credentials. The primary boundary is elsewhere: Claude Code auto-approves read commands ({@code
+   * cat}/{@code head}/{@code tail}/{@code grep}) only inside the working directory (the workspace),
+   * and refuses a read of any path outside it (verified empirically) — so the container's secrets,
+   * all of which live outside {@code ~/workspace}, are unreadable by default even without a rule.
+   * These denies harden the box FDE {@code box.credential}, the box SSH identity ({@code ~/.ssh} —
+   * the Sail CLI identity), and the {@code ~/.git-credentials} token explicitly on top of that, so
+   * the protection does not rest solely on the cwd heuristic. Claude Code applies a {@code
+   * Read(path)} deny to a Bash command that reads that path (verified), deny outranks every allow
+   * rule, and the room invocation pins {@code --setting-sources ""} so no ambient settings file can
+   * shadow these. A full (YOLO) agent skips permission rules by design — it is the trusted member
+   * lane. Spec-CLI auth is untouched: the helper reads the credential at the OS level, not through
+   * a tool. Residual (a secret committed inside the workspace, a kernel escape, a
+   * harness-enforcement bug) is owned by the room-lane hardening follow-up — a read-only-disk
+   * sidecar — not this denylist.
    */
+  public static List<String> roomReadDenyRules() {
+    return List.of(
+        boxCredentialReadDeny(), "Read(" + DEV_HOME + "/.ssh/**)", gitCredentialReadDeny());
+  }
+
+  private static final String DEV_HOME = "/home/dev";
+
+  /** Deny rule for the ambient box FDE credential; see {@link #roomReadDenyRules}. */
   public static String boxCredentialReadDeny() {
     var credential = SailPaths.apiSocketContainerDir().resolve(BoxCredentialFile.FILE_NAME);
     return "Read(/" + credential + ")";
+  }
+
+  private static String gitCredentialReadDeny() {
+    return "Read(" + DEV_HOME + "/.git-credentials)";
   }
 
   /**

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/ClaudeCodeHookConfig.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/ClaudeCodeHookConfig.java
@@ -19,6 +19,10 @@ import java.util.concurrent.TimeoutException;
  * sessions that run bare {@code claude} never see these hooks, so their {@code Stop} events do not
  * leak into the spec event bus.
  *
+ * <p>Besides hooks, the file carries the {@link #boxCredentialReadDeny} permission rule, so every
+ * sail-launched session — most critically the room lane, whose whole file surface is the {@code
+ * Read} tool — is denied tool-level reads of the ambient box credential.
+ *
  * <p>Hooks wired:
  *
  * <ul>
@@ -90,8 +94,24 @@ public final class ClaudeCodeHookConfig {
 
     var root = new LinkedHashMap<String, Object>();
     root.put("includeCoAuthoredBy", false);
+    root.put("permissions", Map.of("deny", List.of(boxCredentialReadDeny())));
     root.put("hooks", hooks);
     return YamlUtil.dumpJson(root);
+  }
+
+  /**
+   * The deny rule keeping the {@code Read} tool away from the ambient box credential. The file is
+   * world-readable by design (it rides the socket bind-mount, inside the box owner's SSH trust
+   * boundary), but it resolves to the box FDE's identity — a higher tier than the viewer credential
+   * a room or read-only-invite session holds — so the one lane whose only file access is the {@code
+   * Read} tool must not be able to lift it. Deny rules outrank every allow rule, and the room
+   * invocation pins {@code --setting-sources ""} so no ambient settings file can shadow this one.
+   * Spec-CLI authentication is untouched: the helper script reads the file at the OS level, not
+   * through the tool.
+   */
+  public static String boxCredentialReadDeny() {
+    var credential = SailPaths.apiSocketContainerDir().resolve(BoxCredentialFile.FILE_NAME);
+    return "Read(/" + credential + ")";
   }
 
   /**

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/SailStopGate.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/SailStopGate.java
@@ -33,9 +33,11 @@ import java.util.concurrent.TimeoutException;
  * or previous dispatch in the shared container) never nudges this run. When the session lists no
  * repos — a missing session file or a non-dispatch launch — every workspace repo is checked, the
  * prior behavior. A {@code room}-role run (the wake lane's chat sessions, marked by {@code role} in
- * the session file) skips the git protocol entirely: a chat owns no repos, so a dirty tree in the
- * shared container is never its concern — but it keeps the room last-look below, so a human reply
- * racing the chat's end is still guaranteed a reading.
+ * the session file) and a read-only {@code invite} run skip the git protocol entirely: a chat owns
+ * no repos, so a dirty tree in the shared container is never its concern — but both keep the room
+ * last-look below, so a human reply racing the chat's end is still guaranteed a reading. A full
+ * invite ({@code invite-full}) runs the git protocol like a build: it reserved repos and may have
+ * changed code, so it commits and pushes before its turn may end.
  *
  * <p>Beyond the git protocol, the gate takes one last look at the spec room: the run's undelivered
  * messages ({@code GET /v1/run/messages}, run-credential-scoped) block the stop with their bodies
@@ -88,9 +90,10 @@ public final class SailStopGate {
       # the git protocol, stop-room-nudged for the room), so a message that
       # arrives after a git nudge still gets its one block and neither concern
       # can wedge a run. stdout is reserved for the hook-protocol block JSON.
-      # A room-role run (role "room" in its session file) skips the git protocol
-      # entirely — a chat owns no repos and must never be nudged about other
-      # runs' trees — while keeping the room last-look.
+      # A room-role run (role "room" in its session file) and a read-only
+      # invite (role "invite") skip the git protocol entirely — a chat owns no
+      # repos and must never be nudged about other runs' trees — while keeping
+      # the room last-look. A full invite (role "invite-full") keeps it.
       # Any unexpected condition fails open: this gate is a nudge, not a jail.
       set -u
 
@@ -145,7 +148,7 @@ public final class SailStopGate {
       ' "$SESSION" 2>/dev/null || true)"
 
       REASONS=""
-      if [ "$RUN_ROLE" != "room" ] && [ ! -f "$GIT_MARKER" ]; then
+      if [ "$RUN_ROLE" != "room" ] && [ "$RUN_ROLE" != "invite" ] && [ ! -f "$GIT_MARKER" ]; then
         REPOS="$(python3 -c '
       import json, sys
       try:

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/AgentSessionTest.java
@@ -571,6 +571,57 @@ class AgentSessionTest {
   }
 
   @Test
+  void aReadOnlyInviteLaunchIsHarnessRestrictedEvenWhenFullPermissionsIsMispassed() {
+    var joined =
+        String.join(
+            " ",
+            AgentSession.buildBackgroundLaunchCommand(
+                "acme",
+                "dev",
+                "/home/dev/workspace",
+                true,
+                AgentCli.CLAUDE_CODE,
+                null,
+                null,
+                "spec-1",
+                "claude-code",
+                RUN_UNIT.logPath(),
+                RUN_ID,
+                "cred-0",
+                "invite",
+                null));
+
+    assertFalse(joined.contains("--dangerously-skip-permissions"), joined);
+    assertTrue(joined.contains("--tools \"Bash,Read,Grep,Glob\""), joined);
+    assertTrue(joined.contains("\"Bash(spec:*)\""), joined);
+  }
+
+  @Test
+  void aFullInviteLaunchKeepsTheFullPermissionCommand() {
+    var joined =
+        String.join(
+            " ",
+            AgentSession.buildBackgroundLaunchCommand(
+                "acme",
+                "dev",
+                "/home/dev/workspace",
+                true,
+                AgentCli.CLAUDE_CODE,
+                null,
+                null,
+                "spec-1",
+                "claude-code",
+                RUN_UNIT.logPath(),
+                RUN_ID,
+                "cred-0",
+                "invite-full",
+                null));
+
+    assertTrue(joined.contains("--dangerously-skip-permissions"), joined);
+    assertFalse(joined.contains("--tools"), joined);
+  }
+
+  @Test
   void runScopedLaunchCommandsRejectABlankOrInvalidRunId() {
     assertThrows(
         IllegalArgumentException.class,

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/ClaudeCodeHookConfigTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/ClaudeCodeHookConfigTest.java
@@ -75,16 +75,23 @@ class ClaudeCodeHookConfigTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  void renderDeniesToolLevelReadsOfTheBoxCredential() {
+  void renderDeniesReadsOfTheContainerCredentialsAndKeys() {
     var json = ClaudeCodeHookConfig.render();
     var permissions = (Map<String, Object>) YamlUtil.parseMap(json).get("permissions");
     var deny = (List<String>) permissions.get("deny");
     assertEquals(
-        List.of("Read(//var/lib/sail/run/box.credential)"),
+        List.of(
+            "Read(//var/lib/sail/run/box.credential)",
+            "Read(/home/dev/.ssh/**)",
+            "Read(/home/dev/.git-credentials)"),
         deny,
-        "the world-readable box credential resolves to the box FDE's identity; the room lane's"
-            + " only file access is the Read tool, so the sail-owned settings must deny it — and"
-            + " the room invocation pins --setting-sources so no ambient file can out-vote this");
+        "the room lane's reads are cwd-scoped (Claude auto-approves cat/head/tail/grep only inside"
+            + " the workspace, refusing out-of-tree paths), so the container's secrets are unreadable"
+            + " by default; these Read-denies belt-and-suspenders the top credentials — the box FDE"
+            + " credential, the box SSH identity, the git credential — explicitly on top. Deny"
+            + " outranks allow and --setting-sources is pinned, so no ambient file can out-vote"
+            + " these; a full (YOLO) agent skips them by design. Hermetic isolation stays with the"
+            + " sidecar follow-up.");
   }
 
   @Test

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/ClaudeCodeHookConfigTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/ClaudeCodeHookConfigTest.java
@@ -74,6 +74,20 @@ class ClaudeCodeHookConfigTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  void renderDeniesToolLevelReadsOfTheBoxCredential() {
+    var json = ClaudeCodeHookConfig.render();
+    var permissions = (Map<String, Object>) YamlUtil.parseMap(json).get("permissions");
+    var deny = (List<String>) permissions.get("deny");
+    assertEquals(
+        List.of("Read(//var/lib/sail/run/box.credential)"),
+        deny,
+        "the world-readable box credential resolves to the box FDE's identity; the room lane's"
+            + " only file access is the Read tool, so the sail-owned settings must deny it — and"
+            + " the room invocation pins --setting-sources so no ambient file can out-vote this");
+  }
+
+  @Test
   void renderDisablesCommitCoAuthorAttribution() {
     var json = ClaudeCodeHookConfig.render();
     assertTrue(

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/SailStopGateTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/SailStopGateTest.java
@@ -426,6 +426,29 @@ class SailStopGateTest {
     assertTrue(reason.contains("commit your work in api"), reason);
   }
 
+  @Test
+  void aReadOnlyInviteRoleRunSkipsTheGitProtocolLikeARoom() throws Exception {
+    var repo = repo("api");
+    Files.writeString(repo.resolve("dirty.txt"), "wip");
+    writeSessionRole("invite");
+
+    var result = runGate(STOP_INPUT, RUN_ID);
+
+    assertEquals("", result.stdout(), "a read-only invite is never nudged about shared trees");
+    assertFalse(Files.exists(marker()), "the git concern never runs for a read-only invite");
+  }
+
+  @Test
+  void aFullInviteRoleSessionFileKeepsTheGitProtocol() throws Exception {
+    var repo = repo("api");
+    Files.writeString(repo.resolve("dirty.txt"), "wip");
+    writeSessionRole("invite-full");
+
+    var reason = blockReason(runGate(STOP_INPUT, RUN_ID));
+
+    assertTrue(reason.contains("commit your work in api"), reason);
+  }
+
   private String blockReason(GateResult result) {
     var block = YamlUtil.parseMap(result.stdout());
     assertEquals("block", block.get("decision"), result.stdout());

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -627,6 +627,63 @@ record SpecRestoreRequest(String rev) {
   }
 }
 
+/** Body of {@code POST /v1/specs/{id}/invite}: the agent to invite and the one mode choice. */
+record InviteRequest(String agent, String model, boolean full) {
+  static InviteRequest fromMap(Map<String, Object> map) {
+    return new InviteRequest(
+        (String) map.get("agent"), (String) map.get("model"), Boolean.TRUE.equals(map.get("full")));
+  }
+}
+
+/** Response of {@code POST /v1/specs/{id}/invite}: the launched invite run. */
+record InviteResponse(String runId, String principal, String mode, String snapshot)
+    implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("run_id", runId);
+    m.put("principal", principal);
+    m.put("mode", mode);
+    m.put("snapshot", snapshot);
+    return m;
+  }
+}
+
+/** One invite mode an agent does or does not support, with the seam-declared reason when not. */
+record AgentModeView(String mode, boolean supported, String reason) implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("mode", mode);
+    m.put("supported", supported);
+    if (reason != null) {
+      m.put("reason", reason);
+    }
+    return m;
+  }
+}
+
+/** One installable agent CLI and its invite-mode support, for {@code GET /v1/agents}. */
+record AgentView(String name, String displayName, List<AgentModeView> modes) implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("name", name);
+    m.put("display_name", displayName);
+    m.put("modes", modes);
+    return m;
+  }
+}
+
+record AgentsResponse(List<AgentView> agents) implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("agents", agents);
+    return m;
+  }
+}
+
 record SpecRevisionView(
     String rev, String actor, String recordedAt, String origin, boolean deleted, String peer)
     implements Mappable {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -56,6 +56,8 @@ public final class ApiRouter implements HttpHandler {
   private static final String DISMISS = "dismiss";
   private static final String FOLLOWUP = "followup";
   private static final String MESSAGES = "messages";
+  private static final String INVITE = "invite";
+  private static final String AGENTS = "agents";
   private static final int DEFAULT_MESSAGES = 50;
   private static final int MAX_MESSAGES = 100;
   private static final int DEFAULT_TAIL = 200;
@@ -169,6 +171,10 @@ public final class ApiRouter implements HttpHandler {
 
     if (request.matches(GET, V1, FDES)) {
       return ApiResponse.from(operations.fdes());
+    }
+
+    if (request.matches(GET, V1, AGENTS)) {
+      return ApiResponse.from(operations.agents());
     }
 
     if (request.hasEventsPrefix()) {
@@ -355,6 +361,15 @@ public final class ApiRouter implements HttpHandler {
                 specId,
                 FollowupCreateRequest.fromMap(JsonBody.readMap(exchange))
                     .withCreatedBy(actor(exchange))));
+      }
+      if (INVITE.equals(sub)) {
+        requireMethod(request, POST);
+        return ApiResponse.from(
+            operations.inviteToSpec(
+                specId,
+                InviteRequest.fromMap(JsonBody.readMap(exchange)),
+                actorOf(exchange),
+                nodeHandle.get()));
       }
       if (MESSAGES.equals(sub)) {
         return switch (request.method()) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -652,6 +652,7 @@ public final class DispatchOperations {
                         ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
     requireAllowed(actor, spec.toSpec(), localHandle);
     var agentCli = inviteAgent(agentYamlName);
+    var inviteModel = inviteModel(model);
     if (!full && !agentCli.supportsReadOnlyInvite()) {
       throw new ApiException(
           ErrorCode.BAD_REQUEST,
@@ -665,6 +666,7 @@ public final class DispatchOperations {
       throw new ApiException(
           ErrorCode.AGENT_NOT_CONFIGURED, "No agent configured in sail.yaml's agent block.");
     }
+    requireInstalled(agentCli, project);
     var body = specStore.getContent(specId).map(SpecStore.SpecContent::body).orElse("");
     var room =
         messageStore == null
@@ -712,7 +714,7 @@ public final class DispatchOperations {
               config,
               workDir,
               full,
-              model,
+              inviteModel,
               null,
               specId,
               agentCli.yamlName(),
@@ -738,6 +740,40 @@ public final class DispatchOperations {
     } catch (RuntimeException e) {
       releaseIfAbsent(runId, project, unit);
       throw e;
+    }
+  }
+
+  /**
+   * Validates the invite's model exactly like a spec write, refusing shell-unsafe values as a
+   * client error before any reservation or snapshot — the model rides the agent command through
+   * {@code bash -l -c}, so only a single safe token may reach it.
+   */
+  private static String inviteModel(String model) {
+    try {
+      return Spec.validatedModel(model);
+    } catch (IllegalArgumentException e) {
+      throw new ApiException(ErrorCode.INVALID_REQUEST, e.getMessage());
+    }
+  }
+
+  /**
+   * Refuses the invite before any reservation or snapshot when the chosen agent's binary is not on
+   * the container's PATH — sail.yaml's agent block declares what a project apply installed, but the
+   * container is the authority on what can actually launch.
+   */
+  private void requireInstalled(AgentCli agentCli, String project) {
+    var found =
+        exec(
+            ContainerExec.asDevUser(
+                project,
+                List.of("bash", "-lc", "command -v -- \"$1\"", "bash", agentCli.binaryName())));
+    if (!found.ok()) {
+      throw new ApiException(
+          ErrorCode.AGENT_NOT_CONFIGURED,
+          "Agent '" + agentCli.yamlName() + "' is not installed in project '" + project + "'.",
+          "Add "
+              + agentCli.yamlName()
+              + " to sail.yaml's agent.install list and run 'sail project apply'.");
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -651,6 +651,7 @@ public final class DispatchOperations {
                     new ApiException(
                         ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
     requireAllowed(actor, spec.toSpec(), localHandle);
+    requireTrustedRoster(localHandle);
     var agentCli = inviteAgent(agentYamlName);
     var inviteModel = inviteModel(model);
     if (!full && !agentCli.supportsReadOnlyInvite()) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -22,6 +22,7 @@ import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.ContainerSailSetup;
 import ai.singlr.sail.engine.DispatchRepos;
 import ai.singlr.sail.engine.HostInfo;
+import ai.singlr.sail.engine.InvitePrompt;
 import ai.singlr.sail.engine.RoomWakePrompt;
 import ai.singlr.sail.engine.RunRetention;
 import ai.singlr.sail.engine.SailPaths;
@@ -88,6 +89,12 @@ public final class DispatchOperations {
       AgentSession.SessionInfo session,
       Integer exitCode,
       Optional<WatcherSpawner.Spawned> watcher) {}
+
+  /**
+   * One launched invite: the run it minted, the principal it posts under, its mode, and — full mode
+   * only — the label of the pre-launch snapshot ({@code ""} for read only).
+   */
+  public record InviteLaunch(String runId, String principal, boolean full, String snapshot) {}
 
   /**
    * Container preparation that must not run until the whole-container reservation is won — the
@@ -610,6 +617,172 @@ public final class DispatchOperations {
   }
 
   /**
+   * Launches an invited agent into {@code specId}'s room — the explicit lane beside the wake lane's
+   * automatic one: a human chose the agent, the model, and the mode, so the human's choice decides
+   * the contract. Read only is the room lane verbatim under a new role ({@code invite}): viewer
+   * credential, harness tool cut, no repo reservation (the gate lets it run alongside anything, its
+   * own spec's live build included), worktree-digest guard. Full ({@code invite-full}) is the
+   * member credential a dispatched agent holds, bought with two structural payments: the repo
+   * reservation (reserved like a build, so one writer per repo always holds — a held reservation
+   * refuses the invite with the same vocabulary as a dispatch conflict) and a mandatory pre-launch
+   * snapshot labeled {@code invite-<runId>}, published into the room as {@code snapshot_created}; a
+   * failed snapshot aborts the launch loudly. Neither mode claims the spec, checks out a branch, or
+   * triggers the review pipeline on stop — the review loop stays anchored to dispatch. Inviting
+   * requires the same tier as dispatching on the spec, checked via {@link DispatchPolicy}. Always a
+   * fresh session: the point of an invite is a new participant.
+   */
+  public InviteLaunch startInvite(
+      String specId,
+      String agentYamlName,
+      boolean full,
+      String model,
+      Actor actor,
+      String localHandle) {
+    if (runStore == null) {
+      throw new ApiException(
+          ErrorCode.COMMAND_FAILED,
+          "This box keeps no run aggregate, so an invite cannot be reserved or tracked.");
+    }
+    var spec =
+        specStore
+            .findById(specId)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
+    requireAllowed(actor, spec.toSpec(), localHandle);
+    var agentCli = inviteAgent(agentYamlName);
+    if (!full && !agentCli.supportsReadOnlyInvite()) {
+      throw new ApiException(
+          ErrorCode.BAD_REQUEST,
+          agentCli.readOnlyInviteRefusal(),
+          "Invite " + agentCli.yamlName() + " with full access, or invite claude-code read-only.");
+    }
+    var project = spec.project();
+    var loaded = projects.loadRunning(project);
+    var config = loaded.config();
+    if (config.agent() == null) {
+      throw new ApiException(
+          ErrorCode.AGENT_NOT_CONFIGURED, "No agent configured in sail.yaml's agent block.");
+    }
+    var body = specStore.getContent(specId).map(SpecStore.SpecContent::body).orElse("");
+    var room =
+        messageStore == null
+            ? List.<MessageStore.MessageRow>of()
+            : messageStore.list(specId, null, 20);
+    var built = InvitePrompt.build(spec, body.isBlank() ? spec.title() : body, room, full);
+    var task = built.prompt();
+    var runId = DateTimeUtils.newId().toString();
+    var unit = AgentUnit.forRun(runId);
+    var role = full ? DispatchGate.FULL_INVITE_ROLE : DispatchGate.READ_ONLY_INVITE_ROLE;
+    var targetRepos =
+        full ? DispatchRepos.resolve(config, spec.toSpec(), List.of()) : List.<SailYaml.Repo>of();
+    var repoPaths = targetRepos.stream().map(SailYaml.Repo::path).toList();
+    var branch = full ? Objects.toString(spec.branch(), "") : "";
+    var owner = Strings.isBlank(spec.assignee()) ? localHandle : spec.assignee();
+    var credential =
+        reserve(
+            runId,
+            project,
+            specId,
+            localHandle,
+            owner,
+            role,
+            repoPaths,
+            agentCli.yamlName(),
+            Strings.isBlank(branch) ? null : branch,
+            task,
+            unit,
+            config);
+    try {
+      seedRoomDelivery(runId, built.renderedMessages());
+      var snapshot = "";
+      if (full) {
+        snapshot = inviteSnapshot(project, specId, runId);
+      } else {
+        captureRoomBaseline(project, config, runId);
+      }
+      var workDir =
+          full
+              ? AgentSession.launchWorkDir(config.sshUser(), targetRepos)
+              : "/home/" + config.sshUser() + "/workspace";
+      var launch =
+          launchSession(
+              project,
+              config,
+              workDir,
+              full,
+              model,
+              null,
+              specId,
+              agentCli.yamlName(),
+              task,
+              branch,
+              repoPaths,
+              true,
+              unit,
+              runId,
+              credential,
+              role,
+              null);
+      var status = querySession(new AgentSession(shell), project, unit);
+      if (!updateRunProcess(runId, project, status, launch.watcher())) {
+        throw launchLostToCancel(runId, project, unit);
+      }
+      if (status != null && status.running()) {
+        publishAgentSessionStarted(
+            project, specId, agentCli.yamlName(), status.pid(), runId, launch.watcher());
+      }
+      var principal = runStore.findById(runId).map(RunStore.RunRow::principal).orElse("");
+      return new InviteLaunch(runId, principal, full, snapshot);
+    } catch (RuntimeException e) {
+      releaseIfAbsent(runId, project, unit);
+      throw e;
+    }
+  }
+
+  /** Resolves the invite's agent, refusing an unknown or missing name as a client error. */
+  private static AgentCli inviteAgent(String agentYamlName) {
+    if (Strings.isBlank(agentYamlName)) {
+      throw new ApiException(
+          ErrorCode.BAD_REQUEST,
+          "An invite must name the agent to launch.",
+          "Pass agent: claude-code or codex.");
+    }
+    try {
+      return AgentCli.fromYamlName(agentYamlName);
+    } catch (IllegalArgumentException e) {
+      throw new ApiException(ErrorCode.BAD_REQUEST, e.getMessage());
+    }
+  }
+
+  /**
+   * The full invite's mandatory pre-launch snapshot, labeled {@code invite-<runId>} so rollback is
+   * one visible step. Published with the spec id — unlike the container-scoped dispatch snapshot —
+   * so the {@code snapshot_created} event renders in the room the invite was made from. Failure
+   * aborts the invite: the snapshot is the payment for full access, and a YOLO session with no
+   * rollback point must not launch.
+   */
+  private String inviteSnapshot(String project, String specId, String runId) {
+    var label = "invite-" + runId;
+    try {
+      new SnapshotManager(shell).create(project, label);
+    } catch (Exception e) {
+      throw new ApiException(
+          ErrorCode.SNAPSHOT_FAILED,
+          "Failed to create the pre-invite snapshot, so the invite does not launch.",
+          "Check the host's snapshot capacity (incus storage) and retry.",
+          e);
+    }
+    publish(
+        project,
+        specId,
+        Event.WellKnownTypes.SNAPSHOT_CREATED,
+        Map.of("label", label, Event.WellKnownData.RUN_ID, runId));
+    return label;
+  }
+
+  /**
    * The spec's most recent conversation this box can actually resume: the latest run that recorded
    * a session id, restricted to runs executed on this node (conversation state lives on the box
    * that ran it; run rows and session ids replicate fleet-wide), to the same agent (a Claude
@@ -716,7 +889,7 @@ public final class DispatchOperations {
     var others =
         runStore.listForProject(project).stream()
             .filter(candidate -> !candidate.id().equals(runId))
-            .filter(candidate -> !candidate.roomRole())
+            .filter(candidate -> !candidate.readOnlyLane())
             .filter(candidate -> sameNode(roomNode, candidate))
             .filter(candidate -> overlapsRoomInterval(candidate, roomStarted, guardAt))
             .toList();

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
@@ -187,16 +187,29 @@ public record Event(
     /** {@link #RUN_ROLE} value: a fix run — its own stop must never re-enter the pipeline. */
     public static final String RUN_ROLE_FIX = "fix";
 
+    /** {@link #RUN_ROLE} value: a read-only invited consultant — chat only, never a review. */
+    public static final String RUN_ROLE_INVITE = "invite";
+
+    /**
+     * {@link #RUN_ROLE} value: a full-access invited agent. Its stop never triggers the review
+     * pipeline — the review loop stays anchored to dispatch; commits it pushed surface in the room
+     * and the next build's review sees them.
+     */
+    public static final String RUN_ROLE_INVITE_FULL = "invite-full";
+
     /**
      * Whether a run role names a lane whose own stop must never drive the review pipeline: a {@link
-     * #RUN_ROLE_ROOM} chat, or the pipeline's own {@link #RUN_ROLE_REVIEW} / {@link #RUN_ROLE_FIX}
-     * run. Reactors on {@code agent_session_stopped} drop such stops by role so the loop can never
-     * re-enter on its own agents. Null (a role-less stop) is a normal build stop.
+     * #RUN_ROLE_ROOM} chat, an invited agent ({@link #RUN_ROLE_INVITE} / {@link
+     * #RUN_ROLE_INVITE_FULL}), or the pipeline's own {@link #RUN_ROLE_REVIEW} / {@link
+     * #RUN_ROLE_FIX} run. Reactors on {@code agent_session_stopped} drop such stops by role so the
+     * loop can never re-enter on its own agents. Null (a role-less stop) is a normal build stop.
      */
     public static boolean nonTriggeringLane(String role) {
       return RUN_ROLE_ROOM.equals(role)
           || RUN_ROLE_REVIEW.equals(role)
-          || RUN_ROLE_FIX.equals(role);
+          || RUN_ROLE_FIX.equals(role)
+          || RUN_ROLE_INVITE.equals(role)
+          || RUN_ROLE_INVITE_FULL.equals(role);
     }
 
     private WellKnownData() {}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
@@ -84,13 +84,15 @@ final class LocalApiRouter implements LocalApiHandler {
       }
 
       /**
-       * A {@code room} run's credential resolves to the read-and-converse room principal, never the
-       * write-capable agent principal: the chat lane's authority is decided here, at the boundary,
-       * by the run row the server minted — not by anything the session says.
+       * A read-only lane run's credential — a {@code room} wake or a read-only {@code invite} —
+       * resolves to the read-and-converse room principal, never the write-capable agent principal:
+       * the lane's authority is decided here, at the boundary, by the run row the server minted —
+       * not by anything the session says. A full invite carries the member-tier agent principal a
+       * dispatched agent holds, nothing more.
        */
       @Override
       public Actor actor() {
-        return run.roomRole()
+        return run.readOnlyLane()
             ? Actor.roomPrincipal(run.principal(), run.owner())
             : Actor.agentPrincipal(run.principal(), run.owner());
       }
@@ -290,7 +292,9 @@ final class LocalApiRouter implements LocalApiHandler {
         yield ApiResponse.from(result);
       }
       case "POST" -> {
-        if (caller instanceof Caller.Run(var run) && run.roomRole() && !id.equals(run.specId())) {
+        if (caller instanceof Caller.Run(var run)
+            && run.readOnlyLane()
+            && !id.equals(run.specId())) {
           yield problem(403, "A room session posts only to its own spec's room.");
         }
         var form = request.form();

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
@@ -37,6 +37,8 @@ public interface Operations {
   /** The org-wide FDE roster, sorted by handle — a member-tier read backed by the synced roster. */
   Result<FdesResponse> fdes();
 
+  Result<AgentsResponse> agents();
+
   Result<ProjectResponse> project(String project);
 
   /** Returns the two-hop SSH target (server jump + container) for a running project. */
@@ -157,6 +159,9 @@ public interface Operations {
 
   Result<GlobalSpecRestoredResponse> restoreGlobalSpec(
       String specId, SpecRestoreRequest request, Actor actor);
+
+  Result<InviteResponse> inviteToSpec(
+      String specId, InviteRequest request, Actor actor, String localHandle);
 
   Result<GlobalBoardResponse> globalBoard(String project);
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -1024,7 +1024,10 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     var runId = Objects.toString(event.data().get(Event.WellKnownData.RUN_ID), null);
     return runId != null
         && !runId.isBlank()
-        && runStore.findById(runId).map(row -> row.roomRole() || row.reviewRole()).orElse(false);
+        && runStore
+            .findById(runId)
+            .map(row -> row.roomRole() || row.reviewRole() || row.inviteRole())
+            .orElse(false);
   }
 
   private static Integer exitCodeOf(Event event) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
@@ -214,7 +214,9 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
   }
 
   private void handleStop(Event event) throws Exception {
-    if (!Event.WellKnownData.RUN_ROLE_ROOM.equals(event.data().get(Event.WellKnownData.RUN_ROLE))) {
+    var role = event.data().get(Event.WellKnownData.RUN_ROLE);
+    if (!Event.WellKnownData.RUN_ROLE_ROOM.equals(role)
+        && !Event.WellKnownData.RUN_ROLE_INVITE.equals(role)) {
       return;
     }
     var runId = Objects.toString(event.data().get(Event.WellKnownData.RUN_ID), null);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -9,6 +9,7 @@ import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecCatalog;
+import ai.singlr.sail.engine.AgentCli;
 import ai.singlr.sail.engine.AgentReporter;
 import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.AgentUnit;
@@ -386,6 +387,53 @@ public final class SailOperations implements Operations {
                 fde -> new FdeSummaryView(fde.handle(), fde.displayName(), fde.email(), fde.role()))
             .toList();
     return new FdesResponse(roster);
+  }
+
+  /**
+   * The known agent CLIs and their invite-mode support, declared at the {@link AgentCli} seam: read
+   * only is offered only where the harness enforces it, and the refusal reason travels so clients
+   * grey the option out with the same words the launch gate refuses with.
+   */
+  @Override
+  public Result<AgentsResponse> agents() {
+    var agents =
+        Arrays.stream(AgentCli.values())
+            .map(
+                cli ->
+                    new AgentView(
+                        cli.yamlName(),
+                        cli.displayName(),
+                        List.of(
+                            new AgentModeView(
+                                "read_only",
+                                cli.supportsReadOnlyInvite(),
+                                cli.readOnlyInviteRefusal()),
+                            new AgentModeView("full", true, null))))
+            .toList();
+    return Result.success(new AgentsResponse(agents));
+  }
+
+  @Override
+  public Result<InviteResponse> inviteToSpec(
+      String specId, InviteRequest request, Actor actor, String localHandle) {
+    freshenForRead();
+    var result = safe(() -> inviteValue(specId, request, actor, localHandle));
+    if (result instanceof Result.Success<InviteResponse>) {
+      triggerSyncAfterWrite();
+    }
+    return result;
+  }
+
+  private InviteResponse inviteValue(
+      String specId, InviteRequest request, Actor actor, String localHandle) {
+    var launch =
+        dispatchOps.startInvite(
+            specId, request.agent(), request.full(), request.model(), actor, localHandle);
+    return new InviteResponse(
+        launch.runId(),
+        launch.principal(),
+        launch.full() ? "full" : "read_only",
+        launch.snapshot());
   }
 
   @Override

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SyncTransitionEvents.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SyncTransitionEvents.java
@@ -118,8 +118,9 @@ public final class SyncTransitionEvents {
     var agent = Objects.requireNonNullElse(text(transition.snapshot(), "agent"), Event.SAIL_AGENT);
     var data = new LinkedHashMap<String, Object>();
     data.put(Event.WellKnownData.RUN_ID, transition.entityId());
-    if (Event.WellKnownData.RUN_ROLE_ROOM.equals(text(transition.snapshot(), "role"))) {
-      data.put(Event.WellKnownData.RUN_ROLE, Event.WellKnownData.RUN_ROLE_ROOM);
+    var role = text(transition.snapshot(), "role");
+    if (Event.WellKnownData.nonTriggeringLane(role)) {
+      data.put(Event.WellKnownData.RUN_ROLE, role);
     }
     var exitCode = transition.snapshot().get("exit_code") instanceof Number n ? n.intValue() : null;
     if (exitCode != null) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecInviteCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecInviteCommand.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.api.SailApiClient;
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.NameValidator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+/**
+ * Invites an agent into a spec's room: one choice, read only (default) or {@code --full}. The
+ * server owns the whole launch — mode support, reservation, the full lane's pre-launch snapshot —
+ * so this command is a thin client of {@code POST /v1/specs/{id}/invite} and renders the server's
+ * refusals verbatim.
+ */
+@Command(
+    name = "invite",
+    description =
+        "Invite an agent into this spec's room — read only by default, --full to let it change"
+            + " specs and code (snapshots first).",
+    mixinStandardHelpOptions = true)
+public final class ApiSpecInviteCommand implements Runnable {
+
+  @Parameters(index = "0", description = "Spec ID.")
+  private String specId;
+
+  @Option(names = "--agent", required = true, description = "Agent to invite: claude-code, codex.")
+  private String agent;
+
+  @Option(names = "--model", description = "Model override for the invited agent.")
+  private String model;
+
+  @Option(
+      names = "--full",
+      description = "Full access: spec CLI writes and code changes, paid with a snapshot.")
+  private boolean full;
+
+  @Mixin private SyncOptions syncOptions;
+
+  @Mixin private ConnectionOptions connection;
+
+  @Option(names = "--json", description = "Output in JSON format.")
+  private boolean json;
+
+  @Spec private CommandSpec commandSpec;
+
+  @Override
+  public void run() {
+    CliCommand.run(commandSpec, this::execute);
+  }
+
+  private void execute() throws Exception {
+    NameValidator.requireValidSpecId(specId);
+    var config = connection.resolve();
+    var body = new LinkedHashMap<String, Object>();
+    body.put("agent", agent);
+    if (Strings.isNotBlank(model)) {
+      body.put("model", model);
+    }
+    body.put("full", full);
+    try (var client = new SailApiClient(config.serverUrl(), config.token(), syncOptions.noSync())) {
+      var result = client.post("/v1/specs/" + specId + "/invite", Map.copyOf(body));
+
+      if (json) {
+        System.out.println(YamlUtil.dumpJson(new LinkedHashMap<>(result)));
+        return;
+      }
+      var mode = full ? "full access" : "read only";
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|green ✓|@ Invited "
+                  + agent
+                  + " ("
+                  + mode
+                  + ") into spec '"
+                  + specId
+                  + "' — run "
+                  + result.get("run_id")
+                  + " as "
+                  + result.get("principal")
+                  + "."));
+      var snapshot = result.get("snapshot");
+      if (snapshot != null && !snapshot.toString().isBlank()) {
+        System.out.println("    Snapshot: " + snapshot);
+      }
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SpecCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SpecCommand.java
@@ -23,6 +23,7 @@ import picocli.CommandLine.Command;
       ApiSpecRestoreCommand.class,
       ApiSpecCommentCommand.class,
       ApiSpecCommentsCommand.class,
+      ApiSpecInviteCommand.class,
       DispatchCommand.class,
     })
 public final class SpecCommand implements Runnable {

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/InvitePrompt.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/InvitePrompt.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import ai.singlr.sail.store.MessageStore;
+import ai.singlr.sail.store.SpecStore;
+import java.util.List;
+
+/**
+ * Builds the prompt an invited agent receives: the spec's identity, the room's recent conversation,
+ * the spec body, and the invite duty for the chosen mode. An invite is always a fresh session — the
+ * point of inviting is a new participant's perspective, so it never resumes another run's
+ * conversation. The duty differs by mode: read only is the room lane's read-and-converse contract
+ * under an explicit invitation; full access may draft specs and change code, paid for by the
+ * pre-launch snapshot and the repo reservation the launcher took.
+ */
+public final class InvitePrompt {
+
+  private InvitePrompt() {}
+
+  /**
+   * A built invite prompt and the room messages it rendered in full — the exact set the launcher
+   * may acknowledge as delivered. Delivery derives from presentation, exactly like {@link
+   * RoomWakePrompt.Built}.
+   */
+  public record Built(String prompt, List<MessageStore.MessageRow> renderedMessages) {}
+
+  public static Built build(
+      SpecStore.SpecRow spec, String body, List<MessageStore.MessageRow> messages, boolean full) {
+    var conversation =
+        PromptConversation.renderNewest(
+            messages,
+            message ->
+                message.author() + " (" + message.createdAt() + "):\n" + message.body() + "\n\n");
+    var conversationBlock =
+        conversation.text().isEmpty()
+            ? ""
+            : "## Conversation on this spec\n\n" + conversation.text();
+    var prompt =
+        "You are an invited agent in the room of spec \""
+            + spec.title()
+            + "\" (id: "
+            + spec.id()
+            + ", status: "
+            + spec.status().wire()
+            + "). A human invited you into this conversation with "
+            + (full ? "full access" : "read-only access")
+            + " to help: chat, critique, or draft — bring your own perspective.\n\n"
+            + conversationBlock
+            + "## Spec body\n\n"
+            + body
+            + "\n\n"
+            + (full ? fullDuty(spec.id()) : readOnlyDuty(spec.id()));
+    return new Built(prompt, conversation.fullyRendered());
+  }
+
+  private static String readOnlyDuty(String specId) {
+    return """
+        ## Invite Duty (read only)
+
+        Read the conversation and spec body above, investigate in the workspace as needed,
+        and post your contribution in the room with `spec comment %s --body <text>`
+        (or `--body -` for stdin).
+
+        This is a read-only chat session, and the harness enforces it: file edits and spec
+        state changes are denied, and the only shell commands that run are the `spec` CLI
+        and `cd` — use the Read and Grep tools for files. Do not fight a denial; work
+        within the lane. If the conversation asks for code changes, describe them in the
+        room — dispatch (or a full invite) is the lane that changes code. If the
+        conversation asks something you cannot answer or decide alone, post it back with
+        `spec comment %s --question --body <text>` — the flag pages the engineer on the
+        board until a human replies.
+
+        The room stays live while you work: replies posted in the meantime are delivered
+        into your context automatically after a tool call finishes, and unread messages
+        block your first attempt to stop. When you have contributed, stop.
+        """
+        .formatted(specId, specId);
+  }
+
+  private static String fullDuty(String specId) {
+    return """
+        ## Invite Duty (full access)
+
+        Read the conversation and spec body above, then help however the conversation
+        asks: answer, critique, draft, or change code.
+
+        - Post to the room with `spec comment %s --body <text>` (or `--body -` for
+          stdin), and post a final summary there before you stop. For a question only a
+          human can settle, add `--question` — the flag pages the engineer on the board.
+        - Draft the spec body with `spec content %s --body-file <file>` when the
+          conversation is shaping this spec, or create sibling specs with
+          `spec create --id <id> --title "<title>" --body-file <file>`. New specs are
+          born draft; a human promotes them on the board — never set a status yourself.
+        - For code changes: a container snapshot was taken before you launched and you
+          hold the repo reservation, so work directly in the workspace. Work on the
+          spec's branch when one exists; commit and push before stopping — the stop gate
+          holds your turn open until every touched repo is clean and pushed.
+
+        The room stays live while you work: replies posted in the meantime are delivered
+        into your context automatically after a tool call finishes, and unread messages
+        block your first attempt to stop. When you have contributed, stop.
+        """
+        .formatted(specId, specId);
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -881,6 +881,77 @@ class ApiRouterTest {
   }
 
   @Test
+  void agentsListsTheInviteModeSupportToAnAuthenticatedCaller() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/agents", "token");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"name\": \"claude-code\""));
+      assertTrue(response.body().contains("\"display_name\": \"Claude Code\""));
+      assertTrue(response.body().contains("\"mode\": \"read_only\""));
+      assertTrue(response.body().contains("\"supported\": true"));
+      assertTrue(response.body().contains("\"supported\": false"));
+      assertTrue(
+          response.body().contains("\"reason\": \"no harness-enforced sandbox\""),
+          "an unsupported mode travels with its reason so clients grey it honestly");
+      assertTrue(response.body().contains("\"schema_version\": 1"));
+    }
+  }
+
+  @Test
+  void agentsRequiresABearerToken() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/agents", null);
+
+      assertEquals(401, response.statusCode());
+    }
+  }
+
+  @Test
+  void invitePostRoutesTheBodyToTheOperation() throws Exception {
+    var ops = new FakeOperations();
+    try (var server = serverWith(ops, true)) {
+      var response =
+          post(
+              server,
+              "/v1/specs/auth-flow/invite",
+              "token",
+              "{\"agent\": \"codex\", \"model\": \"gpt-6\", \"full\": true}");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"run_id\": \"run-9\""));
+      assertTrue(response.body().contains("\"principal\": \"claude/invite-run-9\""));
+      assertTrue(response.body().contains("\"mode\": \"full\""));
+      assertTrue(response.body().contains("\"snapshot\": \"invite-run-9\""));
+      assertEquals("auth-flow", ops.lastInvite.specId());
+      assertEquals("codex", ops.lastInvite.request().agent());
+      assertEquals("gpt-6", ops.lastInvite.request().model());
+      assertTrue(ops.lastInvite.request().full());
+    }
+  }
+
+  @Test
+  void invitePostDefaultsToReadOnly() throws Exception {
+    var ops = new FakeOperations();
+    try (var server = serverWith(ops, true)) {
+      var response =
+          post(server, "/v1/specs/auth-flow/invite", "token", "{\"agent\": \"claude-code\"}");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"mode\": \"read_only\""));
+      assertFalse(ops.lastInvite.request().full());
+    }
+  }
+
+  @Test
+  void inviteRejectsNonPost() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/specs/auth-flow/invite", "token");
+      assertEquals(405, response.statusCode());
+    }
+  }
+
+  @Test
   void followupPostReturns201WithDraftedSpec() throws Exception {
     try (var server = server()) {
       var response = post(server, "/v1/specs/auth-flow/followup", "token", "{}");
@@ -1221,6 +1292,10 @@ class ApiRouterTest {
   }
 
   private static class FakeOperations implements Operations {
+    record Invite(String specId, InviteRequest request, String localHandle) {}
+
+    volatile Invite lastInvite;
+
     @Override
     public Result<HealthResponse> health() {
       return Result.success(new HealthResponse("ok"));
@@ -1242,6 +1317,37 @@ class ApiRouterTest {
               java.util.List.of(
                   new FdeSummaryView("ada", "Ada Lovelace", "ada@x.dev", "admin"),
                   new FdeSummaryView("bob", "Bob", "bob@x.dev", "member"))));
+    }
+
+    @Override
+    public Result<AgentsResponse> agents() {
+      return Result.success(
+          new AgentsResponse(
+              java.util.List.of(
+                  new AgentView(
+                      "claude-code",
+                      "Claude Code",
+                      java.util.List.of(
+                          new AgentModeView("read_only", true, null),
+                          new AgentModeView("full", true, null))),
+                  new AgentView(
+                      "codex",
+                      "Codex CLI",
+                      java.util.List.of(
+                          new AgentModeView("read_only", false, "no harness-enforced sandbox"),
+                          new AgentModeView("full", true, null))))));
+    }
+
+    @Override
+    public Result<InviteResponse> inviteToSpec(
+        String specId, InviteRequest request, Actor actor, String localHandle) {
+      lastInvite = new Invite(specId, request, localHandle);
+      return Result.success(
+          new InviteResponse(
+              "run-9",
+              "claude/invite-run-9",
+              request.full() ? "full" : "read_only",
+              request.full() ? "invite-run-9" : ""));
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
@@ -417,6 +417,23 @@ class InviteLaunchTest {
   }
 
   @Test
+  void anUntrustedNodeIsRefusedBeforeReserveOrSnapshot() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth", "ghost", null);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.startInvite(
+                    "auth", "claude-code", true, null, Actor.cliOperator("ghost"), "ghost"));
+
+    assertEquals(ErrorCode.FDE_NOT_IN_ROSTER, refusal.failure().errorCode());
+    assertTrue(runStore.listForSpec("auth").isEmpty(), "an untrusted node reserves nothing");
+    assertEquals(List.of(), order, "an untrusted node takes no snapshot and launches nothing");
+  }
+
+  @Test
   void aMissingSpecIsRefused() throws Exception {
     var ops = operations(liveAgentShell());
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
@@ -178,6 +178,12 @@ class InviteLaunchTest {
     var joined = String.join(" ", launched.get());
     assertFalse(joined.contains("--dangerously-skip-permissions"), joined);
     assertTrue(joined.contains("--tools \"Bash,Read,Grep,Glob\""), joined);
+    assertTrue(
+        joined.contains("--setting-sources \"\"") && joined.contains("--strict-mcp-config"),
+        "a read-only invite runs beside live builds without a reservation, so the launched"
+            + " command must exclude ambient settings and MCP configs — no workspace file may"
+            + " widen the tool cut. Command: "
+            + joined);
     assertFalse(joined.contains("--resume"), "an invite is always a fresh participant");
     assertEquals("invite", launched.get().getLast(), "SAIL_RUN_ROLE rides the launch");
     assertTrue(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
@@ -115,6 +115,7 @@ class InviteLaunchTest {
   private StubShell liveAgentShell() {
     return new StubShell(order)
         .on("incus list ^acme$", RUNNING_JSON)
+        .on("command -v", "/usr/local/bin/claude\n")
         .on("incus snapshot create", "")
         .on("mkdir -p /home/dev/.sail", "")
         .on("rev-parse HEAD", "aaa111\n")
@@ -270,6 +271,7 @@ class InviteLaunchTest {
     var shell =
         new StubShell(order)
             .on("incus list ^acme$", RUNNING_JSON)
+            .on("command -v", "/usr/local/bin/claude\n")
             .on("mkdir -p /home/dev/.sail", "");
     var ops = operations(shell);
     seedSpec("auth");
@@ -316,6 +318,46 @@ class InviteLaunchTest {
     assertEquals("codex/invite-" + launch.runId(), launch.principal());
     var joined = String.join(" ", launched.get());
     assertTrue(joined.contains("--dangerously-bypass-approvals-and-sandbox"), joined);
+  }
+
+  @Test
+  void aShellUnsafeModelIsRefusedBeforeAnyReservation() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.startInvite(
+                    "auth",
+                    "claude-code",
+                    false,
+                    "x; touch /home/dev/workspace/PWNED #",
+                    Actor.cliOperator(HANDLE),
+                    HANDLE));
+
+    assertEquals(ErrorCode.INVALID_REQUEST, refusal.failure().errorCode());
+    assertTrue(refusal.failure().errorMessage().contains("shell"), "names the shell hazard");
+    assertTrue(runStore.listForSpec("auth").isEmpty(), "a refused model reserves nothing");
+    assertEquals(List.of(), order, "a refused model takes no snapshot and launches nothing");
+  }
+
+  @Test
+  void anAgentAbsentFromTheContainerIsRefusedBeforeReserveOrSnapshot() throws Exception {
+    var shell = new StubShell(order).on("incus list ^acme$", RUNNING_JSON);
+    var ops = operations(shell);
+    seedSpec("auth");
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.startInvite("auth", "codex", true, null, Actor.cliOperator(HANDLE), HANDLE));
+
+    assertEquals(ErrorCode.AGENT_NOT_CONFIGURED, refusal.failure().errorCode());
+    assertTrue(refusal.failure().errorMessage().contains("codex"), "names the absent agent");
+    assertTrue(runStore.listForSpec("auth").isEmpty(), "an absent agent reserves nothing");
+    assertEquals(List.of(), order, "an absent agent takes no snapshot and launches nothing");
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
@@ -1,0 +1,488 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.ContainerSailSetup;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.WatcherSpawner;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.MessageStore;
+import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The invite launch lane: {@code startInvite} mints an {@code invite} (read only) or {@code
+ * invite-full} run through the same reservation transaction as dispatch. Read only is the room
+ * lane's wiring verbatim — harness-restricted command, no repos, guard baseline, ledger seeding —
+ * and runs alongside anything, its own spec's live build included. Full reserves like a build,
+ * takes a mandatory pre-launch snapshot labeled {@code invite-<runId>} (published into the room),
+ * and launches full-permission; a held reservation refuses with the dispatch vocabulary and a
+ * failed snapshot aborts the launch.
+ */
+class InviteLaunchTest {
+
+  private static final String HANDLE = "uday";
+
+  private static final String RUNNING_JSON =
+      """
+      [{"name": "acme", "status": "Running", "state": {}}]
+      """;
+
+  private static final String YAML =
+      """
+      name: acme
+      ssh:
+        user: dev
+      repos:
+        - url: https://github.com/acme/app.git
+          path: app
+      agent:
+        type: claude-code
+      """;
+
+  @TempDir Path tempDir;
+
+  private SpecStore specStore;
+  private RunStore runStore;
+  private MessageStore messageStore;
+  private Sqlite db;
+  private final List<Event> events = new ArrayList<>();
+  private final List<String> order = new ArrayList<>();
+  private final AtomicReference<List<String>> launched = new AtomicReference<>();
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) {
+      db.close();
+    }
+  }
+
+  private DispatchOperations operations(ShellExec shell) throws IOException {
+    var yaml = tempDir.resolve("sail-" + System.nanoTime() + ".yaml");
+    Files.writeString(yaml, YAML);
+    db = Sqlite.open(tempDir.resolve("invite-" + System.nanoTime() + ".db"));
+    new SchemaManager(db).migrate();
+    specStore = new SpecStore(db);
+    runStore = new RunStore(db);
+    messageStore = new MessageStore(db);
+    new FdeStore(db).add(HANDLE, null, null, "admin");
+    return new DispatchOperations(
+            shell,
+            yaml.toString(),
+            specStore,
+            new ReviewStore(db),
+            runStore,
+            new FdeStore(db),
+            events::add,
+            new WatcherSpawner(shell, (command, logPath) -> 4242L),
+            (project, config) -> "",
+            command -> {
+              launched.set(command);
+              order.add("launch");
+              return 0;
+            },
+            DispatchOperations.Listener.NONE)
+        .useMessages(messageStore);
+  }
+
+  private StubShell liveAgentShell() {
+    return new StubShell(order)
+        .on("incus list ^acme$", RUNNING_JSON)
+        .on("incus snapshot create", "")
+        .on("mkdir -p /home/dev/.sail", "")
+        .on("rev-parse HEAD", "aaa111\n")
+        .on("diff --binary HEAD", "")
+        .on("printf '%s'", "")
+        .on("agent.pid", "123")
+        .on("kill -0 123", "")
+        .on("agent-session.json", "{\"task\": \"work\"}");
+  }
+
+  private void seedSpec(String id) {
+    seedSpec(id, HANDLE, null);
+  }
+
+  private void seedSpec(String id, String assignee, String branch) {
+    specStore.create(
+        new SpecStore.SpecRow(
+            id,
+            "acme",
+            "OAuth flow",
+            SpecStatus.DRAFT,
+            assignee,
+            null,
+            null,
+            null,
+            branch,
+            0,
+            HANDLE,
+            "",
+            "",
+            null,
+            List.of(),
+            List.of("app")));
+    specStore.setContent(id, "Build the OAuth flow.", "");
+  }
+
+  @Test
+  void aReadOnlyInviteMintsAnInviteRunOnTheRoomContract() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+    var question = messageStore.append("auth", "uday", "poke holes in this design", null);
+
+    var launch =
+        ops.startInvite("auth", "claude-code", false, null, Actor.cliOperator(HANDLE), HANDLE);
+
+    var run = runStore.findById(launch.runId()).orElseThrow();
+    assertEquals("invite", run.role());
+    assertEquals("auth", run.specId());
+    assertEquals(HANDLE, run.owner());
+    assertEquals("claude/invite-" + launch.runId(), run.principal());
+    assertEquals(launch.principal(), run.principal());
+    assertEquals(List.of(), run.repos(), "read only reserves nothing");
+    assertEquals("", launch.snapshot(), "read only pays no snapshot");
+    assertEquals(
+        Set.of(question.id()),
+        runStore.deliveredMessageIds(launch.runId()),
+        "the prompt is the run's first delivery, seeded by identity");
+    assertTrue(run.task().contains("Invite Duty (read only)"));
+    assertTrue(run.task().contains("Build the OAuth flow."));
+    var joined = String.join(" ", launched.get());
+    assertFalse(joined.contains("--dangerously-skip-permissions"), joined);
+    assertTrue(joined.contains("--tools \"Bash,Read,Grep,Glob\""), joined);
+    assertFalse(joined.contains("--resume"), "an invite is always a fresh participant");
+    assertEquals("invite", launched.get().getLast(), "SAIL_RUN_ROLE rides the launch");
+    assertTrue(
+        runStore.consumeRoomGuardBaseline(launch.runId()).orElseThrow().contains("aaa111"),
+        "the worktree-digest guard baseline is recorded exactly like a wake");
+    assertTrue(
+        events.stream().noneMatch(e -> Event.WellKnownTypes.SNAPSHOT_CREATED.equals(e.type())));
+    var started =
+        events.stream()
+            .filter(e -> Event.WellKnownTypes.AGENT_SESSION_STARTED.equals(e.type()))
+            .findFirst()
+            .orElseThrow();
+    assertEquals("auth", started.spec());
+  }
+
+  @Test
+  void aReadOnlyInviteRunsAlongsideItsOwnSpecsLiveBuild() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+    var live = DateTimeUtils.newId().toString();
+    db.execute(
+        "INSERT INTO runs (id, project, spec_id, node, role, agent, status, started_at, repos)"
+            + " VALUES (?, 'acme', 'auth', ?, 'build', 'claude-code', 'running', 't0',"
+            + " '[\"app\"]')",
+        live,
+        HANDLE);
+
+    var launch =
+        ops.startInvite("auth", "claude-code", false, null, Actor.cliOperator(HANDLE), HANDLE);
+
+    assertEquals("invite", runStore.findById(launch.runId()).orElseThrow().role());
+  }
+
+  @Test
+  void aFullInviteReservesSnapshotsAndLaunchesFullPermission() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth", HANDLE, "agent/auth");
+
+    var launch =
+        ops.startInvite("auth", "claude-code", true, "opus-x", Actor.cliOperator(HANDLE), HANDLE);
+
+    var run = runStore.findById(launch.runId()).orElseThrow();
+    assertEquals("invite-full", run.role());
+    assertEquals(List.of("app"), run.repos(), "full reserves like a build");
+    assertEquals("agent/auth", run.branch());
+    assertEquals("claude/invite-" + launch.runId(), run.principal());
+    assertEquals("invite-" + launch.runId(), launch.snapshot());
+    assertEquals(List.of("snapshot", "launch"), order, "the snapshot precedes the launch");
+    assertTrue(run.task().contains("Invite Duty (full access)"));
+    var joined = String.join(" ", launched.get());
+    assertTrue(joined.contains("--dangerously-skip-permissions"), joined);
+    assertTrue(joined.contains("--model opus-x"), joined);
+    assertEquals("invite-full", launched.get().getLast(), "SAIL_RUN_ROLE rides the launch");
+    var snapshot =
+        events.stream()
+            .filter(e -> Event.WellKnownTypes.SNAPSHOT_CREATED.equals(e.type()))
+            .findFirst()
+            .orElseThrow();
+    assertEquals("auth", snapshot.spec(), "the snapshot event renders in the room");
+    assertEquals("invite-" + launch.runId(), snapshot.data().get("label"));
+    assertEquals(launch.runId(), snapshot.data().get(Event.WellKnownData.RUN_ID));
+  }
+
+  @Test
+  void aFullInviteIsRefusedWhileABuildHoldsTheRepos() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+    var live = DateTimeUtils.newId().toString();
+    db.execute(
+        "INSERT INTO runs (id, project, spec_id, node, role, agent, status, started_at, repos)"
+            + " VALUES (?, 'acme', 'other', ?, 'build', 'claude-code', 'running', 't0',"
+            + " '[\"app\"]')",
+        live,
+        HANDLE);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.startInvite(
+                    "auth", "claude-code", true, null, Actor.cliOperator(HANDLE), HANDLE));
+
+    assertEquals(ErrorCode.AGENT_ALREADY_RUNNING, refusal.failure().errorCode());
+    assertTrue(
+        refusal.failure().errorMessage().contains(live), "the refusal names the reservation");
+    assertEquals(List.of(), order, "a refused invite takes no snapshot and launches nothing");
+  }
+
+  @Test
+  void aSnapshotFailureAbortsTheFullInviteBeforeLaunch() throws Exception {
+    var shell =
+        new StubShell(order)
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("mkdir -p /home/dev/.sail", "");
+    var ops = operations(shell);
+    seedSpec("auth");
+
+    var failure =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.startInvite(
+                    "auth", "claude-code", true, null, Actor.cliOperator(HANDLE), HANDLE));
+
+    assertEquals(ErrorCode.SNAPSHOT_FAILED, failure.failure().errorCode());
+    assertEquals(null, launched.get(), "the invite does not launch without its rollback point");
+    var run = runStore.listForSpec("auth").getFirst();
+    assertEquals("failed", run.status(), "the reservation is released through the failed run");
+    assertTrue(
+        events.stream().noneMatch(e -> Event.WellKnownTypes.SNAPSHOT_CREATED.equals(e.type())));
+  }
+
+  @Test
+  void aCodexReadOnlyInviteIsRefusedNamingWhatItSupports() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () -> ops.startInvite("auth", "codex", false, null, Actor.cliOperator(HANDLE), HANDLE));
+
+    assertEquals(ErrorCode.BAD_REQUEST, refusal.failure().errorCode());
+    assertTrue(
+        refusal.failure().errorMessage().contains("full access"), refusal.failure().errorMessage());
+    assertTrue(runStore.listForSpec("auth").isEmpty(), "a refused mode reserves nothing");
+  }
+
+  @Test
+  void aCodexFullInviteLaunchesWithTheBypassFlags() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+
+    var launch = ops.startInvite("auth", "codex", true, null, Actor.cliOperator(HANDLE), HANDLE);
+
+    assertEquals("invite-full", runStore.findById(launch.runId()).orElseThrow().role());
+    assertEquals("codex/invite-" + launch.runId(), launch.principal());
+    var joined = String.join(" ", launched.get());
+    assertTrue(joined.contains("--dangerously-bypass-approvals-and-sandbox"), joined);
+  }
+
+  @Test
+  void anUnknownAgentIsRefused() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.startInvite("auth", "gemini", false, null, Actor.cliOperator(HANDLE), HANDLE));
+
+    assertEquals(ErrorCode.BAD_REQUEST, refusal.failure().errorCode());
+    assertTrue(refusal.failure().errorMessage().contains("claude-code"), "names the known agents");
+  }
+
+  @Test
+  void anAgentLanePrincipalCannotInvite() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.startInvite(
+                    "auth",
+                    "claude-code",
+                    false,
+                    null,
+                    Actor.agentPrincipal("claude/x", HANDLE),
+                    HANDLE));
+
+    assertEquals(ErrorCode.AGENT_LANE_FORBIDDEN, refusal.failure().errorCode());
+  }
+
+  @Test
+  void aSpecAssignedToAnotherNodeIsRefused() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth", "raj", null);
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.startInvite(
+                    "auth", "claude-code", false, null, Actor.cliOperator(HANDLE), HANDLE));
+
+    assertEquals(ErrorCode.RUNS_ON_OTHER_NODE, refusal.failure().errorCode());
+  }
+
+  @Test
+  void aMissingSpecIsRefused() throws Exception {
+    var ops = operations(liveAgentShell());
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.startInvite(
+                    "ghost", "claude-code", false, null, Actor.cliOperator(HANDLE), HANDLE));
+
+    assertEquals(ErrorCode.SPEC_NOT_FOUND, refusal.failure().errorCode());
+  }
+
+  @Test
+  void aFullInviteStopNeverTriggersTheReviewPipeline() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+
+    var launch =
+        ops.startInvite("auth", "claude-code", true, null, Actor.cliOperator(HANDLE), HANDLE);
+
+    assertNotNull(launch.runId());
+    assertTrue(Event.WellKnownData.nonTriggeringLane("invite"));
+    assertTrue(Event.WellKnownData.nonTriggeringLane("invite-full"));
+    assertTrue(runStore.findById(launch.runId()).orElseThrow().inviteRole());
+  }
+
+  @Test
+  void theServerLaneDelegatesInviteThroughSailOperationsAndReportsAgentModes() throws Exception {
+    var shell = liveAgentShell();
+    operations(shell);
+    seedSpec("auth");
+    var yaml = tempDir.resolve("sail-server.yaml");
+    Files.writeString(yaml, YAML);
+    try (var bus = new EventBus()) {
+      var sailOps =
+          new SailOperations(
+                  shell,
+                  yaml.toString(),
+                  (command, logPath) -> 4242L,
+                  bus,
+                  null,
+                  specStore,
+                  new ReviewStore(db),
+                  runStore)
+              .useMessages(messageStore);
+
+      var launched =
+          sailOps.inviteToSpec(
+              "auth",
+              new InviteRequest("claude-code", null, false),
+              Actor.cliOperator(HANDLE),
+              HANDLE);
+      assertTrue(launched instanceof Result.Success<InviteResponse>);
+      var response = ((Result.Success<InviteResponse>) launched).value();
+      assertEquals("read_only", response.mode());
+      assertEquals("invite", runStore.findById(response.runId()).orElseThrow().role());
+      assertEquals("", response.snapshot());
+
+      var refused =
+          sailOps.inviteToSpec(
+              "auth", new InviteRequest("codex", null, false), Actor.cliOperator(HANDLE), HANDLE);
+      assertTrue(refused instanceof Result.Failure<InviteResponse>);
+      assertEquals(ErrorCode.BAD_REQUEST, ((Result.Failure<InviteResponse>) refused).errorCode());
+
+      var agents = sailOps.agents();
+      assertTrue(agents instanceof Result.Success<AgentsResponse>);
+      var roster = ((Result.Success<AgentsResponse>) agents).value().agents();
+      assertEquals(List.of("claude-code", "codex"), roster.stream().map(AgentView::name).toList());
+      var codexModes = roster.getLast().modes();
+      assertEquals("read_only", codexModes.getFirst().mode());
+      assertFalse(codexModes.getFirst().supported());
+      assertNotNull(codexModes.getFirst().reason());
+      assertTrue(codexModes.getLast().supported(), "every agent supports the full lane");
+    }
+  }
+
+  private static final class StubShell implements ShellExec {
+    private final Map<String, ShellExec.Result> scripts = new LinkedHashMap<>();
+    private final List<String> order;
+
+    StubShell(List<String> order) {
+      this.order = order;
+      on("incus config device add", "");
+      on("cat " + ContainerSailSetup.STAMP_PATH, ContainerSailSetup.fingerprint());
+    }
+
+    StubShell on(String pattern, String stdout) {
+      scripts.put(pattern, new ShellExec.Result(0, stdout, ""));
+      return this;
+    }
+
+    @Override
+    public ShellExec.Result exec(List<String> command) {
+      var joined = String.join(" ", command);
+      if (joined.contains("incus snapshot create")) {
+        order.add("snapshot");
+      }
+      for (var entry : scripts.entrySet()) {
+        if (joined.contains(entry.getKey())) {
+          return entry.getValue();
+        }
+      }
+      return new ShellExec.Result(1, "", "no script for " + joined);
+    }
+
+    @Override
+    public ShellExec.Result exec(List<String> command, Path workDir, Duration timeout) {
+      return exec(command);
+    }
+
+    @Override
+    public boolean isDryRun() {
+      return false;
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/InvitePrincipalAccessTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/InvitePrincipalAccessTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.MessageStore;
+import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The two invite credentials at the local socket, enforced at the boundary: a read-only {@code
+ * invite} run carries the room contract verbatim (viewer role, chat is the one write), and an
+ * {@code invite-full} run carries exactly the member-tier agent principal a dispatched agent holds
+ * — it can post, draft the spec body, and create sibling specs that are born draft and attributed
+ * to its principal.
+ */
+class InvitePrincipalAccessTest {
+
+  private static final String HANDLE = "uday";
+
+  private static final String YAML =
+      """
+      name: acme
+      ssh:
+        user: dev
+      agent:
+        type: claude-code
+      """;
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private EventBus bus;
+  private SpecStore specStore;
+  private MessageStore messageStore;
+  private LocalApiRouter router;
+  private String readOnlyCredential;
+  private String readOnlyRunId;
+  private String fullCredential;
+  private String fullRunId;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    var yaml = tempDir.resolve("sail.yaml");
+    Files.writeString(yaml, YAML);
+    db = Sqlite.open(tempDir.resolve("invite-access.db"));
+    new SchemaManager(db).migrate();
+    bus = new EventBus();
+    specStore = new SpecStore(db);
+    messageStore = new MessageStore(db);
+    var runStore = new RunStore(db);
+    new FdeStore(db).add(HANDLE, null, null, "admin");
+    seedSpec("auth");
+    seedSpec("other");
+    readOnlyRunId = DateTimeUtils.newId().toString();
+    readOnlyCredential = reserve(runStore, readOnlyRunId, "invite", "claude-code");
+    fullRunId = DateTimeUtils.newId().toString();
+    fullCredential = reserve(runStore, fullRunId, "invite-full", "codex");
+    var operations =
+        new SailOperations(
+                NoShell.INSTANCE,
+                yaml.toString(),
+                (command, logPath) -> 4242L,
+                bus,
+                null,
+                specStore,
+                new ReviewStore(db),
+                runStore)
+            .useMessages(messageStore);
+    router = new LocalApiRouter(bus, operations);
+  }
+
+  private static String reserve(RunStore runStore, String runId, String role, String agent) {
+    var reservation =
+        runStore.reserveDispatch(
+            runId,
+            "acme",
+            "auth",
+            HANDLE,
+            HANDLE,
+            role,
+            List.of(),
+            agent,
+            null,
+            "help in the room",
+            "log",
+            "sail-agent-" + runId);
+    return ((RunStore.Reservation.Reserved) reservation).credential();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (bus != null) {
+      bus.close();
+    }
+    if (db != null) {
+      db.close();
+    }
+  }
+
+  private void seedSpec(String id) {
+    specStore.create(
+        new SpecStore.SpecRow(
+            id,
+            "acme",
+            "OAuth flow",
+            SpecStatus.DONE,
+            HANDLE,
+            null,
+            null,
+            null,
+            null,
+            0,
+            HANDLE,
+            "",
+            "",
+            null,
+            List.of(),
+            List.of()));
+  }
+
+  private ApiResponse call(String credential, String method, String path, String body) {
+    return router.handle(
+        new LocalApiRequest(
+            method,
+            path,
+            Map.of(),
+            Map.of("authorization", "Bearer " + credential),
+            body.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  void aReadOnlyInviteWhoamiNamesTheRoomLaneAndItsViewerRole() {
+    var whoami = call(readOnlyCredential, "GET", "/v1/whoami", "");
+
+    assertEquals(200, whoami.status());
+    assertEquals("claude/invite-" + readOnlyRunId, whoami.body().get("handle"));
+    assertEquals(HANDLE, whoami.body().get("owner"));
+    assertEquals("viewer", whoami.body().get("role"));
+    assertEquals("room", whoami.body().get("lane"));
+  }
+
+  @Test
+  void aReadOnlyInviteIsRefusedEverySpecMutation() {
+    assertEquals(403, call(readOnlyCredential, "PUT", "/v1/specs/auth", "status=pending").status());
+    assertEquals(
+        403, call(readOnlyCredential, "PUT", "/v1/specs/auth/content", "body=rewritten").status());
+    assertEquals(
+        403,
+        call(readOnlyCredential, "POST", "/v1/specs", "id=sneaky&title=New&project=acme").status());
+    assertTrue(specStore.findById("sneaky").isEmpty());
+  }
+
+  @Test
+  void aReadOnlyInvitePostsOnlyToItsOwnSpecsRoom() {
+    assertEquals(
+        201, call(readOnlyCredential, "POST", "/v1/specs/auth/messages", "body=critique").status());
+    assertEquals(
+        403,
+        call(readOnlyCredential, "POST", "/v1/specs/other/messages", "body=drive-by").status());
+
+    var messages = messageStore.list("auth", null, 10);
+    assertEquals(1, messages.size());
+    assertEquals("claude/invite-" + readOnlyRunId, messages.getFirst().author());
+  }
+
+  @Test
+  void aFullInviteWhoamiNamesTheAgentLaneAndItsMemberRole() {
+    var whoami = call(fullCredential, "GET", "/v1/whoami", "");
+
+    assertEquals(200, whoami.status());
+    assertEquals("codex/invite-" + fullRunId, whoami.body().get("handle"));
+    assertEquals(HANDLE, whoami.body().get("owner"));
+    assertEquals("member", whoami.body().get("role"));
+    assertEquals("agent", whoami.body().get("lane"));
+  }
+
+  @Test
+  void aFullInviteCreatesASpecBornDraftAttributedToItsPrincipal() {
+    var created =
+        call(
+            fullCredential,
+            "POST",
+            "/v1/specs",
+            "id=oauth-hardening&title=Harden the flow&project=acme");
+
+    assertEquals(201, created.status());
+    var spec = specStore.findById("oauth-hardening").orElseThrow();
+    assertEquals(SpecStatus.DRAFT, spec.status(), "new specs from a room conversation are drafts");
+    assertEquals("codex/invite-" + fullRunId, spec.createdBy());
+  }
+
+  @Test
+  void aFullInvitePostsToTheRoomUnderItsOwnPrincipal() {
+    var posted = call(fullCredential, "POST", "/v1/specs/auth/messages", "body=shipping a fix");
+
+    assertEquals(201, posted.status());
+    assertEquals(
+        "codex/invite-" + fullRunId, messageStore.list("auth", null, 10).getFirst().author());
+  }
+
+  @Test
+  void aFullInviteRevisesTheSpecBodyTheBrainstormLane() {
+    var revised = call(fullCredential, "PUT", "/v1/specs/auth/content", "body=A sharper spec body");
+
+    assertEquals(200, revised.status());
+    assertEquals(
+        "A sharper spec body",
+        specStore.getContent("auth").orElseThrow().body(),
+        "drafting the spec body via the CLI is the brainstorm flow's whole point");
+  }
+
+  private enum NoShell implements ShellExec {
+    INSTANCE;
+
+    @Override
+    public ShellExec.Result exec(List<String> command) {
+      return new ShellExec.Result(1, "", "no shell in this test");
+    }
+
+    @Override
+    public ShellExec.Result exec(List<String> command, Path workDir, Duration timeout) {
+      return exec(command);
+    }
+
+    @Override
+    public boolean isDryRun() {
+      return false;
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -315,6 +315,71 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
+  void anInviteLaneStopNeverTriggersAReviewInEitherMode() {
+    createSpec("auth", "in_progress");
+    var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);
+
+    ctrl.onEvent(laneStopEvent("auth", Event.WellKnownData.RUN_ROLE_INVITE, null));
+    ctrl.onEvent(laneStopEvent("auth", Event.WellKnownData.RUN_ROLE_INVITE_FULL, null));
+
+    assertTrue(
+        reviewStore.reviewsForSpec("auth").isEmpty(),
+        "an invited agent's stop — read only or full — must never enter the pipeline: the"
+            + " review loop stays anchored to dispatch");
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
+  void anInviteStopThatLostItsRoleMarkerIsStillCaughtByTheRunRow() {
+    createSpec("auth", "in_progress");
+    var runStore = new ai.singlr.sail.store.RunStore(db);
+    var runId = ai.singlr.sail.common.DateTimeUtils.newId().toString();
+    runStore.create(
+        runId,
+        "test-project",
+        "auth",
+        "node-a",
+        "node-a",
+        "invite-full",
+        "codex",
+        null,
+        "t",
+        null,
+        null,
+        null,
+        "sail-agent-" + runId);
+    var ctrl =
+        new ReviewPipelineController(
+            specStore,
+            reviewStore,
+            p -> singleAgentStage("no_critical"),
+            p -> "codex",
+            (p, a, pr, rid, cred) -> CLEAN_REVIEW,
+            null,
+            () -> {},
+            new DirectExecutorService(),
+            runStore,
+            () -> "node-a");
+    var data = new java.util.LinkedHashMap<String, Object>();
+    data.put(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_WATCHER);
+    data.put(Event.WellKnownData.RUN_ID, runId);
+
+    ctrl.onEvent(
+        Event.of(
+            "test-project",
+            "auth",
+            Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+            "claude-code",
+            "host",
+            data));
+
+    assertTrue(
+        reviewStore.reviewsForSpec("auth").isEmpty(),
+        "the run row is the fallback when an invite's signal lost its role");
+    assertEquals(SpecStatus.IN_PROGRESS, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
   void aRoomStopOnADoneSpecTriggersNothing() {
     createSpec("auth", "done");
     var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
@@ -182,6 +182,9 @@ class RoomWakeLaunchTest {
         "the chat lane never launches full-permission");
     assertTrue(joined.contains("--tools \"Bash,Read,Grep,Glob\""), joined);
     assertTrue(
+        joined.contains("--setting-sources \"\"") && joined.contains("--strict-mcp-config"),
+        "the chat lane must exclude ambient settings and MCP configs. Command: " + joined);
+    assertTrue(
         runStore.consumeRoomGuardBaseline(runId).orElseThrow().contains("aaa111"),
         "the guard baseline is recorded host-side before the chat launches");
     var started =

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakePolicyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakePolicyTest.java
@@ -19,6 +19,9 @@ class RoomWakePolicyTest {
     assertFalse(RoomWakePolicy.humanAuthor("sail"));
     assertFalse(RoomWakePolicy.humanAuthor("claude/room-0195a2f0"));
     assertFalse(RoomWakePolicy.humanAuthor("codex/review-0195a2f0"));
+    assertFalse(
+        RoomWakePolicy.humanAuthor("codex/invite-0195a2f0"),
+        "an invited agent's post never wakes or invites anything");
     assertFalse(RoomWakePolicy.humanAuthor(""));
     assertFalse(RoomWakePolicy.humanAuthor(null));
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
@@ -536,6 +536,82 @@ class RoomWakeReactorTest {
   }
 
   @Test
+  void aReadOnlyInviteStopOnAnOwnedRunTriggersTheCommitGuard() {
+    seed("auth", "done", "uday", null);
+    var runId = DateTimeUtils.newId().toString();
+    runStore.create(
+        runId,
+        "acme",
+        "auth",
+        "uday",
+        "uday",
+        "invite",
+        "claude-code",
+        null,
+        "t",
+        null,
+        null,
+        null,
+        "sail-agent-" + runId);
+    runStore.complete(runId, "completed", 0);
+    var stop = new LinkedHashMap<String, Object>();
+    stop.put(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_WATCHER);
+    stop.put(Event.WellKnownData.RUN_ID, runId);
+    stop.put(Event.WellKnownData.RUN_ROLE, "invite");
+
+    reactor()
+        .onEvent(
+            Event.of(
+                "acme",
+                "auth",
+                Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+                "claude-code",
+                "host",
+                stop));
+
+    assertEquals(
+        List.of("acme/" + runId),
+        launcher.guarded,
+        "a read-only invite carries the same worktree-digest guard as a wake");
+  }
+
+  @Test
+  void aFullInviteStopNeverGuardsItMayLegitimatelyChangeCode() {
+    seed("auth", "done", "uday", null);
+    var runId = DateTimeUtils.newId().toString();
+    runStore.create(
+        runId,
+        "acme",
+        "auth",
+        "uday",
+        "uday",
+        "invite-full",
+        "claude-code",
+        null,
+        "t",
+        null,
+        null,
+        null,
+        "sail-agent-" + runId);
+    var stop = new LinkedHashMap<String, Object>();
+    stop.put(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_WATCHER);
+    stop.put(Event.WellKnownData.RUN_ID, runId);
+    stop.put(Event.WellKnownData.RUN_ROLE, "invite-full");
+
+    reactor()
+        .onEvent(
+            Event.of(
+                "acme",
+                "auth",
+                Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+                "claude-code",
+                "host",
+                stop));
+
+    assertTrue(launcher.guarded.isEmpty());
+  }
+
+  @Test
   void stopsThatAreNotThisBoxsRoomRunsNeverGuard() {
     seed("auth", "done", "uday", null);
     var reactor = reactor();

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SpecLifecycleReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SpecLifecycleReactorTest.java
@@ -89,6 +89,24 @@ class SpecLifecycleReactorTest {
   }
 
   @Test
+  void anInviteStopNeverAdvancesTheSpecInEitherMode() {
+    seed("auth", "in_progress");
+    for (var role :
+        List.of(Event.WellKnownData.RUN_ROLE_INVITE, Event.WellKnownData.RUN_ROLE_INVITE_FULL)) {
+      var stop =
+          Event.of(
+              "acme",
+              "auth",
+              Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+              "claude-code",
+              "host",
+              java.util.Map.of(Event.WellKnownData.RUN_ROLE, role));
+
+      assertFalse(reactor.filter().test(stop), "an invited agent's turn end is not a build");
+    }
+  }
+
+  @Test
   void aReviewOrFixStopNeverAdvancesTheSpec() {
     seed("auth", "in_progress");
     for (var role :

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SyncTransitionEventsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SyncTransitionEventsTest.java
@@ -156,6 +156,22 @@ class SyncTransitionEventsTest {
   }
 
   @Test
+  void aSyncedInviteStopKeepsItsRoleSoTheReviewLoopIgnoresIt() {
+    for (var role : java.util.List.of("invite", "invite-full")) {
+      var snapshot = run("completed", 0);
+      snapshot.put("role", role);
+
+      var stop = map(new SyncTransition("run", "r1", "running", "completed", snapshot)).getFirst();
+
+      assertEquals(
+          role,
+          stop.data().get(Event.WellKnownData.RUN_ROLE),
+          "an invite's terminal stop must carry its role across sync — the review loop stays"
+              + " anchored to dispatch");
+    }
+  }
+
+  @Test
   void aSyncedBuildStopCarriesNoRoomRole() {
     var stop =
         map(new SyncTransition("run", "r1", "running", "completed", run("completed", 0)))

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -73,6 +73,17 @@ class TestOperations implements Operations {
   }
 
   @Override
+  public Result<AgentsResponse> agents() {
+    return Result.success(new AgentsResponse(List.of()));
+  }
+
+  @Override
+  public Result<InviteResponse> inviteToSpec(
+      String specId, InviteRequest request, Actor actor, String localHandle) {
+    return Result.success(new InviteResponse("run-1", "claude/invite-run-1", "read_only", ""));
+  }
+
+  @Override
   public Result<ProjectResponse> project(String project) {
     return Result.success(new ProjectResponse(project, "running", null));
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
@@ -108,6 +108,7 @@ class CommandTaxonomyTest {
             "board",
             "history",
             "restore",
+            "invite",
             "comment",
             "comments",
             "dispatch"),

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/InvitePromptTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/InvitePromptTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.store.MessageStore;
+import ai.singlr.sail.store.SpecStore;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class InvitePromptTest {
+
+  private static SpecStore.SpecRow spec() {
+    return new SpecStore.SpecRow(
+        "auth",
+        "acme",
+        "OAuth flow",
+        SpecStatus.DRAFT,
+        "uday",
+        null,
+        null,
+        null,
+        null,
+        0,
+        "uday",
+        "",
+        "",
+        null,
+        List.of(),
+        List.of());
+  }
+
+  private static MessageStore.MessageRow message(String id, String author, String body) {
+    return new MessageStore.MessageRow(
+        id, "auth", author, body, null, "2026-08-16T12:00:00Z", "1-a", null, false);
+  }
+
+  @Test
+  void aReadOnlyInviteIsPrimedWithBodyConversationAndTheReadOnlyDuty() {
+    var ask = message("m1", "uday", "poke holes in this design");
+
+    var built = InvitePrompt.build(spec(), "Build the OAuth flow.", List.of(ask), false);
+
+    assertTrue(built.prompt().contains("invited agent in the room of spec \"OAuth flow\""));
+    assertTrue(built.prompt().contains("id: auth, status: draft"));
+    assertTrue(built.prompt().contains("read-only access"));
+    assertTrue(built.prompt().contains("## Spec body"));
+    assertTrue(built.prompt().contains("Build the OAuth flow."));
+    assertTrue(built.prompt().contains("poke holes in this design"));
+    assertTrue(built.prompt().contains("## Invite Duty (read only)"));
+    assertTrue(built.prompt().contains("spec comment auth --body"));
+    assertTrue(built.prompt().contains("read-only chat session, and the harness enforces it"));
+    assertTrue(built.prompt().contains("spec comment auth --question --body"));
+    assertFalse(built.prompt().contains("spec create"), "the read-only lane drafts nothing");
+    assertEquals(List.of(ask), built.renderedMessages());
+  }
+
+  @Test
+  void aFullInviteTeachesTheDraftAndCodeLanesAndTheGitProtocol() {
+    var built = InvitePrompt.build(spec(), "Build the OAuth flow.", List.of(), true);
+
+    assertTrue(built.prompt().contains("full access"));
+    assertTrue(built.prompt().contains("## Invite Duty (full access)"));
+    assertTrue(built.prompt().contains("spec content auth --body-file"));
+    assertTrue(built.prompt().contains("spec create --id"));
+    assertTrue(
+        built.prompt().contains("born draft"),
+        "new specs from a room conversation are drafts a human promotes");
+    assertTrue(built.prompt().contains("commit and push before stopping"));
+    assertFalse(built.prompt().contains("harness enforces it"));
+  }
+
+  @Test
+  void anEmptyRoomBuildsAPromptWithNoConversationBlock() {
+    var built = InvitePrompt.build(spec(), "body", List.of(), false);
+
+    assertFalse(built.prompt().contains("## Conversation on this spec"));
+    assertTrue(built.renderedMessages().isEmpty());
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectProvisionerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectProvisionerTest.java
@@ -1043,7 +1043,12 @@ class ProjectProvisionerTest {
         cmds.stream().anyMatch(c -> c.contains("git config --global user.name")),
         "Should still set git identity");
     assertFalse(
-        cmds.stream().anyMatch(c -> c.contains(".git-credentials")),
+        cmds.stream()
+            .anyMatch(
+                c ->
+                    c.contains("incus file push")
+                        && c.contains("--mode 0600")
+                        && c.contains(".git-credentials")),
         "Should NOT write .git-credentials for ssh auth");
     assertFalse(
         cmds.stream().anyMatch(c -> c.contains("credential.helper")),
@@ -1095,7 +1100,12 @@ class ProjectProvisionerTest {
         cmds.stream().anyMatch(c -> c.contains("git config --global user.name")),
         "Should still set git identity even without token");
     assertFalse(
-        cmds.stream().anyMatch(c -> c.contains(".git-credentials")),
+        cmds.stream()
+            .anyMatch(
+                c ->
+                    c.contains("incus file push")
+                        && c.contains("--mode 0600")
+                        && c.contains(".git-credentials")),
         "Should NOT write credentials when token is null");
     assertTrue(
         steps.stream().anyMatch(s -> s.contains("done:11/")),
@@ -1129,7 +1139,12 @@ class ProjectProvisionerTest {
         cmds.stream().anyMatch(c -> c.contains("id_ed25519.pub")),
         "Should push public key when .pub file exists alongside private key");
     assertFalse(
-        cmds.stream().anyMatch(c -> c.contains(".git-credentials")),
+        cmds.stream()
+            .anyMatch(
+                c ->
+                    c.contains("incus file push")
+                        && c.contains("--mode 0600")
+                        && c.contains(".git-credentials")),
         "Should NOT write .git-credentials for ssh auth");
   }
 


### PR DESCRIPTION
Spec: sail-room-invite. Mast counterpart: standardapplied/mast PR on the same branch (`agent/sail-room-invite`).

A room is a channel; the missing verb was inviting an *agent* — a second claude-code, a codex, a different model — to chat, critique, draft specs, or pitch in on code. One choice at invite time: **read only** or **full**. No new permission tiers — the two modes map onto the two credential tiers sail already ships, and the harness's own permission modes do the enforcement. Wake stays the automatic lane, unchanged; invite is the explicit one.

## Design

**An invite is a run.** `POST /v1/specs/{id}/invite` / `sail spec invite <id> --agent <a> [--model m] [--full]` launches a fresh session (never a resume — the point is a new participant) seeded with the spec body and room tail, ledger seeded exactly like wake, principal `<agent>/invite-<runId>`, one bounded turn under the normal watcher + guardrail ceiling. Two new run roles carry the contract end to end:

- **`invite` (read only)** — the shipped room-lane machinery verbatim under a new role: viewer credential decided at the API boundary from the run row, the harness tool-cut command in `AgentSession` regardless of mispassed flags, no repo reservation, worktree-digest guard on stop, stop-gate git protocol skipped. `DispatchGate` lets it run alongside anything, **its own spec's live build included** — which is why it cannot reuse role `room`: the same-spec conflict is the wake lane's atomic backstop and stays intact for wakes. Mode support is declared at the `AgentCli` seam (`supportsReadOnlyInvite()` + the refusal reason), so `GET /v1/agents` reports the same words the launch gate refuses with; codex read-only is a 400 naming full access as its lane.
- **`invite-full`** — exactly the member credential a dispatched agent holds: post to the room, draft the spec body, `spec create` (born draft by API default; a human promotes), change code under full permissions. Bought with two structural payments: the **repo reservation** (reserved like a build through the same `BEGIN IMMEDIATE` transaction; a held reservation refuses with the dispatch conflict vocabulary, not a queue) and a **mandatory pre-launch snapshot** labeled `invite-<runId>`, published as `snapshot_created` *with the spec id* so it renders in the room. Snapshot failure aborts the launch and releases the reservation — the payment for YOLO is not optional.

**Review-pipeline exclusion is structural**: both roles join `nonTriggeringLane`, the pipeline's run-row fallback, the lifecycle reactor's filter, and the synced-stop role stamping. The review loop stays anchored to dispatch; a full invite's pushed commits surface in the room and the next build's review sees them. Both roles join `SESSION_ROLES` so stop/status/reaper cover dead invites. Inviting requires the same tier as dispatching (`DispatchPolicy` verbatim), so agent principals cannot invite — structural, like the wake lane's human-authors-only rule.

**One deliberate deviation from the spec text**: the full lane's order is reserve → snapshot → launch (the acceptance bullet reads snapshot → reserve → launch). Reservation-first preserves the load-bearing "no mutation before the reservation" dispatch invariant, means the snapshot captures a quiesced tree rather than a concurrent build mid-write, and a refused invite takes no stray multi-minute dir-backend snapshot. Flagged in the spec room.

**Schema**: `runs_v6` rebuild widening the role CHECK (append-only tail, FK-suspension handled by the runner, child-table survival covered by the existing rebuild tests).

**Not done, deliberately**: no in-container `spec invite` (agent-to-agent invites are a non-goal; `LocalApiRouter` keeps its no-dispatch-routes contract); no queueing on conflict; no wake-contract changes.

## Tests

`InviteLaunchTest` (13 cases: room-contract wiring, runs-alongside-own-build, reserve→snapshot→launch order, refusal vocabulary + no stray snapshot, snapshot-failure abort + release, codex 400 / codex full, unknown agent, agent-lane refusal, locality, `SailOperations` delegation + `GET /v1/agents` modes), `InvitePrincipalAccessTest` (viewer vs member tiers at the local socket; full invite `spec create` born draft and attributed), `InvitePromptTest`, plus additions to `DispatchGateTest`, `RunStoreTest`, `SchemaManagerTest`, `AgentCliTest`, `AgentSessionTest` (harness-restricted even when full-permissions is mispassed), `SailStopGateTest` (real bash: invite skips the git protocol, invite-full keeps it), `ReviewPipelineControllerTest`, `SpecLifecycleReactorTest`, `RoomWakeReactorTest` (read-only invites get the commit guard; full invites don't), `SyncTransitionEventsTest`, `ApiRouterTest`. `mvn clean verify` green — 2771 tests, all JaCoCo gates including api.* 100%.