### PR TITLE
Per-spec event history: GET /v1/events?spec= serves the durable record

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -339,6 +339,16 @@ credential minted at dispatch (`SAIL_RUN_CREDENTIAL`), which resolves to the run
 principal; a missing or revoked credential is refused with 401. Every box runs it, and it
 is what lets an engineer dispatch agents locally.
 
+Event history has two read shapes. `GET /v1/events/recent?limit=` is the unscoped window,
+and `GET /v1/events?spec=<id>[&since=<eventId>][&limit=]` serves one spec's durable history
+from the `EventStore`: RECORD-class events only (telemetry is pruned by retention and never
+served from history), oldest first, with `since` an exclusive monotonic event-id cursor for
+gap-fill after an SSE reconnect. The record is **node-local** — there is no event replica,
+so events recorded on another FDE's box never land in this box's audit store (same
+provenance posture as agent logs). The route serves the local record completely; the
+fleet-consistent room content is and remains the durable synced stores — messages, reviews,
+runs.
+
 **Dispatch and agent execution** (`DispatchCommand` plus `sail-harness`): autonomous
 dispatch reads the next ready spec from the database, honoring `depends_on` and assignee,
 marks it `in_progress`, snapshots the container for rollback, creates the work branch, and

--- a/sail-core/src/main/java/ai/singlr/sail/store/EventStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/EventStore.java
@@ -64,6 +64,41 @@ public final class EventStore {
         specId);
   }
 
