### PR TITLE
Snapshot API: list, async restore, and async delete per project

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -414,12 +414,103 @@ public final class RunStore implements ConflictResolver {
 
   /**
    * What a dispatch reservation produced: the reserved run's plaintext credential (returned exactly
-   * once, hashed at rest), or the blocking conflict.
+   * once, hashed at rest), the blocking conflict, or the exclusive container operation (a snapshot
+   * restore) that owns the whole container right now.
    */
   public sealed interface Reservation {
     record Reserved(String credential) implements Reservation {}
 
     record Conflicted(DispatchGate.Conflict conflict) implements Reservation {}
+
+    record LeaseHeld(String action) implements Reservation {}
+  }
+
+  /**
+   * What acquiring an exclusive container lease produced: the lease, the live run that blocks it,
+   * or the lease some other exclusive operation already holds.
+   */
+  public sealed interface ContainerLease {
+    record Acquired() implements ContainerLease {}
+
+    record BlockedByRun(RunRow run) implements ContainerLease {}
+
+    record BlockedByLease(String action) implements ContainerLease {}
+  }
+
+  /**
+   * How long a container lease is honored before readers treat it as abandoned: the leasing process
+   * releases in a {@code finally}, so an expired row only ever means that process died mid-mutation
+   * — and the mutation itself (a snapshot restore) completes well inside this bound. Expired rows
+   * are pruned on the next acquire or reservation, so a crash never wedges dispatch for good.
+   */
+  public static final Duration LEASE_TTL = Duration.ofMinutes(30);
+
+  /**
+   * Atomically claims the project's container on this box for one exclusive operation (a snapshot
+   * restore): within a single {@code BEGIN IMMEDIATE} transaction, refuses if another lease is held
+   * or any local run of the project is live ({@code running} or {@code stopping}, every role — even
+   * a read-only invite loses its session when the container is rolled back), then inserts the
+   * lease. {@link #reserveDispatch} checks this lease inside its own transaction, so the two sides
+   * can never interleave: a restore is refused over live work, and no run can start until {@link
+   * #releaseContainerLease} runs.
+   */
+  public ContainerLease acquireContainerLease(String project, String localHandle, String action) {
+    return db.immediateTransaction(
+        () -> {
+          var held = activeLease(project, localHandle);
+          if (held.isPresent()) {
+            return new ContainerLease.BlockedByLease(held.get());
+          }
+          var live =
+              db.queryOne(
+                  "SELECT "
+                      + COLUMNS
+                      + " FROM runs WHERE project = ? AND status IN ('running', 'stopping')"
+                      + " AND IFNULL(node, '') = ? ORDER BY started_at LIMIT 1",
+                  this::mapRow,
+                  project,
+                  ownerKey(localHandle));
+          if (live.isPresent()) {
+            return new ContainerLease.BlockedByRun(live.get());
+          }
+          db.execute(
+              "INSERT INTO container_leases (project, node, action, created_at)"
+                  + " VALUES (?, ?, ?, ?)",
+              project,
+              ownerKey(localHandle),
+              action,
+              DateTimeUtils.now().toString());
+          return new ContainerLease.Acquired();
+        });
+  }
+
+  /** Releases the box's container lease on the project. Idempotent. */
+  public void releaseContainerLease(String project, String localHandle) {
+    db.execute(
+        "DELETE FROM container_leases WHERE project = ? AND node = ?",
+        project,
+        ownerKey(localHandle));
+  }
+
+  /**
+   * The action of the unexpired container lease on this box's container, or empty. An expired row
+   * is pruned on lookup like {@link #findByCredential}'s credential rows.
+   */
+  private Optional<String> activeLease(String project, String localHandle) {
+    var row =
+        db.queryOne(
+            "SELECT action, created_at FROM container_leases WHERE project = ? AND node = ?",
+            r -> new String[] {r.text(0), r.text(1)},
+            project,
+            ownerKey(localHandle));
+    if (row.isEmpty()) {
+      return Optional.empty();
+    }
+    if (Instant.parse(row.get()[1]).plus(LEASE_TTL).isBefore(DateTimeUtils.now())) {
+      releaseContainerLease(project, localHandle);
+      return Optional.empty();
+    }
+    return Optional.of(row.get()[0]);
   }
 
   /**
@@ -431,13 +522,16 @@ public final class RunStore implements ConflictResolver {
    * row; a check-then-insert split across transactions could admit both into the same repo. The
    * run's agent principal (handle, {@code owner}) and its credential are minted inside the same
    * transaction, so a reserved run always carries an attributable identity and a refused one mints
-   * nothing. Returns the blocking conflict, or the reserved run's credential. A run mid-stop
-   * ({@code stopping}) still occupies its repos — its agent is not verified dead until the claim is
-   * finalized — so it conflicts exactly like a running one. Any database failure propagates — a
-   * dispatch must never launch without the row every later overlap check depends on. {@code
-   * maxDuration} is the run's configured hard stop ({@code guardrails.max_duration}): the
-   * credential expires that long plus {@link #CREDENTIAL_GRACE} after minting, and a null means no
-   * hard stop, so the credential lives until a verified finisher revokes it.
+   * nothing. An exclusive container lease (a snapshot restore mid-flight, see {@link
+   * #acquireContainerLease}) refuses every reservation inside the same transaction, so a run can
+   * never start into a container about to be rolled back. Returns the blocking conflict, the held
+   * lease, or the reserved run's credential. A run mid-stop ({@code stopping}) still occupies its
+   * repos — its agent is not verified dead until the claim is finalized — so it conflicts exactly
+   * like a running one. Any database failure propagates — a dispatch must never launch without the
+   * row every later overlap check depends on. {@code maxDuration} is the run's configured hard stop
+   * ({@code guardrails.max_duration}): the credential expires that long plus {@link
+   * #CREDENTIAL_GRACE} after minting, and a null means no hard stop, so the credential lives until
+   * a verified finisher revokes it.
    */
   public Reservation reserveDispatch(
       String id,
@@ -473,6 +567,10 @@ public final class RunStore implements ConflictResolver {
     var reserved = Objects.requireNonNullElse(repos, List.<String>of());
     return db.immediateTransaction(
         () -> {
+          var lease = activeLease(project, node);
+          if (lease.isPresent()) {
+            return new Reservation.LeaseHeld(lease.get());
+          }
           var running =
               db.query(
                   "SELECT "

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -269,7 +269,8 @@ public final class RunStore implements ConflictResolver {
    * addressable before the agent starts; {@code node} is the executing box's FDE handle at launch;
    * {@code owner} is the FDE the run's agent principal acts for. The principal handle and the run's
    * credential are minted inside the same transaction as the row, so a run and its identity are
-   * atomic. Returns the id.
+   * atomic. Fails if an exclusive container lease (see {@link #acquireContainerLease}) is held — a
+   * run must never start into a container about to be rolled back. Returns the id.
    */
   public String create(
       String id,
@@ -316,8 +317,19 @@ public final class RunStore implements ConflictResolver {
       Integer watcherPid,
       String logPath,
       String unit) {
-    return db.transaction(
+    return db.immediateTransaction(
         () -> {
+          var lease = activeLease(project, node);
+          if (lease.isPresent()) {
+            throw new IllegalStateException(
+                "Refusing to record run "
+                    + id
+                    + " for project "
+                    + project
+                    + ": an exclusive "
+                    + lease.get()
+                    + " operation holds its container. Retry after it completes.");
+          }
           db.execute(
               """
               INSERT INTO runs (id, project, spec_id, node, role, agent, branch, task, pid,
@@ -351,9 +363,12 @@ public final class RunStore implements ConflictResolver {
    * addressable as {@code ~/.sail/runs/<reviewId>/review.log} throughout the negotiation. {@code
    * unit} is the review's real execution identity ({@code sail-review-<id>}), recorded so a probe
    * of any run row is honest even though reviews execute as blocking foreground work. {@code owner}
-   * is the reviewed spec's assignee — the FDE the review principal acts for. Returns the run's
-   * plaintext credential, surfaced exactly once so the launched review agent can actually act as
-   * the principal this row records; only the hash is at rest.
+   * is the reviewed spec's assignee — the FDE the review principal acts for. Fails if an exclusive
+   * container lease (see {@link #acquireContainerLease}) is held — a review must never launch into
+   * a container mid-restore; the pipeline surfaces the error and the reconciler's rescue replay
+   * retries the kickoff after the lease is released. Returns the run's plaintext credential,
+   * surfaced exactly once so the launched review agent can actually act as the principal this row
+   * records; only the hash is at rest.
    */
   public String createReview(
       String reviewId,
@@ -450,9 +465,11 @@ public final class RunStore implements ConflictResolver {
    * restore): within a single {@code BEGIN IMMEDIATE} transaction, refuses if another lease is held
    * or any local run of the project is live ({@code running} or {@code stopping}, every role — even
    * a read-only invite loses its session when the container is rolled back), then inserts the
-   * lease. {@link #reserveDispatch} checks this lease inside its own transaction, so the two sides
-   * can never interleave: a restore is refused over live work, and no run can start until {@link
-   * #releaseContainerLease} runs.
+   * lease. Every run insert — {@link #reserveDispatch}, {@link #create}, {@link #createReview} —
+   * checks this lease inside its own transaction, so the two sides can never interleave: a restore
+   * is refused over live work, and no run can start until {@link #releaseContainerLease} runs.
+   * Rejoining an existing negotiation via {@link #rotateCredential} needs no check: it requires a
+   * {@code running} row, and any running row refuses the lease.
    */
   public ContainerLease acquireContainerLease(String project, String localHandle, String action) {
     return db.immediateTransaction(

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -84,9 +84,10 @@ public final class SchemaManager {
    * database in a prior release's shape and migrates it forward — a fresh-database test cannot
    * catch a mid-list insertion, because it never replays the earlier version→SQL mapping. The
    * {@code run_credentials} table is local-only secret material (per-run credential hashes), and
-   * {@code run_delivered_messages} (delivery bookkeeping) and {@code room_guard} (the room commit
-   * guard's launch baseline, kept host-side so the guarded agent can never reach it) are local-only
-   * as well — none of the three ever joins a sync snapshot.
+   * {@code run_delivered_messages} (delivery bookkeeping), {@code room_guard} (the room commit
+   * guard's launch baseline, kept host-side so the guarded agent can never reach it), and {@code
+   * container_leases} (a box's own exclusive-container-operation claims) are local-only as well —
+   * none of the four ever joins a sync snapshot.
    */
   static final List<String> MIGRATIONS =
       List.of(
@@ -263,7 +264,15 @@ public final class SchemaManager {
           "DROP TABLE runs",
           "ALTER TABLE runs_v6 RENAME TO runs",
           "CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project)",
-          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)");
+          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)",
+          """
+          CREATE TABLE container_leases (
+              project TEXT NOT NULL,
+              node TEXT NOT NULL DEFAULT '',
+              action TEXT NOT NULL,
+              created_at TEXT NOT NULL,
+              PRIMARY KEY (project, node)
+          )""");
 
   /** The schema version this binary converges every database to. */
   static final int CURRENT_VERSION = V1_VERSION + MIGRATIONS.size();

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -1207,6 +1207,57 @@ class RunStoreTest {
   }
 
   @Test
+  void aContainerLeaseBlocksReviewRunCreationUntilReleased() {
+    store.acquireContainerLease("backend", "node-a", "restore");
+
+    var reviewId = DateTimeUtils.newId().toString();
+    var refused = assertThrows(IllegalStateException.class, () -> createReview(reviewId, "node-a"));
+    assertTrue(refused.getMessage().contains("restore"), refused.getMessage());
+    assertTrue(store.findById(reviewId).isEmpty(), "a lease-refused review must not insert a row");
+
+    store.releaseContainerLease("backend", "node-a");
+    createReview(reviewId, "node-a");
+    assertEquals("running", store.findById(reviewId).orElseThrow().status());
+  }
+
+  @Test
+  void aForeignNodesContainerLeaseNeverBlocksReviewRunCreationHere() {
+    store.acquireContainerLease("backend", "node-b", "restore");
+
+    var reviewId = DateTimeUtils.newId().toString();
+    createReview(reviewId, "node-a");
+
+    assertEquals("running", store.findById(reviewId).orElseThrow().status());
+  }
+
+  @Test
+  void anExpiredContainerLeaseNeverBlocksReviewRunCreation() {
+    db.execute(
+        "INSERT INTO container_leases (project, node, action, created_at)"
+            + " VALUES ('backend', 'node-a', 'restore', ?)",
+        DateTimeUtils.now().minus(RunStore.LEASE_TTL).minus(Duration.ofMinutes(1)).toString());
+
+    var reviewId = DateTimeUtils.newId().toString();
+    createReview(reviewId, "node-a");
+
+    assertEquals("running", store.findById(reviewId).orElseThrow().status());
+  }
+
+  private void createReview(String reviewId, String node) {
+    store.createReview(
+        reviewId,
+        "backend",
+        "auth",
+        node,
+        node,
+        "claude-code",
+        "feat/x",
+        "review",
+        "/home/dev/.sail/runs/" + reviewId + "/review.log",
+        "sail-review-" + reviewId);
+  }
+
+  @Test
   void aLiveRunBlocksTheContainerLeaseAndNamesItself() {
     var id = newRun("backend", "auth");
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -1171,6 +1171,112 @@ class RunStoreTest {
   }
 
   @Test
+  void aContainerLeaseIsExclusiveAndBlocksEveryReservationUntilReleased() {
+    assertInstanceOf(
+        RunStore.ContainerLease.Acquired.class,
+        store.acquireContainerLease("backend", "node-a", "restore"));
+
+    var again = store.acquireContainerLease("backend", "node-a", "restore");
+    var held = assertInstanceOf(RunStore.ContainerLease.BlockedByLease.class, again);
+    assertEquals("restore", held.action());
+
+    var refusedId = DateTimeUtils.newId().toString();
+    var reservation =
+        store.reserveDispatch(
+            refusedId,
+            "backend",
+            "auth",
+            "node-a",
+            "node-a",
+            "build",
+            java.util.List.of("app"),
+            "claude-code",
+            "feat/x",
+            "do it",
+            "/log",
+            "sail-agent-" + refusedId);
+    var refused = assertInstanceOf(RunStore.Reservation.LeaseHeld.class, reservation);
+    assertEquals("restore", refused.action());
+    assertTrue(
+        store.findById(refusedId).isEmpty(), "a lease-refused reservation must not insert a row");
+
+    store.releaseContainerLease("backend", "node-a");
+    assertTrue(
+        reserve(store, DateTimeUtils.newId().toString(), "auth", "node-a", java.util.List.of("app"))
+            .isEmpty());
+  }
+
+  @Test
+  void aLiveRunBlocksTheContainerLeaseAndNamesItself() {
+    var id = newRun("backend", "auth");
+
+    var blocked =
+        assertInstanceOf(
+            RunStore.ContainerLease.BlockedByRun.class,
+            store.acquireContainerLease("backend", "node-a", "restore"));
+
+    assertEquals(id, blocked.run().id());
+  }
+
+  @Test
+  void aReadOnlyInviteBlocksTheContainerLeaseEvenThoughItBlocksNoDispatch() {
+    var invite = DateTimeUtils.newId().toString();
+    store.reserveDispatch(
+        invite,
+        "backend",
+        "",
+        "node-a",
+        "node-a",
+        "invite",
+        java.util.List.of(),
+        "claude-code",
+        null,
+        "consult",
+        "/log",
+        "sail-agent-" + invite);
+
+    var blocked =
+        assertInstanceOf(
+            RunStore.ContainerLease.BlockedByRun.class,
+            store.acquireContainerLease("backend", "node-a", "restore"));
+
+    assertEquals(invite, blocked.run().id());
+  }
+
+  @Test
+  void aForeignNodesRunNeverBlocksTheContainerLeaseHere() {
+    newRun("backend", "auth");
+
+    assertInstanceOf(
+        RunStore.ContainerLease.Acquired.class,
+        store.acquireContainerLease("backend", "node-b", "restore"));
+  }
+
+  @Test
+  void anExpiredContainerLeaseIsPrunedOnAcquire() {
+    db.execute(
+        "INSERT INTO container_leases (project, node, action, created_at)"
+            + " VALUES ('backend', 'node-a', 'restore', ?)",
+        DateTimeUtils.now().minus(RunStore.LEASE_TTL).minus(Duration.ofMinutes(1)).toString());
+
+    assertInstanceOf(
+        RunStore.ContainerLease.Acquired.class,
+        store.acquireContainerLease("backend", "node-a", "restore"));
+  }
+
+  @Test
+  void anExpiredContainerLeaseNeverBlocksAReservation() {
+    db.execute(
+        "INSERT INTO container_leases (project, node, action, created_at)"
+            + " VALUES ('backend', 'node-a', 'restore', ?)",
+        DateTimeUtils.now().minus(RunStore.LEASE_TTL).minus(Duration.ofMinutes(1)).toString());
+
+    assertTrue(
+        reserve(store, DateTimeUtils.newId().toString(), "auth", "node-a", java.util.List.of("app"))
+            .isEmpty());
+  }
+
+  @Test
   void anEmptyRepoSetReservesTheWholeContainer() {
     reserve(store, DateTimeUtils.newId().toString(), "auth", "node-a", java.util.List.of());
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -49,6 +49,7 @@ class SchemaManagerTest {
     assertTrue(tables.contains("api_tokens"));
     assertTrue(tables.contains("schema_version"));
     assertTrue(tables.contains("runs"));
+    assertTrue(tables.contains("container_leases"));
     assertFalse(tables.contains("agent_sessions"));
   }
 
@@ -394,6 +395,29 @@ class SchemaManagerTest {
         "ok",
         db.queryOne("PRAGMA integrity_check", r -> r.text(0)).orElseThrow(),
         "the upgraded database is structurally sound");
+  }
+
+  @Test
+  void aV0_24_0ShapedDatabaseGainsTheContainerLeasesTable() {
+    stageAtBaseline();
+    var tail = migrationIndex("CREATE TABLE container_leases");
+    db.execute("PRAGMA foreign_keys = OFF");
+    SchemaManager.MIGRATIONS.subList(0, tail).forEach(db::execute);
+    db.execute("PRAGMA foreign_keys = ON");
+    db.execute(
+        "INSERT INTO schema_version (version, applied_at) VALUES (?, 'staged')",
+        SchemaManager.V1_VERSION + tail);
+
+    new SchemaManager(db).migrate();
+
+    assertEquals(SchemaManager.CURRENT_VERSION, new SchemaManager(db).currentVersion());
+    assertTrue(
+        db.query(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+                    + " AND name = 'container_leases'",
+                r -> r.text(0))
+            .contains("container_leases"),
+        "a released 0.24.x box must gain the exclusive-container-lease table on upgrade");
   }
 
   private void stageAtBaseline() {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -1268,6 +1268,45 @@ record RunLogResponse(String runId, List<String> lines, String error) implements
   }
 }
 
+record SnapshotView(String name, String createdAt, String source) implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("name", name);
+    m.put("created_at", createdAt);
+    m.put("source", source);
+    return m;
+  }
+}
+
+record SnapshotListResponse(List<SnapshotView> snapshots) implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("snapshots", snapshots);
+    m.put("total", snapshots.size());
+    return m;
+  }
+}
+
+/**
+ * The accepted receipt for an async snapshot mutation: the request returned before the mutation
+ * ran, and its completion arrives as the matching {@code snapshot_restored} / {@code
+ * snapshot_deleted} event carrying this {@code name}.
+ */
+record SnapshotActionResponse(String project, String name, String action, String status)
+    implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("project", project);
+    m.put("name", name);
+    m.put("action", action);
+    m.put("status", status);
+    return m;
+  }
+}
+
 record StopRunResponse(
     String runId, boolean stopped, String reason, Integer pid, boolean specCancelled)
     implements Mappable {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiResponse.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiResponse.java
@@ -35,6 +35,13 @@ public record ApiResponse(int status, Map<String, Object> body, Map<String, Stri
     };
   }
 
+  public static ApiResponse fromAccepted(Result<?> result) {
+    return switch (result) {
+      case Result.Success<?> success -> new ApiResponse(202, ApiJson.withSchema(success.value()));
+      case Result.Failure<?> failure -> error(failure);
+    };
+  }
+
   public static ApiResponse fromCreated(Result<?> result) {
     return switch (result) {
       case Result.Success<?> success -> new ApiResponse(201, ApiJson.withSchema(success.value()));

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -58,6 +58,7 @@ public final class ApiRouter implements HttpHandler {
   private static final String MESSAGES = "messages";
   private static final String INVITE = "invite";
   private static final String AGENTS = "agents";
+  private static final String SNAPSHOTS = "snapshots";
   private static final int DEFAULT_MESSAGES = 50;
   private static final int MAX_MESSAGES = 100;
   private static final int DEFAULT_TAIL = 200;
@@ -213,8 +214,33 @@ public final class ApiRouter implements HttpHandler {
       case DISPATCH -> routeDispatch(exchange, request, project);
       case AGENT -> routeAgent(request, project);
       case CONNECT -> routeConnect(request, project);
+      case SNAPSHOTS -> routeSnapshots(request, project);
       default -> throw notFound();
     };
+  }
+
+  /**
+   * Routes the snapshot surface — {@code GET /v1/projects/{p}/snapshots}, {@code DELETE
+   * .../snapshots/{label}}, {@code POST .../snapshots/{label}/restore}. The mutations are accepted
+   * asynchronously (202); their completion arrives as {@code snapshot_restored} / {@code
+   * snapshot_deleted} events on the stream, so no client ever holds a request open for a mutation
+   * that can outlive its timeout.
+   */
+  private ApiResponse routeSnapshots(RouteRequest request, String project) {
+    if (request.size() == 4) {
+      requireMethod(request, GET);
+      return ApiResponse.from(operations.snapshots(project));
+    }
+    if (request.size() == 5) {
+      requireMethod(request, DELETE);
+      return ApiResponse.fromAccepted(operations.deleteSnapshot(project, request.subResource()));
+    }
+    if (request.size() == 6 && RESTORE.equals(request.segments().get(5))) {
+      requireMethod(request, POST);
+      return ApiResponse.fromAccepted(
+          operations.restoreSnapshot(project, request.subResource(), nodeHandle.get()));
+    }
+    throw notFound();
   }
 
   private ApiResponse routeProject(RouteRequest request, String project) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -578,6 +578,9 @@ public final class DispatchOperations {
     if (reservation instanceof RunStore.Reservation.Conflicted conflicted) {
       throw overlapRefusal(conflicted.conflict());
     }
+    if (reservation instanceof RunStore.Reservation.LeaseHeld held) {
+      throw leaseRefusal(held);
+    }
     var credential = ((RunStore.Reservation.Reserved) reservation).credential();
     try {
       seedRoomDelivery(runId, built.renderedMessages());
@@ -1584,6 +1587,17 @@ public final class DispatchOperations {
             });
   }
 
+  /**
+   * The refusal when an exclusive container operation (a snapshot restore) holds the container: no
+   * run of any role may start into a container that is about to be rolled back.
+   */
+  private static ApiException leaseRefusal(RunStore.Reservation.LeaseHeld held) {
+    return new ApiException(
+        ErrorCode.CONFLICT,
+        "A snapshot " + held.action() + " is in progress in this container.",
+        "Wait for its snapshot_restored event, then retry.");
+  }
+
   private static ApiException overlapRefusal(DispatchGate.Conflict conflict) {
     var run = conflict.run();
     var occupied =
@@ -1736,6 +1750,9 @@ public final class DispatchOperations {
     }
     if (reservation instanceof RunStore.Reservation.Conflicted conflicted) {
       throw overlapRefusal(conflicted.conflict());
+    }
+    if (reservation instanceof RunStore.Reservation.LeaseHeld held) {
+      throw leaseRefusal(held);
     }
     pruneRuns(project);
     return ((RunStore.Reservation.Reserved) reservation).credential();

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
@@ -51,6 +51,19 @@ public interface Operations {
   Result<DispatchResponse> dispatch(
       String project, DispatchRequest request, Actor actor, String localHandle);
 
+  /** Lists the project's container snapshots with the source each name's prefix encodes. */
+  Result<SnapshotListResponse> snapshots(String project);
+
+  /**
+   * Accepts an async restore of the container to {@code label}: validation and the live-run gate
+   * run inline, the mutation completes in the background and reports via {@code snapshot_restored}.
+   * Refused while any run is live on this box's container — a restore discards its work.
+   */
+  Result<SnapshotActionResponse> restoreSnapshot(String project, String label, String localHandle);
+
+  /** Accepts an async snapshot delete; completion is reported via {@code snapshot_deleted}. */
+  Result<SnapshotActionResponse> deleteSnapshot(String project, String label);
+
   /**
    * The project's agent status: every local running run (scoped by {@code localHandle} so a synced
    * foreign run is never probed on this box) plus the single-session fields the one-run common case

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ProjectLoader.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ProjectLoader.java
@@ -66,13 +66,18 @@ final class ProjectLoader {
   }
 
   void requireExists(String project) {
-    var state = load(project).state();
-    if (state instanceof ContainerState.NotCreated) {
+    loadCreated(project);
+  }
+
+  LoadedProject loadCreated(String project) {
+    var loaded = load(project);
+    if (loaded.state() instanceof ContainerState.NotCreated) {
       throw new ApiException(
           ErrorCode.PROJECT_NOT_CREATED, "Project '" + project + "' does not exist.");
     }
-    if (state instanceof ContainerState.Error error) {
+    if (loaded.state() instanceof ContainerState.Error error) {
       throw new ApiException(ErrorCode.CONTAINER_ERROR, error.message());
     }
+    return loaded;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -54,6 +54,7 @@ public final class SailOperations implements Operations {
   private final Supplier<ConnectEnvironment> connectEnvironment;
   private final SyncScheduler syncScheduler;
   private final ProjectLoader projects;
+  private final SnapshotOperations snapshotOps;
   private final GlobalSpecOperations globalSpecOps;
   private final ReviewOperations reviewOps;
   private final DispatchOperations dispatchOps;
@@ -316,6 +317,7 @@ public final class SailOperations implements Operations {
     this.syncScheduler = syncScheduler;
     this.fdeStore = fdeStore;
     this.projects = new ProjectLoader(shell, file);
+    this.snapshotOps = new SnapshotOperations(shell, projects, runStore, this::publishOnBus);
     this.globalSpecOps = new GlobalSpecOperations(specStore, reviewStore, eventBus, runStore);
     this.reviewOps = new ReviewOperations(reviewStore, specStore);
     this.dispatchOps =
@@ -466,6 +468,22 @@ public final class SailOperations implements Operations {
       triggerSyncAfterWrite();
     }
     return result;
+  }
+
+  @Override
+  public Result<SnapshotListResponse> snapshots(String project) {
+    return safe(() -> snapshotOps.list(project));
+  }
+
+  @Override
+  public Result<SnapshotActionResponse> restoreSnapshot(
+      String project, String label, String localHandle) {
+    return safe(() -> snapshotOps.restore(project, label, localHandle));
+  }
+
+  @Override
+  public Result<SnapshotActionResponse> deleteSnapshot(String project, String label) {
+    return safe(() -> snapshotOps.delete(project, label));
   }
 
   @Override

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SnapshotOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SnapshotOperations.java
@@ -32,8 +32,13 @@ import java.util.concurrent.Executors;
  * snapshot_restored} / {@code snapshot_deleted} events already declared on the bus. A failed
  * mutation publishes the same event with an {@code error} entry so a listener never waits forever.
  *
- * <p>Restore is the dangerous verb — it discards the container's current state — so it refuses
- * while any run is live on this box's container, with the same vocabulary as dispatch conflicts.
+ * <p>Restore is the dangerous verb — it discards the container's current state — so acceptance
+ * takes the {@link RunStore#acquireContainerLease exclusive container lease}: one transaction
+ * refuses the restore while any run is live on this box's container (with the same vocabulary as
+ * dispatch conflicts) and, until the worker releases the lease, refuses every new run reservation —
+ * so a dispatch can never start into a container about to be rolled back. A failed restore that had
+ * stopped a running container starts it again best-effort, so the failure mode is "still on the old
+ * state", never "down".
  */
 final class SnapshotOperations {
 
@@ -81,11 +86,16 @@ final class SnapshotOperations {
 
   SnapshotActionResponse restore(String project, String label, String localHandle) {
     NameValidator.requireValidSnapshotLabel(label);
-    var state = projects.loadCreated(project).state();
+    projects.loadCreated(project);
     requireSnapshotExists(project, label);
-    refuseLiveRun(project, label, localHandle);
     claim(project);
-    executor.execute(() -> runRestore(project, label, state));
+    try {
+      acquireRestoreLease(project, label, localHandle);
+    } catch (RuntimeException e) {
+      inFlight.remove(project);
+      throw e;
+    }
+    executor.execute(() -> runRestore(project, label, localHandle));
     return new SnapshotActionResponse(project, label, RESTORE_ACTION, "accepted");
   }
 
@@ -117,18 +127,39 @@ final class SnapshotOperations {
     return "manual";
   }
 
-  private void runRestore(String project, String label, ContainerState state) {
+  private void runRestore(String project, String label, String localHandle) {
+    var stopped = false;
     try {
-      if (state instanceof ContainerState.Running) {
+      if (projects.loadCreated(project).state() instanceof ContainerState.Running) {
         containers.stop(project);
+        stopped = true;
       }
       snapshots.restore(project, label);
       containers.start(project);
       publish(project, Event.WellKnownTypes.SNAPSHOT_RESTORED, Map.of("label", label));
     } catch (Exception e) {
+      recoverStoppedContainer(project, stopped, e);
       publishFailure(project, Event.WellKnownTypes.SNAPSHOT_RESTORED, label, e);
     } finally {
+      releaseRestoreLease(project, localHandle);
       inFlight.remove(project);
+    }
+  }
+
+  /**
+   * A restore that failed after stopping a running container starts it again, so the failure mode
+   * is "still on the old state", never "down". A restart failure rides the original exception as
+   * suppressed — both reach the published error and the log.
+   */
+  private void recoverStoppedContainer(String project, boolean stopped, Exception failure) {
+    if (!stopped) {
+      return;
+    }
+    try {
+      containers.start(project);
+    } catch (Exception restartFailure) {
+      restoreInterrupt(restartFailure);
+      failure.addSuppressed(restartFailure);
     }
   }
 
@@ -169,18 +200,42 @@ final class SnapshotOperations {
     }
   }
 
-  private void refuseLiveRun(String project, String label, String localHandle) {
+  /**
+   * Claims the container for the restore through {@link RunStore#acquireContainerLease}: one
+   * transaction refuses over any live local run (any role — even a read-only invite loses its
+   * session to a rollback) or an already-held lease, and blocks every new run reservation until
+   * {@link #releaseRestoreLease}. A box without a run aggregate has no runs to race and no
+   * dispatches to fence — the in-flight claim alone gates it.
+   */
+  private void acquireRestoreLease(String project, String label, String localHandle) {
     if (runStore == null) {
       return;
     }
-    runStore.listForProject(project).stream()
-        .filter(DispatchOperations::ownsLiveAgent)
-        .filter(run -> SailOperations.ownsRun(run.node(), localHandle))
-        .findFirst()
-        .ifPresent(
-            run -> {
-              throw restoreRefusal(run, label);
-            });
+    switch (runStore.acquireContainerLease(project, localHandle, RESTORE_ACTION)) {
+      case RunStore.ContainerLease.BlockedByRun blocked ->
+          throw restoreRefusal(blocked.run(), label);
+      case RunStore.ContainerLease.BlockedByLease held ->
+          throw new ApiException(
+              ErrorCode.CONFLICT,
+              "A snapshot "
+                  + held.action()
+                  + " is already in progress for project '"
+                  + project
+                  + "'.",
+              "Wait for its snapshot_restored or snapshot_deleted event, then retry.");
+      case RunStore.ContainerLease.Acquired acquired -> {}
+    }
+  }
+
+  private void releaseRestoreLease(String project, String localHandle) {
+    if (runStore == null) {
+      return;
+    }
+    try {
+      runStore.releaseContainerLease(project, localHandle);
+    } catch (RuntimeException e) {
+      ApiLog.unexpected("releasing the container lease for '" + project + "'", e);
+    }
   }
 
   private static ApiException restoreRefusal(RunStore.RunRow run, String label) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SnapshotOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SnapshotOperations.java
@@ -35,10 +35,10 @@ import java.util.concurrent.Executors;
  * <p>Restore is the dangerous verb — it discards the container's current state — so acceptance
  * takes the {@link RunStore#acquireContainerLease exclusive container lease}: one transaction
  * refuses the restore while any run is live on this box's container (with the same vocabulary as
- * dispatch conflicts) and, until the worker releases the lease, refuses every new run reservation —
- * so a dispatch can never start into a container about to be rolled back. A failed restore that had
- * stopped a running container starts it again best-effort, so the failure mode is "still on the old
- * state", never "down".
+ * dispatch conflicts) and, until the worker releases the lease, refuses every new run start —
+ * dispatch reservations and review-run creation alike — so no agent can ever launch into a
+ * container about to be rolled back. A failed restore that had stopped a running container starts
+ * it again best-effort, so the failure mode is "still on the old state", never "down".
  */
 final class SnapshotOperations {
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SnapshotOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SnapshotOperations.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.engine.ContainerManager;
+import ai.singlr.sail.engine.ContainerState;
+import ai.singlr.sail.engine.HostInfo;
+import ai.singlr.sail.engine.NameValidator;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.SnapshotManager;
+import ai.singlr.sail.store.RunStore;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * The single snapshot lane behind the API: reads and mutations over the existing {@link
+ * SnapshotManager} — no new snapshot mechanism, and no snapshot creation (cadence stays at the
+ * dispatch, guardrail, and invite seams).
+ *
+ * <p>Restore and delete can run for many minutes on the dir backend, far past any client's request
+ * timeout, so both are accepted-then-async: the request validates and claims the project, returns
+ * immediately, and the mutation completes on the executor, reporting through the {@code
+ * snapshot_restored} / {@code snapshot_deleted} events already declared on the bus. A failed
+ * mutation publishes the same event with an {@code error} entry so a listener never waits forever.
+ *
+ * <p>Restore is the dangerous verb — it discards the container's current state — so it refuses
+ * while any run is live on this box's container, with the same vocabulary as dispatch conflicts.
+ */
+final class SnapshotOperations {
+
+  static final String RESTORE_ACTION = "restore";
+  static final String DELETE_ACTION = "delete";
+
+  private final ProjectLoader projects;
+  private final RunStore runStore;
+  private final DispatchOperations.EventSink events;
+  private final ContainerManager containers;
+  private final SnapshotManager snapshots;
+  private final ExecutorService executor;
+  private final Set<String> inFlight = ConcurrentHashMap.newKeySet();
+
+  SnapshotOperations(
+      ShellExec shell,
+      ProjectLoader projects,
+      RunStore runStore,
+      DispatchOperations.EventSink events) {
+    this(shell, projects, runStore, events, Executors.newVirtualThreadPerTaskExecutor());
+  }
+
+  SnapshotOperations(
+      ShellExec shell,
+      ProjectLoader projects,
+      RunStore runStore,
+      DispatchOperations.EventSink events,
+      ExecutorService executor) {
+    this.projects = projects;
+    this.runStore = runStore;
+    this.events = events;
+    this.containers = new ContainerManager(shell);
+    this.snapshots = new SnapshotManager(shell);
+    this.executor = executor;
+  }
+
+  SnapshotListResponse list(String project) {
+    projects.requireExists(project);
+    var views =
+        listSnapshots(project).stream()
+            .map(info -> new SnapshotView(info.name(), info.createdAt(), sourceOf(info.name())))
+            .toList();
+    return new SnapshotListResponse(views);
+  }
+
+  SnapshotActionResponse restore(String project, String label, String localHandle) {
+    NameValidator.requireValidSnapshotLabel(label);
+    var state = projects.loadCreated(project).state();
+    requireSnapshotExists(project, label);
+    refuseLiveRun(project, label, localHandle);
+    claim(project);
+    executor.execute(() -> runRestore(project, label, state));
+    return new SnapshotActionResponse(project, label, RESTORE_ACTION, "accepted");
+  }
+
+  SnapshotActionResponse delete(String project, String label) {
+    NameValidator.requireValidSnapshotLabel(label);
+    projects.requireExists(project);
+    requireSnapshotExists(project, label);
+    claim(project);
+    executor.execute(() -> runDelete(project, label));
+    return new SnapshotActionResponse(project, label, DELETE_ACTION, "accepted");
+  }
+
+  /**
+   * Classifies a snapshot by the naming convention its producer already uses: {@code invite-} from
+   * the hands-on invite lane, {@code guardrail-} from the guardrail watcher, {@code snap-} from the
+   * dispatch auto-snapshot's default label, anything else operator-chosen. A CLI create that kept
+   * the default label reads as {@code dispatch} — the name is all the metadata Incus keeps.
+   */
+  static String sourceOf(String name) {
+    if (name.startsWith("invite-")) {
+      return "invite";
+    }
+    if (name.startsWith("guardrail-")) {
+      return "guardrail";
+    }
+    if (name.startsWith("snap-")) {
+      return "dispatch";
+    }
+    return "manual";
+  }
+
+  private void runRestore(String project, String label, ContainerState state) {
+    try {
+      if (state instanceof ContainerState.Running) {
+        containers.stop(project);
+      }
+      snapshots.restore(project, label);
+      containers.start(project);
+      publish(project, Event.WellKnownTypes.SNAPSHOT_RESTORED, Map.of("label", label));
+    } catch (Exception e) {
+      publishFailure(project, Event.WellKnownTypes.SNAPSHOT_RESTORED, label, e);
+    } finally {
+      inFlight.remove(project);
+    }
+  }
+
+  private void runDelete(String project, String label) {
+    try {
+      snapshots.delete(project, label);
+      publish(project, Event.WellKnownTypes.SNAPSHOT_DELETED, Map.of("label", label));
+    } catch (Exception e) {
+      publishFailure(project, Event.WellKnownTypes.SNAPSHOT_DELETED, label, e);
+    } finally {
+      inFlight.remove(project);
+    }
+  }
+
+  private void publishFailure(String project, String type, String label, Exception e) {
+    restoreInterrupt(e);
+    ApiLog.unexpected("a snapshot mutation for '" + project + "'", e);
+    publish(
+        project,
+        type,
+        Map.of(
+            "label",
+            label,
+            "error",
+            Objects.toString(e.getMessage(), "snapshot operation failed")));
+  }
+
+  private void publish(String project, String type, Map<String, Object> data) {
+    events.publish(Event.of(project, null, type, Event.SAIL_AGENT, HostInfo.hostname(), data));
+  }
+
+  private void claim(String project) {
+    if (!inFlight.add(project)) {
+      throw new ApiException(
+          ErrorCode.CONFLICT,
+          "A snapshot operation is already in progress for project '" + project + "'.",
+          "Wait for its snapshot_restored or snapshot_deleted event, then retry.");
+    }
+  }
+
+  private void refuseLiveRun(String project, String label, String localHandle) {
+    if (runStore == null) {
+      return;
+    }
+    runStore.listForProject(project).stream()
+        .filter(DispatchOperations::ownsLiveAgent)
+        .filter(run -> SailOperations.ownsRun(run.node(), localHandle))
+        .findFirst()
+        .ifPresent(
+            run -> {
+              throw restoreRefusal(run, label);
+            });
+  }
+
+  private static ApiException restoreRefusal(RunStore.RunRow run, String label) {
+    var occupied =
+        Strings.isBlank(run.specId())
+            ? "Ad-hoc agent run " + run.id() + " is occupying this container"
+            : "Agent run "
+                + run.id()
+                + " is already working spec '"
+                + run.specId()
+                + "' in this container";
+    return new ApiException(
+        ErrorCode.AGENT_ALREADY_RUNNING,
+        occupied + "; restoring snapshot '" + label + "' would discard its live work.",
+        "Wait for it to finish or stop it, then retry the restore.");
+  }
+
+  private void requireSnapshotExists(String project, String label) {
+    var exists = listSnapshots(project).stream().anyMatch(info -> label.equals(info.name()));
+    if (!exists) {
+      throw new ApiException(
+          ErrorCode.NOT_FOUND,
+          "Snapshot '" + label + "' does not exist for project '" + project + "'.",
+          "List snapshots with GET /v1/projects/" + project + "/snapshots.");
+    }
+  }
+
+  private List<SnapshotManager.SnapshotInfo> listSnapshots(String project) {
+    try {
+      return snapshots.list(project);
+    } catch (Exception e) {
+      restoreInterrupt(e);
+      throw new ApiException(
+          ErrorCode.SNAPSHOT_FAILED,
+          Objects.toString(e.getMessage(), "snapshot listing failed"),
+          "Check the host's incus daemon and retry.",
+          e);
+    }
+  }
+
+  private static void restoreInterrupt(Exception e) {
+    if (e instanceof InterruptedException) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AdhocDispatchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AdhocDispatchTest.java
@@ -395,6 +395,22 @@ class AdhocDispatchTest {
   }
 
   @Test
+  void aHeldContainerLeaseRefusesTheAdhocLaunch() throws Exception {
+    var ops = operations(liveAgentShell());
+    runStore.acquireContainerLease("acme", HANDLE, "restore");
+
+    var refusal =
+        assertThrows(ApiException.class, () -> ops.startAdhoc("acme", background("task"), HANDLE));
+
+    assertEquals(ErrorCode.CONFLICT, refusal.failure().errorCode());
+    assertTrue(
+        refusal.getMessage().contains("snapshot restore is in progress"), refusal.getMessage());
+    assertTrue(
+        runStore.listForProject("acme").isEmpty(),
+        "a lease-refused launch must not insert a run row");
+  }
+
+  @Test
   void aSecondAdhocSessionIsRefusedWhileTheFirstIsLive() throws Exception {
     var ops = operations(liveAgentShell());
     var first = ops.startAdhoc("acme", background("one"), HANDLE);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiResponseTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiResponseTest.java
@@ -52,6 +52,15 @@ class ApiResponseTest {
   }
 
   @Test
+  void fromAcceptedMapsSuccessTo202AndFailureToItsErrorStatus() {
+    var accepted = ApiResponse.fromAccepted(Result.success(new HealthResponse("ok")));
+    assertEquals(202, accepted.status());
+
+    var refused = ApiResponse.fromAccepted(Result.failure(ErrorCode.CONFLICT, "Busy.", "Wait."));
+    assertEquals(409, refused.status());
+  }
+
+  @Test
   void threeArgConstructorCopiesHeadersDefensively() {
     var headers = new java.util.HashMap<String, String>();
     headers.put("ETag", "\"v1\"");

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -370,6 +370,55 @@ class ApiRouterTest {
   }
 
   @Test
+  void snapshotRoutesListDeleteAndRestore() throws Exception {
+    try (var server = server()) {
+      var list = get(server, "/v1/projects/acme/snapshots", "token");
+      assertEquals(200, list.statusCode());
+      assertTrue(list.body().contains("\"invite-run-7\""));
+      assertTrue(list.body().contains("\"source\": \"invite\""));
+
+      var deleted = delete(server, "/v1/projects/acme/snapshots/invite-run-7", "token");
+      assertEquals(202, deleted.statusCode());
+      assertTrue(deleted.body().contains("\"status\": \"accepted\""));
+      assertTrue(deleted.body().contains("\"action\": \"delete\""));
+
+      var restored =
+          post(server, "/v1/projects/acme/snapshots/invite-run-7/restore", "token", "{}");
+      assertEquals(202, restored.statusCode());
+      assertTrue(restored.body().contains("\"action\": \"restore\""));
+    }
+  }
+
+  @Test
+  void snapshotRoutesRefuseWrongMethodsAndUnknownSubResources() throws Exception {
+    try (var server = server()) {
+      assertEquals(405, post(server, "/v1/projects/acme/snapshots", "token", "{}").statusCode());
+      assertEquals(405, get(server, "/v1/projects/acme/snapshots/snap-1", "token").statusCode());
+      assertEquals(
+          405, get(server, "/v1/projects/acme/snapshots/snap-1/restore", "token").statusCode());
+      assertEquals(
+          404,
+          post(server, "/v1/projects/acme/snapshots/snap-1/bogus", "token", "{}").statusCode());
+      assertEquals(
+          404,
+          post(server, "/v1/projects/acme/snapshots/snap-1/restore/extra", "token", "{}")
+              .statusCode());
+    }
+  }
+
+  @Test
+  void aRefusedSnapshotRestoreRendersTheRefusalVerbatim() throws Exception {
+    try (var server = serverWith(new SnapshotRefusingOperations())) {
+      server.start();
+
+      var response = post(server, "/v1/projects/acme/snapshots/snap-1/restore", "token", "{}");
+      assertEquals(409, response.statusCode());
+      assertTrue(response.body().contains("\"agent_already_running\""));
+      assertTrue(response.body().contains("would discard its live work"));
+    }
+  }
+
+  @Test
   void unknownRunSubResourceReturnsNotFound() throws Exception {
     try (var server = server()) {
       assertEquals(404, get(server, "/v1/runs/r1/bogus", "token").statusCode());
@@ -1412,6 +1461,26 @@ class ApiRouterTest {
     }
 
     @Override
+    public Result<SnapshotListResponse> snapshots(String project) {
+      return Result.success(
+          new SnapshotListResponse(
+              java.util.List.of(
+                  new SnapshotView("invite-run-7", "2026-08-17T10:00:00Z", "invite"),
+                  new SnapshotView("snap-20260817-100000", "2026-08-17T11:00:00Z", "dispatch"))));
+    }
+
+    @Override
+    public Result<SnapshotActionResponse> restoreSnapshot(
+        String project, String label, String localHandle) {
+      return Result.success(new SnapshotActionResponse(project, label, "restore", "accepted"));
+    }
+
+    @Override
+    public Result<SnapshotActionResponse> deleteSnapshot(String project, String label) {
+      return Result.success(new SnapshotActionResponse(project, label, "delete", "accepted"));
+    }
+
+    @Override
     public Result<AgentStatusResponse> agentStatus(String project, String localHandle) {
       return Result.success(
           new AgentStatusResponse(
@@ -1739,6 +1808,19 @@ class ApiRouterTest {
     @Override
     public Result<AgentStatusResponse> agentStatus(String project, String localHandle) {
       return Result.failure(ErrorCode.CONFLICT, "Agent is busy.", "Wait.");
+    }
+  }
+
+  private static final class SnapshotRefusingOperations extends FakeOperations {
+    @Override
+    public Result<SnapshotActionResponse> restoreSnapshot(
+        String project, String label, String localHandle) {
+      return Result.failure(
+          ErrorCode.AGENT_ALREADY_RUNNING,
+          "Agent run r-7 is already working spec 'auth' in this container; restoring snapshot '"
+              + label
+              + "' would discard its live work.",
+          "Wait for it to finish or stop it, then retry the restore.");
     }
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -440,6 +440,45 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
+  void aContainerLeaseHeldByARestoreErrorsTheReviewInsteadOfLaunchingIntoTheContainer() {
+    createSpec("auth", "in_progress");
+    var runStore = new RunStore(db);
+    runStore.acquireContainerLease("test-project", "node-a", "restore");
+    var launched = new java.util.concurrent.atomic.AtomicBoolean();
+    var ctrl =
+        new ReviewPipelineController(
+            specStore,
+            reviewStore,
+            p -> singleAgentStage("no_critical"),
+            p -> "codex",
+            (p, a, pr, rid, cred) -> {
+              launched.set(true);
+              return CLEAN_REVIEW;
+            },
+            null,
+            () -> {},
+            new DirectExecutorService(),
+            runStore,
+            () -> "node-a");
+
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    assertFalse(launched.get(), "a review agent must never launch into a container mid-restore");
+    var errored = reviewStore.latestReviewForSpec("auth").orElseThrow();
+    assertEquals("failed", errored.status());
+    assertTrue(errored.errored());
+    assertTrue(errored.error().contains("restore"), errored.error());
+    assertTrue(
+        runStore.listForSpec("auth").isEmpty(), "a refused review must not insert a run row");
+
+    runStore.releaseContainerLease("test-project", "node-a");
+    ctrl.onEvent(agentStoppedEvent("auth"));
+
+    assertTrue(launched.get(), "the replayed stop must review normally once the lease is gone");
+    assertEquals(SpecStatus.AWAITING_MERGE, specStore.findById("auth").orElseThrow().status());
+  }
+
+  @Test
   void aBuildStopStillTriggersTheReviewAfterTheRoomExclusion() {
     createSpec("auth", "in_progress");
     var ctrl = controller(singleAgentStage("no_critical"), (p, a, pr, rid, cred) -> CLEAN_REVIEW);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
@@ -222,6 +222,19 @@ class RoomWakeLaunchTest {
   }
 
   @Test
+  void aHeldContainerLeaseRefusesTheWake() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+    runStore.acquireContainerLease("acme", HANDLE, "restore");
+
+    var refusal = assertThrows(ApiException.class, () -> ops.startRoomRun("acme", "auth", HANDLE));
+
+    assertEquals(ErrorCode.CONFLICT, refusal.failure().errorCode());
+    assertTrue(
+        refusal.getMessage().contains("snapshot restore is in progress"), refusal.getMessage());
+  }
+
+  @Test
   void aDisjointSpecsLiveBuildNeverBlocksTheWake() throws Exception {
     var ops = operations(liveAgentShell());
     seedSpec("auth");

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -655,6 +655,30 @@ class SailOperationsTest {
   }
 
   @Test
+  void snapshotRoutesDelegateToTheSnapshotLane() throws Exception {
+    var yaml = tempDir.resolve("sail-snapshots.yaml");
+    Files.writeString(yaml, baseYaml());
+    var shell =
+        shell()
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on(
+                "incus snapshot list acme",
+                "[{\"name\": \"snap-1\", \"created_at\": \"2026-08-17T08:00:00Z\"}]");
+    var operations = new SailOperations(shell, yaml.toString());
+
+    var list = operations.snapshots("acme");
+    assertEquals("dispatch", list.orThrow().snapshots().getFirst().source());
+
+    assertError(ErrorCode.NOT_FOUND, operations.deleteSnapshot("acme", "missing"));
+    assertError(ErrorCode.INVALID_REQUEST, operations.restoreSnapshot("acme", "-bad", "uday"));
+
+    assertEquals(
+        "accepted", operations.restoreSnapshot("acme", "snap-1", "uday").orThrow().status());
+    var deleter = new SailOperations(shell, yaml.toString());
+    assertEquals("accepted", deleter.deleteSnapshot("acme", "snap-1").orThrow().status());
+  }
+
+  @Test
   void aFailedRunReservationAbortsDispatchBeforeAnyMutation() throws Exception {
     var yaml = tempDir.resolve("sail-broken-runs.yaml");
     Files.writeString(yaml, baseYaml());

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SnapshotOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SnapshotOperationsTest.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -217,6 +218,111 @@ class SnapshotOperationsTest {
     assertThrows(IllegalArgumentException.class, () -> ops.restore("acme", "-bad", "uday"));
 
     assertTrue(shell.invocations().isEmpty());
+  }
+
+  @Test
+  void anAcceptedRestoreLeasesTheContainerAgainstDispatchUntilItCompletes() throws Exception {
+    var runs = runStore();
+    var executor = new HoldingExecutorService();
+    var ops = ops(shell(RUNNING_JSON), runs, executor);
+
+    ops.restore("acme", "my-checkpoint", "uday");
+
+    var during = reserve(runs, "r-1");
+    var held = assertInstanceOf(RunStore.Reservation.LeaseHeld.class, during);
+    assertEquals("restore", held.action());
+
+    executor.runAll();
+    assertInstanceOf(RunStore.Reservation.Reserved.class, reserve(runs, "r-2"));
+  }
+
+  @Test
+  void aFailedRestoreReleasesTheLeaseSoDispatchCanProceed() throws Exception {
+    var runs = runStore();
+    var shell =
+        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+            .onOk("incus list ^acme$", RUNNING_JSON)
+            .onOk("incus snapshot list acme", SNAPSHOTS_JSON)
+            .onFail("incus snapshot restore acme my-checkpoint", "boom");
+    var ops = ops(shell, runs, new DirectExecutorService());
+
+    ops.restore("acme", "my-checkpoint", "uday");
+
+    assertEquals(1, events.size());
+    assertTrue(events.getFirst().data().get("error").toString().contains("boom"));
+    assertInstanceOf(RunStore.Reservation.Reserved.class, reserve(runs, "r-3"));
+  }
+
+  @Test
+  void aRestoreIsRefusedWhileAnotherLeaseHoldsTheContainer() throws Exception {
+    var runs = runStore();
+    runs.acquireContainerLease("acme", "uday", "restore");
+    var ops = ops(shell(RUNNING_JSON), runs, new DirectExecutorService());
+
+    var error =
+        assertThrows(ApiException.class, () -> ops.restore("acme", "my-checkpoint", "uday"));
+
+    assertEquals(ErrorCode.CONFLICT, error.failure().errorCode());
+    assertTrue(error.getMessage().contains("already in progress"));
+    assertEquals(
+        "accepted",
+        ops.delete("acme", "my-checkpoint").status(),
+        "the refused restore must release its in-flight claim");
+  }
+
+  @Test
+  void aFailedRestoreOfARunningContainerStartsItAgain() throws Exception {
+    var shell = shell(RUNNING_JSON).onFail("incus snapshot restore acme my-checkpoint", "boom");
+    var ops = ops(shell, null, new DirectExecutorService());
+
+    ops.restore("acme", "my-checkpoint", "uday");
+
+    var commands = shell.invocations();
+    assertTrue(
+        commands.indexOf("incus stop acme") < commands.indexOf("incus start acme"),
+        "a restore that stopped a running container must start it again on failure");
+    assertEquals(1, events.size());
+    assertTrue(events.getFirst().data().get("error").toString().contains("boom"));
+  }
+
+  @Test
+  void aFailedRestartAfterAFailedRestoreStillPublishesTheError() throws Exception {
+    var shell =
+        shell(RUNNING_JSON)
+            .onFail("incus snapshot restore acme my-checkpoint", "boom")
+            .onFail("incus start acme", "cannot start");
+    var ops = ops(shell, null, new DirectExecutorService());
+
+    ops.restore("acme", "my-checkpoint", "uday");
+
+    assertTrue(shell.invocations().contains("incus start acme"));
+    assertEquals(1, events.size());
+    assertTrue(events.getFirst().data().get("error").toString().contains("boom"));
+  }
+
+  @Test
+  void aFailedLeaseReleaseStillClearsTheInFlightClaim() throws Exception {
+    var db = Sqlite.open(tempDir.resolve("lease-" + System.nanoTime() + ".db"));
+    new SchemaManager(db).migrate();
+    var runs = new RunStore(db);
+    var executor = new HoldingExecutorService();
+    var ops = ops(shell(RUNNING_JSON), runs, executor);
+    ops.restore("acme", "my-checkpoint", "uday");
+    db.close();
+
+    executor.runAll();
+
+    assertEquals(1, events.size());
+    assertEquals(Event.WellKnownTypes.SNAPSHOT_RESTORED, events.getFirst().type());
+    assertEquals(
+        "accepted",
+        ops.delete("acme", "my-checkpoint").status(),
+        "a lease release that fails must never wedge the in-flight claim");
+  }
+
+  private static RunStore.Reservation reserve(RunStore runs, String id) {
+    return runs.reserveDispatch(
+        id, "acme", "auth", "uday", "uday", "build", List.of(), "claude-code", null, "t", "l", "u");
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SnapshotOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SnapshotOperationsTest.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.engine.ScriptedShellExecutor;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SnapshotOperationsTest {
+
+  private static final String RUNNING_JSON =
+      """
+      [{"name": "acme", "status": "Running", "state": {}}]
+      """;
+
+  private static final String STOPPED_JSON =
+      """
+      [{"name": "acme", "status": "Stopped", "state": {}}]
+      """;
+
+  private static final String SNAPSHOTS_JSON =
+      """
+      [
+        {"name": "invite-run-7", "created_at": "2026-08-17T10:00:00Z"},
+        {"name": "guardrail-20260817-090000", "created_at": "2026-08-17T09:00:00Z"},
+        {"name": "snap-20260817-080000", "created_at": "2026-08-17T08:00:00Z"},
+        {"name": "my-checkpoint", "created_at": "2026-08-17T07:00:00Z"}
+      ]
+      """;
+
+  @TempDir Path tempDir;
+
+  private final List<Event> events = new ArrayList<>();
+
+  @Test
+  void listClassifiesEverySourceByItsNamePrefix() throws Exception {
+    var ops = ops(shell(RUNNING_JSON), null, new DirectExecutorService());
+
+    var response = ops.list("acme");
+
+    assertEquals(4, response.snapshots().size());
+    assertEquals("invite", response.snapshots().get(0).source());
+    assertEquals("guardrail", response.snapshots().get(1).source());
+    assertEquals("dispatch", response.snapshots().get(2).source());
+    assertEquals("manual", response.snapshots().get(3).source());
+    assertEquals("invite-run-7", response.snapshots().getFirst().name());
+    assertEquals("2026-08-17T10:00:00Z", response.snapshots().getFirst().createdAt());
+  }
+
+  @Test
+  void listRefusesAProjectWithoutAContainer() throws Exception {
+    var shell =
+        new ScriptedShellExecutor()
+            .onOk("incus list ^acme$", "[]")
+            .onOk("incus snapshot list acme", SNAPSHOTS_JSON);
+    var ops = ops(shell, null, new DirectExecutorService());
+
+    var error = assertThrows(ApiException.class, () -> ops.list("acme"));
+
+    assertEquals(ErrorCode.PROJECT_NOT_CREATED, error.failure().errorCode());
+  }
+
+  @Test
+  void listWrapsAnIncusFailureAsSnapshotFailed() throws Exception {
+    var shell =
+        new ScriptedShellExecutor()
+            .onOk("incus list ^acme$", RUNNING_JSON)
+            .onFail("incus snapshot list acme", "daemon not running");
+    var ops = ops(shell, null, new DirectExecutorService());
+
+    var error = assertThrows(ApiException.class, () -> ops.list("acme"));
+
+    assertEquals(ErrorCode.SNAPSHOT_FAILED, error.failure().errorCode());
+    assertTrue(error.getMessage().contains("daemon not running"));
+  }
+
+  @Test
+  void listMarksAnInterruptedThreadBeforeRefusing() {
+    var ops = ops(new InterruptingShell(), null, new DirectExecutorService());
+
+    var error = assertThrows(ApiException.class, () -> ops.list("acme"));
+
+    assertEquals(ErrorCode.SNAPSHOT_FAILED, error.failure().errorCode());
+    assertTrue(Thread.interrupted(), "the interrupt flag must be restored before wrapping");
+  }
+
+  @Test
+  void restoreStopsARunningContainerRestoresAndStartsIt() throws Exception {
+    var shell = shell(RUNNING_JSON);
+    var ops = ops(shell, null, new DirectExecutorService());
+
+    var response = ops.restore("acme", "my-checkpoint", "uday");
+
+    assertEquals("accepted", response.status());
+    assertEquals("restore", response.action());
+    var commands = shell.invocations();
+    var stopIndex = commands.indexOf("incus stop acme");
+    var restoreIndex = commands.indexOf("incus snapshot restore acme my-checkpoint");
+    var startIndex = commands.indexOf("incus start acme");
+    assertTrue(stopIndex >= 0 && stopIndex < restoreIndex && restoreIndex < startIndex);
+    assertEquals(1, events.size());
+    assertEquals(Event.WellKnownTypes.SNAPSHOT_RESTORED, events.getFirst().type());
+    assertEquals("my-checkpoint", events.getFirst().data().get("label"));
+  }
+
+  @Test
+  void restoreOfAStoppedContainerNeverStopsIt() throws Exception {
+    var shell = shell(STOPPED_JSON);
+    var ops = ops(shell, null, new DirectExecutorService());
+
+    ops.restore("acme", "my-checkpoint", "uday");
+
+    assertFalse(shell.invocations().contains("incus stop acme"));
+    assertTrue(shell.invocations().contains("incus snapshot restore acme my-checkpoint"));
+  }
+
+  @Test
+  void restoreRefusesWhileASpecRunIsLiveAndNamesWhatItWouldDiscard() throws Exception {
+    var runs = runStore();
+    runs.reserveDispatch(
+        "r-7",
+        "acme",
+        "auth",
+        "uday",
+        "uday",
+        "build",
+        List.of(),
+        "claude-code",
+        null,
+        "t",
+        "l",
+        "u");
+    var ops = ops(shell(RUNNING_JSON), runs, new DirectExecutorService());
+
+    var error =
+        assertThrows(ApiException.class, () -> ops.restore("acme", "my-checkpoint", "uday"));
+
+    assertEquals(ErrorCode.AGENT_ALREADY_RUNNING, error.failure().errorCode());
+    assertTrue(error.getMessage().contains("r-7"));
+    assertTrue(error.getMessage().contains("spec 'auth'"));
+    assertTrue(error.getMessage().contains("would discard its live work"));
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void restoreRefusesWhileAnInviteOccupiesTheContainer() throws Exception {
+    var runs = runStore();
+    runs.reserveDispatch(
+        "r-9", "acme", "", "uday", "uday", "invite", List.of(), "claude-code", null, "t", "l", "u");
+    var ops = ops(shell(RUNNING_JSON), runs, new DirectExecutorService());
+
+    var error =
+        assertThrows(ApiException.class, () -> ops.restore("acme", "my-checkpoint", "uday"));
+
+    assertEquals(ErrorCode.AGENT_ALREADY_RUNNING, error.failure().errorCode());
+    assertTrue(error.getMessage().contains("Ad-hoc agent run r-9 is occupying this container"));
+  }
+
+  @Test
+  void aForeignNodesRunNeverBlocksARestoreHere() throws Exception {
+    var runs = runStore();
+    runs.reserveDispatch(
+        "r-8",
+        "acme",
+        "auth",
+        "other",
+        "uday",
+        "build",
+        List.of(),
+        "claude-code",
+        null,
+        "t",
+        "l",
+        "u");
+    var ops = ops(shell(RUNNING_JSON), runs, new DirectExecutorService());
+
+    var response = ops.restore("acme", "my-checkpoint", "uday");
+
+    assertEquals("accepted", response.status());
+  }
+
+  @Test
+  void restoreOfAnUnknownLabelIsNotFound() throws Exception {
+    var ops = ops(shell(RUNNING_JSON), null, new DirectExecutorService());
+
+    var error = assertThrows(ApiException.class, () -> ops.restore("acme", "no-such", "uday"));
+
+    assertEquals(ErrorCode.NOT_FOUND, error.failure().errorCode());
+  }
+
+  @Test
+  void restoreOfAnInvalidLabelIsRejectedBeforeAnyShellCall() throws Exception {
+    var shell = shell(RUNNING_JSON);
+    var ops = ops(shell, null, new DirectExecutorService());
+
+    assertThrows(IllegalArgumentException.class, () -> ops.restore("acme", "-bad", "uday"));
+
+    assertTrue(shell.invocations().isEmpty());
+  }
+
+  @Test
+  void restoreFailurePublishesTheErrorAndReleasesTheClaim() throws Exception {
+    var shell =
+        new ScriptedShellExecutor()
+            .onOk("incus list ^acme$", STOPPED_JSON)
+            .onOk("incus snapshot list acme", SNAPSHOTS_JSON)
+            .onFail("incus snapshot restore acme my-checkpoint", "boom");
+    var ops = ops(shell, null, new DirectExecutorService());
+
+    ops.restore("acme", "my-checkpoint", "uday");
+
+    assertEquals(1, events.size());
+    assertEquals(Event.WellKnownTypes.SNAPSHOT_RESTORED, events.getFirst().type());
+    assertTrue(events.getFirst().data().get("error").toString().contains("boom"));
+    assertEquals("accepted", ops.restore("acme", "my-checkpoint", "uday").status());
+  }
+
+  @Test
+  void deleteDeletesAndPublishesCompletion() throws Exception {
+    var shell = shell(RUNNING_JSON);
+    var ops = ops(shell, null, new DirectExecutorService());
+
+    var response = ops.delete("acme", "invite-run-7");
+
+    assertEquals("accepted", response.status());
+    assertEquals("delete", response.action());
+    assertTrue(shell.invocations().contains("incus snapshot delete acme invite-run-7"));
+    assertEquals(1, events.size());
+    assertEquals(Event.WellKnownTypes.SNAPSHOT_DELETED, events.getFirst().type());
+    assertEquals("invite-run-7", events.getFirst().data().get("label"));
+  }
+
+  @Test
+  void deleteFailurePublishesTheErrorAndReleasesTheClaim() throws Exception {
+    var shell =
+        new ScriptedShellExecutor()
+            .onOk("incus list ^acme$", RUNNING_JSON)
+            .onOk("incus snapshot list acme", SNAPSHOTS_JSON)
+            .onFail("incus snapshot delete acme invite-run-7", "storage error");
+    var ops = ops(shell, null, new DirectExecutorService());
+
+    ops.delete("acme", "invite-run-7");
+
+    assertEquals(1, events.size());
+    assertTrue(events.getFirst().data().get("error").toString().contains("storage error"));
+    assertEquals("accepted", ops.delete("acme", "invite-run-7").status());
+  }
+
+  @Test
+  void deleteOfAnUnknownLabelIsNotFound() throws Exception {
+    var ops = ops(shell(RUNNING_JSON), null, new DirectExecutorService());
+
+    var error = assertThrows(ApiException.class, () -> ops.delete("acme", "no-such"));
+
+    assertEquals(ErrorCode.NOT_FOUND, error.failure().errorCode());
+  }
+
+  @Test
+  void aSecondMutationIsRefusedWhileOneIsInFlight() throws Exception {
+    var executor = new HoldingExecutorService();
+    var ops = ops(shell(RUNNING_JSON), null, executor);
+
+    ops.delete("acme", "invite-run-7");
+    var error = assertThrows(ApiException.class, () -> ops.delete("acme", "my-checkpoint"));
+
+    assertEquals(ErrorCode.CONFLICT, error.failure().errorCode());
+    assertTrue(error.getMessage().contains("already in progress"));
+
+    executor.runAll();
+    assertEquals(1, events.size());
+    assertEquals("accepted", ops.delete("acme", "my-checkpoint").status());
+  }
+
+  @Test
+  void theDefaultExecutorConstructorServesSynchronousReads() throws Exception {
+    var loader = loader(shell(RUNNING_JSON));
+    var ops = new SnapshotOperations(shell(RUNNING_JSON), loader, null, events::add);
+
+    assertEquals(4, ops.list("acme").snapshots().size());
+  }
+
+  private ScriptedShellExecutor shell(String stateJson) {
+    return new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+        .onOk("incus list ^acme$", stateJson)
+        .onOk("incus snapshot list acme", SNAPSHOTS_JSON);
+  }
+
+  private SnapshotOperations ops(ShellExec shell, RunStore runs, ExecutorService executor) {
+    return new SnapshotOperations(shell, loader(shell), runs, events::add, executor);
+  }
+
+  private ProjectLoader loader(ShellExec shell) {
+    try {
+      var yaml = tempDir.resolve("sail-" + System.nanoTime() + ".yaml");
+      Files.writeString(
+          yaml,
+          """
+          name: acme
+          ssh:
+            user: dev
+          agent:
+            type: claude-code
+          """);
+      return new ProjectLoader(shell, yaml.toString());
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private RunStore runStore() throws Exception {
+    var db = Sqlite.open(tempDir.resolve("runs-" + System.nanoTime() + ".db"));
+    new SchemaManager(db).migrate();
+    return new RunStore(db);
+  }
+
+  private static final class InterruptingShell implements ShellExec {
+    @Override
+    public Result exec(List<String> command) throws InterruptedException {
+      if (String.join(" ", command).contains("snapshot")) {
+        throw new InterruptedException("interrupted");
+      }
+      return new Result(0, RUNNING_JSON, "");
+    }
+
+    @Override
+    public Result exec(List<String> command, Path workDir, Duration timeout)
+        throws InterruptedException {
+      return exec(command);
+    }
+
+    @Override
+    public boolean isDryRun() {
+      return false;
+    }
+  }
+
+  private static final class HoldingExecutorService extends AbstractExecutorService {
+    private final List<Runnable> held = new ArrayList<>();
+
+    void runAll() {
+      var pending = List.copyOf(held);
+      held.clear();
+      pending.forEach(Runnable::run);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+      held.add(command);
+    }
+
+    @Override
+    public void shutdown() {}
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      return List.of();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return false;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+      return true;
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -134,6 +134,22 @@ class TestOperations implements Operations {
   }
 
   @Override
+  public Result<SnapshotListResponse> snapshots(String project) {
+    return Result.success(new SnapshotListResponse(List.of()));
+  }
+
+  @Override
+  public Result<SnapshotActionResponse> restoreSnapshot(
+      String project, String label, String localHandle) {
+    return Result.success(new SnapshotActionResponse(project, label, "restore", "accepted"));
+  }
+
+  @Override
+  public Result<SnapshotActionResponse> deleteSnapshot(String project, String label) {
+    return Result.success(new SnapshotActionResponse(project, label, "delete", "accepted"));
+  }
+
+  @Override
   public Result<AgentStatusResponse> agentStatus(String project, String localHandle) {
     return Result.success(
         new AgentStatusResponse(project, false, null, null, null, null, null, java.util.List.of()));


### PR DESCRIPTION
Spec: mast-snapshots (the Mast panel consuming this is standardapplied/mast#43).

## What

The read/act snapshot API — thin routes over the existing `SnapshotManager`, no new snapshot mechanism and **no snapshot creation** (cadence stays at the dispatch, guardrail, and invite seams):

- `GET /v1/projects/{p}/snapshots` — name, `created_at`, and a `source` (`invite` / `guardrail` / `dispatch` / `manual`) derived from the naming convention the producers already use. Synchronous (fast metadata query).
- `POST /v1/projects/{p}/snapshots/{label}/restore` and `DELETE /v1/projects/{p}/snapshots/{label}` — **accepted-then-async**: validation, the live-run gate, and a one-mutation-per-project claim run inline; the route returns `202` and the mutation completes on a virtual-thread executor. Dir-backend mutations run up to 10 minutes, far past any client's request timeout, so no request is ever held open for one.

## Completion travels on the bus

The mutation's completion publishes `snapshot_restored` / `snapshot_deleted` — event types that were declared in `Event.WellKnownTypes` but never emitted anywhere until now. A failed mutation publishes the same event with `data.error`, so a stream listener never waits forever.

## Restore is the dangerous verb

It discards the container's current state, so it refuses with the `agent_already_running` (409) vocabulary while **any** run is live on this box's container, and the message names what a restore would discard. The gate uses `listForProject` + `ownsLiveAgent` + `ownsRun` rather than `RunStore.runningForProjectOnNode`, because the latter's role filter excludes invite sessions — and "restore refused while the invite runs" is exactly the field flow this exists for. Restore mirrors the CLI's `RestoreCommand`: stop if running → restore → start.

## Tests

`mvn clean verify` green — 2796 tests, JaCoCo gates met (`SnapshotOperations` and the new `ApiModels` records land under the `api.*` 100% line+method rule; no exclusions added). `SnapshotOperationsTest` covers source classification, the ordered stop→restore→start flow, the spec-run and invite-run refusals, foreign-node non-blocking, unknown/invalid labels, in-flight conflict, failure-event publication with claim release, and interrupt restoration; `ApiRouterTest` covers the routes, methods, and verbatim refusal rendering.