### PR TITLE
An agent joins the room and stays: engagement replaces one-turn chat lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## Unreleased
 
+- An agent can be engaged in a spec's room: it joins the conversation and answers every human
+  message until dismissed. `sail spec engage <id> --agent <a>` (API `POST /v1/specs/{id}/engage`)
+  records the engagement on the spec row as one atomic synced value — agent, mode, model,
+  engaged-at as a single JSON column, so field-level sync merging can never stitch two boxes'
+  engagements together — and `sail spec disengage` clears it; both transitions publish room-visible
+  events (`spec_engaged`, `spec_disengaged`). **Full access is the default mode**: conversations
+  produce artifacts (diagrams, drafts, files), so an engaged agent works in the workspace, drafts
+  spec bodies, and creates sibling draft specs, paid for with one engage-time container snapshot
+  (never per turn) and the same one-writer-per-repo reservation a build takes per turn.
+  `--read-only` is the explicit narrow choice, enforced by the harness and offered only where
+  enforcement exists (claude-code today); full mode works on every agent, so codex is a
+  first-class conversationalist. An engagement did not take effect until its snapshot succeeded —
+  a failed payment publishes `spec_engage_failed` and engages nobody.
+- Engaged rooms converse at conversation speed. The wake reactor answers every human message in an
+  engaged room regardless of wake mode or dispatch history — a fresh chat room needs no build-run
+  ancestry — with a 5-second debounce and **no post-finish cooldown** (the 30s/10min rules remain
+  exactly as shipped for non-engaged specs). Turns resume the engagement's own conversation: the
+  session selector is now role- and agent-filtered, so a build's session can never reopen under a
+  chat turn's tool cut. A read-only chat turn runs alongside its own spec's live build (the gate's
+  same-spec rule now applies within working lanes and within chat lanes, never across); a full
+  turn defers on the build through its repo claim and fires on the build's stop, which — like a
+  message landing in a turn's tail — re-evaluates the room for owed turns (newest human message vs
+  newest chat-turn start; derived, never bookkept). A periodic engagement sweep backstops the
+  event edges. Chat turns skip the read-only worktree fingerprint in full mode and never snapshot.
+- Engaged turn prompts drop "when you have contributed, stop": a turn ends, the engagement
+  continues, and the agent is told it will be resumed for the next message — never to say goodbye.
+  The wake prompt also stops promising read-only git the allowlist deliberately denies.
+- The one-shot read-only invite is retired, superseded by engagement (the API refuses it naming
+  the replacement); `sail spec invite` is now the task-shaped lane it always really was — one
+  full-access turn, snapshot first. Slack stops narrating conversation plumbing: a chat or invite
+  turn's clean exit ("Agent stopped (exit 0)") no longer posts, while failures and build stops
+  keep their narration.
+
 - A room message now wakes the agent when no run is live. A new `room-wake` reactor on
   `spec_message_posted` (local and sync-arrived alike) runs on the dispatch-owning box — the one
   whose handle is the spec's assignee, so the fleet has exactly one waker per spec — and launches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@
   engagements together — and `sail spec disengage` clears it; both transitions publish room-visible
   events (`spec_engaged`, `spec_disengaged`). **Full access is the default mode**: conversations
   produce artifacts (diagrams, drafts, files), so an engaged agent works in the workspace, drafts
-  spec bodies, and creates sibling draft specs, paid for with one engage-time container snapshot
-  (never per turn) and the same one-writer-per-repo reservation a build takes per turn.
+  spec bodies, and creates sibling draft specs, guarded by the same one-writer-per-repo
+  reservation a build takes per turn. An engage-time rollback snapshot is opt-in
+  (`--snapshot` / the dialog checkbox) and off by default — on the `dir` backend a snapshot is a
+  slow full filesystem copy, and the choice to skip it belongs to the human.
   `--read-only` is the explicit narrow choice, enforced by the harness and offered only where
   enforcement exists (claude-code today); full mode works on every agent, so codex is a
   first-class conversationalist. An engagement did not take effect until its snapshot succeeded —