+  /**
+   * The bounded, ascending history window for one spec: at most {@code limit} rows with {@code id >
+   * afterId} when {@code afterId} is non-null, otherwise the newest {@code limit} rows. Rows whose
+   * type is in {@code excludedTypes} never occupy the window. Both shapes range-scan {@code
+   * idx_events_spec} (spec_id plus the implicit rowid), so a large events table is never scanned.
+   */
+  public List<EventRow> forSpec(String specId, Long afterId, int limit, Set<String> excludedTypes) {
+    if (limit <= 0) {
+      throw new IllegalArgumentException("limit must be positive, got " + limit);
+    }
+    var exclusion =
+        excludedTypes.isEmpty()
+            ? ""
+            : " AND type NOT IN ("
+                + String.join(", ", Collections.nCopies(excludedTypes.size(), "?"))
+                + ")";
+    var parameters = new ArrayList<Object>();
+    parameters.add(specId);
+    if (afterId != null) {
+      parameters.add(afterId);
+    }
+    parameters.addAll(excludedTypes);
+    parameters.add(limit);
+    var sql =
+        "SELECT id, timestamp, type, project, spec_id, agent, host, data FROM events"
+            + " WHERE spec_id = ?"
+            + (afterId != null ? " AND id > ?" : "")
+            + exclusion
+            + " ORDER BY id "
+            + (afterId != null ? "ASC" : "DESC")
+            + " LIMIT ?";
+    var rows = db.query(sql, this::mapEvent, parameters.toArray());
+    return afterId != null ? rows : rows.reversed();
+  }
+
   public List<EventRow> forSpecAndType(String specId, String type) {
     return db.query(
         """

--- a/sail-core/src/test/java/ai/singlr/sail/store/EventStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/EventStoreTest.java
@@ -6,11 +6,13 @@
 package ai.singlr.sail.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,6 +88,101 @@ class EventStoreTest {
   @Test
   void forSpecReturnsEmptyForUnknownSpec() {
     assertTrue(store.forSpec("nonexistent").isEmpty());
+  }
+
+  @Test
+  void boundedForSpecScopesAndOrdersAscending() {
+    store.insert(event("dispatched", "backend", "auth"));
+    store.insert(event("dispatched", "backend", "payment"));
+    store.insert(event("started", "backend", "auth"));
+    store.insert(event("stopped", "backend", "auth"));
+
+    var events = store.forSpec("auth", null, 10, Set.of());
+    assertEquals(3, events.size());
+    assertEquals("dispatched", events.get(0).type());
+    assertEquals("started", events.get(1).type());
+    assertEquals("stopped", events.get(2).type());
+  }
+
+  @Test
+  void boundedForSpecWithoutCursorReturnsNewestWindowOldestFirst() {
+    store.insert(event("first", "backend", "auth"));
+    store.insert(event("second", "backend", "auth"));
+    store.insert(event("third", "backend", "auth"));
+
+    var events = store.forSpec("auth", null, 2, Set.of());
+    assertEquals(2, events.size());
+    assertEquals("second", events.get(0).type());
+    assertEquals("third", events.get(1).type());
+  }
+
+  @Test
+  void boundedForSpecCursorIsExclusive() {
+    store.insert(event("first", "backend", "auth"));
+    var cursor = store.insert(event("second", "backend", "auth"));
+    store.insert(event("noise", "backend", "payment"));
+    store.insert(event("third", "backend", "auth"));
+
+    var events = store.forSpec("auth", cursor, 10, Set.of());
+    assertEquals(1, events.size());
+    assertEquals("third", events.getFirst().type());
+    assertTrue(store.forSpec("auth", events.getFirst().id(), 10, Set.of()).isEmpty());
+  }
+
+  @Test
+  void boundedForSpecCursorRespectsLimitAscending() {
+    var cursor = store.insert(event("seed", "backend", "auth"));
+    store.insert(event("a", "backend", "auth"));
+    store.insert(event("b", "backend", "auth"));
+    store.insert(event("c", "backend", "auth"));
+
+    var events = store.forSpec("auth", cursor, 2, Set.of());
+    assertEquals(2, events.size());
+    assertEquals("a", events.get(0).type());
+    assertEquals("b", events.get(1).type());
+  }
+
+  @Test
+  void boundedForSpecExcludesTypesBeforeApplyingTheLimit() {
+    store.insert(event("record_one", "backend", "auth"));
+    for (var i = 0; i < 5; i++) {
+      store.insert(event("agent_log_chunk", "backend", "auth"));
+    }
+    store.insert(event("record_two", "backend", "auth"));
+
+    var events = store.forSpec("auth", null, 2, Set.of("agent_log_chunk"));
+    assertEquals(2, events.size());
+    assertEquals("record_one", events.get(0).type());
+    assertEquals("record_two", events.get(1).type());
+  }
+
+  @Test
+  void boundedForSpecReturnsEmptyForUnknownSpec() {
+    store.insert(event("dispatched", "backend", "auth"));
+    assertTrue(store.forSpec("nonexistent", null, 10, Set.of()).isEmpty());
+  }
+
+  @Test
+  void boundedForSpecRejectsNonPositiveLimit() {
+    assertThrows(IllegalArgumentException.class, () -> store.forSpec("auth", null, 0, Set.of()));
+  }
+
+  @Test
+  void boundedForSpecUsesTheSpecIndexNotATableScan() {
+    var plans =
+        List.of(
+            "EXPLAIN QUERY PLAN SELECT id FROM events WHERE spec_id = ? AND id > ?"
+                + " AND type NOT IN (?) ORDER BY id ASC LIMIT ?",
+            "EXPLAIN QUERY PLAN SELECT id FROM events WHERE spec_id = ?"
+                + " AND type NOT IN (?) ORDER BY id DESC LIMIT ?");
+    var indexed = db.query(plans.get(0), row -> row.text(3), "auth", 1L, "agent_log_chunk", 10);
+    var newest = db.query(plans.get(1), row -> row.text(3), "auth", "agent_log_chunk", 10);
+    for (var detail : List.of(indexed.getFirst(), newest.getFirst())) {
+      assertTrue(
+          detail.contains("USING INDEX idx_events_spec"),
+          "expected idx_events_spec range scan, got: " + detail);
+      assertFalse(detail.startsWith("SCAN"), "combined predicate must not table-scan: " + detail);
+    }
   }
 
   @Test

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -443,6 +443,23 @@ record RecentEventsResponse(int limit, int returned, List<Map<String, Object>> e
   }
 }
 
+record SpecEventsResponse(
+    String spec, Long since, int limit, int returned, List<Map<String, Object>> events)
+    implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("spec", spec);
+    if (since != null) {
+      m.put("since", since);
+    }
+    m.put("limit", limit);
+    m.put("returned", returned);
+    m.put("events", events);
+    return m;
+  }
+}
+
 record EventBusStatsResponse(
     long published, long rejectedSubscribers, List<SubscriberStatsView> subscribers)
     implements Mappable {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -44,6 +44,8 @@ public final class ApiRouter implements HttpHandler {
   private static final String TAIL = "tail";
   private static final String EVENTS = "events";
   private static final String RECENT = "recent";
+  private static final String SPEC = "spec";
+  private static final String SINCE = "since";
   private static final String STATS = "stats";
   private static final String LIMIT = "limit";
   private static final String BOARD = "board";
@@ -65,6 +67,7 @@ public final class ApiRouter implements HttpHandler {
   private static final int MIN_TAIL = 1;
   private static final int MAX_TAIL = 5000;
   private static final int DEFAULT_RECENT = 100;
+  private static final int MAX_SPEC_EVENTS = 1000;
 
   private final Operations operations;
   private final ApiAuth auth;
@@ -459,10 +462,19 @@ public final class ApiRouter implements HttpHandler {
     throw notFound();
   }
 
+  /**
+   * The events surface. {@code GET /v1/events?spec=<id>[&since=<eventId>][&limit=]} is the
+   * spec-scoped history read: {@code spec} is required for this route shape (the unscoped firehose
+   * stays {@code /recent}), {@code since} is the exclusive monotonic event-id cursor for gap-fill
+   * after an SSE reconnect, and {@code limit} is clamped rather than rejected.
+   */
   private ApiResponse routeEvents(HttpExchange exchange, RouteRequest request) throws IOException {
     if (request.size() == 2) {
-      requireMethod(request, POST);
-      return ApiResponse.from(operations.publishEvent(JsonBody.readEvent(exchange)));
+      return switch (request.method()) {
+        case GET -> specEvents(request);
+        case POST -> ApiResponse.from(operations.publishEvent(JsonBody.readEvent(exchange)));
+        default -> throw methodNotAllowed();
+      };
     }
     if (request.size() == 3) {
       return switch (request.segments().get(2)) {
@@ -479,6 +491,39 @@ public final class ApiRouter implements HttpHandler {
       };
     }
     throw notFound();
+  }
+
+  private ApiResponse specEvents(RouteRequest request) {
+    var params = QueryParameters.from(request.uri()).values();
+    var specId = params.get(SPEC);
+    if (Strings.isBlank(specId)) {
+      throw new ApiException(
+          ErrorCode.INVALID_REQUEST,
+          "spec query parameter is required.",
+          "Use GET /v1/events?spec=<id> for a spec's history;"
+              + " the unscoped window is GET /v1/events/recent.");
+    }
+    NameValidator.requireValidSpecId(specId);
+    return ApiResponse.from(
+        operations.specEvents(
+            specId,
+            sinceOf(params.get(SINCE)),
+            clampedLimit(params.get(LIMIT), DEFAULT_RECENT, MAX_SPEC_EVENTS)));
+  }
+
+  private static Long sinceOf(String value) {
+    if (Strings.isBlank(value)) {
+      return null;
+    }
+    try {
+      var since = Long.parseLong(value);
+      if (since < 0) {
+        throw new NumberFormatException();
+      }
+      return since;
+    } catch (NumberFormatException e) {
+      throw new ApiException(ErrorCode.INVALID_REQUEST, "since must be a non-negative integer.");
+    }
   }
 
   private ApiResponse routeAgent(RouteRequest request, String project) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
@@ -13,6 +13,7 @@ import java.time.format.DateTimeParseException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * One immutable event traveling through the sail {@link EventBus}. Events are emitted by the
@@ -106,9 +107,18 @@ public record Event(
      */
     public static final String AGENT_FAILED = "agent_failed";
 
+    /**
+     * The {@link RetentionClass#TELEMETRY} types: high-volume liveness signals the retention
+     * sweeper prunes and history reads exclude, so "the record" always means RECORD-class events.
+     */
+    public static final Set<String> TELEMETRY_TYPES =
+        Set.of(AGENT_TOOL_STARTED, AGENT_TOOL_FINISHED, AGENT_LOG_CHUNK);
+
     public static RetentionClass retentionClass(String type) {
+      if (TELEMETRY_TYPES.contains(type)) {
+        return RetentionClass.TELEMETRY;
+      }
       return switch (type) {
-        case AGENT_TOOL_STARTED, AGENT_TOOL_FINISHED, AGENT_LOG_CHUNK -> RetentionClass.TELEMETRY;
         case AGENT_PRESENCE, HEARTBEAT -> RetentionClass.EPHEMERAL;
         default -> RetentionClass.RECORD;
       };

--- a/sail-infra/src/main/java/ai/singlr/sail/api/EventRetentionSweeper.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/EventRetentionSweeper.java
@@ -8,7 +8,6 @@ package ai.singlr.sail.api;
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.store.EventStore;
 import java.time.Duration;
-import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -18,12 +17,6 @@ public final class EventRetentionSweeper implements AutoCloseable {
 
   public static final Duration DEFAULT_RETENTION = Duration.ofDays(60);
   public static final int BATCH_SIZE = 5000;
-
-  private static final Set<String> TELEMETRY_TYPES =
-      Set.of(
-          Event.WellKnownTypes.AGENT_TOOL_STARTED,
-          Event.WellKnownTypes.AGENT_TOOL_FINISHED,
-          Event.WellKnownTypes.AGENT_LOG_CHUNK);
 
   private final EventStore events;
   private final Duration retention;
@@ -46,7 +39,9 @@ public final class EventRetentionSweeper implements AutoCloseable {
 
   int sweep() {
     return events.pruneBefore(
-        DateTimeUtils.now().minus(retention).toString(), TELEMETRY_TYPES, BATCH_SIZE);
+        DateTimeUtils.now().minus(retention).toString(),
+        Event.WellKnownTypes.TELEMETRY_TYPES,
+        BATCH_SIZE);
   }
 
   void sweepQuietly() {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
@@ -100,6 +100,16 @@ public interface Operations {
   /** Returns up to {@code limit} most-recent events (oldest first). */
   Result<RecentEventsResponse> recentEvents(int limit);
 
+  /**
+   * The spec's durable event history from this box's audit store, oldest first: RECORD-class events
+   * only, at most {@code limit} rows, and — when {@code since} is non-null — only rows with an
+   * event id strictly greater than it (the gap-fill cursor after an SSE reconnect). {@code since}
+   * null means the newest {@code limit} rows. A spec with no events answers an empty list, never
+   * 404. The record is node-local: events published on another box never land in this store, so the
+   * fleet-consistent room content remains the synced stores (messages, reviews, runs).
+   */
+  Result<SpecEventsResponse> specEvents(String specId, Long since, int limit);
+
   /** Returns per-subscriber + bus stats for {@code /v1/events/stats}. */
   Result<EventBusStatsResponse> eventBusStats();
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -9,6 +9,7 @@ import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecCatalog;
+import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.AgentCli;
 import ai.singlr.sail.engine.AgentReporter;
 import ai.singlr.sail.engine.AgentSession;
@@ -23,6 +24,7 @@ import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.store.BoxCredentialStore;
+import ai.singlr.sail.store.EventStore;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ProjectStore;
@@ -62,6 +64,7 @@ public final class SailOperations implements Operations {
   private final FdeStore fdeStore;
   private MessageStore messageStore;
   private BoxCredentialStore boxCredentialStore;
+  private EventStore eventStore;
 
   public SailOperations() {
     this(new ShellExecutor(false), SailPaths.PROJECT_DESCRIPTOR);
@@ -175,6 +178,12 @@ public final class SailOperations implements Operations {
   /** Wires the box's ambient credential store for the local socket lane; returns {@code this}. */
   public SailOperations useBoxCredentials(BoxCredentialStore boxCredentialStore) {
     this.boxCredentialStore = Objects.requireNonNull(boxCredentialStore, "boxCredentialStore");
+    return this;
+  }
+
+  /** Wires the audit store so per-spec event history is servable; returns {@code this}. */
+  public SailOperations useEvents(EventStore eventStore) {
+    this.eventStore = Objects.requireNonNull(eventStore, "eventStore");
     return this;
   }
 
@@ -1054,6 +1063,59 @@ public final class SailOperations implements Operations {
           var maps = events.stream().map(Event::toMap).toList();
           return new RecentEventsResponse(limit, maps.size(), maps);
         });
+  }
+
+  @Override
+  public Result<SpecEventsResponse> specEvents(String specId, Long since, int limit) {
+    if (Strings.isBlank(specId)) {
+      return Result.failure(ErrorCode.INVALID_REQUEST, "spec is required");
+    }
+    if (since != null && since < 0) {
+      return Result.failure(ErrorCode.INVALID_REQUEST, "since must be non-negative, got " + since);
+    }
+    if (limit <= 0 || limit > 5000) {
+      return Result.failure(
+          ErrorCode.INVALID_REQUEST, "limit must be between 1 and 5000, got " + limit);
+    }
+    if (eventStore == null) {
+      return Result.success(new SpecEventsResponse(specId, since, limit, 0, List.of()));
+    }
+    return safe(
+        () -> {
+          var rows = eventStore.forSpec(specId, since, limit, Event.WellKnownTypes.TELEMETRY_TYPES);
+          var maps = rows.stream().map(SailOperations::eventRowMap).toList();
+          return new SpecEventsResponse(specId, since, limit, maps.size(), maps);
+        });
+  }
+
+  /**
+   * The wire view of a stored event row, matching the shape live SSE frames and {@code /recent}
+   * carry so one client-side decoder serves all three. A row whose data payload no longer parses is
+   * served without it — one damaged row must not take the whole history read down.
+   */
+  private static Map<String, Object> eventRowMap(EventStore.EventRow row) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("v", Event.CURRENT_VERSION);
+    map.put("id", row.id());
+    map.put("ts", row.timestamp());
+    map.put("project", row.project());
+    if (Strings.isNotBlank(row.specId())) {
+      map.put("spec", row.specId());
+    }
+    map.put("type", row.type());
+    map.put("agent", row.agent());
+    map.put("host", row.host());
+    if (Strings.isNotBlank(row.data())) {
+      try {
+        var data = YamlUtil.parseMap(row.data());
+        if (!data.isEmpty()) {
+          map.put("data", data);
+        }
+      } catch (RuntimeException e) {
+        ApiLog.unexpected("parsing stored event data for event " + row.id(), e);
+      }
+    }
+    return map;
   }
 
   @Override

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -199,7 +199,8 @@ public final class ServerStartCommand implements Runnable {
                 syncScheduler,
                 new FdeStore(db))
             .useMessages(messageStore)
-            .useBoxCredentials(boxCredentialStore);
+            .useBoxCredentials(boxCredentialStore)
+            .useEvents(eventStore);
     var orphaned = reviewStore.failOrphanedRunning();
     var orphanedRuns = runStore.failRunningReviewsOnNode(NodeIdentity.handle());
     if (orphanedRuns > 0) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -602,10 +602,88 @@ class ApiRouterTest {
   }
 
   @Test
-  void publishEventRejectsGet() throws Exception {
+  void eventsRejectsUnsupportedMethod() throws Exception {
+    try (var server = server()) {
+      var request =
+          HttpRequest.newBuilder(uri(server, "/v1/events"))
+              .header("Authorization", "Bearer token")
+              .method("DELETE", HttpRequest.BodyPublishers.noBody())
+              .build();
+      var response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+      assertEquals(405, response.statusCode());
+    }
+  }
+
+  @Test
+  void specEventsRequiresSpecQueryParameter() throws Exception {
     try (var server = server()) {
       var response = get(server, "/v1/events", "token");
-      assertEquals(405, response.statusCode());
+      assertEquals(422, response.statusCode());
+      assertTrue(response.body().contains("spec query parameter is required"));
+    }
+  }
+
+  @Test
+  void specEventsReturnsScopedHistory() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/events?spec=auth", "token");
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"spec\": \"auth\""));
+      assertTrue(response.body().contains("\"limit\": 100"));
+      assertTrue(response.body().contains("\"events\""));
+      assertFalse(response.body().contains("\"since\""));
+    }
+  }
+
+  @Test
+  void specEventsPassesSinceCursorThrough() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/events?spec=auth&since=42", "token");
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"since\": 42"));
+    }
+  }
+
+  @Test
+  void specEventsClampsLimitInsteadOfRejecting() throws Exception {
+    try (var server = server()) {
+      assertTrue(
+          get(server, "/v1/events?spec=auth&limit=99999", "token")
+              .body()
+              .contains("\"limit\": 1000"));
+      assertTrue(
+          get(server, "/v1/events?spec=auth&limit=0", "token").body().contains("\"limit\": 1"));
+    }
+  }
+
+  @Test
+  void specEventsRejectsNonNumericLimit() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/events?spec=auth&limit=abc", "token");
+      assertEquals(400, response.statusCode());
+    }
+  }
+
+  @Test
+  void specEventsRejectsInvalidSince() throws Exception {
+    try (var server = server()) {
+      assertEquals(422, get(server, "/v1/events?spec=auth&since=abc", "token").statusCode());
+      assertEquals(422, get(server, "/v1/events?spec=auth&since=-1", "token").statusCode());
+    }
+  }
+
+  @Test
+  void specEventsRejectsInvalidSpecId() throws Exception {
+    try (var server = server()) {
+      var response = get(server, "/v1/events?spec=Bad%20Spec!", "token");
+      assertEquals(422, response.statusCode());
+    }
+  }
+
+  @Test
+  void specEventsRequiresAuth() throws Exception {
+    try (var server = server()) {
+      assertEquals(401, get(server, "/v1/events?spec=auth", null).statusCode());
     }
   }
 
@@ -704,6 +782,14 @@ class ApiRouterTest {
     assertEquals(2, recent.returned());
     assertEquals(1L, stats.rejectedSubscribers());
     assertEquals("audit", stats.subscribers().getFirst().name());
+    var scoped = new SpecEventsResponse("auth", 3L, 100, 1, java.util.List.of(Map.of("id", 4)));
+    assertEquals("auth", scoped.spec());
+    assertEquals(3L, scoped.toMap().get("since"));
+    assertEquals(1, scoped.toMap().get("returned"));
+    assertFalse(
+        new SpecEventsResponse("auth", null, 100, 0, java.util.List.of())
+            .toMap()
+            .containsKey("since"));
   }
 
   @Test
@@ -1556,6 +1642,11 @@ class ApiRouterTest {
     @Override
     public Result<RecentEventsResponse> recentEvents(int limit) {
       return Result.success(new RecentEventsResponse(limit, 0, java.util.List.of()));
+    }
+
+    @Override
+    public Result<SpecEventsResponse> specEvents(String specId, Long since, int limit) {
+      return Result.success(new SpecEventsResponse(specId, since, limit, 0, java.util.List.of()));
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -16,6 +16,7 @@ import ai.singlr.sail.engine.ContainerSailSetup;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.store.BoxCredentialStore;
+import ai.singlr.sail.store.EventStore;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.Finding;
 import ai.singlr.sail.store.MessageStore;
@@ -2393,6 +2394,92 @@ class SailOperationsTest {
       var result = operations.recentEvents(5);
       assertTrue(result.isSuccess());
     }
+  }
+
+  @Test
+  void specEventsRejectsBadArguments() throws Exception {
+    var operations = operations(baseYaml(), shell());
+    assertError(ErrorCode.INVALID_REQUEST, operations.specEvents(" ", null, 10));
+    assertError(ErrorCode.INVALID_REQUEST, operations.specEvents("auth", -1L, 10));
+    assertError(ErrorCode.INVALID_REQUEST, operations.specEvents("auth", null, 0));
+    assertError(ErrorCode.INVALID_REQUEST, operations.specEvents("auth", null, 99999));
+  }
+
+  @Test
+  void specEventsEmptyWhenStoreNotWired() throws Exception {
+    var operations = operations(baseYaml(), shell());
+    var result = operations.specEvents("auth", null, 10);
+    assertTrue(result.isSuccess());
+    assertEquals("auth", get(result, "spec"));
+    assertEquals(0, get(result, "returned"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void specEventsServesTheScopedRecordOldestFirst() throws Exception {
+    var db = Sqlite.open(tempDir.resolve("events-" + System.nanoTime() + ".db"));
+    new SchemaManager(db).migrate();
+    var events = new EventStore(db);
+    events.insert(eventRow("spec_dispatched", "auth", "{\"run_id\": \"r-1\"}"));
+    events.insert(eventRow("agent_log_chunk", "auth", "{}"));
+    events.insert(eventRow("agent_session_stopped", "payment", "{}"));
+    events.insert(eventRow("agent_session_stopped", "auth", "{}"));
+    var operations = operations(baseYaml(), shell()).useEvents(events);
+
+    var result = operations.specEvents("auth", null, 10);
+
+    assertTrue(result.isSuccess());
+    assertEquals(2, get(result, "returned"));
+    var served = (List<Map<String, Object>>) get(result, "events");
+    assertEquals(
+        List.of("spec_dispatched", "agent_session_stopped"),
+        served.stream().map(event -> event.get("type")).toList(),
+        "telemetry and other specs never reach the room");
+    assertEquals("auth", served.getFirst().get("spec"));
+    assertEquals("r-1", ((Map<String, Object>) served.getFirst().get("data")).get("run_id"));
+    assertTrue((long) served.getFirst().get("id") < (long) served.getLast().get("id"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void specEventsSinceCursorIsExclusiveAndLimitBounds() throws Exception {
+    var db = Sqlite.open(tempDir.resolve("events-" + System.nanoTime() + ".db"));
+    new SchemaManager(db).migrate();
+    var events = new EventStore(db);
+    events.insert(eventRow("spec_dispatched", "auth", "{}"));
+    events.insert(eventRow("agent_session_started", "auth", "{}"));
+    events.insert(eventRow("agent_session_stopped", "auth", "{}"));
+    var operations = operations(baseYaml(), shell()).useEvents(events);
+
+    var all = (List<Map<String, Object>>) get(operations.specEvents("auth", null, 10), "events");
+    var cursor = (long) all.getFirst().get("id");
+    var after = (List<Map<String, Object>>) get(operations.specEvents("auth", cursor, 1), "events");
+
+    assertEquals(1, after.size());
+    assertEquals("agent_session_started", after.getFirst().get("type"));
+    assertEquals(
+        0, get(operations.specEvents("auth", (long) all.getLast().get("id"), 10), "returned"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void specEventsServesARowWhoseDataNoLongerParses() throws Exception {
+    var db = Sqlite.open(tempDir.resolve("events-" + System.nanoTime() + ".db"));
+    new SchemaManager(db).migrate();
+    var events = new EventStore(db);
+    events.insert(eventRow("spec_dispatched", "auth", "{broken"));
+    var operations = operations(baseYaml(), shell()).useEvents(events);
+
+    var result = operations.specEvents("auth", null, 10);
+
+    assertTrue(result.isSuccess());
+    var served = (List<Map<String, Object>>) get(result, "events");
+    assertEquals("spec_dispatched", served.getFirst().get("type"));
+  }
+
+  private static EventStore.EventRow eventRow(String type, String specId, String data) {
+    return new EventStore.EventRow(
+        0, "2026-08-17T00:00:00Z", type, "acme", specId, "sail", "host-01", data);
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -227,6 +227,11 @@ class TestOperations implements Operations {
   }
 
   @Override
+  public Result<SpecEventsResponse> specEvents(String specId, Long since, int limit) {
+    return Result.success(new SpecEventsResponse(specId, since, limit, 0, List.of()));
+  }
+
+  @Override
   public Result<EventBusStatsResponse> eventBusStats() {
     return Result.success(new EventBusStatsResponse(0L, 0L, List.of()));
   }


### PR DESCRIPTION
Spec: sail-spec-events (mast PR: standardapplied/mast — same branch name).

## Why

The audit store keeps every RECORD-class event forever (retention prunes telemetry only), but the API could only answer the single global `/v1/events/recent?limit=` window. Mast's rooms backfilled from the last 100 global events, so on an active control plane a spec's lifecycle rows (dispatches, stops, review beats, guardrails, snapshots) silently vanished from its room while sitting durably in the store. Storage existed; retrieval was never finished.

## What

- **`GET /v1/events?spec=<id>[&since=<eventId>][&limit=]`** — a thin route over the store. `spec` is required for this shape (the unscoped firehose stays `/recent`); `since` is the exclusive monotonic event-id cursor for gap-fill after SSE reconnects, omitted means the newest `limit` rows; results are oldest first; `limit` is clamped (default 100, max 1000); same auth tier as every other read.
- **`EventStore.forSpec(specId, afterId, limit, excludedTypes)`** — the bounded variant. Both query shapes range-scan `idx_events_spec` (spec_id + implicit rowid); a query-plan test asserts no table scan.
- **RECORD-only** — telemetry types are excluded in SQL so they never occupy the window. The telemetry taxonomy now lives once, in `Event.WellKnownTypes.TELEMETRY_TYPES`, shared by `retentionClass` and the retention sweeper. Retention itself is unchanged.
- **Semantics** — a spec with no events answers an empty list, never 404; history stays readable while the spec row exists. A stored row whose data payload no longer parses is served without its data rather than failing the whole read.
- **Wiring** — the production server's `SailOperations` never had a working `/recent` source (`SpecStoreAuditPersister` is not an `AuditPersister`), so the new read is wired explicitly via `useEvents(eventStore)` in `ServerStartCommand`.
- **Contract** — event history is node-local: there is no event replica, and events recorded on another FDE's box never land in this box's store. ARCHITECTURE.md now states this plainly (same provenance posture as agent logs). The fleet-consistent room content remains the synced stores: messages, reviews, runs.

Behavior change: `GET /v1/events` without `spec` now answers 422 with a pointer to both shapes (previously 405).

## Verification

`mvn clean verify` green (all modules, coverage gates included). New tests: store scoping/`since` exclusivity/limit/telemetry exclusion/query plan; operations validation, wiring-absent, corrupt-data tolerance; route auth, missing/invalid `spec`, `since` validation, limit clamping.