### PR TITLE
gh and ripgrep in every container baseline

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/engine/ContainerExec.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/ContainerExec.java
@@ -63,6 +63,21 @@ public final class ContainerExec {
   }
 
   /**
+   * Builds an {@code incus exec} command that runs the given args as root — the privilege apt and
+   * dpkg need. Mirrors {@link #asDevUser} for the few operations (baseline package installs) that
+   * cannot run as the dev user, and validates the container name the same way.
+   *
+   * @param containerName the Incus container name
+   * @param args the command and arguments to run inside the container
+   * @return an unmodifiable command list ready for {@link ShellExec#exec}
+   */
+  public static List<String> asRoot(String containerName, List<String> args) {
+    NameValidator.requireValidProjectName(containerName);
+    var prefix = List.of("incus", "exec", containerName, "--");
+    return Stream.concat(prefix.stream(), args.stream()).toList();
+  }
+
+  /**
    * Queries running Podman containers inside an Incus container and extracts the published host
    * ports. Returns a deduplicated, sorted list of port numbers. Returns an empty list if no
    * containers are running or the query fails.

--- a/sail-core/src/test/java/ai/singlr/sail/engine/ContainerExecTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/ContainerExecTest.java
@@ -69,6 +69,27 @@ class ContainerExecTest {
   }
 
   @Test
+  void asRootBuildsBarePrefixWithNoUserSwitch() {
+    var cmd = ContainerExec.asRoot("acme", List.of("dpkg", "-s", "gh"));
+
+    assertEquals(List.of("incus", "exec", "acme", "--", "dpkg", "-s", "gh"), cmd);
+  }
+
+  @Test
+  void asRootRejectsInvalidContainerName() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ContainerExec.asRoot("proj;touch-owned", List.of("apt-get", "update")));
+  }
+
+  @Test
+  void asRootReturnsUnmodifiableList() {
+    var cmd = ContainerExec.asRoot("proj", List.of("echo", "hi"));
+
+    assertThrows(UnsupportedOperationException.class, () -> cmd.add("extra"));
+  }
+
+  @Test
   void queryServicePortsExtractsHostPorts() throws Exception {
     var podmanJson =
         """

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectApplyCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ProjectApplyCommand.java
@@ -448,6 +448,7 @@ public final class ProjectApplyCommand implements Runnable {
     var token = Strings.isNotBlank(gitToken) ? gitToken : null;
 
     var results = new ArrayList<ProjectApplier.ApplyResult>();
+    results.add(applier.applyPackages(project, config.packages()));
     results.add(applier.applyServices(project, config.services()));
     results.add(applier.reconcileServices(project, config.services()));
     results.add(

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectApplier.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectApplier.java
@@ -60,6 +60,52 @@ public final class ProjectApplier {
   }
 
   /**
+   * Installs missing apt packages — the sail baseline plus any declared in sail.yaml. Packages
+   * already installed are skipped, so a converge on a current container never touches apt. This is
+   * how containers provisioned before a baseline addition pick up the new tools.
+   */
+  public ApplyResult applyPackages(String name, List<String> configPackages)
+      throws IOException, InterruptedException, TimeoutException {
+    var desired = new ArrayList<>(ProjectProvisioner.BASELINE_PACKAGES);
+    if (configPackages != null) {
+      configPackages.stream().filter(p -> !desired.contains(p)).forEach(desired::add);
+    }
+    var missing = new ArrayList<String>();
+    var skipped = 0;
+    for (var pkg : desired) {
+      var check = probes.exec(asRoot(name, List.of("dpkg", "-s", pkg)));
+      if (check.ok()) {
+        skipped++;
+      } else {
+        missing.add(pkg);
+      }
+    }
+    if (missing.isEmpty()) {
+      out.println("  [skip] All " + skipped + " packages already installed");
+      return new ApplyResult(0, 0, skipped, List.of());
+    }
+    out.println("  [add] Installing package(s): " + String.join(", ", missing) + "...");
+    var update =
+        shell.exec(asRoot(name, List.of("apt-get", "update", "-qq")), null, INSTALL_TIMEOUT);
+    if (!update.ok()) {
+      throw new IOException("Failed to update package lists: " + update.stderr());
+    }
+    var install = new ArrayList<>(List.of("apt-get", "install", "-y", "-qq"));
+    install.addAll(missing);
+    var result = shell.exec(asRoot(name, install), null, INSTALL_TIMEOUT);
+    if (!result.ok()) {
+      throw new IOException("Failed to install packages: " + result.stderr());
+    }
+    return new ApplyResult(missing.size(), 0, skipped, List.of());
+  }
+
+  private static List<String> asRoot(String name, List<String> args) {
+    var cmd = new ArrayList<>(List.of("incus", "exec", name, "--"));
+    cmd.addAll(args);
+    return cmd;
+  }
+
+  /**
    * Applies new services from the config. Services already running in the container are skipped.
    */
   public ApplyResult applyServices(String name, Map<String, SailYaml.Service> services)

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectApplier.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectApplier.java
@@ -73,7 +73,7 @@ public final class ProjectApplier {
     var missing = new ArrayList<String>();
     var skipped = 0;
     for (var pkg : desired) {
-      var check = probes.exec(asRoot(name, List.of("dpkg", "-s", pkg)));
+      var check = probes.exec(ContainerExec.asRoot(name, List.of("dpkg", "-s", pkg)));
       if (check.ok()) {
         skipped++;
       } else {
@@ -86,23 +86,18 @@ public final class ProjectApplier {
     }
     out.println("  [add] Installing package(s): " + String.join(", ", missing) + "...");
     var update =
-        shell.exec(asRoot(name, List.of("apt-get", "update", "-qq")), null, INSTALL_TIMEOUT);
+        shell.exec(
+            ContainerExec.asRoot(name, List.of("apt-get", "update", "-qq")), null, INSTALL_TIMEOUT);
     if (!update.ok()) {
       throw new IOException("Failed to update package lists: " + update.stderr());
     }
     var install = new ArrayList<>(List.of("apt-get", "install", "-y", "-qq"));
     install.addAll(missing);
-    var result = shell.exec(asRoot(name, install), null, INSTALL_TIMEOUT);
+    var result = shell.exec(ContainerExec.asRoot(name, install), null, INSTALL_TIMEOUT);
     if (!result.ok()) {
       throw new IOException("Failed to install packages: " + result.stderr());
     }
     return new ApplyResult(missing.size(), 0, skipped, List.of());
-  }
-
-  private static List<String> asRoot(String name, List<String> args) {
-    var cmd = new ArrayList<>(List.of("incus", "exec", name, "--"));
-    cmd.addAll(args);
-    return cmd;
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectProvisioner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectProvisioner.java
@@ -38,8 +38,8 @@ public final class ProjectProvisioner {
   private static final String MAVEN_ARCHIVE_BASE_URL =
       "https://archive.apache.org/dist/maven/maven-3/";
 
-  private static final List<String> BASELINE_PACKAGES =
-      List.of("curl", "wget", "git", "sudo", "openssh-server");
+  static final List<String> BASELINE_PACKAGES =
+      List.of("curl", "wget", "git", "sudo", "openssh-server", "gh", "ripgrep");
 
   private final ShellExec shell;
   private final ProvisionTracker<ProjectPhase> tracker;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/AbstractIncusIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/AbstractIncusIT.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Shared plumbing for integration tests that drive a real incus daemon — the boundary unit tests
@@ -62,20 +63,26 @@ public abstract class AbstractIncusIT {
         launched.ok(), "could not launch test container " + IMAGE + ": " + launched.stderr());
   }
 
-  private static final String PREPARED_ALIAS = "sail-it-prepared";
+  private static final String PREPARED_ALIAS = "sail-it-prepared-v2";
   private static final String BUILDER = "sail-it-image-builder";
   private static final List<String> PREPARED_PACKAGES =
-      List.of("curl", "git", "python3", "podman", "uidmap");
+      Stream.concat(
+              ProjectProvisioner.BASELINE_PACKAGES.stream(),
+              Stream.of("python3", "podman", "uidmap"))
+          .distinct()
+          .toList();
   private static final Object PREPARE_LOCK = new Object();
   private static boolean preparedImageReady;
 
   /**
    * Launches {@code container} from the locally published prepared image — the base image plus
-   * every package the incus suite needs. The image is baked at most once per host: baking is the
-   * only step that touches the network (the public image server, container DNS, the apt archive),
-   * each stage is retried and fails naming itself with diagnostics, and every test launch
-   * afterwards is a local copy. Tests must never reach the internet from inside their own bodies —
-   * a bootstrap that depends on external infrastructure at test time is a defect of the test.
+   * every package the incus suite needs, including sail's full provisioning baseline. The alias is
+   * versioned: bump it whenever the package set changes so hosts holding an older bake rebuild
+   * instead of serving a stale image. The image is baked at most once per host: baking is the only
+   * step that touches the network (the public image server, container DNS, the apt archive), each
+   * stage is retried and fails naming itself with diagnostics, and every test launch afterwards is
+   * a local copy. Tests must never reach the internet from inside their own bodies — a bootstrap
+   * that depends on external infrastructure at test time is a defect of the test.
    */
   protected void launchPrepared(String container) throws Exception {
     synchronized (PREPARE_LOCK) {

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/BaselinePackagesIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/BaselinePackagesIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates the baseline tool guarantee against a real Ubuntu 24.04 container: a freshly prepared
+ * container exposes {@code gh} and {@code rg} to the dev user (the bake fails loudly if either apt
+ * name stops resolving on the image), and {@link ProjectApplier#applyPackages} restores them
+ * additively on a container that predates the baseline — the converge path an upgraded box rides —
+ * while a current container converges as a pure skip without touching apt.
+ */
+class BaselinePackagesIT extends AbstractIncusIT {
+
+  private static final String CONTAINER = "sail-it-baseline";
+
+  @Test
+  void baselineToolsPresentFreshAndRestoredByConverge() throws Exception {
+    ensureIncusOrSkip();
+    try {
+      launchPrepared(CONTAINER);
+      var dev =
+          exec(
+              CONTAINER,
+              List.of(
+                  "bash",
+                  "-c",
+                  "userdel -r ubuntu 2>/dev/null || true;"
+                      + " id -u dev >/dev/null 2>&1 || useradd -m -u 1000 -s /bin/bash dev"));
+      assertTrue(dev.ok(), "the dev user must exist: " + dev.stderr());
+      assertToolRuns("gh");
+      assertToolRuns("rg");
+
+      var applier = new ProjectApplier(shell, new PrintStream(OutputStream.nullOutputStream()));
+      var noop = applier.applyPackages(CONTAINER, null);
+      assertEquals(0, noop.added(), "a current container must not reinstall anything");
+      assertEquals(
+          ProjectProvisioner.BASELINE_PACKAGES.size(),
+          noop.skipped(),
+          "every baseline package must be detected as present");
+
+      var removed = exec(CONTAINER, List.of("apt-get", "remove", "-y", "-qq", "gh", "ripgrep"));
+      assertTrue(removed.ok(), "could not stage the pre-baseline container: " + removed.stderr());
+
+      var converge = applier.applyPackages(CONTAINER, null);
+
+      assertEquals(2, converge.added(), "converge must install exactly the missing baseline tools");
+      assertToolRuns("gh");
+      assertToolRuns("rg");
+    } finally {
+      deleteContainerQuietly(CONTAINER);
+    }
+  }
+
+  private void assertToolRuns(String binary) throws Exception {
+    var result = shell.exec(ContainerExec.asDevUser(CONTAINER, List.of(binary, "--version")));
+    assertTrue(result.ok(), binary + " --version must succeed as the dev user: " + result.stderr());
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectApplierTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectApplierTest.java
@@ -28,6 +28,105 @@ class ProjectApplierTest {
   @TempDir Path tempDir;
 
   @Test
+  void applyPackagesInstallsMissingBaselineTools() throws Exception {
+    var shell =
+        new ScriptedShellExecutor()
+            .onFail("dpkg -s gh", "package 'gh' is not installed")
+            .onFail("dpkg -s ripgrep", "package 'ripgrep' is not installed")
+            .onOk("dpkg -s")
+            .onOk("apt-get update")
+            .onOk("apt-get install");
+    var applier = applier(shell);
+
+    var result = applier.applyPackages(CONTAINER, null);
+
+    assertEquals(2, result.added());
+    assertEquals(ProjectProvisioner.BASELINE_PACKAGES.size() - 2, result.skipped());
+    var installCmd =
+        shell.invocations().stream()
+            .filter(c -> c.contains("apt-get install"))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(installCmd.contains("gh"));
+    assertTrue(installCmd.contains("ripgrep"));
+    assertFalse(installCmd.contains("curl"), "packages already present are not reinstalled");
+  }
+
+  @Test
+  void applyPackagesSkipsAptEntirelyWhenAllPresent() throws Exception {
+    var shell = new ScriptedShellExecutor().onOk("dpkg -s");
+    var applier = applier(shell);
+
+    var result = applier.applyPackages(CONTAINER, List.of("postgresql-client-16"));
+
+    assertEquals(0, result.added());
+    assertEquals(ProjectProvisioner.BASELINE_PACKAGES.size() + 1, result.skipped());
+    assertFalse(
+        shell.invocations().stream().anyMatch(c -> c.contains("apt-get")),
+        "a current container must not touch apt on converge");
+  }
+
+  @Test
+  void applyPackagesInstallsMissingConfigPackages() throws Exception {
+    var shell =
+        new ScriptedShellExecutor()
+            .onFail("dpkg -s postgresql-client-16", "not installed")
+            .onOk("dpkg -s")
+            .onOk("apt-get update")
+            .onOk("apt-get install");
+    var applier = applier(shell);
+
+    var result = applier.applyPackages(CONTAINER, List.of("postgresql-client-16"));
+
+    assertEquals(1, result.added());
+    var installCmd =
+        shell.invocations().stream()
+            .filter(c -> c.contains("apt-get install"))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(installCmd.contains("postgresql-client-16"));
+  }
+
+  @Test
+  void applyPackagesDeduplicatesConfigPackagesAlreadyInBaseline() throws Exception {
+    var shell = new ScriptedShellExecutor().onOk("dpkg -s");
+    var applier = applier(shell);
+
+    var result = applier.applyPackages(CONTAINER, List.of("git", "ripgrep"));
+
+    assertEquals(ProjectProvisioner.BASELINE_PACKAGES.size(), result.skipped());
+  }
+
+  @Test
+  void applyPackagesThrowsOnInstallFailure() {
+    var shell =
+        new ScriptedShellExecutor()
+            .onFail("dpkg -s gh", "not installed")
+            .onOk("dpkg -s")
+            .onOk("apt-get update")
+            .onFail("apt-get install", "E: Unable to locate package");
+    var applier = applier(shell);
+
+    var ex = assertThrows(Exception.class, () -> applier.applyPackages(CONTAINER, null));
+
+    assertTrue(ex.getMessage().contains("Failed to install packages"));
+  }
+
+  @Test
+  void applyPackagesThrowsOnAptUpdateFailure() {
+    var shell =
+        new ScriptedShellExecutor()
+            .onFail("dpkg -s gh", "not installed")
+            .onOk("dpkg -s")
+            .onFail("apt-get update", "no network");
+    var applier = applier(shell);
+
+    var ex = assertThrows(Exception.class, () -> applier.applyPackages(CONTAINER, null));
+
+    assertTrue(ex.getMessage().contains("Failed to update package lists"));
+  }
+
+  @Test
   void applyServicesStartsNewService() throws Exception {
     var shell =
         new ScriptedShellExecutor()
@@ -58,10 +157,20 @@ class ProjectApplierTest {
         Map.of("postgres", new SailYaml.Service("postgres:16", List.of(5432), null, null, null));
     applier.applyServices(CONTAINER, services);
     applier.applyAgentTools(CONTAINER, List.of("claude-code"));
+    applier.applyPackages(CONTAINER, null);
 
     assertTrue(
         probes.invocations().stream().anyMatch(c -> c.contains("podman container inspect")),
         "existence probes must observe the live container");
+    assertTrue(
+        probes.invocations().stream().anyMatch(c -> c.contains("dpkg -s")),
+        "package-presence probes must observe the live container");
+    assertTrue(
+        probes.invocations().stream().noneMatch(c -> c.contains("apt-get")),
+        "apt mutations must never ride the probe shell");
+    assertTrue(
+        mutator.invocations().stream().anyMatch(c -> c.contains("apt-get install")),
+        "missing packages install through the mutator shell");
     assertTrue(
         probes.invocations().stream().anyMatch(c -> c.contains("which")),
         "tool-presence probes must observe the live container");

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectProvisionerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ProjectProvisionerTest.java
@@ -481,6 +481,8 @@ class ProjectProvisionerTest {
     assertTrue(installCmd.contains("git"));
     assertTrue(installCmd.contains("sudo"));
     assertTrue(installCmd.contains("openssh-server"));
+    assertTrue(installCmd.contains("gh"));
+    assertTrue(installCmd.contains("ripgrep"));
     assertTrue(installCmd.contains("postgresql-client-16"));
   }
 


### PR DESCRIPTION
## Why

Agents open PRs and search code in every project, yet `BASELINE_PACKAGES` was only `curl, wget, git, sudo, openssh-server` — `gh` and `rg` arrived per-project via `sail.yaml` `packages`, or not at all. The tools every agent reaches for belong in the baseline.

## What

- Add `gh` and `ripgrep` to `BASELINE_PACKAGES` in `ProjectProvisioner`.
- **Close the reconcile gap:** existing containers had no path to new baseline packages — the provisioner's `PACKAGES_INSTALLED` phase is tracker-skipped once complete, and `converge()` had no package step at all. New `ProjectApplier.applyPackages` probes each baseline+config package with `dpkg -s`, apt-installs only the missing ones, and skips apt entirely when the container is current. Wired into the converge path, so `sail up` after an upgrade installs the new tools additively.
- IT prepared image now bakes the full baseline (referencing `BASELINE_PACKAGES` so it can't drift), proving both apt names resolve on the ubuntu/24.04 image in the bake's sanctioned network step. Alias bumped to `sail-it-prepared-v2` so hosts holding an older bake rebuild.
- `BaselinePackagesIT`: fresh prepared container exposes `gh --version` / `rg --version` to the dev user; converge on a current container is a pure skip (no apt); after `apt-get remove gh ripgrep`, `applyPackages` reinstalls exactly the two missing tools.
- Unit tests for install-missing / skip-all / config-package / dedup / failure paths, and the probe-vs-mutator shell invariant extended to package probes (dry-run safe).

Docs carry no redundant `gh`/`ripgrep` package entries, so nothing to drop there.

## Verification

`mvn clean verify` green — 2828 tests, all coverage gates met. No new dependencies.