### PR TITLE
fix: close the review loop so shipped findings reach a terminal state

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/Finding.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/Finding.java
@@ -69,11 +69,17 @@ public record Finding(
     }
   }
 
+  /**
+   * A finding's terminal state. {@code SHIPPED} is distinct from {@code DISMISSED}: the finding was
+   * real, but it sat below the review gate and the human accepted it by merging the spec's work —
+   * so it must close (the loop leaves nothing OPEN) without being mislabeled a false positive.
+   */
   public enum Resolution {
     OPEN,
     FIXED,
     DISMISSED,
-    DISPUTED
+    DISPUTED,
+    SHIPPED
   }
 
   public record Suggestion(String before, String after, String rationale) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
@@ -588,6 +588,20 @@ public final class ReviewStore implements ConflictResolver {
         .orElse(List.of());
   }
 
+  /**
+   * Closes the residue a spec shipped with — the {@link #openFindingsAfterPass} set — as {@link
+   * Finding.Resolution#SHIPPED}, returning how many changed. Called on the {@code → done}
+   * transition so a completed spec leaves no finding OPEN. A spec whose latest review did not pass
+   * has no residue and is left untouched (its findings are in-flight work, not shipped).
+   */
+  public int resolveShippedFindings(String specId) {
+    var residue = openFindingsAfterPass(specId);
+    for (var finding : residue) {
+      resolveFinding(finding.id(), Finding.Resolution.SHIPPED, "shipped below the review gate");
+    }
+    return residue.size();
+  }
+
   // ---- Sync: the review as a replicated aggregate (review + stages + finding counts) ----
 
   /**

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -89,6 +89,26 @@ public final class SchemaManager {
    * container_leases} (a box's own exclusive-container-operation claims) are local-only as well —
    * none of the four ever joins a sync snapshot.
    */
+  /**
+   * One-time sweep of the review-loop convergence gap: findings a spec shipped below the gate were
+   * left {@code OPEN} forever (nothing resolved a passed review's own residue). Closes every such
+   * finding — {@code OPEN} on the non-superseded passed review of a {@code done} spec — as {@code
+   * SHIPPED}, the same terminal state {@code ReviewStore.resolveShippedFindings} now writes on the
+   * {@code → done} transition going forward. Named so the migration test runs this exact statement.
+   */
+  static final String BACKFILL_SHIPPED_RESIDUE =
+      """
+      UPDATE review_findings SET resolution = 'SHIPPED',
+              resolution_evidence = 'shipped below the review gate'
+          WHERE resolution = 'OPEN'
+          AND stage_id IN (
+              SELECT s.id FROM review_stages s
+              JOIN reviews r ON r.id = s.review_id
+              JOIN specs sp ON sp.id = r.spec_id
+              WHERE r.status = 'passed'
+              AND r.superseded_at IS NULL
+              AND sp.status = 'done')""";
+
   static final List<String> MIGRATIONS =
       List.of(
           "ALTER TABLE runs ADD COLUMN principal TEXT",
@@ -318,7 +338,44 @@ public final class SchemaManager {
           "DROP TABLE runs",
           "ALTER TABLE runs_v7 RENAME TO runs",
           "CREATE INDEX IF NOT EXISTS idx_runs_project ON runs(project)",
-          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)");
+          "CREATE INDEX IF NOT EXISTS idx_runs_spec ON runs(spec_id)",
+          """
+          CREATE TABLE review_findings_v3 (
+              id TEXT PRIMARY KEY,
+              stage_id TEXT NOT NULL REFERENCES review_stages(id) ON DELETE CASCADE,
+              severity TEXT NOT NULL,
+              category TEXT NOT NULL,
+              file TEXT,
+              line_start INTEGER,
+              line_end INTEGER,
+              title TEXT NOT NULL,
+              description TEXT NOT NULL,
+              evidence TEXT,
+              suggestion_before TEXT,
+              suggestion_after TEXT,
+              suggestion_rationale TEXT,
+              confidence REAL NOT NULL DEFAULT 0.0,
+              resolution TEXT NOT NULL DEFAULT 'OPEN'
+                  CHECK (resolution IN ('OPEN', 'FIXED', 'DISMISSED', 'DISPUTED', 'SHIPPED')),
+              resolution_evidence TEXT,
+              carried_from TEXT,
+              carry_evidence TEXT
+          )""",
+          """
+          INSERT INTO review_findings_v3 (id, stage_id, severity, category, file,
+                  line_start, line_end, title, description, evidence, suggestion_before,
+                  suggestion_after, suggestion_rationale, confidence, resolution,
+                  resolution_evidence, carried_from, carry_evidence)
+              SELECT id, stage_id, severity, category, file,
+                  line_start, line_end, title, description, evidence, suggestion_before,
+                  suggestion_after, suggestion_rationale, confidence, resolution,
+                  resolution_evidence, carried_from, carry_evidence
+              FROM review_findings""",
+          "DROP TABLE review_findings",
+          "ALTER TABLE review_findings_v3 RENAME TO review_findings",
+          "CREATE INDEX idx_review_findings_stage ON review_findings(stage_id)",
+          "CREATE INDEX idx_review_findings_severity ON review_findings(severity)",
+          BACKFILL_SHIPPED_RESIDUE);
 
   /** The schema version this binary converges every database to. */
   static final int CURRENT_VERSION = V1_VERSION + MIGRATIONS.size();