--- a/sail-core/src/main/java/ai/singlr/sail/config/Engagement.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/Engagement.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.config;
+
+import ai.singlr.sail.common.Strings;
+import java.util.LinkedHashMap;
+
+/**
+ * A room's standing agent: who is engaged, with what access, since when. Stored on the spec row as
+ * one compact JSON value so sync merges it atomically — an engagement is set and cleared as a
+ * whole, and field-level merging across boxes must never stitch one box's agent to another box's
+ * mode. {@code full} is the default mode: conversations produce artifacts (diagrams, drafts,
+ * files), so write access is the normal case and {@code read-only} is the explicit narrow choice.
+ */
+public record Engagement(String agent, String mode, String model, String engagedAt) {
+
+  public static final String MODE_FULL = "full";
+  public static final String MODE_READ_ONLY = "read-only";
+
+  /**
+   * A validated engagement. A blank mode defaults to {@link #MODE_FULL}; a blank model means the
+   * agent's default.
+   */
+  public static Engagement of(String agent, String mode, String model, String engagedAt) {
+    if (Strings.isBlank(agent)) {
+      throw new IllegalArgumentException("An engagement names its agent; got a blank one.");
+    }
+    if (Strings.isBlank(engagedAt)) {
+      throw new IllegalArgumentException("An engagement records when it began; got a blank time.");
+    }
+    var effectiveMode = Strings.isBlank(mode) ? MODE_FULL : mode;
+    if (!MODE_FULL.equals(effectiveMode) && !MODE_READ_ONLY.equals(effectiveMode)) {
+      throw new IllegalArgumentException(
+          "Engagement mode must be '"
+              + MODE_FULL
+              + "' or '"
+              + MODE_READ_ONLY
+              + "', got '"
+              + mode
+              + "'.");
+    }
+    return new Engagement(agent, effectiveMode, Strings.isBlank(model) ? null : model, engagedAt);
+  }
+
+  public boolean full() {
+    return MODE_FULL.equals(mode);
+  }
+
+  /** This engagement as the compact JSON the spec row stores. */
+  public String toJson() {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("agent", agent);
+    map.put("mode", mode);
+    if (model != null) {
+      map.put("model", model);
+    }
+    map.put("engaged_at", engagedAt);
+    return YamlUtil.dumpJson(map);
+  }
+
+  /**
+   * The engagement a spec row's stored value describes, or {@code null} for a blank or unparseable
+   * value — a corrupt column must read as "not engaged", never take the store down.
+   */
+  public static Engagement fromJson(String json) {
+    if (Strings.isBlank(json)) {
+      return null;
+    }
+    try {
+      var map = YamlUtil.parseMap(json);
+      var agent = asText(map.get("agent"));
+      var engagedAt = asText(map.get("engaged_at"));
+      if (Strings.isBlank(agent) || Strings.isBlank(engagedAt)) {
+        return null;
+      }
+      return of(agent, asText(map.get("mode")), asText(map.get("model")), engagedAt);
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+
+  private static String asText(Object value) {
+    return value == null ? null : value.toString();
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/DispatchGate.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/DispatchGate.java
@@ -46,6 +46,14 @@ public final class DispatchGate {
   public static final String FULL_INVITE_ROLE = "invite-full";
 
   /**
+   * The full chat lane: an engaged agent's turn with write access. It reserves the spec's repos
+   * (the whole container when the spec names none), so one writer per repo holds for conversations
+   * exactly as for builds — a full turn defers on a live build through the ordinary repo rule and
+   * frees when the build's stop re-evaluates the room.
+   */
+  public static final String ROOM_FULL_ROLE = "room-full";
+
+  /**
    * One running local run of the project: its id, the spec it works, its role, and its reserved
    * repos.
    */
@@ -60,13 +68,16 @@ public final class DispatchGate {
   /**
    * The first running run that blocks the dispatch, or empty to allow. A {@link
    * #READ_ONLY_INVITE_ROLE} run on either side conflicts with nothing — a read-only consultant runs
-   * alongside anything, including its own spec's live build. Otherwise a run of {@code
-   * targetSpecId} itself always blocks, even on disjoint repos: a spec has one lifecycle and one
-   * review pipeline, so a second live execution — reachable via restart with a repo override —
-   * would race the first over shared spec state. Any other run blocks only on repo overlap, and a
-   * {@link #ROOM_ROLE} run on either side never overlaps anything: a chat reserves no repos, so its
-   * empty repo set must not carry the whole-container meaning the working lanes give it — a wake
-   * never blocks another spec's build, and a build never blocks another spec's wake.
+   * alongside anything, including its own spec's live build. A run of {@code targetSpecId} itself
+   * blocks when both sides are working lanes (a spec has one lifecycle and one review pipeline, so
+   * a second live execution — reachable via restart with a repo override — would race the first
+   * over shared spec state) and when both sides are chat lanes (one conversational turn at a time).
+   * A mixed same-spec pair falls through to the repo rules: a read-only chat turn answers the room
+   * while the build works, and a full chat turn defers on the build through its repo claim. Any
+   * other run blocks only on repo overlap, and a {@link #ROOM_ROLE} run on either side never
+   * overlaps anything: a read-only chat reserves no repos, so its empty repo set must not carry the
+   * whole-container meaning the working lanes give it. {@link #ROOM_FULL_ROLE} carries real repo
+   * claims and gets no such exemption.
    */
   public static Optional<Conflict> decide(
       String targetSpecId, String targetRole, List<String> targetRepos, List<RunningRun> running) {
@@ -77,13 +88,17 @@ public final class DispatchGate {
         .filter(run -> !READ_ONLY_INVITE_ROLE.equals(run.role()))
         .map(
             run ->
-                sameSpec(run.specId(), targetSpecId)
+                sameSpec(run.specId(), targetSpecId) && chatLane(targetRole) == chatLane(run.role())
                     ? Optional.of(new Conflict(run, List.of()))
                     : roomLane(targetRole, run.role())
                         ? Optional.<Conflict>empty()
                         : conflictWith(targetRepos, run))
         .flatMap(Optional::stream)
         .findFirst();
+  }
+
+  private static boolean chatLane(String role) {
+    return ROOM_ROLE.equals(role) || ROOM_FULL_ROLE.equals(role);
   }
 
   private static boolean roomLane(String targetRole, String runRole) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -210,7 +210,16 @@ public final class RunStore implements ConflictResolver {
 
     /** Whether this row is a room wake — a chat-lane run that answers in its spec's room. */
     public boolean roomRole() {
-      return "room".equals(role);
+      return DispatchGate.ROOM_ROLE.equals(role);
+    }
+
+    /**
+     * Whether this row is a conversational turn of the room lane, either mode: a wake or an engaged
+     * agent's turn. Chat stops never trigger the review pipeline, and one chat turn runs at a time
+     * per spec.
+     */
+    public boolean chatRole() {
+      return roomRole() || DispatchGate.ROOM_FULL_ROLE.equals(role);
     }
 
     /**
@@ -219,7 +228,8 @@ public final class RunStore implements ConflictResolver {
      * stays anchored to dispatch.
      */
     public boolean inviteRole() {
-      return "invite".equals(role) || "invite-full".equals(role);
+      return DispatchGate.READ_ONLY_INVITE_ROLE.equals(role)
+          || DispatchGate.FULL_INVITE_ROLE.equals(role);
     }
 
     /**
@@ -229,7 +239,7 @@ public final class RunStore implements ConflictResolver {
      * says.
      */
     public boolean readOnlyLane() {
-      return roomRole() || "invite".equals(role);
+      return roomRole() || DispatchGate.READ_ONLY_INVITE_ROLE.equals(role);
     }
 
     /**
@@ -249,14 +259,15 @@ public final class RunStore implements ConflictResolver {
      * reaped and stoppable like any other.
      */
     public boolean sessionRole() {
-      return buildRole() || adhocRole() || roomRole() || inviteRole();
+      return buildRole() || adhocRole() || chatRole() || inviteRole();
     }
   }
 
   private static final String SESSION_ROLES =
-      "role IN ('build', 'adhoc', 'room', 'invite', 'invite-full')";
+      "role IN ('build', 'adhoc', 'room', 'room-full', 'invite', 'invite-full')";
 
-  private static final String PROJECT_SESSION_ROLES = "role IN ('build', 'adhoc', 'room')";
+  private static final String PROJECT_SESSION_ROLES =
+      "role IN ('build', 'adhoc', 'room', 'room-full')";
 
   private static final String COLUMNS =
       "id, project, spec_id, node, role, agent, branch, task, pid, watcher_pid, status,"

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -272,7 +272,53 @@ public final class SchemaManager {
               action TEXT NOT NULL,
               created_at TEXT NOT NULL,
               PRIMARY KEY (project, node)
-          )""");
+          )""",
+          "ALTER TABLE specs ADD COLUMN engagement TEXT",
+          """
+          CREATE TABLE runs_v7 (
+              id TEXT PRIMARY KEY,
+              project TEXT NOT NULL,
+              spec_id TEXT,
+              agent TEXT NOT NULL,
+              branch TEXT,
+              task TEXT,
+              pid INTEGER,
+              status TEXT NOT NULL DEFAULT 'running'
+                  CHECK (status IN ('running', 'stopping', 'completed', 'stopped', 'failed')),
+              started_at TEXT NOT NULL,
+              completed_at TEXT,
+              exit_code INTEGER,
+              watcher_pid INTEGER,
+              node TEXT,
+              role TEXT NOT NULL DEFAULT 'build'
+                  CHECK (role IN ('build', 'adhoc', 'review', 'room', 'room-full', 'invite',
+                      'invite-full')),
+              log_path TEXT,
+              rev TEXT,
+              base_rev TEXT,
+              unit TEXT,
+              repos TEXT,
+              pid_ticks INTEGER,
+              principal TEXT,
+              owner TEXT,
+              session_id TEXT,
+              session_source TEXT,
+              transcript_path TEXT,
+              last_activity_at TEXT
+          )""",
+          """
+          INSERT INTO runs_v7 (id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos, pid_ticks, principal, owner, session_id,
+                  session_source, transcript_path, last_activity_at)
+              SELECT id, project, spec_id, agent, branch, task, pid, status,
+                  started_at, completed_at, exit_code, watcher_pid, node, role, log_path,
+                  rev, base_rev, unit, repos, pid_ticks, principal, owner, session_id,
+                  session_source, transcript_path, last_activity_at FROM runs""",
+          "DROP TABLE runs",
+          "ALTER TABLE runs_v7 RENAME TO runs",
+          "CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project)",
+          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)");
 
   /** The schema version this binary converges every database to. */
   static final int CURRENT_VERSION = V1_VERSION + MIGRATIONS.size();

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -56,7 +56,8 @@ public final class SpecStore implements ConflictResolver {
       String updatedBy,
       List<String> dependsOn,
       List<String> repos,
-      String wake) {
+      String wake,
+      String engagement) {
 
     /** A row with no explicit wake mode — the default every spec has until an operator sets one. */
     public SpecRow(
@@ -93,6 +94,47 @@ public final class SpecStore implements ConflictResolver {
           updatedBy,
           dependsOn,
           repos,
+          null,
+          null);
+    }
+
+    /** A row with no engagement — the state every spec has until a human engages an agent. */
+    public SpecRow(
+        String id,
+        String project,
+        String title,
+        SpecStatus status,
+        String assignee,
+        String agent,
+        String model,
+        String reasoningEffort,
+        String branch,
+        int priority,
+        String createdBy,
+        String createdAt,
+        String updatedAt,
+        String updatedBy,
+        List<String> dependsOn,
+        List<String> repos,
+        String wake) {
+      this(
+          id,
+          project,
+          title,
+          status,
+          assignee,
+          agent,
+          model,
+          reasoningEffort,
+          branch,
+          priority,
+          createdBy,
+          createdAt,
+          updatedAt,
+          updatedBy,
+          dependsOn,
+          repos,
+          wake,
           null);
     }
 
@@ -115,7 +157,34 @@ public final class SpecStore implements ConflictResolver {
           updatedBy,
           dependsOn,
           repos,
-          wake);
+          wake,
+          engagement);
+    }
+
+    /**
+     * This row with {@code engagement} replaced ({@code null} disengages) — the single-field edit
+     * the engage and disengage surfaces use.
+     */
+    public SpecRow withEngagement(String engagement) {
+      return new SpecRow(
+          id,
+          project,
+          title,
+          status,
+          assignee,
+          agent,
+          model,
+          reasoningEffort,
+          branch,
+          priority,
+          createdBy,
+          createdAt,
+          updatedAt,
+          updatedBy,
+          dependsOn,
+          repos,
+          wake,
+          engagement);
     }
 
     /** Projects this stored row onto the storage-agnostic {@link Spec} value type. */
@@ -163,8 +232,8 @@ public final class SpecStore implements ConflictResolver {
               """
               INSERT INTO specs (id, project, title, status, assignee, agent, model,
                   reasoning_effort, branch, priority, created_by, created_at, updated_at,
-                  updated_by, wake)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                  updated_by, wake, engagement)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
               spec.id(),
               spec.project(),
               spec.title(),
@@ -179,7 +248,8 @@ public final class SpecStore implements ConflictResolver {
               now,
               now,
               spec.updatedBy(),
-              spec.wake());
+              spec.wake(),
+              spec.engagement());
           insertDependencies(spec.id(), spec.dependsOn());
           insertRepos(spec.id(), spec.repos());
           db.execute(
@@ -194,7 +264,8 @@ public final class SpecStore implements ConflictResolver {
     return db.queryOne(
             """
             SELECT id, project, title, status, assignee, agent, model, reasoning_effort,
-                branch, priority, created_by, created_at, updated_at, updated_by, wake
+                branch, priority, created_by, created_at, updated_at, updated_by, wake,
+                engagement
             FROM specs WHERE id = ?""",
             this::mapSpec,
             id)
@@ -205,7 +276,7 @@ public final class SpecStore implements ConflictResolver {
     var sql = new StringBuilder("SELECT DISTINCT s.id, s.project, s.title, s.status, s.assignee,");
     sql.append(
         " s.agent, s.model, s.reasoning_effort, s.branch, s.priority, s.created_by, s.created_at,"
-            + " s.updated_at, s.updated_by, s.wake FROM specs s");
+            + " s.updated_at, s.updated_by, s.wake, s.engagement FROM specs s");
     var params = new ArrayList<>();
     var where = new ArrayList<String>();
 
@@ -274,7 +345,7 @@ public final class SpecStore implements ConflictResolver {
               """
               UPDATE specs SET project = ?, title = ?, status = ?, assignee = ?, agent = ?,
                   model = ?, reasoning_effort = ?, branch = ?, priority = ?, updated_at = ?,
-                  updated_by = ?, wake = ?
+                  updated_by = ?, wake = ?, engagement = ?
               WHERE id = ?""",
               spec.project(),
               spec.title(),
@@ -288,6 +359,7 @@ public final class SpecStore implements ConflictResolver {
               now,
               spec.updatedBy(),
               spec.wake(),
+              spec.engagement(),
               spec.id());
           db.execute("DELETE FROM spec_dependencies WHERE spec_id = ?", spec.id());
           db.execute("DELETE FROM spec_repos WHERE spec_id = ?", spec.id());
@@ -480,6 +552,7 @@ public final class SpecStore implements ConflictResolver {
     map.put("depends_on", spec.dependsOn());
     map.put("repos", spec.repos());
     map.put("wake", spec.wake());
+    map.put("engagement", spec.engagement());
     map.put("body", content.body());
     map.put("plan", content.plan());
     return map;
@@ -493,7 +566,7 @@ public final class SpecStore implements ConflictResolver {
           """
           UPDATE specs SET project = ?, title = ?, status = ?, assignee = ?, agent = ?, model = ?,
               reasoning_effort = ?, branch = ?, priority = ?, updated_at = ?, updated_by = ?,
-              wake = ?
+              wake = ?, engagement = ?
           WHERE id = ?""",
           spec.project(),
           spec.title(),
@@ -507,6 +580,7 @@ public final class SpecStore implements ConflictResolver {
           now,
           spec.updatedBy(),
           spec.wake(),
+          spec.engagement(),
           id);
       db.execute("DELETE FROM spec_dependencies WHERE spec_id = ?", id);
       db.execute("DELETE FROM spec_repos WHERE spec_id = ?", id);
@@ -514,8 +588,8 @@ public final class SpecStore implements ConflictResolver {
       db.execute(
           """
           INSERT INTO specs (id, project, title, status, assignee, agent, model, reasoning_effort,
-              branch, priority, created_by, created_at, updated_at, updated_by, wake)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+              branch, priority, created_by, created_at, updated_at, updated_by, wake, engagement)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
           id,
           spec.project(),
           spec.title(),
@@ -530,7 +604,8 @@ public final class SpecStore implements ConflictResolver {
           spec.createdAt() == null || spec.createdAt().isBlank() ? now : spec.createdAt(),
           now,
           spec.updatedBy(),
-          spec.wake());
+          spec.wake(),
+          spec.engagement());
     }
     insertDependencies(id, spec.dependsOn());
     insertRepos(id, spec.repos());
@@ -567,7 +642,8 @@ public final class SpecStore implements ConflictResolver {
         text(s, "updated_by"),
         (List<String>) s.getOrDefault("depends_on", List.of()),
         (List<String>) s.getOrDefault("repos", List.of()),
-        text(s, "wake"));
+        text(s, "wake"),
+        text(s, "engagement"));
   }
 
   private static String text(Map<String, Object> map, String key) {
@@ -589,6 +665,7 @@ public final class SpecStore implements ConflictResolver {
           "depends_on",
           "repos",
           "wake",
+          "engagement",
           "body",
           "plan");
 
@@ -837,7 +914,7 @@ public final class SpecStore implements ConflictResolver {
             """
             SELECT s.id, s.project, s.title, s.status, s.assignee, s.agent, s.model,
                 s.reasoning_effort, s.branch, s.priority, s.created_by, s.created_at, s.updated_at,
-                s.updated_by, s.wake
+                s.updated_by, s.wake, s.engagement
             FROM specs s
             WHERE s.status = 'pending'
             AND (? IS NULL OR s.project = ?)
@@ -915,7 +992,8 @@ public final class SpecStore implements ConflictResolver {
         row.text(13),
         List.of(),
         List.of(),
-        row.text(14));
+        row.text(14),
+        row.text(15));
   }
 
   private SpecRow hydrate(SpecRow spec) {
@@ -943,7 +1021,8 @@ public final class SpecStore implements ConflictResolver {
         spec.updatedBy(),
         deps,
         repos,
-        spec.wake());
+        spec.wake(),
+        spec.engagement());
   }
 
   /**

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -904,6 +904,17 @@ public final class SpecStore implements ConflictResolver {
         specId);
   }
 
+  /** Every spec with a standing engagement — the rooms the engagement sweeper walks. */
+  public List<SpecRow> listEngaged() {
+    return db.query(
+        """
+        SELECT id, project, title, status, assignee, agent, model, reasoning_effort,
+            branch, priority, created_by, created_at, updated_at, updated_by, wake,
+            engagement
+        FROM specs WHERE engagement IS NOT NULL""",
+        this::mapSpec);
+  }
+
   public List<SpecRow> readySpecs() {
     return readySpecs(null);
   }

--- a/sail-core/src/test/java/ai/singlr/sail/config/EngagementTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/EngagementTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class EngagementTest {
+
+  @Test
+  void fullIsTheDefaultMode() {
+    var engagement = Engagement.of("claude-code", null, null, "2026-08-18T00:00:00Z");
+    assertEquals(Engagement.MODE_FULL, engagement.mode());
+    assertTrue(engagement.full());
+    assertNull(engagement.model());
+  }
+
+  @Test
+  void readOnlyIsTheExplicitNarrowChoice() {
+    var engagement =
+        Engagement.of("claude-code", Engagement.MODE_READ_ONLY, "opus", "2026-08-18T00:00:00Z");
+    assertFalse(engagement.full());
+    assertEquals("opus", engagement.model());
+  }
+
+  @Test
+  void validationFailsLoud() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Engagement.of("", null, null, "2026-08-18T00:00:00Z"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Engagement.of("claude-code", "yolo", null, "2026-08-18T00:00:00Z"));
+    assertThrows(
+        IllegalArgumentException.class, () -> Engagement.of("claude-code", null, null, ""));
+  }
+
+  @Test
+  void jsonRoundTripsIncludingAbsentModel() {
+    var full = Engagement.of("codex", "full", null, "2026-08-18T01:02:03Z");
+    assertEquals(full, Engagement.fromJson(full.toJson()));
+    var readOnly = Engagement.of("claude-code", "read-only", "opus", "2026-08-18T01:02:03Z");
+    assertEquals(readOnly, Engagement.fromJson(readOnly.toJson()));
+  }
+
+  @Test
+  void corruptStoredValuesReadAsNotEngagedNeverThrow() {
+    assertNull(Engagement.fromJson(null));
+    assertNull(Engagement.fromJson(""));
+    assertNull(Engagement.fromJson("not json at all {{{"));
+    assertNull(Engagement.fromJson("{\"mode\":\"full\"}"));
+    assertNull(
+        Engagement.fromJson("{\"agent\":\"claude-code\",\"mode\":\"bogus\",\"engaged_at\":\"t\"}"));
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/DispatchGateTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/DispatchGateTest.java
@@ -115,12 +115,57 @@ class DispatchGateTest {
   }
 
   @Test
-  void aRoomTargetIsBlockedByAnyLiveRunOfItsOwnSpec() {
+  void aRoomTargetRunsAlongsideItsOwnSpecsLiveBuild() {
     var running = List.of(running("auth", "build", List.of("app")));
 
-    var conflict = DispatchGate.decide("auth", "room", List.of(), running).orElseThrow();
+    assertTrue(
+        DispatchGate.decide("auth", "room", List.of(), running).isEmpty(),
+        "a read-only chat turn answers the room while the build works");
+  }
 
-    assertEquals(List.of(), conflict.overlap(), "a wake and a dispatch on one spec serialize");
+  @Test
+  void chatTurnsOfOneSpecSerializeAcrossModes() {
+    assertTrue(
+        DispatchGate.decide(
+                "auth", "room", List.of(), List.of(running("auth", "room-full", List.of("app"))))
+            .isPresent());
+    assertTrue(
+        DispatchGate.decide(
+                "auth", "room-full", List.of("app"), List.of(running("auth", "room", List.of())))
+            .isPresent());
+  }
+
+  @Test
+  void aFullChatTurnReservesLikeABuild() {
+    var running = List.of(running("auth", "build", List.of("app")));
+
+    var deferred = DispatchGate.decide("chat", "room-full", List.of("app"), running).orElseThrow();
+    assertEquals(List.of("app"), deferred.overlap(), "one writer per repo, chat included");
+    assertTrue(
+        DispatchGate.decide("chat", "room-full", List.of("web"), running).isEmpty(),
+        "disjoint repos share the container");
+  }
+
+  @Test
+  void aFullChatTurnWithNoReposClaimsTheWholeContainer() {
+    var running = List.of(running("auth", "build", List.of("app")));
+
+    assertTrue(DispatchGate.decide("chat", "room-full", List.of(), running).isPresent());
+  }
+
+  @Test
+  void aFullChatTurnDefersOnItsOwnSpecsBuildViaTheRepoRule() {
+    var running = List.of(running("auth", "build", List.of("app")));
+
+    assertTrue(DispatchGate.decide("auth", "room-full", List.of("app"), running).isPresent());
+  }
+
+  @Test
+  void aLiveFullChatTurnBlocksAnOverlappingDispatch() {
+    var running = List.of(running("auth", "room-full", List.of("app")));
+
+    assertTrue(DispatchGate.decide("other", "build", List.of("app"), running).isPresent());
+    assertTrue(DispatchGate.decide("other", "build", List.of("web"), running).isEmpty());
   }
 
   @Test
@@ -139,12 +184,12 @@ class DispatchGateTest {
   }
 
   @Test
-  void aLiveRoomRunBlocksItsOwnSpecsDispatch() {
+  void aLiveRoomRunNeverBlocksItsOwnSpecsDispatch() {
     var running = List.of(running("auth", "room", List.of()));
 
-    var conflict = DispatchGate.decide("auth", "build", List.of("web"), running).orElseThrow();
-
-    assertEquals(RUN, conflict.run().runId());
+    assertTrue(
+        DispatchGate.decide("auth", "build", List.of("web"), running).isEmpty(),
+        "dispatch proceeds during a read-only chat turn");
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -1010,21 +1010,25 @@ class RunStoreTest {
   }
 
   @Test
-  void aRoomReservationSerializesWithItsOwnSpecsRuns() {
+  void chatTurnsOfOneSpecSerializeButRunAlongsideItsDispatch() {
     reserveRoom(DateTimeUtils.newId().toString(), "auth", "node-a");
 
     assertTrue(
         reserve(store, DateTimeUtils.newId().toString(), "auth", "node-a", java.util.List.of("app"))
-            .isPresent(),
-        "a wake and a dispatch on one spec serialize");
-    assertTrue(reserveRoom(DateTimeUtils.newId().toString(), "auth", "node-a").isPresent());
+            .isEmpty(),
+        "a dispatch proceeds during a read-only chat turn");
+    assertTrue(
+        reserveRoom(DateTimeUtils.newId().toString(), "auth", "node-a").isPresent(),
+        "one conversational turn at a time per spec");
   }
 
   @Test
-  void aLiveBuildBlocksItsOwnSpecsRoomReservation() {
+  void aLiveBuildRunsAlongsideItsOwnSpecsRoomReservation() {
     reserve(store, DateTimeUtils.newId().toString(), "auth", "node-a", java.util.List.of("app"));
 
-    assertTrue(reserveRoom(DateTimeUtils.newId().toString(), "auth", "node-a").isPresent());
+    assertTrue(
+        reserveRoom(DateTimeUtils.newId().toString(), "auth", "node-a").isEmpty(),
+        "a read-only chat turn answers the room while the build works");
     assertTrue(reserveRoom(DateTimeUtils.newId().toString(), "other", "node-a").isEmpty());
   }
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -560,6 +560,49 @@ class SchemaManagerTest {
   }
 
   @Test
+  void aV0_27_0ShapedDatabaseGainsTheEngagementColumn() {
+    stageAtBaseline();
+    var tail = migrationIndex("ALTER TABLE specs ADD COLUMN engagement");
+    db.execute("PRAGMA foreign_keys = OFF");
+    SchemaManager.MIGRATIONS.subList(0, tail).forEach(db::execute);
+    db.execute("PRAGMA foreign_keys = ON");
+    db.execute(
+        "INSERT INTO schema_version (version, applied_at) VALUES (?, 'staged')",
+        SchemaManager.V1_VERSION + tail);
+    db.execute(
+        "INSERT INTO specs (id, title, status, created_at, updated_at)"
+            + " VALUES ('pre', 'T', 'draft', 't0', 't0')");
+    db.execute(
+        "INSERT INTO runs (id, project, agent, status, started_at, role) VALUES"
+            + " ('r-pre', 'p', 'keep', 'completed', 't0', 'room')");
+
+    new SchemaManager(db).migrate();
+
+    assertEquals(SchemaManager.CURRENT_VERSION, new SchemaManager(db).currentVersion());
+    assertTrue(
+        db.queryOne("SELECT engagement FROM specs WHERE id = 'pre'", r -> r.isNull(0))
+            .orElseThrow(),
+        "a pre-upgrade spec reads as not engaged");
+    assertEquals(
+        "keep",
+        db.queryOne("SELECT agent FROM runs WHERE id = 'r-pre'", r -> r.text(0)).orElseThrow(),
+        "the runs_v7 rebuild carries prior rows forward");
+    db.execute(
+        "INSERT INTO runs (id, project, agent, status, started_at, role) VALUES"
+            + " ('r-chat', 'p', 'claude-code', 'running', 't0', 'room-full')");
+    assertThrows(
+        SqliteException.class,
+        () ->
+            db.execute(
+                "INSERT INTO runs (id, project, agent, status, started_at, role) VALUES"
+                    + " ('r-bad', 'p', 'claude-code', 'running', 't0', 'shout')"));
+    db.execute("UPDATE specs SET engagement = '{\"agent\":\"claude-code\"}' WHERE id = 'pre'");
+    assertEquals(
+        "{\"agent\":\"claude-code\"}",
+        db.queryOne("SELECT engagement FROM specs WHERE id = 'pre'", r -> r.text(0)).orElseThrow());
+  }
+
+  @Test
   void theWakeColumnAdmitsItsThreeModesAndRejectsGarbage() {
     new SchemaManager(db).migrate();
     db.execute(

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
@@ -601,4 +601,30 @@ class SpecStoreTest {
     assertEquals(List.of("auth"), store.findById("billing").orElseThrow().dependsOn());
     assertTrue(store.findById("auth").isEmpty(), "the dependency need not exist");
   }
+
+  @Test
+  void engagementRoundTripsThroughCreateUpdateSnapshotAndList() {
+    var engagement = "{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}";
+    store.create(spec("auth", "OAuth", "draft").withEngagement(engagement));
+    store.create(spec("plain", "Other", "draft"));
+
+    assertEquals(engagement, store.findById("auth").orElseThrow().engagement());
+    assertEquals(
+        List.of("auth"),
+        store.listEngaged().stream().map(SpecStore.SpecRow::id).toList(),
+        "only engaged rooms join the sweep");
+
+    var journaled =
+        db.queryOne(
+                "SELECT snapshot FROM change_log WHERE entity_id = 'auth'"
+                    + " ORDER BY seq DESC LIMIT 1",
+                r -> r.text(0))
+            .orElseThrow();
+    assertTrue(journaled.contains("engagement"), "the engagement syncs as one atomic field");
+
+    store.update(store.findById("auth").orElseThrow().withEngagement(null));
+    assertTrue(store.listEngaged().isEmpty(), "disengaging clears the room");
+    assertEquals(
+        null, store.findById("auth").orElseThrow().engagement(), "the column reads back null");
+  }
 }

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/SailStopGate.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/SailStopGate.java
@@ -90,8 +90,10 @@ public final class SailStopGate {
       # the git protocol, stop-room-nudged for the room), so a message that
       # arrives after a git nudge still gets its one block and neither concern
       # can wedge a run. stdout is reserved for the hook-protocol block JSON.
-      # A room-role run (role "room" in its session file) and a read-only
-      # invite (role "invite") skip the git protocol entirely — a chat owns no
+      # A chat turn (role "room" or "room-full" in its session file) and a
+      # read-only invite (role "invite") skip the git protocol entirely — a
+      # conversation is not a task: a full turn's workspace changes are the
+      # human's to keep or roll back (the engage snapshot), and a chat owns no
       # repos and must never be nudged about other runs' trees — while keeping
       # the room last-look. A full invite (role "invite-full") keeps it.
       # Any unexpected condition fails open: this gate is a nudge, not a jail.
@@ -148,7 +150,8 @@ public final class SailStopGate {
       ' "$SESSION" 2>/dev/null || true)"
 
       REASONS=""
-      if [ "$RUN_ROLE" != "room" ] && [ "$RUN_ROLE" != "invite" ] && [ ! -f "$GIT_MARKER" ]; then
+      if [ "$RUN_ROLE" != "room" ] && [ "$RUN_ROLE" != "room-full" ] \
+          && [ "$RUN_ROLE" != "invite" ] && [ ! -f "$GIT_MARKER" ]; then
         REPOS="$(python3 -c '
       import json, sys
       try:

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -645,6 +645,36 @@ record SpecRestoreRequest(String rev) {
 }
 
 /** Body of {@code POST /v1/specs/{id}/invite}: the agent to invite and the one mode choice. */
+record EngageRequest(String agent, String mode, String model) {
+  static EngageRequest fromMap(Map<String, Object> map) {
+    return new EngageRequest(
+        (String) map.get("agent"), (String) map.get("mode"), (String) map.get("model"));
+  }
+}
+
+/** Response of {@code POST /v1/specs/{id}/engage}: the recorded (or pending) engagement. */
+record EngageResponse(String agent, String mode, String snapshot) implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("agent", agent);
+    m.put("mode", mode);
+    if (snapshot != null && !snapshot.isBlank()) m.put("snapshot", snapshot);
+    return m;
+  }
+}
+
+/** Response of {@code POST /v1/specs/{id}/disengage}: who left, or nothing if nobody was there. */
+record DisengageResponse(String agent) implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    if (agent != null) m.put("agent", agent);
+    m.put("disengaged", agent != null);
+    return m;
+  }
+}
+
 record InviteRequest(String agent, String model, boolean full, boolean snapshot) {
   static InviteRequest fromMap(Map<String, Object> map) {
     return new InviteRequest(
@@ -766,6 +796,7 @@ record GlobalSpecView(
     List<String> dependsOn,
     List<String> repos,
     String wake,
+    Map<String, Object> engagement,
     String createdBy,
     String createdAt,
     String updatedAt,
@@ -786,10 +817,24 @@ record GlobalSpecView(
         row.dependsOn(),
         row.repos(),
         row.wake(),
+        engagementMap(row.engagement()),
         row.createdBy(),
         row.createdAt(),
         row.updatedAt(),
         row.updatedBy());
+  }
+
+  private static Map<String, Object> engagementMap(String stored) {
+    var engagement = ai.singlr.sail.config.Engagement.fromJson(stored);
+    if (engagement == null) {
+      return null;
+    }
+    var m = new LinkedHashMap<String, Object>();
+    m.put("agent", engagement.agent());
+    m.put("mode", engagement.mode());
+    if (engagement.model() != null) m.put("model", engagement.model());
+    m.put("engaged_at", engagement.engagedAt());
+    return m;
   }
 
   @Override
@@ -808,6 +853,7 @@ record GlobalSpecView(
     if (!dependsOn.isEmpty()) m.put("depends_on", dependsOn);
     if (!repos.isEmpty()) m.put("repos", repos);
     if (wake != null) m.put("wake", wake);
+    if (engagement != null) m.put("engagement", engagement);
     if (createdBy != null) m.put("created_by", createdBy);
     m.put("created_at", createdAt);
     m.put("updated_at", updatedAt);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -645,10 +645,13 @@ record SpecRestoreRequest(String rev) {
 }
 
 /** Body of {@code POST /v1/specs/{id}/invite}: the agent to invite and the one mode choice. */
-record EngageRequest(String agent, String mode, String model) {
+record EngageRequest(String agent, String mode, String model, boolean snapshot) {
   static EngageRequest fromMap(Map<String, Object> map) {
     return new EngageRequest(
-        (String) map.get("agent"), (String) map.get("mode"), (String) map.get("model"));
+        (String) map.get("agent"),
+        (String) map.get("mode"),
+        (String) map.get("model"),
+        Boolean.TRUE.equals(map.get("snapshot")));
   }
 }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -59,6 +59,8 @@ public final class ApiRouter implements HttpHandler {
   private static final String FOLLOWUP = "followup";
   private static final String MESSAGES = "messages";
   private static final String INVITE = "invite";
+  private static final String ENGAGE = "engage";
+  private static final String DISENGAGE = "disengage";
   private static final String AGENTS = "agents";
   private static final String SNAPSHOTS = "snapshots";
   private static final int DEFAULT_MESSAGES = 50;
@@ -399,6 +401,20 @@ public final class ApiRouter implements HttpHandler {
                 InviteRequest.fromMap(JsonBody.readMap(exchange)),
                 actorOf(exchange),
                 nodeHandle.get()));
+      }
+      if (ENGAGE.equals(sub)) {
+        requireMethod(request, POST);
+        return ApiResponse.from(
+            operations.engageToSpec(
+                specId,
+                EngageRequest.fromMap(JsonBody.readMap(exchange)),
+                actorOf(exchange),
+                nodeHandle.get()));
+      }
+      if (DISENGAGE.equals(sub)) {
+        requireMethod(request, POST);
+        return ApiResponse.from(
+            operations.disengageSpec(specId, actorOf(exchange), nodeHandle.get()));
       }
       if (MESSAGES.equals(sub)) {
         return switch (request.method()) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.api;
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.BranchPolicy;
+import ai.singlr.sail.config.Engagement;
 import ai.singlr.sail.config.Guardrails;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
@@ -540,8 +541,13 @@ public final class DispatchOperations {
                 () ->
                     new ApiException(
                         ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
-    var agentType = spec.agent() != null ? spec.agent() : config.agent().type();
-    if (!AgentCli.fromYamlName(agentType).supportsRoomLane()) {
+    var engagement = Engagement.fromJson(spec.engagement());
+    var agentType =
+        engagement != null
+            ? engagement.agent()
+            : spec.agent() != null ? spec.agent() : config.agent().type();
+    var full = engagement != null && engagement.full();
+    if (!full && !AgentCli.fromYamlName(agentType).supportsRoomLane()) {
       throw new ApiException(
           ErrorCode.AGENT_NOT_CONFIGURED,
           "Room wake needs a harness-enforced read-only session, and "
@@ -556,13 +562,21 @@ public final class DispatchOperations {
         messageStore == null
             ? List.<MessageStore.MessageRow>of()
             : messageStore.list(specId, null, 20);
-    var resumeSessionId = resumableSessionId(specId, agentType, localHandle);
+    var resumeSessionId =
+        engagement != null
+            ? engagedSessionId(specId, agentType, localHandle)
+            : resumableSessionId(specId, agentType, localHandle);
     var built =
         RoomWakePrompt.build(
-            spec, body.isBlank() ? spec.title() : body, room, resumeSessionId != null);
+            spec, body.isBlank() ? spec.title() : body, room, resumeSessionId != null, engagement);
     var task = built.prompt();
     var runId = DateTimeUtils.newId().toString();
     var unit = AgentUnit.forRun(runId);
+    var role = full ? DispatchGate.ROOM_FULL_ROLE : DispatchGate.ROOM_ROLE;
+    var targetRepos =
+        full ? DispatchRepos.resolve(config, spec.toSpec(), List.of()) : List.<SailYaml.Repo>of();
+    var repoPaths = targetRepos.stream().map(SailYaml.Repo::path).toList();
+    var branch = full ? Objects.toString(spec.branch(), "") : "";
     RunStore.Reservation reservation;
     try {
       reservation =
@@ -572,10 +586,10 @@ public final class DispatchOperations {
               specId,
               localHandle,
               Strings.isBlank(spec.assignee()) ? localHandle : spec.assignee(),
-              "room",
-              List.of(),
+              role,
+              repoPaths,
               agentType,
-              null,
+              Strings.isBlank(branch) ? null : branch,
               task,
               unit.logPath(),
               unit.unitName(),
@@ -592,25 +606,33 @@ public final class DispatchOperations {
     var credential = ((RunStore.Reservation.Reserved) reservation).credential();
     try {
       seedRoomDelivery(runId, built.renderedMessages());
-      captureRoomBaseline(project, config, runId);
+      if (!full) {
+        captureRoomBaseline(project, config, runId);
+      }
+      var model =
+          engagement != null && engagement.model() != null ? engagement.model() : spec.model();
+      var workDir =
+          full
+              ? AgentSession.launchWorkDir(config.sshUser(), targetRepos)
+              : "/home/" + config.sshUser() + "/workspace";
       var launch =
           launchSession(
               project,
               config,
-              "/home/" + config.sshUser() + "/workspace",
-              false,
-              spec.model(),
+              workDir,
+              full,
+              model,
               spec.reasoningEffort(),
               specId,
               agentType,
               task,
-              "",
-              List.of(),
+              branch,
+              repoPaths,
               true,
               unit,
               runId,
               credential,
-              "room",
+              role,
               resumeSessionId);
       var status = querySession(new AgentSession(shell), project, unit);
       if (!updateRunProcess(runId, project, status, launch.watcher())) {
@@ -625,6 +647,23 @@ public final class DispatchOperations {
       releaseIfAbsent(runId, project, unit);
       throw e;
     }
+  }
+
+  /**
+   * The engagement's own conversation: the newest chat-turn session of the engaged agent this box
+   * can resume. A build or invite session never qualifies — a working lane's conversation must not
+   * reopen under a chat turn's contract, and the engaged agent's memory is its chat turns.
+   */
+  private String engagedSessionId(String specId, String agentType, String localHandle) {
+    return runStore.listForSpec(specId).stream()
+        .filter(RunStore.RunRow::chatRole)
+        .filter(run -> SailOperations.ownsRun(run.node(), localHandle))
+        .filter(run -> Strings.isNotBlank(run.sessionId()))
+        .filter(run -> agentType.equals(run.agent()))
+        .filter(run -> AgentCli.isSafeSessionId(run.sessionId()))
+        .findFirst()
+        .map(RunStore.RunRow::sessionId)
+        .orElse(null);
   }
 
   /**
@@ -682,11 +721,13 @@ public final class DispatchOperations {
     requireTrustedRoster(localHandle);
     var agentCli = inviteAgent(agentYamlName);
     var inviteModel = inviteModel(model);
-    if (!full && !agentCli.supportsReadOnlyInvite()) {
+    if (!full) {
       throw new ApiException(
           ErrorCode.BAD_REQUEST,
-          agentCli.readOnlyInviteRefusal(),
-          "Invite " + agentCli.yamlName() + " with full access, or invite claude-code read-only.");
+          "Read-only invites are superseded by engagement: engage the agent in the room instead"
+              + " (POST /v1/specs/{id}/engage, or 'sail spec engage').",
+          "An engaged read-only agent stays in the room and answers every message — the one-shot"
+              + " read-only invite offered strictly less.");
     }
     var project = spec.project();
     var loaded = projects.loadRunning(project);
@@ -701,7 +742,7 @@ public final class DispatchOperations {
         messageStore == null
             ? List.<MessageStore.MessageRow>of()
             : messageStore.list(specId, null, 20);
-    var built = InvitePrompt.build(spec, body.isBlank() ? spec.title() : body, room, full);
+    var built = InvitePrompt.build(spec, body.isBlank() ? spec.title() : body, room);
     var task = built.prompt();
     var runId = DateTimeUtils.newId().toString();
     var unit = AgentUnit.forRun(runId);
@@ -749,7 +790,6 @@ public final class DispatchOperations {
                 repoPaths,
                 credential,
                 role,
-                full,
                 snapshot);
     return new InviteLaunch(runId, principal, full, snapshot, completion);
   }
@@ -775,26 +815,18 @@ public final class DispatchOperations {
       List<String> repoPaths,
       String credential,
       String role,
-      boolean full,
       String snapshot) {
     try {
-      if (full) {
-        if (!Strings.isBlank(snapshot)) {
-          inviteSnapshot(project, specId, runId);
-        }
-      } else {
-        captureRoomBaseline(project, config, runId);
+      if (!Strings.isBlank(snapshot)) {
+        inviteSnapshot(project, specId, runId);
       }
-      var workDir =
-          full
-              ? AgentSession.launchWorkDir(config.sshUser(), targetRepos)
-              : "/home/" + config.sshUser() + "/workspace";
+      var workDir = AgentSession.launchWorkDir(config.sshUser(), targetRepos);
       var launch =
           launchSession(
               project,
               config,
               workDir,
-              full,
+              true,
               inviteModel,
               null,
               specId,
@@ -878,6 +910,133 @@ public final class DispatchOperations {
     } catch (IllegalArgumentException e) {
       throw new ApiException(ErrorCode.BAD_REQUEST, e.getMessage());
     }
+  }
+
+  /** A prepared engagement: the snapshot label a full mode will pay, and the deferred half. */
+  public record EngageLaunch(String agent, String mode, String snapshot, Runnable completion) {}
+
+  /**
+   * Engages an agent in {@code specId}'s room: records the engagement on the spec row (synced,
+   * atomic — one JSON value) so the wake reactor answers every human message with a chat turn until
+   * a human disengages. Mode {@code full} is the default and pays with one engage-time container
+   * snapshot (never per turn); {@code read-only} is the explicit narrow choice, offered only where
+   * the harness enforces it. Requires the dispatch tier on the spec, exactly like an invite. The
+   * full mode's snapshot runs off the request thread ({@code completion}) because a {@code
+   * dir}-backend snapshot would blow the HTTP timeout; the engagement is persisted only after the
+   * snapshot succeeds — the payment precedes the access — and a failure publishes {@code
+   * spec_engage_failed} into the room instead of engaging.
+   */
+  public EngageLaunch engage(
+      String specId,
+      String agentYamlName,
+      String mode,
+      String model,
+      Actor actor,
+      String localHandle) {
+    var spec =
+        specStore
+            .findById(specId)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
+    requireAllowed(actor, spec.toSpec(), localHandle);
+    requireTrustedRoster(localHandle);
+    var agentCli = inviteAgent(agentYamlName);
+    Engagement engagement;
+    try {
+      engagement =
+          Engagement.of(
+              agentCli.yamlName(), mode, inviteModel(model), DateTimeUtils.now().toString());
+    } catch (IllegalArgumentException e) {
+      throw new ApiException(ErrorCode.BAD_REQUEST, e.getMessage());
+    }
+    if (!engagement.full() && !agentCli.supportsRoomLane()) {
+      throw new ApiException(
+          ErrorCode.BAD_REQUEST,
+          agentCli.readOnlyInviteRefusal(),
+          "Engage " + agentCli.yamlName() + " with full access instead.");
+    }
+    var project = spec.project();
+    projects.loadRunning(project);
+    requireInstalled(agentCli, project);
+    if (!engagement.full()) {
+      persistEngagement(specId, engagement, actor);
+      publishEngaged(project, specId, engagement, "");
+      return new EngageLaunch(engagement.agent(), engagement.mode(), "", null);
+    }
+    var label = "engage-" + DateTimeUtils.newId();
+    Runnable completion = () -> completeEngage(project, specId, engagement, label, actor);
+    return new EngageLaunch(engagement.agent(), engagement.mode(), label, completion);
+  }
+
+  private void completeEngage(
+      String project, String specId, Engagement engagement, String label, Actor actor) {
+    try {
+      try {
+        new SnapshotManager(shell).create(project, label, INVITE_SNAPSHOT_TIMEOUT);
+      } catch (Exception e) {
+        throw new ApiException(
+            ErrorCode.SNAPSHOT_FAILED,
+            "Failed to create the engage snapshot, so the engagement does not take effect.",
+            "Check the host's snapshot capacity (incus storage) and retry.",
+            e);
+      }
+      publish(project, specId, Event.WellKnownTypes.SNAPSHOT_CREATED, Map.of("label", label));
+      persistEngagement(specId, engagement, actor);
+      publishEngaged(project, specId, engagement, label);
+    } catch (RuntimeException e) {
+      var data = new LinkedHashMap<String, Object>();
+      data.put("agent", engagement.agent());
+      data.put("label", label);
+      data.put("error", Objects.requireNonNullElse(e.getMessage(), e.toString()));
+      publish(project, specId, Event.WellKnownTypes.SPEC_ENGAGE_FAILED, data);
+    }
+  }
+
+  /** Dismisses the room's engaged agent. Idempotent: dismissing an empty room is a no-op. */
+  public String disengage(String specId, Actor actor, String localHandle) {
+    var spec =
+        specStore
+            .findById(specId)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
+    requireAllowed(actor, spec.toSpec(), localHandle);
+    var engagement = Engagement.fromJson(spec.engagement());
+    if (engagement == null) {
+      return null;
+    }
+    specStore.update(spec.withEngagement(null));
+    publish(
+        spec.project(),
+        specId,
+        Event.WellKnownTypes.SPEC_DISENGAGED,
+        Map.of("agent", engagement.agent(), "mode", engagement.mode()));
+    return engagement.agent();
+  }
+
+  private void persistEngagement(String specId, Engagement engagement, Actor actor) {
+    var current =
+        specStore
+            .findById(specId)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.SPEC_NOT_FOUND,
+                        "Spec '" + specId + "' vanished while engaging."));
+    specStore.update(current.withEngagement(engagement.toJson()));
+  }
+
+  private void publishEngaged(String project, String specId, Engagement engagement, String label) {
+    var data = new LinkedHashMap<String, Object>();
+    data.put("agent", engagement.agent());
+    data.put("mode", engagement.mode());
+    if (!Strings.isBlank(label)) {
+      data.put("label", label);
+    }
+    publish(project, specId, Event.WellKnownTypes.SPEC_ENGAGED, data);
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -918,19 +918,22 @@ public final class DispatchOperations {
   /**
    * Engages an agent in {@code specId}'s room: records the engagement on the spec row (synced,
    * atomic — one JSON value) so the wake reactor answers every human message with a chat turn until
-   * a human disengages. Mode {@code full} is the default and pays with one engage-time container
-   * snapshot (never per turn); {@code read-only} is the explicit narrow choice, offered only where
-   * the harness enforces it. Requires the dispatch tier on the spec, exactly like an invite. The
-   * full mode's snapshot runs off the request thread ({@code completion}) because a {@code
-   * dir}-backend snapshot would blow the HTTP timeout; the engagement is persisted only after the
-   * snapshot succeeds — the payment precedes the access — and a failure publishes {@code
-   * spec_engage_failed} into the room instead of engaging.
+   * a human disengages. Mode {@code full} is the default; {@code read-only} is the explicit narrow
+   * choice, offered only where the harness enforces it. A full engagement may take one engage-time
+   * rollback snapshot (never per turn), but the default is none — on the {@code dir} backend a
+   * snapshot is a slow full filesystem copy, so the rollback point is opt-in ({@code takeSnapshot})
+   * and the per-turn repo reservation remains the standing guard. A requested snapshot runs off the
+   * request thread ({@code completion}) because a {@code dir}-backend snapshot would blow the HTTP
+   * timeout; the engagement is then persisted only after the snapshot succeeds — the payment
+   * precedes the access — and a failure publishes {@code spec_engage_failed} into the room instead
+   * of engaging. Requires the dispatch tier on the spec, exactly like an invite.
    */
   public EngageLaunch engage(
       String specId,
       String agentYamlName,
       String mode,
       String model,
+      boolean takeSnapshot,
       Actor actor,
       String localHandle) {
     var spec =
@@ -960,7 +963,7 @@ public final class DispatchOperations {
     var project = spec.project();
     projects.loadRunning(project);
     requireInstalled(agentCli, project);
-    if (!engagement.full()) {
+    if (!engagement.full() || !takeSnapshot) {
       persistEngagement(specId, engagement, actor);
       publishEngaged(project, specId, engagement, "");
       return new EngageLaunch(engagement.agent(), engagement.mode(), "", null);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
@@ -95,6 +95,16 @@ public record Event(
     public static final String PROJECT_STOPPED = "project_stopped";
     public static final String BOARD_UPDATED = "board_updated";
     public static final String SPEC_MESSAGE_POSTED = "spec_message_posted";
+
+    /** A human put an agent in the spec's room; it answers every human message until dismissed. */
+    public static final String SPEC_ENGAGED = "spec_engaged";
+
+    /** The room's engaged agent was dismissed (or its engagement expired). */
+    public static final String SPEC_DISENGAGED = "spec_disengaged";
+
+    /** An engagement did not take effect — the full mode's snapshot payment failed. */
+    public static final String SPEC_ENGAGE_FAILED = "spec_engage_failed";
+
     public static final String AGENT_PRESENCE = "agent_presence";
     public static final String HEARTBEAT = "heartbeat";
 
@@ -191,6 +201,13 @@ public record Event(
     /** {@link #RUN_ROLE} value: a room wake — a chat that must never trigger a review. */
     public static final String RUN_ROLE_ROOM = "room";
 
+    /**
+     * {@link #RUN_ROLE} value: an engaged agent's full-access chat turn. A conversation, not a
+     * task: never a review trigger, and its clean stop is turn plumbing, not news.
+     */
+    public static final String RUN_ROLE_ROOM_FULL =
+        ai.singlr.sail.store.DispatchGate.ROOM_FULL_ROLE;
+
     /** {@link #RUN_ROLE} value: a reviewer run — its own stop must never re-enter the pipeline. */
     public static final String RUN_ROLE_REVIEW = "review";
 
@@ -216,6 +233,7 @@ public record Event(
      */
     public static boolean nonTriggeringLane(String role) {
       return RUN_ROLE_ROOM.equals(role)
+          || RUN_ROLE_ROOM_FULL.equals(role)
           || RUN_ROLE_REVIEW.equals(role)
           || RUN_ROLE_FIX.equals(role)
           || RUN_ROLE_INVITE.equals(role)

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
@@ -186,5 +186,10 @@ public interface Operations {
   Result<InviteResponse> inviteToSpec(
       String specId, InviteRequest request, Actor actor, String localHandle);
 
+  Result<EngageResponse> engageToSpec(
+      String specId, EngageRequest request, Actor actor, String localHandle);
+
+  Result<DisengageResponse> disengageSpec(String specId, Actor actor, String localHandle);
+
   Result<GlobalBoardResponse> globalBoard(String project);
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -1026,7 +1026,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
         && !runId.isBlank()
         && runStore
             .findById(runId)
-            .map(row -> row.roomRole() || row.reviewRole() || row.inviteRole())
+            .map(row -> row.chatRole() || row.reviewRole() || row.inviteRole())
             .orElse(false);
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakePolicy.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakePolicy.java
@@ -22,6 +22,11 @@ import ai.singlr.sail.common.Strings;
  * mention} only when the message addresses {@code @agent}, {@code off} never. An unset mode
  * defaults to {@code on} for any spec that has been dispatched at least once — the agent joined the
  * room when it first worked there — and {@code off} for a spec no agent has ever touched.
+ *
+ * <p>An engaged room ignores the wake vocabulary entirely: engagement is the explicit statement
+ * that an agent is in the room, so every human message deserves an answer regardless of the stored
+ * mode or dispatch history. The human-author rule is the one gate engagement never overrides —
+ * silence is a dismissal away, storms stay impossible by construction.
  */
 public final class RoomWakePolicy {
 
@@ -48,9 +53,16 @@ public final class RoomWakePolicy {
 
   /** Whether a human-authored {@code body} under this spec's mode should wake the agent. */
   public static boolean shouldWake(
-      String storedWake, boolean dispatchedAtLeastOnce, String author, String body) {
+      String storedWake,
+      boolean dispatchedAtLeastOnce,
+      boolean engaged,
+      String author,
+      String body) {
     if (!humanAuthor(author)) {
       return false;
+    }
+    if (engaged) {
+      return true;
     }
     return switch (effectiveMode(storedWake, dispatchedAtLeastOnce)) {
       case "on" -> true;

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
@@ -90,6 +90,8 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
   private final Delay delay;
   private final Supplier<Instant> clock;
   private final Set<String> pending = ConcurrentHashMap.newKeySet();
+  private final PeriodicPass sweepPass =
+      new PeriodicPass("room-engagement", this::sweepEngagedRooms);
 
   public RoomWakeReactor(
       SpecStore specStore,
@@ -307,6 +309,24 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
         : null;
   }
 
+  /**
+   * The engaged loop's safety net, run by a periodic pass: any engaged room this box owns whose
+   * newest human message no chat turn has answered gets its turn scheduled — a crashed debounce, a
+   * lost event, or a turn deferred behind a build must never strand a conversation.
+   */
+  public void sweepEngagedRooms() {
+    for (var spec : specStore.listEngaged()) {
+      try {
+        if (ownsSpec(spec)) {
+          refireOwedTurn(spec.id());
+        }
+      } catch (RuntimeException e) {
+        System.err.println(
+            "room-wake: engagement sweep of spec " + spec.id() + " failed: " + e.getMessage());
+      }
+    }
+  }
+
   private boolean ownsSpec(SpecStore.SpecRow spec) {
     var handle = localHandle.get();
     return Strings.isNotBlank(handle) && handle.equals(spec.assignee());
@@ -352,8 +372,14 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
     return new Message(event.agent(), Objects.toString(event.data().get("preview"), ""));
   }
 
+  /** Arms the engagement sweep at the given cadence — the safety net behind the event edges. */
+  public void startSweep(Duration interval) {
+    sweepPass.start(interval);
+  }
+
   @Override
   public void close() {
+    sweepPass.close();
     executor.close();
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.api;
 
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.Engagement;
 import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
@@ -47,6 +48,12 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
   /** How long a triggering message waits so the messages right behind it ride the same wake. */
   public static final Duration DEBOUNCE = Duration.ofSeconds(30);
 
+  /**
+   * The engaged room's debounce: an agent someone deliberately put in the room answers promptly, so
+   * the batching window shrinks to what still catches a quick follow-up keystroke.
+   */
+  public static final Duration ENGAGED_DEBOUNCE = Duration.ofSeconds(5);
+
   /** How long after any run finish the room stays quiet — no thank-you refire, no loop sniping. */
   public static final Duration COOLDOWN = Duration.ofMinutes(10);
 
@@ -77,6 +84,7 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
   private final Waker waker;
   private final Guard guard;
   private final Duration debounce;
+  private final Duration engagedDebounce;
   private final Duration cooldown;
   private final ExecutorService executor;
   private final Delay delay;
@@ -98,6 +106,7 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
         waker,
         guard,
         DEBOUNCE,
+        ENGAGED_DEBOUNCE,
         COOLDOWN,
         Executors.newVirtualThreadPerTaskExecutor(),
         Thread::sleep,
@@ -112,6 +121,7 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
       Waker waker,
       Guard guard,
       Duration debounce,
+      Duration engagedDebounce,
       Duration cooldown,
       ExecutorService executor,
       Delay delay,
@@ -123,6 +133,7 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
     this.waker = Objects.requireNonNull(waker, "waker");
     this.guard = Objects.requireNonNull(guard, "guard");
     this.debounce = debounce;
+    this.engagedDebounce = engagedDebounce;
     this.cooldown = cooldown;
     this.executor = executor;
     this.delay = delay;
@@ -168,20 +179,25 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
     if (spec == null || !ownsSpec(spec)) {
       return;
     }
+    var engaged = Engagement.fromJson(spec.engagement()) != null;
     var message = messageOf(event);
     if (!RoomWakePolicy.shouldWake(
-        spec.wake(), dispatchedAtLeastOnce(specId), message.author(), message.body())) {
+        spec.wake(), dispatchedAtLeastOnce(specId), engaged, message.author(), message.body())) {
       return;
     }
+    schedule(specId, message, engaged);
+  }
+
+  private void schedule(String specId, Message message, boolean engaged) {
     if (!pending.add(specId)) {
       return;
     }
-    executor.execute(() -> debounceThenFire(specId, message));
+    executor.execute(() -> debounceThenFire(specId, message, engaged ? engagedDebounce : debounce));
   }
 
-  private void debounceThenFire(String specId, Message message) {
+  private void debounceThenFire(String specId, Message message, Duration pause) {
     try {
-      delay.pause(debounce);
+      delay.pause(pause);
       fire(specId, message);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -196,16 +212,23 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
       if (spec == null || !ownsSpec(spec)) {
         return;
       }
+      var engaged = Engagement.fromJson(spec.engagement()) != null;
       if (!RoomWakePolicy.shouldWake(
-          spec.wake(), dispatchedAtLeastOnce(specId), message.author(), message.body())) {
+          spec.wake(), dispatchedAtLeastOnce(specId), engaged, message.author(), message.body())) {
         return;
       }
       var runs = runStore.listForSpec(specId);
-      if (runs.stream().anyMatch(run -> LIVE_STATUSES.contains(run.status()))) {
-        return;
-      }
-      if (withinCooldown(runs)) {
-        return;
+      if (engaged) {
+        if (runs.stream().anyMatch(run -> LIVE_STATUSES.contains(run.status()) && run.chatRole())) {
+          return;
+        }
+      } else {
+        if (runs.stream().anyMatch(run -> LIVE_STATUSES.contains(run.status()))) {
+          return;
+        }
+        if (withinCooldown(runs)) {
+          return;
+        }
       }
       waker.wake(spec.project(), specId);
     } catch (Exception e) {
@@ -214,6 +237,11 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
   }
 
   private void handleStop(Event event) throws Exception {
+    guardChatStop(event);
+    refireOwedTurn(event.spec());
+  }
+
+  private void guardChatStop(Event event) throws Exception {
     var role = event.data().get(Event.WellKnownData.RUN_ROLE);
     if (!Event.WellKnownData.RUN_ROLE_ROOM.equals(role)
         && !Event.WellKnownData.RUN_ROLE_INVITE.equals(role)) {
@@ -228,6 +256,55 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
       return;
     }
     guard.guard(run.project(), runId);
+  }
+
+  /**
+   * The stop edge of the engaged loop: a message that landed in a turn's tail — after the relay's
+   * last check — or a full turn deferred behind a build's repo claim gets its turn when any run of
+   * the spec stops. The owed check is derived, never bookkept: the newest human message arrived
+   * after the newest chat turn started, so no turn has read it.
+   */
+  private void refireOwedTurn(String specId) {
+    var spec = specStore.findById(specId).orElse(null);
+    if (spec == null || !ownsSpec(spec) || Engagement.fromJson(spec.engagement()) == null) {
+      return;
+    }
+    var owed = owedMessage(specId);
+    if (owed == null) {
+      return;
+    }
+    schedule(specId, owed, true);
+  }
+
+  /** The newest human message no chat turn has started after, or {@code null} when none is owed. */
+  private Message owedMessage(String specId) {
+    if (messageStore == null) {
+      return null;
+    }
+    var newestHuman =
+        messageStore.list(specId, null, 20).stream()
+            .filter(row -> RoomWakePolicy.humanAuthor(row.author()))
+            .reduce((first, second) -> second)
+            .orElse(null);
+    if (newestHuman == null) {
+      return null;
+    }
+    var humanAt = parseInstant(newestHuman.createdAt());
+    if (humanAt == null) {
+      return null;
+    }
+    var newestChatStart =
+        runStore.listForSpec(specId).stream()
+            .filter(RunStore.RunRow::chatRole)
+            .map(RunStore.RunRow::startedAt)
+            .filter(Strings::isNotBlank)
+            .map(RoomWakeReactor::parseInstant)
+            .filter(Objects::nonNull)
+            .max(Instant::compareTo)
+            .orElse(Instant.MIN);
+    return humanAt.isAfter(newestChatStart)
+        ? new Message(newestHuman.author(), newestHuman.body())
+        : null;
   }
 
   private boolean ownsSpec(SpecStore.SpecRow spec) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -449,6 +449,38 @@ public final class SailOperations implements Operations {
     return result;
   }
 
+  @Override
+  public Result<EngageResponse> engageToSpec(
+      String specId, EngageRequest request, Actor actor, String localHandle) {
+    freshenForRead();
+    var result =
+        safe(
+            () -> {
+              var launch =
+                  dispatchOps.engage(
+                      specId, request.agent(), request.mode(), request.model(), actor, localHandle);
+              if (launch.completion() != null) {
+                inviteExecutor.execute(launch.completion());
+              }
+              return new EngageResponse(launch.agent(), launch.mode(), launch.snapshot());
+            });
+    if (result instanceof Result.Success<EngageResponse>) {
+      triggerSyncAfterWrite();
+    }
+    return result;
+  }
+
+  @Override
+  public Result<DisengageResponse> disengageSpec(String specId, Actor actor, String localHandle) {
+    freshenForRead();
+    var result =
+        safe(() -> new DisengageResponse(dispatchOps.disengage(specId, actor, localHandle)));
+    if (result instanceof Result.Success<DisengageResponse>) {
+      triggerSyncAfterWrite();
+    }
+    return result;
+  }
+
   private InviteResponse inviteValue(
       String specId, InviteRequest request, Actor actor, String localHandle) {
     var launch =

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -458,7 +458,13 @@ public final class SailOperations implements Operations {
             () -> {
               var launch =
                   dispatchOps.engage(
-                      specId, request.agent(), request.mode(), request.model(), actor, localHandle);
+                      specId,
+                      request.agent(),
+                      request.mode(),
+                      request.model(),
+                      request.snapshot(),
+                      actor,
+                      localHandle);
               if (launch.completion() != null) {
                 inviteExecutor.execute(launch.completion());
               }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SlackReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SlackReactor.java
@@ -174,7 +174,27 @@ public final class SlackReactor implements EventSubscriber {
    * stop (which carries a {@code source}) is the real termination worth a thread reply.
    */
   private static boolean isTurnEndStop(Event event) {
-    return Event.WellKnownTypes.AGENT_SESSION_STOPPED.equals(event.type())
-        && event.data().get(Event.WellKnownData.SOURCE) == null;
+    if (!Event.WellKnownTypes.AGENT_SESSION_STOPPED.equals(event.type())) {
+      return false;
+    }
+    if (event.data().get(Event.WellKnownData.SOURCE) == null) {
+      return true;
+    }
+    return isCleanChatStop(event);
+  }
+
+  /**
+   * A non-triggering lane's clean stop is plumbing, not news: chat and invite turns speak through
+   * their room replies, review and fix runs through the pipeline's own stage events — so Slack must
+   * not narrate "agent stopped (exit 0)" after every turn of an engaged conversation. Failures
+   * still post, and build stops are untouched.
+   */
+  private static boolean isCleanChatStop(Event event) {
+    var role = Objects.toString(event.data().get(Event.WellKnownData.RUN_ROLE), null);
+    if (role == null || !Event.WellKnownData.nonTriggeringLane(role)) {
+      return false;
+    }
+    var exit = event.data().get(Event.WellKnownData.EXIT_CODE);
+    return exit == null || "0".equals(exit.toString());
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecDisengageCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecDisengageCommand.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.api.SailApiClient;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.NameValidator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+/**
+ * Dismisses a spec room's engaged agent. Idempotent — dismissing an empty room reports that nobody
+ * was there rather than erroring. A thin client of {@code POST /v1/specs/{id}/disengage}.
+ */
+@Command(
+    name = "disengage",
+    description = "Dismiss this spec room's engaged agent.",
+    mixinStandardHelpOptions = true)
+public final class ApiSpecDisengageCommand implements Runnable {
+
+  @Parameters(index = "0", description = "Spec ID.")
+  private String specId;
+
+  @Mixin private SyncOptions syncOptions;
+
+  @Mixin private ConnectionOptions connection;
+
+  @Option(names = "--json", description = "Output in JSON format.")
+  private boolean json;
+
+  @Spec private CommandSpec commandSpec;
+
+  @Override
+  public void run() {
+    CliCommand.run(commandSpec, this::execute);
+  }
+
+  private void execute() throws Exception {
+    NameValidator.requireValidSpecId(specId);
+    var config = connection.resolve();
+    try (var client = new SailApiClient(config.serverUrl(), config.token(), syncOptions.noSync())) {
+      var result = client.post("/v1/specs/" + specId + "/disengage", Map.of());
+
+      if (json) {
+        System.out.println(YamlUtil.dumpJson(new LinkedHashMap<>(result)));
+        return;
+      }
+      var agent = result.get("agent");
+      if (agent == null) {
+        System.out.println("  No agent was engaged in spec '" + specId + "'.");
+        return;
+      }
+      System.out.println(
+          Ansi.AUTO.string("  @|green ✓|@ Dismissed " + agent + " from spec '" + specId + "'."));
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecEngageCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecEngageCommand.java
@@ -21,17 +21,17 @@ import picocli.CommandLine.Spec;
 
 /**
  * Engages an agent in a spec's room: it joins the conversation and answers every human message
- * until dismissed. Full access is the default — conversations produce artifacts — and pays with one
- * engage-time snapshot; {@code --read-only} is the explicit narrow choice, offered only where the
- * harness enforces it. A thin client of {@code POST /v1/specs/{id}/engage}; the server's refusals
- * render verbatim.
+ * until dismissed. Full access is the default — conversations produce artifacts. {@code --snapshot}
+ * opts into a rollback point first (off by default: a dir-backend snapshot is a slow full copy);
+ * {@code --read-only} is the explicit narrow choice, offered only where the harness enforces it. A
+ * thin client of {@code POST /v1/specs/{id}/engage}; the server's refusals render verbatim.
  */
 @Command(
     name = "engage",
     description =
         "Put an agent in this spec's room — it answers every message until 'spec disengage'."
-            + " Full access by default (snapshots first); --read-only for the enforced narrow"
-            + " mode.",
+            + " Full access by default; --read-only for the enforced narrow mode, --snapshot for"
+            + " a rollback point first.",
     mixinStandardHelpOptions = true)
 public final class ApiSpecEngageCommand implements Runnable {
 
@@ -48,6 +48,13 @@ public final class ApiSpecEngageCommand implements Runnable {
       names = "--read-only",
       description = "Enforced read-only conversation (claude-code only today).")
   private boolean readOnly;
+
+  @Option(
+      names = "--snapshot",
+      description =
+          "Take a rollback snapshot before the engagement takes effect (full mode only)."
+              + " Off by default — on the dir backend a snapshot is a slow full copy.")
+  private boolean snapshot;
 
   @Mixin private SyncOptions syncOptions;
 
@@ -69,6 +76,9 @@ public final class ApiSpecEngageCommand implements Runnable {
     var body = new LinkedHashMap<String, Object>();
     body.put("agent", agent);
     body.put("mode", readOnly ? "read-only" : "full");
+    if (snapshot && !readOnly) {
+      body.put("snapshot", true);
+    }
     if (Strings.isNotBlank(model)) {
       body.put("model", model);
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecEngageCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecEngageCommand.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.api.SailApiClient;
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.NameValidator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+/**
+ * Engages an agent in a spec's room: it joins the conversation and answers every human message
+ * until dismissed. Full access is the default — conversations produce artifacts — and pays with one
+ * engage-time snapshot; {@code --read-only} is the explicit narrow choice, offered only where the
+ * harness enforces it. A thin client of {@code POST /v1/specs/{id}/engage}; the server's refusals
+ * render verbatim.
+ */
+@Command(
+    name = "engage",
+    description =
+        "Put an agent in this spec's room — it answers every message until 'spec disengage'."
+            + " Full access by default (snapshots first); --read-only for the enforced narrow"
+            + " mode.",
+    mixinStandardHelpOptions = true)
+public final class ApiSpecEngageCommand implements Runnable {
+
+  @Parameters(index = "0", description = "Spec ID.")
+  private String specId;
+
+  @Option(names = "--agent", required = true, description = "Agent to engage: claude-code, codex.")
+  private String agent;
+
+  @Option(names = "--model", description = "Model override for the engaged agent.")
+  private String model;
+
+  @Option(
+      names = "--read-only",
+      description = "Enforced read-only conversation (claude-code only today).")
+  private boolean readOnly;
+
+  @Mixin private SyncOptions syncOptions;
+
+  @Mixin private ConnectionOptions connection;
+
+  @Option(names = "--json", description = "Output in JSON format.")
+  private boolean json;
+
+  @Spec private CommandSpec commandSpec;
+
+  @Override
+  public void run() {
+    CliCommand.run(commandSpec, this::execute);
+  }
+
+  private void execute() throws Exception {
+    NameValidator.requireValidSpecId(specId);
+    var config = connection.resolve();
+    var body = new LinkedHashMap<String, Object>();
+    body.put("agent", agent);
+    body.put("mode", readOnly ? "read-only" : "full");
+    if (Strings.isNotBlank(model)) {
+      body.put("model", model);
+    }
+    try (var client = new SailApiClient(config.serverUrl(), config.token(), syncOptions.noSync())) {
+      var result = client.post("/v1/specs/" + specId + "/engage", Map.copyOf(body));
+
+      if (json) {
+        System.out.println(YamlUtil.dumpJson(new LinkedHashMap<>(result)));
+        return;
+      }
+      var snapshot = result.get("snapshot");
+      if (snapshot != null && !snapshot.toString().isBlank()) {
+        System.out.println(
+            Ansi.AUTO.string(
+                "  @|green ✓|@ Engaging "
+                    + agent
+                    + " (full) in spec '"
+                    + specId
+                    + "' — snapshot "
+                    + snapshot
+                    + " is being taken; the engagement takes effect when it completes."));
+        return;
+      }
+      System.out.println(
+          Ansi.AUTO.string(
+              "  @|green ✓|@ Engaged "
+                  + agent
+                  + " ("
+                  + result.get("mode")
+                  + ") in spec '"
+                  + specId
+                  + "' — it now answers every message in this room."));
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecInviteCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecInviteCommand.java
@@ -20,16 +20,16 @@ import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Spec;
 
 /**
- * Invites an agent into a spec's room: one choice, read only (default) or {@code --full}. The
- * server owns the whole launch — mode support, reservation, the full lane's pre-launch snapshot —
- * so this command is a thin client of {@code POST /v1/specs/{id}/invite} and renders the server's
- * refusals verbatim.
+ * Runs a task-shaped invite: one full-access agent turn in the spec's room, paid with a pre-launch
+ * snapshot and the repo reservation. Joining a room conversationally is {@code sail spec engage} —
+ * this lane is for "do this now" work. The server owns the whole launch, so this command is a thin
+ * client of {@code POST /v1/specs/{id}/invite} and renders the server's refusals verbatim.
  */
 @Command(
     name = "invite",
     description =
-        "Invite an agent into this spec's room — read only by default, --full to let it change"
-            + " specs and code (snapshots first).",
+        "Run one full-access agent turn in this spec's room (snapshots first). To add an agent to"
+            + " the conversation, use 'spec engage'.",
     mixinStandardHelpOptions = true)
 public final class ApiSpecInviteCommand implements Runnable {
 
@@ -41,11 +41,6 @@ public final class ApiSpecInviteCommand implements Runnable {
 
   @Option(names = "--model", description = "Model override for the invited agent.")
   private String model;
-
-  @Option(
-      names = "--full",
-      description = "Full access: spec CLI writes and code changes, paid with a snapshot.")
-  private boolean full;
 
   @Mixin private SyncOptions syncOptions;
 
@@ -69,7 +64,7 @@ public final class ApiSpecInviteCommand implements Runnable {
     if (Strings.isNotBlank(model)) {
       body.put("model", model);
     }
-    body.put("full", full);
+    body.put("full", true);
     try (var client = new SailApiClient(config.serverUrl(), config.token(), syncOptions.noSync())) {
       var result = client.post("/v1/specs/" + specId + "/invite", Map.copyOf(body));
 
@@ -77,7 +72,7 @@ public final class ApiSpecInviteCommand implements Runnable {
         System.out.println(YamlUtil.dumpJson(new LinkedHashMap<>(result)));
         return;
       }
-      var mode = full ? "full access" : "read only";
+      var mode = "full access";
       System.out.println(
           Ansi.AUTO.string(
               "  @|green ✓|@ Invited "

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -63,6 +63,7 @@ import ai.singlr.sail.store.WebauthnCredentialStore;
 import ai.singlr.sail.webauthn.RelyingParty;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -235,6 +236,7 @@ public final class ServerStartCommand implements Runnable {
             (project, specId) -> operations.startRoomRun(project, specId, NodeIdentity.handle()),
             operations::guardRoomRun);
     bus.subscribe(roomWake);
+    roomWake.startSweep(Duration.ofSeconds(60));
     shutdown.register(roomWake);
     if (narratesSlack(HostSync.config())) {
       bus.subscribe(SlackReactor.withDefaults(new SlackThreadStore(db), specStore));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SpecCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SpecCommand.java
@@ -24,6 +24,8 @@ import picocli.CommandLine.Command;
       ApiSpecCommentCommand.class,
       ApiSpecCommentsCommand.class,
       ApiSpecInviteCommand.class,
+      ApiSpecEngageCommand.class,
+      ApiSpecDisengageCommand.class,
       DispatchCommand.class,
     })
 public final class SpecCommand implements Runnable {

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/InvitePrompt.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/InvitePrompt.java
@@ -29,7 +29,7 @@ public final class InvitePrompt {
   public record Built(String prompt, List<MessageStore.MessageRow> renderedMessages) {}
 
   public static Built build(
-      SpecStore.SpecRow spec, String body, List<MessageStore.MessageRow> messages, boolean full) {
+      SpecStore.SpecRow spec, String body, List<MessageStore.MessageRow> messages) {
     var conversation =
         PromptConversation.renderNewest(
             messages,
@@ -46,39 +46,14 @@ public final class InvitePrompt {
             + spec.id()
             + ", status: "
             + spec.status().wire()
-            + "). A human invited you into this conversation with "
-            + (full ? "full access" : "read-only access")
+            + "). A human invited you into this conversation with full access"
             + " to help: chat, critique, or draft — bring your own perspective.\n\n"
             + conversationBlock
             + "## Spec body\n\n"
             + body
             + "\n\n"
-            + (full ? fullDuty(spec.id()) : readOnlyDuty(spec.id()));
+            + fullDuty(spec.id());
     return new Built(prompt, conversation.fullyRendered());
-  }
-
-  private static String readOnlyDuty(String specId) {
-    return """
-        ## Invite Duty (read only)
-
-        Read the conversation and spec body above, investigate in the workspace as needed,
-        and post your contribution in the room with `spec comment %s --body <text>`
-        (or `--body -` for stdin).
-
-        This is a read-only chat session, and the harness enforces it: file edits and spec
-        state changes are denied, and the only shell commands that run are the `spec` CLI
-        and `cd` — use the Read and Grep tools for files. Do not fight a denial; work
-        within the lane. If the conversation asks for code changes, describe them in the
-        room — dispatch (or a full invite) is the lane that changes code. If the
-        conversation asks something you cannot answer or decide alone, post it back with
-        `spec comment %s --question --body <text>` — the flag pages the engineer on the
-        board until a human replies.
-
-        The room stays live while you work: replies posted in the meantime are delivered
-        into your context automatically after a tool call finishes, and unread messages
-        block your first attempt to stop. When you have contributed, stop.
-        """
-        .formatted(specId, specId);
   }
 
   private static String fullDuty(String specId) {

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/RoomWakePrompt.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/RoomWakePrompt.java
@@ -5,23 +5,27 @@
 
 package ai.singlr.sail.engine;
 
+import ai.singlr.sail.config.Engagement;
 import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.SpecStore;
 import java.util.List;
 
 /**
- * Builds the prompt a room wake hands its agent: the spec's identity, the room's recent
- * conversation, and the standing chat-lane instruction — answer in the room, never touch the
- * worktrees, "dispatch to change code" is the answer to change requests. A fresh session is
- * additionally primed with the spec body, exactly like dispatch; a resumed session already carries
- * that context in its conversation and gets only the room tail.
+ * Builds the prompt a chat turn hands its agent: the spec's identity, the room's recent
+ * conversation, and the lane duty. Three duties exist. A plain wake (no engagement) keeps the
+ * original standing-agent contract: answer read-only, dispatch is the lane that changes code, stop
+ * when answered. An engaged turn — read-only or full — is one turn of a continuing conversation:
+ * the agent answers (or, in full mode, does the asked work in the workspace), posts to the room,
+ * and ends its turn knowing it will be resumed for the next message; "stop" never means "leave". A
+ * fresh session is additionally primed with the spec body, exactly like dispatch; a resumed session
+ * already carries that context in its conversation and gets only the room tail.
  */
 public final class RoomWakePrompt {
 
   private RoomWakePrompt() {}
 
   /**
-   * A built wake prompt and the room messages it rendered in full — the exact set the launcher may
+   * A built chat prompt and the room messages it rendered in full — the exact set the launcher may
    * acknowledge as delivered. Delivery derives from presentation, exactly like {@link
    * AgentTaskPrompt.Built}.
    */
@@ -31,7 +35,8 @@ public final class RoomWakePrompt {
       SpecStore.SpecRow spec,
       String body,
       List<MessageStore.MessageRow> messages,
-      boolean resumed) {
+      boolean resumed,
+      Engagement engagement) {
     var conversation =
         PromptConversation.renderNewest(
             messages,
@@ -42,6 +47,12 @@ public final class RoomWakePrompt {
             ? ""
             : "## Conversation on this spec\n\n" + conversation.text();
     var specBlock = resumed ? "" : "## Spec body\n\n" + body + "\n\n";
+    var opening =
+        engagement == null
+            ? "). A human posted in this spec's room while no run was live; you were woken to"
+                + " answer.\n\n"
+            : "). You are engaged in this room — a standing participant, not a visitor: humans"
+                + " post, you answer, and the conversation continues across turns.\n\n";
     var prompt =
         "You are the standing agent of spec \""
             + spec.title()
@@ -49,15 +60,21 @@ public final class RoomWakePrompt {
             + spec.id()
             + ", status: "
             + spec.status().wire()
-            + "). A human posted in this spec's room while no run was live; you were woken to"
-            + " answer.\n\n"
+            + opening
             + conversationBlock
             + specBlock
-            + roomDuty(spec.id());
+            + duty(spec.id(), engagement);
     return new Built(prompt, conversation.fullyRendered());
   }
 
-  private static String roomDuty(String specId) {
+  private static String duty(String specId, Engagement engagement) {
+    if (engagement == null) {
+      return wakeDuty(specId);
+    }
+    return engagement.full() ? engagedFullDuty(specId) : engagedReadOnlyDuty(specId);
+  }
+
+  private static String wakeDuty(String specId) {
     return """
         ## Room Duty
 
@@ -65,13 +82,13 @@ public final class RoomWakePrompt {
         the room with `spec comment %s --body <text>` (or `--body -` for stdin).
 
         This is a read-only chat session, and the harness enforces it: file edits and spec
-        state changes are denied, and the only shell commands that run are the `spec` CLI,
-        `cd`, and read-only git (log, show, diff, status, blame, grep) — use the Read and
-        Grep tools for files. Do not fight a denial; work within the lane. If the
-        conversation asks for code changes, answer that dispatch is the lane that changes
-        code — describe what a re-dispatch (`sail spec dispatch %s --restart`) or a
-        follow-up spec should do instead of doing it here. If the conversation asks
-        something you cannot answer or decide alone, post it back with
+        state changes are denied, and the only shell commands that run are the `spec` CLI
+        and `cd` — use the Read and Grep tools for files (git commands are denied too;
+        read what you need through the tools). Do not fight a denial; work within the
+        lane. If the conversation asks for code changes, answer that dispatch is the lane
+        that changes code — describe what a re-dispatch (`sail spec dispatch %s --restart`)
+        or a follow-up spec should do instead of doing it here. If the
+        conversation asks something you cannot answer or decide alone, post it back with
         `spec comment %s --question --body <text>` — the flag pages the engineer on the
         board until a human replies.
 
@@ -80,5 +97,60 @@ public final class RoomWakePrompt {
         block your first attempt to stop. When you have answered, stop.
         """
         .formatted(specId, specId, specId);
+  }
+
+  private static String engagedReadOnlyDuty(String specId) {
+    return """
+        ## Engaged Turn (read only)
+
+        Read the newest human messages above, investigate in the workspace as needed, and
+        answer in the room with `spec comment %s --body <text>` (or `--body -` for
+        stdin).
+
+        This engagement is read only, and the harness enforces it: file edits and spec
+        state changes are denied, and the only shell commands that run are the `spec` CLI
+        and `cd` — use the Read and Grep tools for files (git commands are denied too).
+        Do not fight a denial; work within the lane. If the conversation asks for code
+        changes, describe them in the room — a human can dispatch, or re-engage you with
+        full access. For a question only a human can settle, use
+        `spec comment %s --question --body <text>` — the flag pages the engineer on the
+        board until a human replies.
+
+        This is one turn of a continuing conversation. Replies posted while you work are
+        delivered into your context automatically after a tool call finishes, and unread
+        messages block your first attempt to stop. When you have answered, post your reply
+        and end your turn — you remain engaged and will be resumed for the next message.
+        Never say goodbye; the room continues.
+        """
+        .formatted(specId, specId);
+  }
+
+  private static String engagedFullDuty(String specId) {
+    return """
+        ## Engaged Turn (full access)
+
+        Read the newest human messages above, then help however the conversation asks:
+        answer, critique, draft, or work in the workspace.
+
+        - Post to the room with `spec comment %s --body <text>` (or `--body -` for
+          stdin). For a question only a human can settle, add `--question` — the flag
+          pages the engineer on the board until a human replies.
+        - Draft this spec's body with `spec content %s --body-file <file>` when the
+          conversation is shaping it, or create sibling specs with
+          `spec create --id <id> --title "<title>" --body-file <file>`. New specs are
+          born draft; a human promotes them on the board — never set a status yourself.
+        - Work in the workspace freely when asked — diagrams, files, experiments: a
+          container snapshot was taken when you were engaged, and this turn holds the
+          repo reservation. Nothing forces a commit at turn end: leave work in the
+          worktree and say where it is, or commit and push when the change is worth
+          keeping and the conversation asks for it.
+
+        This is one turn of a continuing conversation. Replies posted while you work are
+        delivered into your context automatically after a tool call finishes, and unread
+        messages block your first attempt to stop. When you have done what was asked,
+        post your reply and end your turn — you remain engaged and will be resumed for
+        the next message. Never say goodbye; the room continues.
+        """
+        .formatted(specId, specId);
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/RoomWakePrompt.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/RoomWakePrompt.java
@@ -139,11 +139,10 @@ public final class RoomWakePrompt {
           conversation is shaping it, or create sibling specs with
           `spec create --id <id> --title "<title>" --body-file <file>`. New specs are
           born draft; a human promotes them on the board — never set a status yourself.
-        - Work in the workspace freely when asked — diagrams, files, experiments: a
-          container snapshot was taken when you were engaged, and this turn holds the
-          repo reservation. Nothing forces a commit at turn end: leave work in the
-          worktree and say where it is, or commit and push when the change is worth
-          keeping and the conversation asks for it.
+        - Work in the workspace freely when asked — diagrams, files, experiments: this
+          turn holds the repo reservation. Nothing forces a commit at turn end: leave
+          work in the worktree and say where it is, or commit and push when the change
+          is worth keeping and the conversation asks for it.
 
         This is one turn of a continuing conversation. Replies posted while you work are
         delivered into your context automatically after a tool call finishes, and unread

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -1043,6 +1043,41 @@ class ApiRouterTest {
   }
 
   @Test
+  void engagePostRoutesTheBodyToTheOperation() throws Exception {
+    var ops = new FakeOperations();
+    try (var server = serverWith(ops, true)) {
+      var response =
+          post(
+              server,
+              "/v1/specs/auth-flow/engage",
+              "token",
+              "{\"agent\": \"claude-code\", \"model\": \"opus-x\"}");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"agent\": \"claude-code\""));
+      assertTrue(response.body().contains("\"mode\": \"full\""));
+      assertTrue(response.body().contains("\"snapshot\": \"engage-1\""));
+      assertEquals("auth-flow", ops.lastEngage.specId());
+      assertEquals("claude-code", ops.lastEngage.request().agent());
+      assertEquals("opus-x", ops.lastEngage.request().model());
+    }
+  }
+
+  @Test
+  void engageRequiresPostAndDisengageRoutesTheSpec() throws Exception {
+    var ops = new FakeOperations();
+    try (var server = serverWith(ops, true)) {
+      assertEquals(405, get(server, "/v1/specs/auth-flow/engage", "token").statusCode());
+
+      var response = post(server, "/v1/specs/auth-flow/disengage", "token", "{}");
+
+      assertEquals(200, response.statusCode());
+      assertTrue(response.body().contains("\"disengaged\": true"));
+      assertEquals("auth-flow", ops.lastDisengage);
+    }
+  }
+
+  @Test
   void invitePostRoutesTheBodyToTheOperation() throws Exception {
     var ops = new FakeOperations();
     try (var server = serverWith(ops, true)) {
@@ -1473,6 +1508,28 @@ class ApiRouterTest {
                           new AgentModeView("full", true, null))))));
     }
 
+    Engage lastEngage;
+    String lastDisengage;
+
+    record Engage(String specId, EngageRequest request, String localHandle) {}
+
+    @Override
+    public Result<EngageResponse> engageToSpec(
+        String specId, EngageRequest request, Actor actor, String localHandle) {
+      lastEngage = new Engage(specId, request, localHandle);
+      return Result.success(
+          new EngageResponse(
+              request.agent(),
+              request.mode() == null ? "full" : request.mode(),
+              "read-only".equals(request.mode()) ? "" : "engage-1"));
+    }
+
+    @Override
+    public Result<DisengageResponse> disengageSpec(String specId, Actor actor, String localHandle) {
+      lastDisengage = specId;
+      return Result.success(new DisengageResponse("claude-code"));
+    }
+
     @Override
     public Result<InviteResponse> inviteToSpec(
         String specId, InviteRequest request, Actor actor, String localHandle) {
@@ -1679,6 +1736,7 @@ class ApiRouterTest {
                   java.util.List.of(),
                   null,
                   null,
+                  null,
                   "",
                   "",
                   null),
@@ -1708,6 +1766,7 @@ class ApiRouterTest {
                   java.util.List.of(),
                   java.util.List.of(),
                   null,
+                  null,
                   request.createdBy(),
                   "",
                   "",
@@ -1736,6 +1795,7 @@ class ApiRouterTest {
                   java.util.List.of(),
                   null,
                   null,
+                  null,
                   "",
                   "",
                   null)));
@@ -1759,6 +1819,7 @@ class ApiRouterTest {
                   0,
                   java.util.List.of(),
                   java.util.List.of(),
+                  null,
                   null,
                   null,
                   "",

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -1051,7 +1051,7 @@ class ApiRouterTest {
               server,
               "/v1/specs/auth-flow/engage",
               "token",
-              "{\"agent\": \"claude-code\", \"model\": \"opus-x\"}");
+              "{\"agent\": \"claude-code\", \"model\": \"opus-x\", \"snapshot\": true}");
 
       assertEquals(200, response.statusCode());
       assertTrue(response.body().contains("\"agent\": \"claude-code\""));
@@ -1060,6 +1060,7 @@ class ApiRouterTest {
       assertEquals("auth-flow", ops.lastEngage.specId());
       assertEquals("claude-code", ops.lastEngage.request().agent());
       assertEquals("opus-x", ops.lastEngage.request().model());
+      assertTrue(ops.lastEngage.request().snapshot());
     }
   }
 
@@ -1521,7 +1522,7 @@ class ApiRouterTest {
           new EngageResponse(
               request.agent(),
               request.mode() == null ? "full" : request.mode(),
-              "read-only".equals(request.mode()) ? "" : "engage-1"));
+              request.snapshot() ? "engage-1" : ""));
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
@@ -179,12 +179,28 @@ class EngagementLifecycleTest {
   }
 
   @Test
-  void aFullEngageTakesEffectOnlyAfterItsSnapshotAndInOrder() throws Exception {
+  void theDefaultFullEngageTakesEffectImmediatelyWithNoSnapshot() throws Exception {
     var ops = operations(shell());
     seedSpec("auth");
 
     var launch =
-        ops.engage("auth", "claude-code", null, "opus-x", Actor.cliOperator(HANDLE), HANDLE);
+        ops.engage("auth", "claude-code", null, null, false, Actor.cliOperator(HANDLE), HANDLE);
+
+    assertEquals("full", launch.mode(), "full is the default mode");
+    assertEquals("", launch.snapshot(), "no snapshot unless asked — dir backends are slow");
+    assertNull(launch.completion(), "nothing is deferred");
+    assertTrue(stored("auth").full());
+    assertTrue(ofType(Event.WellKnownTypes.SNAPSHOT_CREATED).isEmpty());
+    assertEquals(1, ofType(Event.WellKnownTypes.SPEC_ENGAGED).size());
+  }
+
+  @Test
+  void aFullEngageTakesEffectOnlyAfterItsRequestedSnapshotAndInOrder() throws Exception {
+    var ops = operations(shell());
+    seedSpec("auth");
+
+    var launch =
+        ops.engage("auth", "claude-code", null, "opus-x", true, Actor.cliOperator(HANDLE), HANDLE);
 
     assertEquals("full", launch.mode(), "full is the default mode");
     assertTrue(launch.snapshot().startsWith("engage-"));
@@ -215,7 +231,8 @@ class EngagementLifecycleTest {
     var ops = operations(failing);
     seedSpec("auth");
 
-    var launch = ops.engage("auth", "claude-code", "full", null, Actor.cliOperator(HANDLE), HANDLE);
+    var launch =
+        ops.engage("auth", "claude-code", "full", null, true, Actor.cliOperator(HANDLE), HANDLE);
     launch.completion().run();
 
     assertNull(stored("auth"), "a failed payment engages nobody");
@@ -232,7 +249,8 @@ class EngagementLifecycleTest {
     seedSpec("auth");
 
     var launch =
-        ops.engage("auth", "claude-code", "read-only", null, Actor.cliOperator(HANDLE), HANDLE);
+        ops.engage(
+            "auth", "claude-code", "read-only", null, true, Actor.cliOperator(HANDLE), HANDLE);
 
     assertNull(launch.completion(), "nothing is deferred — no payment to make");
     assertEquals("", launch.snapshot());
@@ -251,7 +269,8 @@ class EngagementLifecycleTest {
         assertThrows(
             ApiException.class,
             () ->
-                ops.engage("auth", "codex", "read-only", null, Actor.cliOperator(HANDLE), HANDLE));
+                ops.engage(
+                    "auth", "codex", "read-only", null, false, Actor.cliOperator(HANDLE), HANDLE));
 
     assertEquals(ErrorCode.BAD_REQUEST, refusal.failure().errorCode());
     assertNull(stored("auth"));
@@ -264,10 +283,12 @@ class EngagementLifecycleTest {
 
     assertThrows(
         ApiException.class,
-        () -> ops.engage("auth", "claude-code", "yolo", null, Actor.cliOperator(HANDLE), HANDLE));
+        () ->
+            ops.engage(
+                "auth", "claude-code", "yolo", null, false, Actor.cliOperator(HANDLE), HANDLE));
     assertThrows(
         ApiException.class,
-        () -> ops.engage("auth", "hal9000", null, null, Actor.cliOperator(HANDLE), HANDLE));
+        () -> ops.engage("auth", "hal9000", null, null, false, Actor.cliOperator(HANDLE), HANDLE));
     assertNull(stored("auth"));
     assertTrue(events.isEmpty());
   }
@@ -296,7 +317,7 @@ class EngagementLifecycleTest {
       var engaged =
           sailOps.engageToSpec(
               "auth",
-              new EngageRequest("claude-code", null, null),
+              new EngageRequest("claude-code", null, null, true),
               Actor.cliOperator(HANDLE),
               HANDLE);
       assertTrue(engaged instanceof Result.Success<EngageResponse>);
@@ -308,7 +329,7 @@ class EngagementLifecycleTest {
       var refused =
           sailOps.engageToSpec(
               "auth",
-              new EngageRequest("codex", "read-only", null),
+              new EngageRequest("codex", "read-only", null, false),
               Actor.cliOperator(HANDLE),
               HANDLE);
       assertTrue(refused instanceof Result.Failure<EngageResponse>);
@@ -328,7 +349,7 @@ class EngagementLifecycleTest {
   void disengageClearsTheRoomSpeaksOnTheBusAndIsIdempotent() throws Exception {
     var ops = operations(shell());
     seedSpec("auth");
-    ops.engage("auth", "claude-code", "read-only", null, Actor.cliOperator(HANDLE), HANDLE);
+    ops.engage("auth", "claude-code", "read-only", null, false, Actor.cliOperator(HANDLE), HANDLE);
 
     var dismissed = ops.disengage("auth", Actor.cliOperator(HANDLE), HANDLE);
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.Engagement;
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.WatcherSpawner;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.MessageStore;
+import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.SpecStore;
+import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The engagement lifecycle: engage records the standing agent on the spec row (full mode only after
+ * its snapshot payment succeeds, off the request thread), disengage clears it, and every transition
+ * speaks on the bus so the room renders joins and leaves.
+ */
+class EngagementLifecycleTest {
+
+  private static final String HANDLE = "uday";
+
+  private static final String RUNNING_JSON =
+      """
+      [{"name": "acme", "status": "Running", "state": {}}]
+      """;
+
+  private static final String YAML =
+      """
+      name: acme
+      ssh:
+        user: dev
+      repos:
+        - url: https://github.com/acme/app.git
+          path: app
+      agent:
+        type: claude-code
+      """;
+
+  @TempDir Path tempDir;
+
+  private SpecStore specStore;
+  private RunStore runStore;
+  private Sqlite db;
+  private final List<Event> events = new ArrayList<>();
+  private final List<String> order = new ArrayList<>();
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) {
+      db.close();
+    }
+  }
+
+  private DispatchOperations operations(ShellExec shell) throws IOException {
+    var yaml = tempDir.resolve("sail-" + System.nanoTime() + ".yaml");
+    Files.writeString(yaml, YAML);
+    db = Sqlite.open(tempDir.resolve("engage-" + System.nanoTime() + ".db"));
+    new SchemaManager(db).migrate();
+    specStore = new SpecStore(db);
+    runStore = new RunStore(db);
+    new FdeStore(db).add(HANDLE, null, null, "admin");
+    return new DispatchOperations(
+            shell,
+            yaml.toString(),
+            specStore,
+            new ReviewStore(db),
+            runStore,
+            new FdeStore(db),
+            events::add,
+            new WatcherSpawner(shell, (command, logPath) -> 4242L),
+            (project, config) -> "",
+            command -> 0,
+            DispatchOperations.Listener.NONE)
+        .useMessages(new MessageStore(db));
+  }
+
+  private StubShell shell() {
+    return new StubShell(order)
+        .on("incus list ^acme$", RUNNING_JSON)
+        .on("command -v", "/usr/local/bin/claude\n")
+        .on("incus snapshot create", "");
+  }
+
+  private void seedSpec(String id) {
+    specStore.create(
+        new SpecStore.SpecRow(
+            id,
+            "acme",
+            "OAuth flow",
+            SpecStatus.DRAFT,
+            HANDLE,
+            null,
+            null,
+            null,
+            null,
+            0,
+            HANDLE,
+            "",
+            "",
+            null,
+            List.of(),
+            List.of("app")));
+  }
+
+  private Engagement stored(String specId) {
+    return Engagement.fromJson(specStore.findById(specId).orElseThrow().engagement());
+  }
+
+  private List<Event> ofType(String type) {
+    return events.stream().filter(e -> type.equals(e.type())).toList();
+  }
+
+  private static final class StubShell implements ShellExec {
+    private final java.util.Map<String, ShellExec.Result> scripts = new java.util.LinkedHashMap<>();
+    private final List<String> order;
+
+    StubShell(List<String> order) {
+      this.order = order;
+      on("incus config device add", "");
+      on(
+          "cat " + ai.singlr.sail.engine.ContainerSailSetup.STAMP_PATH,
+          ai.singlr.sail.engine.ContainerSailSetup.fingerprint());
+    }
+
+    StubShell on(String pattern, String stdout) {
+      scripts.put(pattern, new ShellExec.Result(0, stdout, ""));
+      return this;
+    }
+
+    StubShell failing(String pattern, String stderr) {
+      scripts.put(pattern, new ShellExec.Result(1, "", stderr));
+      return this;
+    }
+
+    @Override
+    public ShellExec.Result exec(List<String> command) {
+      var joined = String.join(" ", command);
+      if (joined.contains("incus snapshot create")) {
+        order.add("snapshot");
+      }
+      for (var entry : scripts.entrySet()) {
+        if (joined.contains(entry.getKey())) {
+          return entry.getValue();
+        }
+      }
+      return new ShellExec.Result(1, "", "no script for " + joined);
+    }
+
+    @Override
+    public ShellExec.Result exec(List<String> command, Path workDir, java.time.Duration timeout) {
+      return exec(command);
+    }
+
+    @Override
+    public boolean isDryRun() {
+      return false;
+    }
+  }
+
+  @Test
+  void aFullEngageTakesEffectOnlyAfterItsSnapshotAndInOrder() throws Exception {
+    var ops = operations(shell());
+    seedSpec("auth");
+
+    var launch =
+        ops.engage("auth", "claude-code", null, "opus-x", Actor.cliOperator(HANDLE), HANDLE);
+
+    assertEquals("full", launch.mode(), "full is the default mode");
+    assertTrue(launch.snapshot().startsWith("engage-"));
+    assertNotNull(launch.completion());
+    assertNull(stored("auth"), "the payment precedes the access");
+
+    launch.completion().run();
+
+    var engagement = stored("auth");
+    assertEquals("claude-code", engagement.agent());
+    assertEquals("opus-x", engagement.model());
+    assertTrue(engagement.full());
+    assertEquals(1, ofType(Event.WellKnownTypes.SNAPSHOT_CREATED).size());
+    var engaged = ofType(Event.WellKnownTypes.SPEC_ENGAGED);
+    assertEquals(1, engaged.size());
+    assertEquals("auth", engaged.getFirst().spec());
+    assertEquals("full", engaged.getFirst().data().get("mode"));
+    assertEquals(launch.snapshot(), engaged.getFirst().data().get("label"));
+  }
+
+  @Test
+  void aFailedSnapshotPublishesEngageFailedAndLeavesTheRoomEmpty() throws Exception {
+    var failing =
+        new StubShell(order)
+            .on("incus list ^acme$", RUNNING_JSON)
+            .on("command -v", "/usr/local/bin/claude\n")
+            .failing("incus snapshot create", "no space left on storage pool");
+    var ops = operations(failing);
+    seedSpec("auth");
+
+    var launch = ops.engage("auth", "claude-code", "full", null, Actor.cliOperator(HANDLE), HANDLE);
+    launch.completion().run();
+
+    assertNull(stored("auth"), "a failed payment engages nobody");
+    assertTrue(ofType(Event.WellKnownTypes.SPEC_ENGAGED).isEmpty());
+    var failedEvents = ofType(Event.WellKnownTypes.SPEC_ENGAGE_FAILED);
+    assertEquals(1, failedEvents.size());
+    assertEquals("claude-code", failedEvents.getFirst().data().get("agent"));
+    assertNotNull(failedEvents.getFirst().data().get("error"));
+  }
+
+  @Test
+  void aReadOnlyEngagePersistsImmediatelyWithNoSnapshot() throws Exception {
+    var ops = operations(shell());
+    seedSpec("auth");
+
+    var launch =
+        ops.engage("auth", "claude-code", "read-only", null, Actor.cliOperator(HANDLE), HANDLE);
+
+    assertNull(launch.completion(), "nothing is deferred — no payment to make");
+    assertEquals("", launch.snapshot());
+    var engagement = stored("auth");
+    assertEquals("read-only", engagement.mode());
+    assertTrue(ofType(Event.WellKnownTypes.SNAPSHOT_CREATED).isEmpty());
+    assertEquals(1, ofType(Event.WellKnownTypes.SPEC_ENGAGED).size());
+  }
+
+  @Test
+  void aCodexReadOnlyEngageIsRefusedWithTheHarnessReason() throws Exception {
+    var ops = operations(shell());
+    seedSpec("auth");
+
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.engage("auth", "codex", "read-only", null, Actor.cliOperator(HANDLE), HANDLE));
+
+    assertEquals(ErrorCode.BAD_REQUEST, refusal.failure().errorCode());
+    assertNull(stored("auth"));
+  }
+
+  @Test
+  void aBogusModeOrUnknownAgentIsRefusedBeforeAnythingHappens() throws Exception {
+    var ops = operations(shell());
+    seedSpec("auth");
+
+    assertThrows(
+        ApiException.class,
+        () -> ops.engage("auth", "claude-code", "yolo", null, Actor.cliOperator(HANDLE), HANDLE));
+    assertThrows(
+        ApiException.class,
+        () -> ops.engage("auth", "hal9000", null, null, Actor.cliOperator(HANDLE), HANDLE));
+    assertNull(stored("auth"));
+    assertTrue(events.isEmpty());
+  }
+
+  @Test
+  void theServerLaneDelegatesEngageAndDisengageThroughSailOperations() throws Exception {
+    var shell = shell();
+    operations(shell);
+    seedSpec("auth");
+    var yaml = tempDir.resolve("sail-server.yaml");
+    Files.writeString(yaml, YAML);
+    try (var bus = new EventBus()) {
+      var sailOps =
+          new SailOperations(
+                  shell,
+                  yaml.toString(),
+                  (command, logPath) -> 4242L,
+                  bus,
+                  null,
+                  specStore,
+                  new ReviewStore(db),
+                  runStore)
+              .useMessages(new MessageStore(db))
+              .useInviteExecutor(Runnable::run);
+
+      var engaged =
+          sailOps.engageToSpec(
+              "auth",
+              new EngageRequest("claude-code", null, null),
+              Actor.cliOperator(HANDLE),
+              HANDLE);
+      assertTrue(engaged instanceof Result.Success<EngageResponse>);
+      var response = ((Result.Success<EngageResponse>) engaged).value();
+      assertEquals("full", response.mode());
+      assertTrue(response.snapshot().startsWith("engage-"));
+      assertNotNull(stored("auth"), "the deferred snapshot ran inline and engaged the room");
+
+      var refused =
+          sailOps.engageToSpec(
+              "auth",
+              new EngageRequest("codex", "read-only", null),
+              Actor.cliOperator(HANDLE),
+              HANDLE);
+      assertTrue(refused instanceof Result.Failure<EngageResponse>);
+
+      var dismissed = sailOps.disengageSpec("auth", Actor.cliOperator(HANDLE), HANDLE);
+      assertTrue(dismissed instanceof Result.Success<DisengageResponse>);
+      assertEquals("claude-code", ((Result.Success<DisengageResponse>) dismissed).value().agent());
+      assertNull(stored("auth"));
+
+      var empty = sailOps.disengageSpec("auth", Actor.cliOperator(HANDLE), HANDLE);
+      assertTrue(empty instanceof Result.Success<DisengageResponse>);
+      assertNull(((Result.Success<DisengageResponse>) empty).value().agent());
+    }
+  }
+
+  @Test
+  void disengageClearsTheRoomSpeaksOnTheBusAndIsIdempotent() throws Exception {
+    var ops = operations(shell());
+    seedSpec("auth");
+    ops.engage("auth", "claude-code", "read-only", null, Actor.cliOperator(HANDLE), HANDLE);
+
+    var dismissed = ops.disengage("auth", Actor.cliOperator(HANDLE), HANDLE);
+
+    assertEquals("claude-code", dismissed);
+    assertNull(stored("auth"));
+    var left = ofType(Event.WellKnownTypes.SPEC_DISENGAGED);
+    assertEquals(1, left.size());
+    assertEquals("claude-code", left.getFirst().data().get("agent"));
+
+    assertNull(
+        ops.disengage("auth", Actor.cliOperator(HANDLE), HANDLE),
+        "dismissing an empty room is a no-op, not an error");
+    assertEquals(1, ofType(Event.WellKnownTypes.SPEC_DISENGAGED).size());
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecViewTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecViewTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import ai.singlr.sail.config.Engagement;
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.store.SpecStore;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class GlobalSpecViewTest {
+
+  private static SpecStore.SpecRow row(String engagement) {
+    return new SpecStore.SpecRow(
+        "auth",
+        "acme",
+        "OAuth",
+        SpecStatus.DRAFT,
+        "uday",
+        null,
+        null,
+        null,
+        null,
+        0,
+        "uday",
+        "t0",
+        "t1",
+        "uday",
+        List.of(),
+        List.of(),
+        null,
+        engagement);
+  }
+
+  @Test
+  void anEngagedRowCarriesTheEngagementIntoTheViewAndItsMap() {
+    var engagement = Engagement.of("claude-code", "full", "opus-x", "t0");
+
+    var view = GlobalSpecView.from(row(engagement.toJson()));
+
+    assertEquals("claude-code", view.engagement().get("agent"));
+    assertEquals("full", view.engagement().get("mode"));
+    assertEquals("opus-x", view.engagement().get("model"));
+    assertEquals("t0", view.engagement().get("engaged_at"));
+    @SuppressWarnings("unchecked")
+    var mapped = (Map<String, Object>) view.toMap().get("engagement");
+    assertEquals("claude-code", mapped.get("agent"));
+  }
+
+  @Test
+  void aModelLessEngagementOmitsTheModelKey() {
+    var engagement = Engagement.of("codex", "full", null, "t0");
+
+    var view = GlobalSpecView.from(row(engagement.toJson()));
+
+    assertFalse(view.engagement().containsKey("model"));
+  }
+
+  @Test
+  void anUnengagedOrCorruptRowRendersNoEngagement() {
+    assertNull(GlobalSpecView.from(row(null)).engagement());
+    assertNull(GlobalSpecView.from(row("garbage {{{")).engagement());
+    assertFalse(GlobalSpecView.from(row(null)).toMap().containsKey("engagement"));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -153,69 +152,24 @@ class InviteLaunchTest {
   }
 
   @Test
-  void aReadOnlyInviteMintsAnInviteRunOnTheRoomContract() throws Exception {
+  void aReadOnlyInviteIsRefusedAsSupersededByEngagement() throws Exception {
     var ops = operations(liveAgentShell());
     seedSpec("auth");
-    var question = messageStore.append("auth", "uday", "poke holes in this design", null);
+    messageStore.append("auth", "uday", "poke holes in this design", null);
 
-    var launch =
-        ops.startInvite("auth", "claude-code", false, null, Actor.cliOperator(HANDLE), HANDLE);
-    launch.completion().run();
+    var refusal =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.startInvite(
+                    "auth", "claude-code", false, null, Actor.cliOperator(HANDLE), HANDLE));
 
-    var run = runStore.findById(launch.runId()).orElseThrow();
-    assertEquals("invite", run.role());
-    assertEquals("auth", run.specId());
-    assertEquals(HANDLE, run.owner());
-    assertEquals("claude/invite-" + launch.runId(), run.principal());
-    assertEquals(launch.principal(), run.principal());
-    assertEquals(List.of(), run.repos(), "read only reserves nothing");
-    assertEquals("", launch.snapshot(), "read only pays no snapshot");
-    assertEquals(
-        Set.of(question.id()),
-        runStore.deliveredMessageIds(launch.runId()),
-        "the prompt is the run's first delivery, seeded by identity");
-    assertTrue(run.task().contains("Invite Duty (read only)"));
-    assertTrue(run.task().contains("Build the OAuth flow."));
-    var joined = String.join(" ", launched.get());
-    assertFalse(joined.contains("--dangerously-skip-permissions"), joined);
-    assertTrue(joined.contains("--tools \"Bash,Read,Grep,Glob\""), joined);
+    assertEquals(ErrorCode.BAD_REQUEST, refusal.failure().errorCode());
     assertTrue(
-        joined.contains("--setting-sources \"\"") && joined.contains("--strict-mcp-config"),
-        "a read-only invite runs beside live builds without a reservation, so the launched"
-            + " command must exclude ambient settings and MCP configs — no workspace file may"
-            + " widen the tool cut. Command: "
-            + joined);
-    assertFalse(joined.contains("--resume"), "an invite is always a fresh participant");
-    assertEquals("invite", launched.get().getLast(), "SAIL_RUN_ROLE rides the launch");
-    assertTrue(
-        runStore.consumeRoomGuardBaseline(launch.runId()).orElseThrow().contains("aaa111"),
-        "the worktree-digest guard baseline is recorded exactly like a wake");
-    assertTrue(
-        events.stream().noneMatch(e -> Event.WellKnownTypes.SNAPSHOT_CREATED.equals(e.type())));
-    var started =
-        events.stream()
-            .filter(e -> Event.WellKnownTypes.AGENT_SESSION_STARTED.equals(e.type()))
-            .findFirst()
-            .orElseThrow();
-    assertEquals("auth", started.spec());
-  }
-
-  @Test
-  void aReadOnlyInviteRunsAlongsideItsOwnSpecsLiveBuild() throws Exception {
-    var ops = operations(liveAgentShell());
-    seedSpec("auth");
-    var live = DateTimeUtils.newId().toString();
-    db.execute(
-        "INSERT INTO runs (id, project, spec_id, node, role, agent, status, started_at, repos)"
-            + " VALUES (?, 'acme', 'auth', ?, 'build', 'claude-code', 'running', 't0',"
-            + " '[\"app\"]')",
-        live,
-        HANDLE);
-
-    var launch =
-        ops.startInvite("auth", "claude-code", false, null, Actor.cliOperator(HANDLE), HANDLE);
-
-    assertEquals("invite", runStore.findById(launch.runId()).orElseThrow().role());
+        refusal.failure().errorMessage().contains("engage"),
+        "the refusal names the engagement lane that replaced this one: "
+            + refusal.failure().errorMessage());
+    assertTrue(runStore.listForSpec("auth").isEmpty(), "a refused mode reserves nothing");
   }
 
   @Test
@@ -329,7 +283,7 @@ class InviteLaunchTest {
   }
 
   @Test
-  void aCodexReadOnlyInviteIsRefusedNamingWhatItSupports() throws Exception {
+  void anyReadOnlyInviteIsRefusedWhateverTheAgent() throws Exception {
     var ops = operations(liveAgentShell());
     seedSpec("auth");
 
@@ -340,7 +294,7 @@ class InviteLaunchTest {
 
     assertEquals(ErrorCode.BAD_REQUEST, refusal.failure().errorCode());
     assertTrue(
-        refusal.failure().errorMessage().contains("full access"), refusal.failure().errorMessage());
+        refusal.failure().errorMessage().contains("engage"), refusal.failure().errorMessage());
     assertTrue(runStore.listForSpec("auth").isEmpty(), "a refused mode reserves nothing");
   }
 
@@ -517,14 +471,13 @@ class InviteLaunchTest {
       var launched =
           sailOps.inviteToSpec(
               "auth",
-              new InviteRequest("claude-code", null, false, true),
+              new InviteRequest("claude-code", null, true, true),
               Actor.cliOperator(HANDLE),
               HANDLE);
       assertTrue(launched instanceof Result.Success<InviteResponse>);
       var response = ((Result.Success<InviteResponse>) launched).value();
-      assertEquals("read_only", response.mode());
-      assertEquals("invite", runStore.findById(response.runId()).orElseThrow().role());
-      assertEquals("", response.snapshot());
+      assertEquals("full", response.mode());
+      assertEquals("invite-full", runStore.findById(response.runId()).orElseThrow().role());
 
       var refused =
           sailOps.inviteToSpec(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
@@ -110,8 +110,13 @@ class RoomWakeLaunchTest {
   }
 
   private static StubShell liveAgentShell() {
+    return liveAgentShellFor("claude");
+  }
+
+  private static StubShell liveAgentShellFor(String binary) {
     return new StubShell()
         .on("incus list ^acme$", RUNNING_JSON)
+        .on("command -v", "/usr/local/bin/" + binary + "\n")
         .on("mkdir -p /home/dev/.sail", "")
         .on("rev-parse HEAD", "aaa111\n")
         .on("diff --binary HEAD", "")
@@ -197,7 +202,7 @@ class RoomWakeLaunchTest {
   }
 
   @Test
-  void aLiveRunOfTheSameSpecRefusesTheWake() throws Exception {
+  void aSameSpecLiveBuildNoLongerBlocksTheReadOnlyWake() throws Exception {
     var ops = operations(liveAgentShell());
     seedSpec("auth");
     var live = DateTimeUtils.newId().toString();
@@ -208,6 +213,31 @@ class RoomWakeLaunchTest {
         HANDLE,
         HANDLE,
         "build",
+        "claude-code",
+        null,
+        "t",
+        null,
+        null,
+        null,
+        "sail-agent-" + live);
+
+    var runId = ops.startRoomRun("acme", "auth", HANDLE);
+
+    assertEquals("room", runStore.findById(runId).orElseThrow().role());
+  }
+
+  @Test
+  void aLiveChatTurnOfTheSameSpecRefusesTheWake() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+    var live = DateTimeUtils.newId().toString();
+    runStore.create(
+        live,
+        "acme",
+        "auth",
+        HANDLE,
+        HANDLE,
+        "room",
         "claude-code",
         null,
         "t",
@@ -372,6 +402,122 @@ class RoomWakeLaunchTest {
         declined.failure().errorMessage().contains("claude-code"),
         declined.failure().errorMessage());
     assertTrue(runStore.listForSpec("auth").isEmpty(), "a declined wake reserves nothing");
+  }
+
+  private void engage(String specId, String agent, String mode) {
+    var spec = specStore.findById(specId).orElseThrow();
+    specStore.update(
+        spec.withEngagement(
+            ai.singlr.sail.config.Engagement.of(agent, mode, null, "2026-08-18T00:00:00Z")
+                .toJson()));
+  }
+
+  @Test
+  void anEngagedFullTurnReservesLaunchesFullPermissionAndSkipsTheBaseline() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+    engage("auth", "claude-code", "full");
+    messageStore.append("auth", "uday", "draw me the architecture diagram", null);
+
+    var runId = ops.startRoomRun("acme", "auth", HANDLE);
+
+    var run = runStore.findById(runId).orElseThrow();
+    assertEquals("room-full", run.role());
+    assertEquals(List.of("app"), run.repos(), "a full turn reserves like a build");
+    assertTrue(run.task().contains("## Engaged Turn (full access)"));
+    var joined = String.join(" ", launched.get());
+    assertTrue(joined.contains("--dangerously-skip-permissions"), joined);
+    assertFalse(joined.contains("--tools"), "full access is the harness's own YOLO, no tool cut");
+    assertTrue(
+        runStore.consumeRoomGuardBaseline(runId).isEmpty(),
+        "a full turn's workspace changes are expected — no read-only guard baseline");
+    assertTrue(
+        events.stream().noneMatch(e -> Event.WellKnownTypes.SNAPSHOT_CREATED.equals(e.type())),
+        "turns never snapshot — the engage paid once");
+    assertEquals("room-full", launched.get().getLast(), "SAIL_RUN_ROLE rides the launch");
+  }
+
+  @Test
+  void anEngagedReadOnlyTurnKeepsTheRoomContractAndRunsBesideTheBuild() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+    engage("auth", "claude-code", "read-only");
+    var live = DateTimeUtils.newId().toString();
+    runStore.create(
+        live,
+        "acme",
+        "auth",
+        HANDLE,
+        HANDLE,
+        "build",
+        "claude-code",
+        null,
+        "t",
+        null,
+        null,
+        null,
+        "sail-agent-" + live);
+
+    var runId = ops.startRoomRun("acme", "auth", HANDLE);
+
+    var run = runStore.findById(runId).orElseThrow();
+    assertEquals("room", run.role());
+    assertTrue(run.task().contains("## Engaged Turn (read only)"));
+    var joined = String.join(" ", launched.get());
+    assertTrue(joined.contains("--tools \"Bash,Read,Grep,Glob\""), joined);
+    assertFalse(joined.contains("--dangerously-skip-permissions"), joined);
+  }
+
+  @Test
+  void anEngagedCodexRoomLaunchesFullWhereTheWakeLaneWouldDecline() throws Exception {
+    var ops = operations(liveAgentShellFor("codex"));
+    seedSpec("auth");
+    engage("auth", "codex", "full");
+
+    var runId = ops.startRoomRun("acme", "auth", HANDLE);
+
+    var run = runStore.findById(runId).orElseThrow();
+    assertEquals("codex", run.agent());
+    assertEquals("room-full", run.role());
+    var joined = String.join(" ", launched.get());
+    assertTrue(joined.contains("--dangerously-bypass-approvals-and-sandbox"), joined);
+  }
+
+  @Test
+  void anEngagedTurnResumesOnlyTheEngagementsOwnChatSessions() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+    engage("auth", "claude-code", "full");
+    var build = DateTimeUtils.newId().toString();
+    runStore.create(
+        build,
+        "acme",
+        "auth",
+        HANDLE,
+        HANDLE,
+        "build",
+        "claude-code",
+        null,
+        "t",
+        null,
+        null,
+        null,
+        "sail-agent-" + build);
+    runStore.complete(build, "completed", 0);
+    runStore.recordSession(build, "build-session-1", "startup", null);
+
+    var firstTurn = ops.startRoomRun("acme", "auth", HANDLE);
+    assertFalse(
+        String.join(" ", launched.get()).contains("--resume"),
+        "a build conversation never reopens under a chat turn");
+
+    runStore.complete(firstTurn, "completed", 0);
+    runStore.recordSession(firstTurn, "chat-session-1", "startup", null);
+
+    ops.startRoomRun("acme", "auth", HANDLE);
+    assertTrue(
+        String.join(" ", launched.get()).contains("--resume chat-session-1"),
+        "the engagement's own conversation continues: " + String.join(" ", launched.get()));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakePolicyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakePolicyTest.java
@@ -37,27 +37,41 @@ class RoomWakePolicyTest {
 
   @Test
   void onWakesOnAnyHumanMessage() {
-    assertTrue(RoomWakePolicy.shouldWake("on", false, "uday", "hello"));
-    assertTrue(RoomWakePolicy.shouldWake(null, true, "uday", "hello"));
+    assertTrue(RoomWakePolicy.shouldWake("on", false, false, "uday", "hello"));
+    assertTrue(RoomWakePolicy.shouldWake(null, true, false, "uday", "hello"));
   }
 
   @Test
   void mentionWakesOnlyWhenTheMessageAddressesTheAgent() {
-    assertTrue(RoomWakePolicy.shouldWake("mention", true, "uday", "hey @agent what's up"));
-    assertFalse(RoomWakePolicy.shouldWake("mention", true, "uday", "hey what's up"));
-    assertFalse(RoomWakePolicy.shouldWake("mention", true, "uday", null));
+    assertTrue(RoomWakePolicy.shouldWake("mention", true, false, "uday", "hey @agent what's up"));
+    assertFalse(RoomWakePolicy.shouldWake("mention", true, false, "uday", "hey what's up"));
+    assertFalse(RoomWakePolicy.shouldWake("mention", true, false, "uday", null));
   }
 
   @Test
   void offAndUndispatchedDefaultsNeverWake() {
-    assertFalse(RoomWakePolicy.shouldWake("off", true, "uday", "@agent please"));
-    assertFalse(RoomWakePolicy.shouldWake(null, false, "uday", "hello"));
+    assertFalse(RoomWakePolicy.shouldWake("off", true, false, "uday", "@agent please"));
+    assertFalse(RoomWakePolicy.shouldWake(null, false, false, "uday", "hello"));
   }
 
   @Test
   void agentsAndSailNeverWakeRegardlessOfMode() {
-    assertFalse(RoomWakePolicy.shouldWake("on", true, "sail", "Review passed."));
-    assertFalse(RoomWakePolicy.shouldWake("on", true, "claude/room-1", "answered"));
-    assertFalse(RoomWakePolicy.shouldWake("mention", true, "claude/1", "@agent"));
+    assertFalse(RoomWakePolicy.shouldWake("on", true, false, "sail", "Review passed."));
+    assertFalse(RoomWakePolicy.shouldWake("on", true, false, "claude/room-1", "answered"));
+    assertFalse(RoomWakePolicy.shouldWake("mention", true, false, "claude/1", "@agent"));
+  }
+
+  @Test
+  void anEngagedRoomAnswersEveryHumanMessageRegardlessOfWakeMode() {
+    assertTrue(RoomWakePolicy.shouldWake(null, false, true, "uday", "hello"));
+    assertTrue(RoomWakePolicy.shouldWake("off", false, true, "uday", "hello"));
+    assertTrue(RoomWakePolicy.shouldWake("mention", false, true, "uday", "no address"));
+  }
+
+  @Test
+  void engagementNeverOverridesTheHumanAuthorRule() {
+    assertFalse(RoomWakePolicy.shouldWake(null, false, true, "sail", "Review passed."));
+    assertFalse(RoomWakePolicy.shouldWake(null, false, true, "claude/room-1", "answered"));
+    assertFalse(RoomWakePolicy.shouldWake(null, false, true, "", "hello"));
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
@@ -682,6 +682,88 @@ class RoomWakeReactorTest {
   }
 
   @Test
+  void theSweepWakesOwedEngagedRoomsAndSkipsForeignOrQuietOnes() {
+    seed("owed", "draft", "uday", null);
+    engage("owed", "claude-code", "full");
+    messageStore.append("owed", "uday", "anyone there?", null);
+
+    seed("foreign", "draft", "someone-else", null);
+    engage("foreign", "claude-code", "full");
+    messageStore.append("foreign", "uday", "not this box's job", null);
+
+    seed("quiet", "draft", "uday", null);
+    engage("quiet", "claude-code", "full");
+
+    reactor().sweepEngagedRooms();
+
+    assertEquals(List.of("acme/owed"), launcher.woken);
+  }
+
+  @Test
+  void aSweepFailureOnOneRoomNeverStopsTheOthers() {
+    seed("first", "draft", "uday", null);
+    engage("first", "claude-code", "full");
+    messageStore.append("first", "uday", "hello", null);
+    seed("second", "draft", "uday", null);
+    engage("second", "claude-code", "full");
+    messageStore.append("second", "uday", "hello too", null);
+    launcher.failWith = new RuntimeException("container offline");
+
+    var reactor = reactor();
+    reactor.sweepEngagedRooms();
+    assertTrue(launcher.woken.isEmpty(), "both wakes failed loudly");
+
+    launcher.failWith = null;
+    reactor.sweepEngagedRooms();
+    assertEquals(2, launcher.woken.size(), "the next sweep retries both");
+  }
+
+  @Test
+  void theOwedCheckSurvivesNullStoresCorruptTimestampsAndMultiMessageRooms() {
+    seed("chat", "draft", "uday", null);
+    engage("chat", "claude-code", "full");
+    var run = chatRun("chat", "room", "completed", now.get().minus(Duration.ofMinutes(2)));
+    messageStore.append("chat", "uday", "first", null);
+    var second = messageStore.append("chat", "uday", "second", null);
+
+    reactor(new DirectExecutorService(), null).onEvent(roomStop("chat", run));
+    assertTrue(launcher.woken.isEmpty(), "no message store, no owed check");
+
+    db.execute("UPDATE spec_messages SET created_at = 'garbage' WHERE id = ?", second.id());
+    db.execute("UPDATE spec_messages SET created_at = 'garbage' WHERE spec_id = 'chat'");
+    reactor().onEvent(roomStop("chat", run));
+    assertTrue(launcher.woken.isEmpty(), "an unparseable timestamp is never owed");
+
+    db.execute(
+        "UPDATE spec_messages SET created_at = ? WHERE spec_id = 'chat'", now.get().toString());
+    reactor().onEvent(roomStop("chat", run));
+    assertEquals(List.of("acme/chat"), launcher.woken, "the newest of several messages decides");
+  }
+
+  @Test
+  void aSweepOverABrokenMessageStoreLogsAndMovesOn(@TempDir Path other) {
+    seed("chat", "draft", "uday", null);
+    engage("chat", "claude-code", "full");
+    var dead = Sqlite.open(other.resolve("dead.db"));
+    new SchemaManager(dead).migrate();
+    var brokenMessages = new MessageStore(dead);
+    dead.close();
+
+    reactor(new DirectExecutorService(), brokenMessages).sweepEngagedRooms();
+
+    assertTrue(launcher.woken.isEmpty());
+  }
+
+  @Test
+  void theSweepPassArmsAndClosesWithoutFiringEarly() {
+    var reactor = reactor();
+    reactor.startSweep(Duration.ofHours(1));
+    reactor.close();
+
+    assertTrue(launcher.woken.isEmpty());
+  }
+
+  @Test
   void aRoomStopOnAnOwnedRunTriggersTheCommitGuard() {
     seed("auth", "done", "uday", null);
     var runId = DateTimeUtils.newId().toString();

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
@@ -144,6 +144,7 @@ class RoomWakeReactorTest {
         launcher,
         launcher,
         Duration.ZERO,
+        Duration.ZERO,
         RoomWakeReactor.COOLDOWN,
         executor,
         duration -> {},
@@ -170,6 +171,36 @@ class RoomWakeReactorTest {
             List.of(),
             List.of(),
             wake));
+  }
+
+  private void engage(String id, String agent, String mode) {
+    var spec = specStore.findById(id).orElseThrow();
+    specStore.update(
+        spec.withEngagement(
+            ai.singlr.sail.config.Engagement.of(agent, mode, null, now.get().toString()).toJson()));
+  }
+
+  private String chatRun(String specId, String role, String status, Instant startedAt) {
+    var id = DateTimeUtils.newId().toString();
+    runStore.create(
+        id,
+        "acme",
+        specId,
+        "uday",
+        "uday",
+        role,
+        "claude-code",
+        null,
+        "t",
+        null,
+        null,
+        null,
+        "sail-agent-" + id);
+    db.execute("UPDATE runs SET started_at = ? WHERE id = ?", startedAt.toString(), id);
+    if (!"running".equals(status)) {
+      runStore.complete(id, status, 0);
+    }
+    return id;
   }
 
   private String buildRun(String specId, String status) {
@@ -497,6 +528,7 @@ class RoomWakeReactorTest {
             launcher,
             launcher,
             Duration.ZERO,
+            Duration.ZERO,
             RoomWakeReactor.COOLDOWN,
             new DirectExecutorService(),
             duration -> {
@@ -508,6 +540,145 @@ class RoomWakeReactorTest {
 
     assertTrue(launcher.woken.isEmpty());
     assertTrue(Thread.interrupted(), "the interrupt flag is restored, then cleared here");
+  }
+
+  @Test
+  void anEngagedDraftRoomWakesWithNoDispatchHistoryAndNoAssignedWakeMode() {
+    seed("chat", "draft", "uday", null);
+    engage("chat", "claude-code", "full");
+
+    reactor().onEvent(message("chat", "uday", "hello"));
+
+    assertEquals(List.of("acme/chat"), launcher.woken);
+  }
+
+  @Test
+  void anEngagedRoomIgnoresTheCooldown() {
+    seed("chat", "draft", "uday", null);
+    engage("chat", "claude-code", "full");
+    var run = chatRun("chat", "room", "completed", now.get().minus(Duration.ofSeconds(90)));
+    finishAt(run, now.get().minusSeconds(30));
+
+    reactor().onEvent(message("chat", "uday", "and another thing"));
+
+    assertEquals(List.of("acme/chat"), launcher.woken);
+  }
+
+  @Test
+  void aLiveChatTurnSuppressesTheEngagedWakeButALiveBuildDoesNot() {
+    seed("chat", "draft", "uday", null);
+    engage("chat", "claude-code", "full");
+    chatRun("chat", "room", "running", now.get());
+
+    reactor().onEvent(message("chat", "uday", "while you think"));
+    assertTrue(launcher.woken.isEmpty(), "the relay owns delivery to a live chat turn");
+
+    seed("busy", "in_progress", "uday", null);
+    engage("busy", "claude-code", "read-only");
+    buildRun("busy", "running");
+
+    reactor().onEvent(message("busy", "uday", "how is it going"));
+    assertEquals(List.of("acme/busy"), launcher.woken, "a build never silences an engaged room");
+  }
+
+  @Test
+  void agentPostsNeverWakeAnEngagedRoom() {
+    seed("chat", "draft", "uday", null);
+    engage("chat", "claude-code", "full");
+
+    reactor().onEvent(message("chat", "claude/room-1", "my own answer"));
+    reactor().onEvent(message("chat", "sail", "narration"));
+
+    assertTrue(launcher.woken.isEmpty());
+  }
+
+  @Test
+  void anEngagedRoomUsesTheShortDebounce() {
+    seed("chat", "draft", "uday", null);
+    engage("chat", "claude-code", "full");
+    seed("plain", "in_progress", "uday", "on");
+    var paused = new ArrayList<Duration>();
+    var reactor =
+        new RoomWakeReactor(
+            specStore,
+            runStore,
+            messageStore,
+            handle::get,
+            launcher,
+            launcher,
+            Duration.ofSeconds(30),
+            Duration.ofSeconds(5),
+            RoomWakeReactor.COOLDOWN,
+            new DirectExecutorService(),
+            paused::add,
+            now::get);
+
+    reactor.onEvent(message("chat", "uday", "hi"));
+    reactor.onEvent(message("plain", "uday", "hi"));
+
+    assertEquals(List.of(Duration.ofSeconds(5), Duration.ofSeconds(30)), paused);
+  }
+
+  @Test
+  void aStopRefiresTheTurnAMessageOwedFromTheTurnsTail() {
+    seed("chat", "draft", "uday", null);
+    engage("chat", "claude-code", "full");
+    var run = chatRun("chat", "room", "completed", now.get().minus(Duration.ofMinutes(2)));
+    messageStore.append("chat", "uday", "landed after your last relay check", null);
+
+    reactor().onEvent(roomStop("chat", run));
+
+    assertEquals(List.of("acme/chat"), launcher.woken);
+    assertEquals(List.of("acme/" + run), launcher.guarded, "the read-only guard still runs");
+  }
+
+  @Test
+  void aStopWithNothingOwedStaysQuiet() {
+    seed("chat", "draft", "uday", null);
+    engage("chat", "claude-code", "full");
+    messageStore.append("chat", "uday", "answered already", null);
+    var run = chatRun("chat", "room", "completed", DateTimeUtils.now().plusSeconds(60));
+
+    reactor().onEvent(roomStop("chat", run));
+
+    assertTrue(launcher.woken.isEmpty(), "the turn started after the newest human message");
+  }
+
+  @Test
+  void aBuildStopFreesADeferredFullTurn() {
+    seed("chat", "draft", "uday", null);
+    engage("chat", "codex", "full");
+    messageStore.append("chat", "uday", "please add the diagram", null);
+    var build = buildRun("chat", "completed");
+    var data = new LinkedHashMap<String, Object>();
+    data.put(Event.WellKnownData.SOURCE, Event.WellKnownData.SOURCE_WATCHER);
+    data.put(Event.WellKnownData.RUN_ID, build);
+    data.put(Event.WellKnownData.RUN_ROLE, "build");
+    var stop =
+        Event.of(
+            "acme",
+            "chat",
+            Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+            "claude-code",
+            "host",
+            data);
+
+    reactor().onEvent(stop);
+
+    assertEquals(List.of("acme/chat"), launcher.woken);
+    assertTrue(launcher.guarded.isEmpty(), "a build stop is not the chat guard's business");
+  }
+
+  @Test
+  void aStopOnAnUnengagedSpecNeverRefires() {
+    seed("plain", "in_progress", "uday", "on");
+    var run = chatRun("plain", "room", "completed", now.get().minus(Duration.ofMinutes(2)));
+    messageStore.append("plain", "uday", "owed but not engaged", null);
+
+    reactor().onEvent(roomStop("plain", run));
+
+    assertTrue(
+        launcher.woken.isEmpty(), "the stop edge is the engaged loop's; wake keeps its own rules");
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SlackReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SlackReactorTest.java
@@ -249,6 +249,50 @@ class SlackReactorTest {
   }
 
   @Test
+  void aCleanChatTurnStopNeverPostsButItsFailureDoes() {
+    var poster = new RecordingPoster();
+    var reactor = reactor(poster);
+    reactor.onEvent(event("spec_dispatched"));
+
+    for (var role : java.util.List.of("room", "room-full", "invite", "invite-full")) {
+      reactor.onEvent(
+          event(
+              Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+              Map.of(
+                  Event.WellKnownData.SOURCE,
+                  Event.WellKnownData.SOURCE_WATCHER,
+                  Event.WellKnownData.RUN_ROLE,
+                  role,
+                  Event.WellKnownData.EXIT_CODE,
+                  0)));
+    }
+    assertEquals(1, poster.posts.size(), "conversation plumbing never reaches Slack");
+
+    reactor.onEvent(
+        event(
+            Event.WellKnownTypes.AGENT_SESSION_STOPPED,
+            Map.of(
+                Event.WellKnownData.SOURCE,
+                Event.WellKnownData.SOURCE_WATCHER,
+                Event.WellKnownData.RUN_ROLE,
+                "room",
+                Event.WellKnownData.EXIT_CODE,
+                137)));
+    assertEquals(2, poster.posts.size(), "a dead chat turn is news");
+  }
+
+  @Test
+  void aCleanBuildStopStillPosts() {
+    var poster = new RecordingPoster();
+    var reactor = reactor(poster);
+    reactor.onEvent(event("spec_dispatched"));
+
+    reactor.onEvent(authoritativeStop());
+
+    assertEquals(2, poster.posts.size(), "role-less and build stops keep their narration");
+  }
+
+  @Test
   void escalationBroadcastsToTheChannel() {
     var poster = new RecordingPoster();
     var reactor = reactor(poster);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -84,6 +84,18 @@ class TestOperations implements Operations {
   }
 
   @Override
+  public Result<EngageResponse> engageToSpec(
+      String specId, EngageRequest request, Actor actor, String localHandle) {
+    return Result.success(
+        new EngageResponse(request.agent(), request.mode() == null ? "full" : request.mode(), ""));
+  }
+
+  @Override
+  public Result<DisengageResponse> disengageSpec(String specId, Actor actor, String localHandle) {
+    return Result.success(new DisengageResponse(null));
+  }
+
+  @Override
   public Result<ProjectResponse> project(String project) {
     return Result.success(new ProjectResponse(project, "running", null));
   }
@@ -260,6 +272,7 @@ class TestOperations implements Operations {
                 List.of(),
                 null,
                 null,
+                null,
                 "",
                 "",
                 null),
@@ -287,6 +300,7 @@ class TestOperations implements Operations {
                 3,
                 List.of(),
                 List.of(),
+                null,
                 null,
                 request.createdBy(),
                 "",
@@ -316,6 +330,7 @@ class TestOperations implements Operations {
                 List.of(),
                 null,
                 null,
+                null,
                 "",
                 "",
                 null)));
@@ -339,6 +354,7 @@ class TestOperations implements Operations {
                 0,
                 List.of(),
                 List.of(),
+                null,
                 null,
                 null,
                 "",

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
@@ -109,6 +109,8 @@ class CommandTaxonomyTest {
             "history",
             "restore",
             "invite",
+            "engage",
+            "disengage",
             "comment",
             "comments",
             "dispatch"),

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/InvitePromptTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/InvitePromptTest.java
@@ -43,28 +43,26 @@ class InvitePromptTest {
   }
 
   @Test
-  void aReadOnlyInviteIsPrimedWithBodyConversationAndTheReadOnlyDuty() {
+  void aTaskInviteIsPrimedWithBodyAndConversationAndIsAlwaysFullAccess() {
     var ask = message("m1", "uday", "poke holes in this design");
 
-    var built = InvitePrompt.build(spec(), "Build the OAuth flow.", List.of(ask), false);
+    var built = InvitePrompt.build(spec(), "Build the OAuth flow.", List.of(ask));
 
     assertTrue(built.prompt().contains("invited agent in the room of spec \"OAuth flow\""));
     assertTrue(built.prompt().contains("id: auth, status: draft"));
-    assertTrue(built.prompt().contains("read-only access"));
+    assertTrue(built.prompt().contains("full access"));
     assertTrue(built.prompt().contains("## Spec body"));
     assertTrue(built.prompt().contains("Build the OAuth flow."));
     assertTrue(built.prompt().contains("poke holes in this design"));
-    assertTrue(built.prompt().contains("## Invite Duty (read only)"));
-    assertTrue(built.prompt().contains("spec comment auth --body"));
-    assertTrue(built.prompt().contains("read-only chat session, and the harness enforces it"));
-    assertTrue(built.prompt().contains("spec comment auth --question --body"));
-    assertFalse(built.prompt().contains("spec create"), "the read-only lane drafts nothing");
+    assertFalse(
+        built.prompt().contains("## Invite Duty (read only)"),
+        "the read-only invite is superseded by engagement");
     assertEquals(List.of(ask), built.renderedMessages());
   }
 
   @Test
   void aFullInviteTeachesTheDraftAndCodeLanesAndTheGitProtocol() {
-    var built = InvitePrompt.build(spec(), "Build the OAuth flow.", List.of(), true);
+    var built = InvitePrompt.build(spec(), "Build the OAuth flow.", List.of());
 
     assertTrue(built.prompt().contains("full access"));
     assertTrue(built.prompt().contains("## Invite Duty (full access)"));
@@ -79,7 +77,7 @@ class InvitePromptTest {
 
   @Test
   void anEmptyRoomBuildsAPromptWithNoConversationBlock() {
-    var built = InvitePrompt.build(spec(), "body", List.of(), false);
+    var built = InvitePrompt.build(spec(), "body", List.of());
 
     assertFalse(built.prompt().contains("## Conversation on this spec"));
     assertTrue(built.renderedMessages().isEmpty());

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/RoomWakePromptTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/RoomWakePromptTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.singlr.sail.config.Engagement;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.SpecStore;
@@ -46,7 +47,8 @@ class RoomWakePromptTest {
   void aFreshWakeIsPrimedWithBodyConversationAndTheStandingInstruction() {
     var question = message("m1", "uday", "what is it stuck on?");
 
-    var built = RoomWakePrompt.build(spec(), "Build the OAuth flow.", List.of(question), false);
+    var built =
+        RoomWakePrompt.build(spec(), "Build the OAuth flow.", List.of(question), false, null);
 
     assertTrue(built.prompt().contains("standing agent of spec \"OAuth flow\""));
     assertTrue(built.prompt().contains("id: auth, status: review"));
@@ -67,7 +69,7 @@ class RoomWakePromptTest {
   void aResumedWakeSkipsTheSpecBodyItsConversationAlreadyCarries() {
     var built =
         RoomWakePrompt.build(
-            spec(), "Build the OAuth flow.", List.of(message("m1", "uday", "hello?")), true);
+            spec(), "Build the OAuth flow.", List.of(message("m1", "uday", "hello?")), true, null);
 
     assertFalse(built.prompt().contains("## Spec body"));
     assertTrue(built.prompt().contains("## Room Duty"));
@@ -75,9 +77,46 @@ class RoomWakePromptTest {
 
   @Test
   void anEmptyRoomBuildsAPromptWithNoConversationBlock() {
-    var built = RoomWakePrompt.build(spec(), "body", List.of(), false);
+    var built = RoomWakePrompt.build(spec(), "body", List.of(), false, null);
 
     assertFalse(built.prompt().contains("## Conversation on this spec"));
     assertTrue(built.renderedMessages().isEmpty());
+  }
+
+  @Test
+  void anEngagedReadOnlyTurnIsAContinuingConversationNotAVisit() {
+    var engagement = Engagement.of("claude-code", "read-only", null, "2026-08-18T00:00:00Z");
+
+    var built = RoomWakePrompt.build(spec(), "body", List.of(), false, engagement);
+
+    assertTrue(built.prompt().contains("You are engaged in this room"));
+    assertTrue(built.prompt().contains("## Engaged Turn (read only)"));
+    assertTrue(built.prompt().contains("git commands are denied too"));
+    assertTrue(built.prompt().contains("you remain engaged and will be resumed"));
+    assertTrue(built.prompt().contains("Never say goodbye"));
+    assertFalse(
+        built.prompt().contains("When you have answered, stop."),
+        "the one-turn stop instruction belongs to the wake lane only");
+  }
+
+  @Test
+  void anEngagedFullTurnTeachesWorkspaceDraftingAndNoForcedCommit() {
+    var engagement = Engagement.of("codex", "full", null, "2026-08-18T00:00:00Z");
+
+    var built = RoomWakePrompt.build(spec(), "body", List.of(), true, engagement);
+
+    assertTrue(built.prompt().contains("## Engaged Turn (full access)"));
+    assertTrue(built.prompt().contains("spec content auth --body-file"));
+    assertTrue(built.prompt().contains("Nothing forces a commit at turn end"));
+    assertTrue(built.prompt().contains("you remain engaged and will be resumed"));
+    assertFalse(built.prompt().contains("## Spec body"), "a resumed turn skips the body");
+  }
+
+  @Test
+  void theWakeDutyNeverPromisesGitTheAllowlistDenies() {
+    var built = RoomWakePrompt.build(spec(), "body", List.of(), false, null);
+
+    assertTrue(built.prompt().contains("git commands are denied too"));
+    assertFalse(built.prompt().contains("read-only git (log, show, diff"));
   }
 }


### PR DESCRIPTION
Implements `sail-room-engagement` — the fix for the field finding that room conversations don't work: invited agents answered once and left, replies woke nobody (draft rooms have no build history, so wake resolved off), the 10-minute cooldown ate prompt replies, and every full re-invite took a container snapshot per conversational turn.

## What changes

**The engagement record.** One atomic `specs.engagement` JSON column (agent, mode, model, engaged_at) — a single synced field so field-level merge can never stitch two boxes' engagements together. `sail spec engage <id> --agent <a>` / `POST /v1/specs/{id}/engage`; `disengage` clears it; `spec_engaged` / `spec_disengaged` / `spec_engage_failed` render in the room. **Full is the default mode** (conversations produce artifacts), paid with one engage-time snapshot — never per turn — and per-turn repo reservation; `--read-only` is the harness-enforced narrow choice (claude-code today; codex declines it with the seam's reason and is a first-class conversationalist in full mode).

**The turn loop.** Engaged rooms answer every human message: 5s extending-window debounce, no cooldown, no dispatch-history gate. Turns resume the engagement's own chat sessions (the resume selector is now role- and agent-filtered — a build's conversation can never reopen under a chat turn's tool cut). A read-only turn runs alongside its own spec's live build; a full turn (`room-full`: member credential, full permissions, reserves like a build, skips the git stop-gate) defers on the build via its repo claim and fires on the build's stop. Owed turns are derived (newest human message vs newest chat-turn start), re-checked on every stop edge, and backstopped by a 60s sweep. Non-engaged specs keep today's wake semantics exactly.

**The noise diet.** Slack no longer narrates chat/invite turn plumbing ("Agent stopped (exit 0)"); failures and build stops still post. Engaged prompts drop "when you have contributed, stop" — a turn ends, the engagement continues. The wake prompt stops promising read-only git the allowlist deliberately denies. The one-shot read-only invite is retired (400 naming engagement as its replacement); `spec invite` is now honestly the task lane.

**Schema:** append-only migrations — `specs.engagement` + a `runs_v7` rebuild admitting the `room-full` role — each with a prior-shape forward-migration test.

## Verification
`mvn clean verify` green: 2,865 infra + 1,576 core + 294 harness tests, JaCoCo `api.*` gates passed. New coverage: engagement lifecycle (snapshot-then-persist ordering, fail-closed payment), engaged turn launches (roles, reservations, resume filtering, codex full), reactor matrix (engaged debounce/cooldown/suppression/stop-edge refire/sweep), gate matrix (chat×chat serialize, chat‖build coexist), Slack filter, prompt goldens.