### PR TITLE
fix: async full invites, skip-snapshot option, auto-assign new rooms

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -645,10 +645,13 @@ record SpecRestoreRequest(String rev) {
 }
 
 /** Body of {@code POST /v1/specs/{id}/invite}: the agent to invite and the one mode choice. */
-record InviteRequest(String agent, String model, boolean full) {
+record InviteRequest(String agent, String model, boolean full, boolean snapshot) {
   static InviteRequest fromMap(Map<String, Object> map) {
     return new InviteRequest(
-        (String) map.get("agent"), (String) map.get("model"), Boolean.TRUE.equals(map.get("full")));
+        (String) map.get("agent"),
+        (String) map.get("model"),
+        Boolean.TRUE.equals(map.get("full")),
+        !Boolean.FALSE.equals(map.get("snapshot")));
   }
 }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -649,6 +649,23 @@ public final class DispatchOperations {
       String model,
       Actor actor,
       String localHandle) {
+    return startInvite(specId, agentYamlName, full, true, model, actor, localHandle);
+  }
+
+  /**
+   * As {@link #startInvite(String, String, boolean, String, Actor, String)}, but {@code
+   * takeSnapshot} may waive the pre-launch snapshot on a full invite. Skipping trades the rollback
+   * point for an instant launch — the escape hatch for the {@code dir} backend, where a snapshot is
+   * a slow full filesystem copy. Read only never snapshots, so the flag is a no-op there.
+   */
+  public InviteLaunch startInvite(
+      String specId,
+      String agentYamlName,
+      boolean full,
+      boolean takeSnapshot,
+      String model,
+      Actor actor,
+      String localHandle) {
     if (runStore == null) {
       throw new ApiException(
           ErrorCode.COMMAND_FAILED,
@@ -715,7 +732,7 @@ public final class DispatchOperations {
       throw e;
     }
     var principal = runStore.findById(runId).map(RunStore.RunRow::principal).orElse("");
-    var snapshot = full ? "invite-" + runId : "";
+    var snapshot = full && takeSnapshot ? "invite-" + runId : "";
     Runnable completion =
         () ->
             completeInvite(
@@ -762,7 +779,9 @@ public final class DispatchOperations {
       String snapshot) {
     try {
       if (full) {
-        inviteSnapshot(project, specId, runId);
+        if (!Strings.isBlank(snapshot)) {
+          inviteSnapshot(project, specId, runId);
+        }
       } else {
         captureRoomBaseline(project, config, runId);
       }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -67,6 +67,8 @@ public final class DispatchOperations {
 
   private static final Duration SNAPSHOT_INTERVAL = Duration.ofHours(24);
 
+  private static final Duration INVITE_SNAPSHOT_TIMEOUT = Duration.ofHours(1);
+
   /** One dispatch invocation, lane-agnostic. */
   public record Request(
       String specId, String mode, boolean dryRun, List<String> repos, boolean restart) {}
@@ -91,10 +93,16 @@ public final class DispatchOperations {
       Optional<WatcherSpawner.Spawned> watcher) {}
 
   /**
-   * One launched invite: the run it minted, the principal it posts under, its mode, and — full mode
-   * only — the label of the pre-launch snapshot ({@code ""} for read only).
+   * One accepted invite: the run it reserved, the principal it posts under, its mode, and — full
+   * mode only — the label of the pre-launch snapshot ({@code ""} for read only). {@code completion}
+   * runs the deferred work — the snapshot (full) and the launch — off the request thread, so the
+   * caller returns immediately (a dir-backend snapshot is a slow full copy that would blow the
+   * client timeout and, if the request were force-killed mid-copy, leave the container in Error).
+   * The reservation is already held when this record exists; {@code completion} releases it and
+   * publishes a failure event if the snapshot or launch fails.
    */
-  public record InviteLaunch(String runId, String principal, boolean full, String snapshot) {}
+  public record InviteLaunch(
+      String runId, String principal, boolean full, String snapshot, Runnable completion) {}
 
   /**
    * Container preparation that must not run until the whole-container reservation is won — the
@@ -702,9 +710,59 @@ public final class DispatchOperations {
             config);
     try {
       seedRoomDelivery(runId, built.renderedMessages());
-      var snapshot = "";
+    } catch (RuntimeException e) {
+      releaseIfAbsent(runId, project, unit);
+      throw e;
+    }
+    var principal = runStore.findById(runId).map(RunStore.RunRow::principal).orElse("");
+    var snapshot = full ? "invite-" + runId : "";
+    Runnable completion =
+        () ->
+            completeInvite(
+                project,
+                config,
+                specId,
+                runId,
+                unit,
+                agentCli,
+                inviteModel,
+                task,
+                branch,
+                targetRepos,
+                repoPaths,
+                credential,
+                role,
+                full,
+                snapshot);
+    return new InviteLaunch(runId, principal, full, snapshot, completion);
+  }
+
+  /**
+   * The deferred half of an invite, run off the request thread: take the pre-launch snapshot (full
+   * mode) or capture the room baseline (read only), then launch the session. The reservation is
+   * already held. A snapshot or launch failure releases it and publishes {@code snapshot_created}
+   * carrying an {@code error} — there is no caller left to throw to, so the room learns the invite
+   * failed through the stream.
+   */
+  private void completeInvite(
+      String project,
+      SailYaml config,
+      String specId,
+      String runId,
+      AgentUnit unit,
+      AgentCli agentCli,
+      String inviteModel,
+      String task,
+      String branch,
+      List<SailYaml.Repo> targetRepos,
+      List<String> repoPaths,
+      String credential,
+      String role,
+      boolean full,
+      String snapshot) {
+    try {
       if (full) {
-        snapshot = inviteSnapshot(project, specId, runId);
+        inviteSnapshot(project, specId, runId);
       } else {
         captureRoomBaseline(project, config, runId);
       }
@@ -739,12 +797,19 @@ public final class DispatchOperations {
         publishAgentSessionStarted(
             project, specId, agentCli.yamlName(), status.pid(), runId, launch.watcher());
       }
-      var principal = runStore.findById(runId).map(RunStore.RunRow::principal).orElse("");
-      return new InviteLaunch(runId, principal, full, snapshot);
     } catch (RuntimeException e) {
       releaseIfAbsent(runId, project, unit);
-      throw e;
+      publishInviteFailed(project, specId, runId, snapshot, e);
     }
+  }
+
+  private void publishInviteFailed(
+      String project, String specId, String runId, String snapshot, RuntimeException e) {
+    var data = new LinkedHashMap<String, Object>();
+    data.put("label", snapshot);
+    data.put(Event.WellKnownData.RUN_ID, runId);
+    data.put("error", Objects.requireNonNullElse(e.getMessage(), e.toString()));
+    publish(project, specId, Event.WellKnownTypes.SNAPSHOT_CREATED, data);
   }
 
   /**
@@ -806,7 +871,7 @@ public final class DispatchOperations {
   private String inviteSnapshot(String project, String specId, String runId) {
     var label = "invite-" + runId;
     try {
-      new SnapshotManager(shell).create(project, label);
+      new SnapshotManager(shell).create(project, label, INVITE_SNAPSHOT_TIMEOUT);
     } catch (Exception e) {
       throw new ApiException(
           ErrorCode.SNAPSHOT_FAILED,

--- a/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
@@ -100,13 +100,14 @@ final class GlobalSpecOperations {
           "spec project is required.",
           "Pass --project <name> or run from a directory containing sail.yaml.");
     }
+    var assignee = Strings.isBlank(request.assignee()) ? request.createdBy() : request.assignee();
     var row =
         new SpecStore.SpecRow(
             request.id(),
             request.project(),
             request.title(),
             parseStatus(request.status(), SpecStatus.PENDING),
-            request.assignee(),
+            assignee,
             request.agent(),
             validModel(request.model()),
             validReasoning(request.reasoningEffort()),

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -40,6 +40,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
 public final class SailOperations implements Operations {
@@ -62,6 +64,7 @@ public final class SailOperations implements Operations {
   private final DispatchOperations dispatchOps;
   private final StopOperations stopOps;
   private final FdeStore fdeStore;
+  private final ExecutorService inviteExecutor = Executors.newVirtualThreadPerTaskExecutor();
   private MessageStore messageStore;
   private BoxCredentialStore boxCredentialStore;
   private EventStore eventStore;
@@ -440,6 +443,7 @@ public final class SailOperations implements Operations {
     var launch =
         dispatchOps.startInvite(
             specId, request.agent(), request.full(), request.model(), actor, localHandle);
+    inviteExecutor.submit(launch.completion());
     return new InviteResponse(
         launch.runId(),
         launch.principal(),

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
@@ -64,7 +64,7 @@ public final class SailOperations implements Operations {
   private final DispatchOperations dispatchOps;
   private final StopOperations stopOps;
   private final FdeStore fdeStore;
-  private final ExecutorService inviteExecutor = Executors.newVirtualThreadPerTaskExecutor();
+  private Executor inviteExecutor = Executors.newVirtualThreadPerTaskExecutor();
   private MessageStore messageStore;
   private BoxCredentialStore boxCredentialStore;
   private EventStore eventStore;
@@ -175,6 +175,17 @@ public final class SailOperations implements Operations {
   public SailOperations useMessages(MessageStore messageStore) {
     this.messageStore = Objects.requireNonNull(messageStore, "messageStore");
     this.dispatchOps.useMessages(messageStore);
+    return this;
+  }
+
+  /**
+   * Overrides the executor that runs the deferred half of an invite (snapshot + launch). Production
+   * keeps the default virtual-thread executor; a test injects {@code Runnable::run} to make the
+   * completion run inline, so its assertions and teardown see a finished launch. Returns {@code
+   * this}.
+   */
+  SailOperations useInviteExecutor(Executor executor) {
+    this.inviteExecutor = Objects.requireNonNull(executor, "executor");
     return this;
   }
 
@@ -442,8 +453,14 @@ public final class SailOperations implements Operations {
       String specId, InviteRequest request, Actor actor, String localHandle) {
     var launch =
         dispatchOps.startInvite(
-            specId, request.agent(), request.full(), request.model(), actor, localHandle);
-    inviteExecutor.submit(launch.completion());
+            specId,
+            request.agent(),
+            request.full(),
+            request.snapshot(),
+            request.model(),
+            actor,
+            localHandle);
+    inviteExecutor.execute(launch.completion());
     return new InviteResponse(
         launch.runId(),
         launch.principal(),

--- a/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
@@ -67,6 +67,27 @@ class GlobalSpecOperationsTest {
   }
 
   @Test
+  void createAutoAssignsToTheCreatorWhenUnassigned() {
+    ops.create(createReq(Map.of()).withCreatedBy("uday"));
+    assertEquals(
+        "uday",
+        ops.get("auth").spec().assignee(),
+        "a new room lands on the caller so their box wakes it — no orphan on nobody's board");
+  }
+
+  @Test
+  void createKeepsAnExplicitAssigneeOverTheCreator() {
+    ops.create(createReq(Map.of("assignee", "alice")).withCreatedBy("uday"));
+    assertEquals("alice", ops.get("auth").spec().assignee());
+  }
+
+  @Test
+  void createLeavesTheAssigneeBlankWhenTheCallerOwnsNoFde() {
+    ops.create(createReq(Map.of()));
+    assertNull(ops.get("auth").spec().assignee());
+  }
+
+  @Test
   void clientSuppliedCreatedByIsIgnored() {
     ops.create(createReq(Map.of("created_by", "attacker")));
     assertNull(ops.get("auth").spec().createdBy());

--- a/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
@@ -307,6 +307,28 @@ class InviteLaunchTest {
   }
 
   @Test
+  void aFullInviteCanSkipTheSnapshotAndLaunchImmediately() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth", HANDLE, "agent/auth");
+
+    var launch =
+        ops.startInvite(
+            "auth", "claude-code", true, false, null, Actor.cliOperator(HANDLE), HANDLE);
+
+    assertEquals("", launch.snapshot(), "a skipped snapshot has no label");
+    assertEquals("invite-full", runStore.findById(launch.runId()).orElseThrow().role());
+
+    launch.completion().run();
+
+    assertEquals(List.of("launch"), order, "the launch runs with no snapshot before it");
+    assertTrue(
+        events.stream().noneMatch(e -> Event.WellKnownTypes.SNAPSHOT_CREATED.equals(e.type())),
+        "skipping the snapshot publishes no snapshot event");
+    var joined = String.join(" ", launched.get());
+    assertTrue(joined.contains("--dangerously-skip-permissions"), "full access still launches");
+  }
+
+  @Test
   void aCodexReadOnlyInviteIsRefusedNamingWhatItSupports() throws Exception {
     var ops = operations(liveAgentShell());
     seedSpec("auth");
@@ -489,12 +511,13 @@ class InviteLaunchTest {
                   specStore,
                   new ReviewStore(db),
                   runStore)
-              .useMessages(messageStore);
+              .useMessages(messageStore)
+              .useInviteExecutor(Runnable::run);
 
       var launched =
           sailOps.inviteToSpec(
               "auth",
-              new InviteRequest("claude-code", null, false),
+              new InviteRequest("claude-code", null, false, true),
               Actor.cliOperator(HANDLE),
               HANDLE);
       assertTrue(launched instanceof Result.Success<InviteResponse>);
@@ -505,7 +528,10 @@ class InviteLaunchTest {
 
       var refused =
           sailOps.inviteToSpec(
-              "auth", new InviteRequest("codex", null, false), Actor.cliOperator(HANDLE), HANDLE);
+              "auth",
+              new InviteRequest("codex", null, false, true),
+              Actor.cliOperator(HANDLE),
+              HANDLE);
       assertTrue(refused instanceof Result.Failure<InviteResponse>);
       assertEquals(ErrorCode.BAD_REQUEST, ((Result.Failure<InviteResponse>) refused).errorCode());
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
@@ -160,6 +160,7 @@ class InviteLaunchTest {
 
     var launch =
         ops.startInvite("auth", "claude-code", false, null, Actor.cliOperator(HANDLE), HANDLE);
+    launch.completion().run();
 
     var run = runStore.findById(launch.runId()).orElseThrow();
     assertEquals("invite", run.role());
@@ -225,12 +226,17 @@ class InviteLaunchTest {
     var launch =
         ops.startInvite("auth", "claude-code", true, "opus-x", Actor.cliOperator(HANDLE), HANDLE);
 
-    var run = runStore.findById(launch.runId()).orElseThrow();
-    assertEquals("invite-full", run.role());
-    assertEquals(List.of("app"), run.repos(), "full reserves like a build");
-    assertEquals("agent/auth", run.branch());
-    assertEquals("claude/invite-" + launch.runId(), run.principal());
+    var reserved = runStore.findById(launch.runId()).orElseThrow();
+    assertEquals("invite-full", reserved.role());
+    assertEquals(List.of("app"), reserved.repos(), "full reserves like a build");
+    assertEquals("agent/auth", reserved.branch());
+    assertEquals("claude/invite-" + launch.runId(), reserved.principal());
     assertEquals("invite-" + launch.runId(), launch.snapshot());
+    assertEquals(List.of(), order, "the invite returns before the snapshot or launch runs");
+
+    launch.completion().run();
+
+    var run = runStore.findById(launch.runId()).orElseThrow();
     assertEquals(List.of("snapshot", "launch"), order, "the snapshot precedes the launch");
     assertTrue(run.task().contains("Invite Duty (full access)"));
     var joined = String.join(" ", launched.get());
@@ -282,19 +288,22 @@ class InviteLaunchTest {
     var ops = operations(shell);
     seedSpec("auth");
 
-    var failure =
-        assertThrows(
-            ApiException.class,
-            () ->
-                ops.startInvite(
-                    "auth", "claude-code", true, null, Actor.cliOperator(HANDLE), HANDLE));
+    var launch =
+        ops.startInvite("auth", "claude-code", true, null, Actor.cliOperator(HANDLE), HANDLE);
+    launch.completion().run();
 
-    assertEquals(ErrorCode.SNAPSHOT_FAILED, failure.failure().errorCode());
     assertEquals(null, launched.get(), "the invite does not launch without its rollback point");
     var run = runStore.listForSpec("auth").getFirst();
     assertEquals("failed", run.status(), "the reservation is released through the failed run");
-    assertTrue(
-        events.stream().noneMatch(e -> Event.WellKnownTypes.SNAPSHOT_CREATED.equals(e.type())));
+    var failure =
+        events.stream()
+            .filter(e -> Event.WellKnownTypes.SNAPSHOT_CREATED.equals(e.type()))
+            .findFirst()
+            .orElseThrow();
+    assertEquals("auth", failure.spec(), "the room learns the invite failed through the stream");
+    assertEquals("invite-" + launch.runId(), failure.data().get("label"));
+    assertEquals(launch.runId(), failure.data().get(Event.WellKnownData.RUN_ID));
+    assertNotNull(failure.data().get("error"), "the failure carries a reason the room can render");
   }
 
   @Test
@@ -319,6 +328,7 @@ class InviteLaunchTest {
     seedSpec("auth");
 
     var launch = ops.startInvite("auth", "codex", true, null, Actor.cliOperator(HANDLE), HANDLE);
+    launch.completion().run();
 
     assertEquals("invite-full", runStore.findById(launch.runId()).orElseThrow().role());
     assertEquals("codex/invite-" + launch.runId(), launch.principal());


### PR DESCRIPTION
Fixes three field-testing issues in the invite feature, plus a new skip-snapshot option. Pairs with mast PR (same branch name).

## Issue #3 — a full invite froze the box (the serious one)

A full invite snapshots the container before launching. On the **dir** storage backend (which we always run) an incus snapshot is a live `rsync` full-copy — no freeze, no CoW; the "freeze" the tester saw was I/O saturation, not a pause (confirmed from incus source). It can take minutes on a large workspace, far past the client's request timeout. The invite ran that snapshot **synchronously on the request thread**, so the client timed out reaching `:7070`, the request was force-killed mid-copy, and the container dropped to **Error** state — taking the box down.

**Fix:** `startInvite` splits into an accepted half and a deferred half. The request thread validates, reserves, and seeds the room, then returns an `InviteLaunch` carrying a completion `Runnable`; `SailOperations` submits it to a virtual-thread executor and answers immediately. The completion takes the snapshot (generous 1h timeout, **never a mid-copy force-kill**) then launches. A snapshot or launch failure has no caller to throw to, so it releases the reservation and publishes `snapshot_created` carrying a `data.error` the room renders. The strict `DispatchOperations` constructor is untouched (the completion-closure avoids rippling it).

## Issue #1 — new rooms orphaned

`GlobalSpecOperations.create` now defaults a blank `assignee` to the creator's FDE, so a freshly created room lands on the caller's board and their box wakes it. A blank creator (machine credential, no FDE) leaves it unassigned.

## New — skip the snapshot

`InviteRequest` gains a `snapshot` flag (default true; absent/older clients still snapshot), threaded to a new `startInvite` overload taking `takeSnapshot`. Full + skip launches immediately with an empty snapshot label — the escape hatch for the slow dir backend. The label being non-empty is the single signal that a snapshot was taken, so read-only and full-skip both settle on the 202 with nothing to wait on.

The invite-completion executor is injectable so the server-lane test runs it inline (`Runnable::run`) rather than racing db teardown on a background thread.

## Why CI didn't catch it

The incus IT lane snapshots a fresh, tiny CI container via the direct API — it finishes in milliseconds, never fills disk, and never goes through the client's tunnel timeout. None of the field conditions were reproduced, and the tests asserted "snapshot succeeds," not "invite returns before the client times out." The reworked `InviteLaunchTest` now pins the accept-then-async contract directly.

## Tests

- `InviteLaunchTest`: async contract (returns before snapshot; completion snapshots-then-launches; failure publishes the error event), skip-snapshot (no snapshot event, launch runs), server-lane inline executor.
- `GlobalSpecOperationsTest`: auto-assign to creator, explicit assignee preserved, blank when no FDE.
- Full sail-infra suite: 2822 tests, 0 failures.
