### PR TITLE
refactor: one source of truth per vocabulary; close CLI swallow hole

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/common/Strings.java
+++ b/sail-core/src/main/java/ai/singlr/sail/common/Strings.java
@@ -28,4 +28,16 @@ public final class Strings {
   public static boolean isNotBlank(String s) {
     return !isBlank(s);
   }
+
+  /**
+   * Returns {@code value} when it holds a non-whitespace character, else throws {@link
+   * IllegalArgumentException} naming {@code name} — the one throwing blank-guard so precondition
+   * checks read consistently instead of each caller inlining its own.
+   */
+  public static String requireNonBlank(String value, String name) {
+    if (isBlank(value)) {
+      throw new IllegalArgumentException(name + " must not be blank.");
+    }
+    return value;
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/common/StringsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/common/StringsTest.java
@@ -5,7 +5,9 @@
 
 package ai.singlr.sail.common;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -33,5 +35,20 @@ class StringsTest {
     assertFalse(Strings.isNotBlank(null));
     assertFalse(Strings.isNotBlank("  "));
     assertTrue(Strings.isNotBlank("x"));
+  }
+
+  @Test
+  void requireNonBlankReturnsTheValueWhenPresent() {
+    assertEquals("x", Strings.requireNonBlank("x", "field"));
+  }
+
+  @Test
+  void requireNonBlankThrowsNamingTheFieldWhenBlank() {
+    for (var blank : new String[] {null, "", "   "}) {
+      var ex =
+          assertThrows(
+              IllegalArgumentException.class, () -> Strings.requireNonBlank(blank, "project"));
+      assertTrue(ex.getMessage().contains("project"), ex.getMessage());
+    }
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/Main.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/Main.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail;
 
+import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.engine.AutoUpgrader;
 import ai.singlr.sail.engine.RemoteCommandRunner;
 import ai.singlr.sail.engine.RuntimeMode;
@@ -20,8 +21,24 @@ public final class Main {
     }
     AutoUpgrader.upgradeIfAvailable(args);
     var cmd = new CommandLine(new Sail());
-    cmd.setExecutionExceptionHandler((ex, commandLine, parseResult) -> 1);
+    cmd.setExecutionExceptionHandler((ex, commandLine, parseResult) -> report(ex, commandLine));
     var exitCode = cmd.execute(args);
     System.exit(exitCode);
+  }
+
+  /**
+   * Prints an escaped command failure instead of swallowing it (the old handler returned 1 with no
+   * output). The message carries the "what happened AND what to do"; a message-less throwable falls
+   * back to its type so the user is never left with a silent non-zero exit.
+   */
+  static int report(Exception ex, CommandLine commandLine) {
+    var message = ex.getMessage();
+    commandLine
+        .getErr()
+        .println(
+            commandLine
+                .getColorScheme()
+                .errorText(Strings.isBlank(message) ? ex.toString() : message));
+    return 1;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
@@ -91,8 +91,6 @@ public record Event(
     public static final String SNAPSHOT_RESTORED = "snapshot_restored";
     public static final String SNAPSHOT_DELETED = "snapshot_deleted";
     public static final String GUARDRAIL_TRIGGERED = "guardrail_triggered";
-    public static final String PROJECT_STARTED = "project_started";
-    public static final String PROJECT_STOPPED = "project_stopped";
     public static final String BOARD_UPDATED = "board_updated";
     public static final String SPEC_MESSAGE_POSTED = "spec_message_posted";
 
@@ -106,7 +104,6 @@ public record Event(
     public static final String SPEC_ENGAGE_FAILED = "spec_engage_failed";
 
     public static final String AGENT_PRESENCE = "agent_presence";
-    public static final String HEARTBEAT = "heartbeat";
 
     /** A spec left in_progress/review past the reconciler threshold — surfaced for triage. */
     public static final String SPEC_STRANDED = "spec_stranded";
@@ -129,7 +126,7 @@ public record Event(
         return RetentionClass.TELEMETRY;
       }
       return switch (type) {
-        case AGENT_PRESENCE, HEARTBEAT -> RetentionClass.EPHEMERAL;
+        case AGENT_PRESENCE -> RetentionClass.EPHEMERAL;
         default -> RetentionClass.RECORD;
       };
     }
@@ -251,10 +248,10 @@ public record Event(
       throw new IllegalArgumentException("id must be non-negative, got " + id);
     }
     Objects.requireNonNull(ts, "ts is required");
-    requireNonBlank(project, "project");
-    requireNonBlank(type, "type");
-    requireNonBlank(agent, "agent");
-    requireNonBlank(host, "host");
+    Strings.requireNonBlank(project, "project");
+    Strings.requireNonBlank(type, "type");
+    Strings.requireNonBlank(agent, "agent");
+    Strings.requireNonBlank(host, "host");
     data = data == null ? Map.of() : Map.copyOf(data);
   }
 
@@ -392,11 +389,5 @@ public record Event(
       case String s when !s.isBlank() -> Long.parseLong(s.strip());
       default -> fallback;
     };
-  }
-
-  private static void requireNonBlank(String value, String name) {
-    if (Strings.isBlank(value)) {
-      throw new IllegalArgumentException(name + " is required");
-    }
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentWatchCommand.java
@@ -479,7 +479,7 @@ public final class AgentWatchCommand implements Runnable {
       var map = new LinkedHashMap<String, Object>();
       map.put("name", name);
       map.put("triggered", false);
-      map.put("reason", "agent_session_stopped");
+      map.put("reason", Event.WellKnownTypes.AGENT_SESSION_STOPPED);
       System.out.println(YamlUtil.dumpJson(map));
     } else {
       System.out.println(Ansi.AUTO.string("  @|faint Agent exited. Watch complete.|@"));
@@ -487,7 +487,7 @@ public final class AgentWatchCommand implements Runnable {
     sendNotification(
         notifier,
         notifications,
-        "agent_session_stopped",
+        Event.WellKnownTypes.AGENT_SESSION_STOPPED,
         name,
         "Agent exited",
         "Agent process is no longer running. Run: sail agent report " + name);
@@ -500,7 +500,7 @@ public final class AgentWatchCommand implements Runnable {
     sendNotification(
         notifier,
         notifications,
-        "guardrail_triggered",
+        Event.WellKnownTypes.GUARDRAIL_TRIGGERED,
         name,
         "Guardrail: " + triggered.reason(),
         triggered.detail() + ". Action: " + triggered.action());
@@ -510,7 +510,7 @@ public final class AgentWatchCommand implements Runnable {
     sendNotification(
         notifier,
         notifications,
-        "agent_session_completed",
+        Event.WellKnownTypes.AGENT_SESSION_COMPLETED,
         name,
         "Watch complete",
         "Agent session ended. Run: sail agent report " + name);

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerManager.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerManager.java
@@ -93,7 +93,7 @@ public final class ContainerManager {
       throws IOException, InterruptedException, TimeoutException {
     var busPath = ContainerExec.DEV_XDG_RUNTIME_DIR + "/bus";
     for (var attempt = 0; attempt < READINESS_ATTEMPTS; attempt++) {
-      if (shell.exec(List.of("incus", "exec", name, "--", "test", "-S", busPath)).ok()) {
+      if (shell.exec(ContainerExec.asRoot(name, List.of("test", "-S", busPath))).ok()) {
         return true;
       }
       Thread.sleep(READINESS_POLL_MILLIS);
@@ -142,7 +142,7 @@ public final class ContainerManager {
         sed -i "s/^\\(127\\.0\\.1\\.1[[:space:]]*\\).*/\\1$1/" /etc/hosts 2>/dev/null || true
         """;
     var result =
-        shell.exec(List.of("incus", "exec", name, "--", "bash", "-c", script, "bash", name));
+        shell.exec(ContainerExec.asRoot(name, List.of("bash", "-c", script, "bash", name)));
     if (!result.ok()) {
       throw new IOException(
           "Failed to set hostname for container '" + name + "': " + result.stderr());
@@ -153,7 +153,7 @@ public final class ContainerManager {
   /** Reads the live guest hostname and reports whether it already equals {@code name}. */
   public boolean hostnameMatches(String name)
       throws IOException, InterruptedException, TimeoutException {
-    var current = shell.exec(List.of("incus", "exec", name, "--", "hostname"));
+    var current = shell.exec(ContainerExec.asRoot(name, List.of("hostname")));
     return current.ok() && current.stdout().strip().equals(name);
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectApplier.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectApplier.java
@@ -394,15 +394,15 @@ public final class ProjectApplier {
 
     var newCron = CleanupScripts.buildUpgradedCrontab(existingCron);
     var mktemp =
-        shell.exec(List.of("incus", "exec", name, "--", "mktemp", "/tmp/sail-crontab.XXXXXX"));
+        shell.exec(ContainerExec.asRoot(name, List.of("mktemp", "/tmp/sail-crontab.XXXXXX")));
     if (!mktemp.ok()) {
       throw new IOException("Failed to create temp file for crontab: " + mktemp.stderr());
     }
     var tmpPath = mktemp.stdout().strip();
     pushFile(name, tmpPath, newCron);
     var cronResult =
-        shell.exec(List.of("incus", "exec", name, "--", "crontab", "-u", sshUser, tmpPath));
-    shell.exec(List.of("incus", "exec", name, "--", "rm", "-f", tmpPath));
+        shell.exec(ContainerExec.asRoot(name, List.of("crontab", "-u", sshUser, tmpPath)));
+    shell.exec(ContainerExec.asRoot(name, List.of("rm", "-f", tmpPath)));
     if (!cronResult.ok()) {
       throw new IOException(
           "Failed to install crontab for user '" + sshUser + "': " + cronResult.stderr());

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectProvisioner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ProjectProvisioner.java
@@ -1184,16 +1184,12 @@ public final class ProjectProvisioner {
 
   private ShellExec.Result execInContainer(String name, List<String> command)
       throws IOException, InterruptedException, TimeoutException {
-    var full = new ArrayList<>(List.of("incus", "exec", name, "--"));
-    full.addAll(command);
-    return shell.exec(full);
+    return shell.exec(ContainerExec.asRoot(name, command));
   }
 
   private ShellExec.Result execInContainer(String name, List<String> command, Duration timeout)
       throws IOException, InterruptedException, TimeoutException {
-    var full = new ArrayList<>(List.of("incus", "exec", name, "--"));
-    full.addAll(command);
-    return shell.exec(full, null, timeout);
+    return shell.exec(ContainerExec.asRoot(name, command), null, timeout);
   }
 
   /**

--- a/sail-infra/src/test/java/ai/singlr/sail/MainTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/MainTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class MainTest {
+
+  private static CommandLine withCapturedErr(StringWriter err) {
+    var cmd = new CommandLine(new Sail());
+    cmd.setErr(new PrintWriter(err));
+    cmd.setColorScheme(CommandLine.Help.defaultColorScheme(CommandLine.Help.Ansi.OFF));
+    return cmd;
+  }
+
+  @Test
+  void reportPrintsTheMessageAndReturnsNonZero() {
+    var err = new StringWriter();
+    var code =
+        Main.report(new IllegalStateException("boom: run sail host init"), withCapturedErr(err));
+    assertEquals(1, code);
+    assertTrue(err.toString().contains("boom: run sail host init"), err.toString());
+  }
+
+  @Test
+  void reportFallsBackToTheTypeWhenTheMessageIsBlank() {
+    var err = new StringWriter();
+    var code = Main.report(new IllegalStateException(), withCapturedErr(err));
+    assertEquals(1, code);
+    assertFalse(err.toString().isBlank());
+    assertTrue(err.toString().contains("IllegalStateException"), err.toString());
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EventTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EventTest.java
@@ -239,9 +239,6 @@ class EventTest {
     assertEquals(
         Event.RetentionClass.EPHEMERAL,
         Event.WellKnownTypes.retentionClass(Event.WellKnownTypes.AGENT_PRESENCE));
-    assertEquals(
-        Event.RetentionClass.EPHEMERAL,
-        Event.WellKnownTypes.retentionClass(Event.WellKnownTypes.HEARTBEAT));
   }
 
   @Test
@@ -251,7 +248,6 @@ class EventTest {
     assertTrue(Event.WellKnownTypes.progress(Event.WellKnownTypes.AGENT_LOG_CHUNK));
     assertFalse(Event.WellKnownTypes.progress(Event.WellKnownTypes.AGENT_SESSION_STARTED));
     assertFalse(Event.WellKnownTypes.progress(Event.WellKnownTypes.AGENT_PRESENCE));
-    assertFalse(Event.WellKnownTypes.progress(Event.WellKnownTypes.HEARTBEAT));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
@@ -273,7 +273,9 @@ class RoomWakeReactorTest {
             .filter()
             .test(Event.of("acme", null, Event.WellKnownTypes.SPEC_MESSAGE_POSTED, "u", "h")));
     assertFalse(
-        reactor.filter().test(Event.of("acme", "auth", Event.WellKnownTypes.HEARTBEAT, "u", "h")));
+        reactor
+            .filter()
+            .test(Event.of("acme", "auth", Event.WellKnownTypes.AGENT_PRESENCE, "u", "h")));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RunActivityStamperTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RunActivityStamperTest.java
@@ -86,7 +86,7 @@ class RunActivityStamperTest {
     assertFalse(
         stamper.filter().test(progress(Event.WellKnownTypes.AGENT_SESSION_STARTED, Map.of())),
         "session lifecycle is not progress — the stall timer and presence must agree");
-    assertFalse(stamper.filter().test(progress(Event.WellKnownTypes.HEARTBEAT, Map.of())));
+    assertFalse(stamper.filter().test(progress(Event.WellKnownTypes.AGENT_PRESENCE, Map.of())));
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SpecStoreAuditPersisterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SpecStoreAuditPersisterTest.java
@@ -57,7 +57,7 @@ class SpecStoreAuditPersisterTest {
     assertFalse(
         persister
             .filter()
-            .test(Event.of("proj", "spec-1", Event.WellKnownTypes.HEARTBEAT, "sail", "host")));
+            .test(Event.of("proj", "spec-1", Event.WellKnownTypes.AGENT_PRESENCE, "sail", "host")));
   }
 
   @Test


### PR DESCRIPTION
## What

First increment of the pre-v1 cleanup arc (`sail-vocab-and-hygiene`): remove split-brain vocabularies and close error-swallow holes that read badly for an OSS v1.

- **`Main.report`** — the global execution-exception handler (`setExecutionExceptionHandler(... -> 1)`) discarded the throwable and printed nothing, so an escaped CLI error surfaced as a silent non-zero exit. It now prints the throwable's message (falling back to its type when blank) to stderr via the color scheme, then returns 1. Extracted so it is unit-tested.
- **`Strings.requireNonBlank(value, name)`** — the one throwing blank-guard in the `common` seam, replacing `Event`'s private duplicate. `Event`'s four constructor guards route through it.
- **`Event`** — deleted the dead `PROJECT_STARTED` / `PROJECT_STOPPED` / `HEARTBEAT` types (zero producers) and collapsed `retentionClass`'s `EPHEMERAL` arm to its sole remaining member, `AGENT_PRESENCE` (live via `RunPresenceEmitter`).
- **`AgentWatchCommand`** — emit webhook notification types via `WellKnownTypes.*` constants instead of bare string literals.
- **`ContainerManager` / `ProjectProvisioner` / `ProjectApplier`** — route in-container `incus exec` through `ContainerExec.asRoot`, so the container-name validation (`NameValidator.requireValidProjectName`) is applied uniformly instead of being skipped inline. The generated command lists are byte-identical.

## Verified false positive (dropped)

The audit flagged `Notifications.VALID_EVENTS` as a drifting hand-copy of `Event.WellKnownTypes`. It is not: `VALID_EVENTS` is the deliberate **webhook-emittable subset**. Deriving it from `WellKnownTypes.ALL` would let users subscribe to bus-internal types (`agent_failed`, `agent_cancelled`, …) that a webhook never sends — silent no-op subscriptions. **No change.**

## Testing

- New `MainTest`: an escaped command error prints a diagnostic (not empty output) and returns 1; a message-less throwable falls back to its type.
- New `StringsTest` cases for `requireNonBlank` (blank/null throw naming the field; value passes).
- `mvn clean verify` green — 2868 tests, JaCoCo coverage checks met, spotless clean.