--- a/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/ReviewStoreTest.java
@@ -196,6 +196,34 @@ class ReviewStoreTest {
   }
 
   @Test
+  void resolveShippedFindingsMarksTheResidueShippedAndClearsIt() {
+    var reviewId = store.createReview("auth", 1);
+    var stageId = store.createStage(reviewId, "security", "agent");
+    var open = addOpenFinding(stageId, Finding.Severity.HIGH, "Below gate");
+    var fixed = addOpenFinding(stageId, Finding.Severity.LOW, "Fixed");
+    store.resolveFinding(fixed.id(), Finding.Resolution.FIXED);
+    store.updateReviewStatus(reviewId, "passed");
+
+    assertEquals(1, store.resolveShippedFindings("auth"));
+    assertTrue(store.openFindingsAfterPass("auth").isEmpty());
+    assertEquals(
+        Finding.Resolution.SHIPPED, store.findFinding(open.id()).orElseThrow().resolution());
+    assertEquals(
+        Finding.Resolution.FIXED, store.findFinding(fixed.id()).orElseThrow().resolution());
+  }
+
+  @Test
+  void resolveShippedFindingsLeavesAnUnpassedReviewsFindingsOpen() {
+    var reviewId = store.createReview("auth", 1);
+    var stageId = store.createStage(reviewId, "security", "agent");
+    var open = addOpenFinding(stageId, Finding.Severity.HIGH, "In flight");
+    store.updateReviewStatus(reviewId, "failed");
+
+    assertEquals(0, store.resolveShippedFindings("auth"));
+    assertEquals(Finding.Resolution.OPEN, store.findFinding(open.id()).orElseThrow().resolution());
+  }
+
+  @Test
   void openFindingsAfterPassEmptyWhenLatestReviewNotPassed() {
     var reviewId = store.createReview("auth", 1);
     var stageId = store.createStage(reviewId, "security", "agent");

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.singlr.sail.config.SpecStatus;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -30,6 +31,59 @@ class SchemaManagerTest {
   @AfterEach
   void tearDown() {
     if (db != null) db.close();
+  }
+
+  @Test
+  void backfillClosesOnlyTheResidueOfADoneSpecsPassedReview() {
+    new SchemaManager(db).migrate();
+    var specs = new SpecStore(db);
+    var reviews = new ReviewStore(db);
+
+    var residue = seedFinding(specs, reviews, "done-passed", SpecStatus.DONE, "passed", false);
+    var wip = seedFinding(specs, reviews, "wip-passed", SpecStatus.IN_PROGRESS, "passed", false);
+    var failed = seedFinding(specs, reviews, "done-failed", SpecStatus.DONE, "failed", false);
+    var gone = seedFinding(specs, reviews, "done-superseded", SpecStatus.DONE, "passed", true);
+
+    db.execute(SchemaManager.BACKFILL_SHIPPED_RESIDUE);
+
+    assertEquals(
+        Finding.Resolution.SHIPPED, reviews.findFinding(residue).orElseThrow().resolution());
+    assertEquals(Finding.Resolution.OPEN, reviews.findFinding(wip).orElseThrow().resolution());
+    assertEquals(Finding.Resolution.OPEN, reviews.findFinding(failed).orElseThrow().resolution());
+    assertEquals(Finding.Resolution.OPEN, reviews.findFinding(gone).orElseThrow().resolution());
+  }
+
+  private String seedFinding(
+      SpecStore specs,
+      ReviewStore reviews,
+      String specId,
+      SpecStatus status,
+      String reviewStatus,
+      boolean superseded) {
+    specs.create(
+        new SpecStore.SpecRow(
+            specId, "proj", "T", status, null, null, null, null, null, 0, null, "", "", null,
+            List.of(), List.of()));
+    var reviewId = reviews.createReview(specId, 1);
+    var stageId = reviews.createStage(reviewId, "security", "agent");
+    var finding =
+        Finding.create(
+            Finding.Severity.HIGH,
+            Finding.Category.SECURITY,
+            "src/A.java",
+            1,
+            2,
+            "title",
+            "desc",
+            "evidence",
+            new Finding.Suggestion("a", "b", "c"),
+            0.5);
+    reviews.addFinding(stageId, finding);
+    reviews.updateReviewStatus(reviewId, reviewStatus);
+    if (superseded) {
+      reviews.supersedeForSpec(specId);
+    }
+    return finding.id();
   }
 
   @Test

--- a/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
@@ -162,6 +162,7 @@ final class GlobalSpecOperations {
         && existing.status() != SpecStatus.DONE
         && reviewStore != null) {
       reviewStore.resolveSourceFindings(specId);
+      reviewStore.resolveShippedFindings(specId);
     }
     var result = specStore.findById(specId).orElseThrow();
     if (result.status() != existing.status()) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
@@ -570,6 +570,19 @@ class GlobalSpecOperationsTest {
   }
 
   @Test
+  void updateToDoneClosesTheSpecsOwnShippedResidue() {
+    ops.create(createReq(Map.of("status", "in_progress")));
+    var reviewId = seedPassedReviewWithOpenFinding("auth");
+
+    ops.update(
+        "auth", SpecUpdateRequest.fromMap(Map.of("status", "done")).withUpdatedBy("uday"), ADMIN);
+
+    assertEquals(
+        Finding.Resolution.SHIPPED,
+        reviewStore.findingsForReview(reviewId).getFirst().resolution());
+  }
+
+  @Test
   void updateWithoutDoneTransitionLeavesFindingsOpen() {
     ops.create(createReq(Map.of("status", "done")));
     var reviewId = seedPassedReviewWithOpenFinding("auth");


### PR DESCRIPTION
## What

First and highest-value slice of `sail-review-converge`: close the review loop so a spec's findings always reach a terminal state.

Autonomous dispatch's code → review → fix loop converged on the *failing* branch but not the *passing* one. When a review **passed** with sub-gate findings still OPEN (the default `NO_CRITICAL` gate lets HIGH/MEDIUM/LOW ship), those findings were orphaned forever: `resolveSourceFindings` only touches follow-up-linked findings, and `carryForwardFindings` only propagates while reviews keep failing. Result: `spec board` reported **41 open findings on specs already `done`**, and the count only grew.

## Change

- **`Finding.Resolution.SHIPPED`** — the honest terminal state for a *real* finding the human accepted by merging below-gate work. Distinct from `DISMISSED` (false positive) so metrics stay meaningful. Findings replicate across nodes as **counts, not rows**, so the new value is node-local — no sync version-skew.
- **`ReviewStore.resolveShippedFindings(specId)`** — closes the `openFindingsAfterPass` residue as `SHIPPED`, reusing that method as the single definition of "what a spec shipped with".
- **`GlobalSpecOperations`** wires it into the `→ done` transition, beside the existing source-findings resolution, so every loop exit leaves every finding terminal.
- **Schema migration** rebuilds `review_findings` with the `SHIPPED`-inclusive CHECK (mirroring the `review_findings_v2` precedent; FK enforcement is already suspended during the migration window), then a one-time **backfill** sweeps the existing residue — `OPEN` on the non-superseded passed review of a `done` spec — clearing the 41.

## Scope

This is item 1 of the spec (the reported bug). The loop-hardening items — surfacing swallowed fix-iteration failures, the gate-failed-no-findings strand edge — and the `ReviewPipelineController` SRP extraction land as separate, independently reviewable PRs so this correctness fix isn't entangled with a large refactor.

## Testing

- `ReviewStore`: residue closes as `SHIPPED`; an unpassed review's findings stay `OPEN`.
- `SchemaManager`: the **exact** backfill statement over a fixture — only a `done` spec's passed, non-superseded review's `OPEN` findings flip; in-progress / failed-review / superseded cases stay `OPEN`.
- `GlobalSpecOperations`: the `→ done` transition closes the spec's own residue end-to-end.
- `mvn clean verify` green — coverage checks met, spotless clean.
