### PR TITLE
fix: a crashed fix agent surfaces and escalates instead of re-reviewing unfixed code

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -593,7 +593,15 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
 
     if (openFindings.isEmpty()) return;
 
-    triggerFixIteration(reviewId, specId, openFindings, project);
+    if (!triggerFixIteration(reviewId, specId, openFindings, project)) {
+      escalate(
+          project,
+          specId,
+          reviewId,
+          "fix iteration could not run — the coding agent errored before addressing the findings;"
+              + " triage and re-dispatch");
+      return;
+    }
     reReview(config, project, specId, review.get().iteration() + 1);
   }
 
@@ -635,10 +643,17 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
    * otherwise the re-review judges a branch without the fixes and the shared clone carries the
    * leftovers into the next dispatch.
    */
-  private void triggerFixIteration(
+  /**
+   * Runs the fix agent, returning whether it completed. A {@code false} return means the fix
+   * crashed before addressing the findings: the caller must not re-review, because the branch still
+   * holds the unfixed code the reviewer just failed. The crash is published as {@code
+   * review_iteration_failed} (parallel to {@code review_errored}) so it is never swallowed to
+   * stderr, and the run is marked failed for the reconciler.
+   */
+  private boolean triggerFixIteration(
       String reviewId, String specId, List<Finding> findings, String project) {
     var spec = specStore.findById(specId);
-    if (spec.isEmpty()) return;
+    if (spec.isEmpty()) return false;
 
     var room = roomMessages(specId);
     var built = FixTaskBuilder.build(specId, spec.get().title(), findings, room);
@@ -674,12 +689,14 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
             "fix agent left uncommitted changes in " + describeRescues(rescued),
             "committed and pushed them to " + spec.get().branch());
       }
+      completeReviewRun(reviewId);
+      return true;
     } catch (Exception e) {
       failReviewRun(reviewId, e);
-      System.err.println(
-          "review-pipeline: fix iteration failed for spec " + specId + ": " + e.getMessage());
+      publishEvent(
+          project, specId, "review_iteration_failed", "fix agent errored: " + e.getMessage());
+      return false;
     }
-    completeReviewRun(reviewId);
   }
 
   /** Errored attempts of this iteration in the current dispatch attempt — the retry budget. */

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ReviewPipelineControllerTest.java
@@ -1523,6 +1523,61 @@ class ReviewPipelineControllerTest {
   }
 
   @Test
+  void aFixCrashSurfacesAsIterationFailedAndEscalatesInsteadOfReReviewingUnfixedCode()
+      throws Exception {
+    createSpec("auth", "in_progress", List.of("api"));
+    var criticalOutput =
+        """
+        ```json
+        {"verdicts": [], "findings": [{"severity": "CRITICAL", "category": "SECURITY", "file": "a.java",
+          "line_start": 1, "line_end": 1, "title": "Bad",
+          "description": "Very bad", "confidence": 0.9}]}
+        ```
+        """;
+    var runner =
+        new ReviewAgentRunner() {
+          @Override
+          public String run(String p, String a, String prompt, String rid, String cred) {
+            return criticalOutput;
+          }
+
+          @Override
+          public String runFix(
+              String p,
+              String a,
+              String prompt,
+              String rid,
+              String cred,
+              String branch,
+              List<String> repos,
+              String model,
+              String effort) {
+            throw new IllegalStateException("fix agent quota exceeded");
+          }
+        };
+
+    try (var bus = new EventBus()) {
+      var captured = captureEvents(bus, Set.of("review_iteration_failed", "review_escalated"), 2);
+      var ctrl = controller(p -> singleAgentStage("no_critical"), p -> "codex", runner, bus);
+
+      ctrl.onEvent(agentStoppedEvent("auth"));
+      BusTesting.awaitDelivery(captured.latch());
+
+      assertEquals(
+          1,
+          reviewStore.reviewsForSpec("auth").size(),
+          "a crashed fix must not spawn a second review — the branch still holds the unfixed code"
+              + " the reviewer just failed");
+      assertEquals("escalated", reviewStore.latestReviewForSpec("auth").orElseThrow().status());
+      var types = captured.events().stream().map(Event::type).toList();
+      assertTrue(
+          types.contains("review_iteration_failed"),
+          "the fix crash must surface as an event, never be swallowed to stderr: " + types);
+      assertTrue(types.contains("review_escalated"), types.toString());
+    }
+  }
+
+  @Test
   void theFixTaskCarriesTheRoomAndSeedsTheDeliveryWatermark() throws Exception {
     createSpec("auth", "in_progress", List.of("api"));
     var messages = new MessageStore(db);


### PR DESCRIPTION
## What

Second slice of `sail-review-converge` — loop hardening. Fixes a swallowed failure on the core dispatch → review → **fix** → re-review loop.

When the fix agent crashed mid-iteration, `triggerFixIteration` marked the run failed, logged the error to **stderr**, and fell through — then the caller `reReview`d the branch, which still held **the unfixed code the reviewer had just failed**. That burned an iteration on a guaranteed re-fail, with no event to show for it.

## Change

- `triggerFixIteration` now **returns whether the fix completed** and publishes `review_iteration_failed` (parallel to `review_errored`) on a crash — the failure rides the event stream instead of being swallowed to stderr.
- `handleStageFailure` **gates the re-review** on that result: a crashed fix **escalates** (surfacing to a human) instead of re-judging unfixed code.

## Dropped after verification

The audit's companion item — "a gate-failed review with no open findings strands the spec" — is a **false positive**. `Gate.passes` is `noneMatch(blocks)`, which is vacuously **true** on an empty finding list, so a `GateFailed` outcome always carries at least one blocking `OPEN` finding. The `openFindings.isEmpty()` branch in `handleStageFailure` is unreachable defensive code, not a live strand — converting it to `escalate` would only add untestable dead lines under the controller's coverage rule. Left as-is.

## Testing

- A fix agent that throws leaves **exactly one review** (no second review of unfixed code), ends the spec **escalated**, and emits **`review_iteration_failed`**.
- `mvn clean verify` green — the `ReviewPipelineController` LINE ≥0.93 / METHOD 1.0 rule holds; coverage checks met.
