### PR TITLE
agent_session_started carries run_role: presence lights at launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- `agent_session_started` now carries `run_role`, so clients can light presence the moment a run
+  launches instead of waiting for its first tool call — the seconds between "message sent" and
+  "agent working" shrink to the wake debounce plus launch.
+
 - An agent can be engaged in a spec's room: it joins the conversation and answers every human
   message until dismissed. `sail spec engage <id> --agent <a>` (API `POST /v1/specs/{id}/engage`)
   records the engagement on the spec row as one atomic synced value — agent, mode, model,

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -399,7 +399,7 @@ public final class DispatchOperations {
       }
       if (status != null && status.running()) {
         publishAgentSessionStarted(
-            project, nextSpec.id(), agentType, status.pid(), runId, launch.watcher());
+            project, nextSpec.id(), agentType, status.pid(), runId, "build", launch.watcher());
       }
       return new Dispatched(
           taskSpec,
@@ -498,7 +498,8 @@ public final class DispatchOperations {
         completeForegroundRun(runId, launch.exitCode());
       }
       if (status != null && status.running()) {
-        publishAgentSessionStarted(project, null, agentType, status.pid(), runId, launch.watcher());
+        publishAgentSessionStarted(
+            project, null, agentType, status.pid(), runId, "adhoc", launch.watcher());
       }
       return new AdhocSession(
           runId, status, background ? null : launch.exitCode(), launch.watcher());
@@ -640,7 +641,7 @@ public final class DispatchOperations {
       }
       if (status != null && status.running()) {
         publishAgentSessionStarted(
-            project, specId, agentType, status.pid(), runId, launch.watcher());
+            project, specId, agentType, status.pid(), runId, role, launch.watcher());
       }
       return runId;
     } catch (RuntimeException e) {
@@ -846,7 +847,7 @@ public final class DispatchOperations {
       }
       if (status != null && status.running()) {
         publishAgentSessionStarted(
-            project, specId, agentCli.yamlName(), status.pid(), runId, launch.watcher());
+            project, specId, agentCli.yamlName(), status.pid(), runId, role, launch.watcher());
       }
     } catch (RuntimeException e) {
       releaseIfAbsent(runId, project, unit);
@@ -2189,6 +2190,7 @@ public final class DispatchOperations {
       String agentType,
       Integer pid,
       String runId,
+      String role,
       Optional<WatcherSpawner.Spawned> watcher) {
     var data = new LinkedHashMap<String, Object>();
     if (pid != null) {
@@ -2196,6 +2198,9 @@ public final class DispatchOperations {
     }
     if (Strings.isNotBlank(runId)) {
       data.put(Event.WellKnownData.RUN_ID, runId);
+    }
+    if (Strings.isNotBlank(role)) {
+      data.put(Event.WellKnownData.RUN_ROLE, role);
     }
     if (watcher.orElse(null) instanceof WatcherSpawner.Fallback fallback) {
       data.put(Event.WellKnownData.WATCHER_PID, fallback.pid());

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
@@ -435,6 +435,15 @@ class RoomWakeLaunchTest {
         events.stream().noneMatch(e -> Event.WellKnownTypes.SNAPSHOT_CREATED.equals(e.type())),
         "turns never snapshot — the engage paid once");
     assertEquals("room-full", launched.get().getLast(), "SAIL_RUN_ROLE rides the launch");
+    var started =
+        events.stream()
+            .filter(e -> Event.WellKnownTypes.AGENT_SESSION_STARTED.equals(e.type()))
+            .findFirst()
+            .orElseThrow();
+    assertEquals(
+        "room-full",
+        started.data().get(Event.WellKnownData.RUN_ROLE),
+        "presence lights at launch: the started event names its lane");
   }
 
   @Test


### PR DESCRIPTION
Field-feedback fix from the first live engagement session (pairs with mast#51): ~10s of dead air between sending a room message and any working signal. The launch event was published without its lane, so Mast's presence store couldn't seed from it and waited for the agent's first tool call instead. Every launch site (dispatch, adhoc, chat turn, invite) now stamps `run_role` on `agent_session_started`. Full `mvn clean verify` green (2,866/1,576/294, coverage gates passed); the engaged-turn launch test pins the stamped role.