### PR TITLE
refactor: promote run/spec ownership to the domain rows

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -261,6 +261,17 @@ public final class RunStore implements ConflictResolver {
     public boolean sessionRole() {
       return buildRole() || adhocRole() || chatRole() || inviteRole();
     }
+
+    /**
+     * Whether this run belongs to the box whose handle is {@code localHandle} — the one predicate
+     * for every run-ownership question (the read guard, the reaper, the reconciler, presence), so
+     * they can never disagree about which box owns a run. A handled box owns the runs stamped with
+     * its handle (a blank node fails closed); an unhandled box — standalone, not yet bound to an
+     * FDE — owns its own blank-node runs.
+     */
+    public boolean ownedBy(String localHandle) {
+      return Strings.isBlank(localHandle) ? Strings.isBlank(node) : localHandle.equals(node);
+    }
   }
 
   private static final String SESSION_ROLES =

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -187,6 +187,15 @@ public final class SpecStore implements ConflictResolver {
           engagement);
     }
 
+    /**
+     * Whether this spec is assigned to the box whose handle is {@code localHandle}. Unlike run
+     * ownership, a blank handle owns nothing: an FDE-bound box serves only its assignee's specs,
+     * and an unbound box drives no spec's room lane at all.
+     */
+    public boolean assignedTo(String localHandle) {
+      return Strings.isNotBlank(localHandle) && localHandle.equals(assignee);
+    }
+
     /** Projects this stored row onto the storage-agnostic {@link Spec} value type. */
     public Spec toSpec() {
       return new Spec(

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -63,6 +63,22 @@ class RunStoreTest {
         "sail-agent-" + id);
   }
 
+  private static RunStore.RunRow runOnNode(String node) {
+    return new RunStore.RunRow(
+        "r", "proj", "spec", node, "build", "codex", "b", "t", null, null, "running", null, "log",
+        "unit", "t", null, List.of(), null, null, null);
+  }
+
+  @Test
+  void ownedByMatchesTheStampedNodeAndFailsClosedOnBlank() {
+    assertTrue(runOnNode("node-a").ownedBy("node-a"));
+    assertFalse(runOnNode("node-a").ownedBy("node-b"));
+    assertFalse(runOnNode("node-a").ownedBy(null), "a handled box never owns another box's run");
+    assertFalse(runOnNode("").ownedBy("node-a"), "a blank node fails closed for a handled box");
+    assertTrue(runOnNode("").ownedBy(null), "a standalone box owns its own blank-node runs");
+    assertTrue(runOnNode(null).ownedBy(""), "blank handle and blank node both mean standalone");
+  }
+
   @Test
   void createAndFindRun() {
     var id = newRun("backend", "auth");

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
@@ -62,6 +62,33 @@ class SpecStoreTest {
   }
 
   @Test
+  void assignedToMatchesOnlyANonBlankHandleEqualToTheAssignee() {
+    var mine =
+        new SpecStore.SpecRow(
+            "s",
+            "test-project",
+            "T",
+            SpecStatus.fromWire("pending"),
+            "uday",
+            null,
+            null,
+            null,
+            null,
+            0,
+            null,
+            "",
+            "",
+            null,
+            List.of(),
+            List.of());
+    assertTrue(mine.assignedTo("uday"));
+    assertFalse(mine.assignedTo("mady"));
+    assertFalse(mine.assignedTo(null), "a blank handle is assigned no spec");
+    assertFalse(
+        spec("s", "T", "pending").assignedTo("uday"), "an unassigned spec is owned by nobody");
+  }
+
+  @Test
   void createAndFindById() {
     store.create(spec("auth", "OAuth flow", "pending"));
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -658,7 +658,7 @@ public final class DispatchOperations {
   private String engagedSessionId(String specId, String agentType, String localHandle) {
     return runStore.listForSpec(specId).stream()
         .filter(RunStore.RunRow::chatRole)
-        .filter(run -> SailOperations.ownsRun(run.node(), localHandle))
+        .filter(run -> run.ownedBy(localHandle))
         .filter(run -> Strings.isNotBlank(run.sessionId()))
         .filter(run -> agentType.equals(run.agent()))
         .filter(run -> AgentCli.isSafeSessionId(run.sessionId()))
@@ -1078,7 +1078,7 @@ public final class DispatchOperations {
    */
   private String resumableSessionId(String specId, String agentType, String localHandle) {
     return runStore.listForSpec(specId).stream()
-        .filter(run -> SailOperations.ownsRun(run.node(), localHandle))
+        .filter(run -> run.ownedBy(localHandle))
         .filter(run -> Strings.isNotBlank(run.sessionId()))
         .filter(run -> agentType.equals(run.agent()))
         .filter(run -> AgentCli.isSafeSessionId(run.sessionId()))
@@ -1879,7 +1879,7 @@ public final class DispatchOperations {
     }
     return runStore.listForProject(project).stream()
         .filter(DispatchOperations::ownsLiveAgent)
-        .filter(run -> SailOperations.ownsRun(run.node(), localHandle))
+        .filter(run -> run.ownedBy(localHandle))
         .map(run -> new DispatchGate.RunningRun(run.id(), run.specId(), run.role(), run.repos()))
         .toList();
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -232,7 +232,7 @@ public final class MissedStopReconciler implements AutoCloseable {
     var released = 0;
     for (var run : sessionStore.running()) {
       if (handledThisSweep.contains(run.specId())
-          || !SailOperations.ownsRun(run.node(), node)
+          || !run.ownedBy(node)
           || !MissedStops.parseOr(run.startedAt(), Instant.MAX).isBefore(deadline)
           || specBeingWorked(run.specId())
           || agentProbablyAlive(run)) {
@@ -283,7 +283,7 @@ public final class MissedStopReconciler implements AutoCloseable {
     var node = localHandle.get();
     var finalized = 0;
     for (var run : sessionStore.stopping()) {
-      if (!SailOperations.ownsRun(run.node(), node)) {
+      if (!run.ownedBy(node)) {
         continue;
       }
       try {
@@ -357,7 +357,7 @@ public final class MissedStopReconciler implements AutoCloseable {
         sessionStore.listForSpec(spec.id()).stream()
             .filter(RunStore.RunRow::buildRole)
             .findFirst()
-            .filter(run -> SailOperations.ownsRun(run.node(), node))
+            .filter(run -> run.ownedBy(node))
             .filter(run -> TERMINAL_RUN_STATUSES.contains(run.status()));
     if (latest.isEmpty() || unitStillActive(spec, latest.get())) {
       return false;
@@ -400,7 +400,7 @@ public final class MissedStopReconciler implements AutoCloseable {
         sessionStore.listForSpec(spec.id()).stream()
             .filter(RunStore.RunRow::buildRole)
             .findFirst()
-            .filter(run -> SailOperations.ownsRun(run.node(), node));
+            .filter(run -> run.ownedBy(node));
     if (latest.isEmpty()) {
       return false;
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
@@ -178,7 +178,7 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
   private void handleMessage(Event event) {
     var specId = event.spec();
     var spec = specStore.findById(specId).orElse(null);
-    if (spec == null || !ownsSpec(spec)) {
+    if (spec == null || !spec.assignedTo(localHandle.get())) {
       return;
     }
     var engaged = Engagement.fromJson(spec.engagement()) != null;
@@ -211,7 +211,7 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
   private void fire(String specId, Message message) {
     try {
       var spec = specStore.findById(specId).orElse(null);
-      if (spec == null || !ownsSpec(spec)) {
+      if (spec == null || !spec.assignedTo(localHandle.get())) {
         return;
       }
       var engaged = Engagement.fromJson(spec.engagement()) != null;
@@ -254,7 +254,7 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
       return;
     }
     var run = runStore.findById(runId).orElse(null);
-    if (run == null || !SailOperations.ownsRun(run.node(), localHandle.get())) {
+    if (run == null || !run.ownedBy(localHandle.get())) {
       return;
     }
     guard.guard(run.project(), runId);
@@ -268,7 +268,9 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
    */
   private void refireOwedTurn(String specId) {
     var spec = specStore.findById(specId).orElse(null);
-    if (spec == null || !ownsSpec(spec) || Engagement.fromJson(spec.engagement()) == null) {
+    if (spec == null
+        || !spec.assignedTo(localHandle.get())
+        || Engagement.fromJson(spec.engagement()) == null) {
       return;
     }
     var owed = owedMessage(specId);
@@ -317,7 +319,7 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
   public void sweepEngagedRooms() {
     for (var spec : specStore.listEngaged()) {
       try {
-        if (ownsSpec(spec)) {
+        if (spec.assignedTo(localHandle.get())) {
           refireOwedTurn(spec.id());
         }
       } catch (RuntimeException e) {
@@ -325,11 +327,6 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
             "room-wake: engagement sweep of spec " + spec.id() + " failed: " + e.getMessage());
       }
     }
-  }
-
-  private boolean ownsSpec(SpecStore.SpecRow spec) {
-    var handle = localHandle.get();
-    return Strings.isNotBlank(handle) && handle.equals(spec.assignee());
   }
 
   private boolean dispatchedAtLeastOnce(String specId) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RunPresenceEmitter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RunPresenceEmitter.java
@@ -74,7 +74,7 @@ public final class RunPresenceEmitter implements AutoCloseable {
     var live = new HashSet<String>();
     var emitted = 0;
     for (var run : runStore.runningForPresence()) {
-      if (!SailOperations.ownsRun(run.node(), node)) {
+      if (!run.ownedBy(node)) {
         continue;
       }
       var presence = RunPresence.of(run.status(), run.lastActivityAt(), now);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RunTracker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RunTracker.java
@@ -92,7 +92,7 @@ public final class RunTracker implements EventSubscriber {
     var node = localHandle.get();
     runStore
         .findById(runId)
-        .filter(run -> SailOperations.ownsRun(run.node(), node))
+        .filter(run -> run.ownedBy(node))
         .ifPresent(run -> completeOrRecord(run, status, exitCode));
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -693,23 +693,12 @@ public final class SailOperations implements Operations {
 
   /**
    * Whether a run did not execute on this box — the provenance test, the inverse of {@link
-   * #ownsRun}. A box with a handle serves only runs stamped with it, so a blank {@code node} fails
-   * closed to foreign; a box with no handle serves only its own blank-node runs and never a synced
-   * run stamped by another box.
+   * RunStore.RunRow#ownedBy}. A box with a handle serves only runs stamped with it, so a blank
+   * {@code node} fails closed to foreign; a box with no handle serves only its own blank-node runs
+   * and never a synced run stamped by another box.
    */
   static boolean isForeign(RunStore.RunRow run, String localHandle) {
-    return !ownsRun(run.node(), localHandle);
-  }
-
-  /**
-   * Whether a run whose execution node is {@code runNode} belongs to the box whose handle is {@code
-   * localHandle}. One predicate for every ownership question — the read guard here and the
-   * completion/report lookups in {@link RunStore#latestForProjectOnNode} — so they can never
-   * disagree. A handled box owns the runs stamped with its handle (blank node → not owned, fail
-   * closed); an unhandled box (standalone / not yet bound to an FDE) owns its own blank-node runs.
-   */
-  static boolean ownsRun(String runNode, String localHandle) {
-    return Strings.isBlank(localHandle) ? Strings.isBlank(runNode) : localHandle.equals(runNode);
+    return !run.ownedBy(localHandle);
   }
 
   /**
@@ -860,7 +849,7 @@ public final class SailOperations implements Operations {
             : runStore.listForProject(project).stream()
                 .filter(DispatchOperations::ownsLiveAgent)
                 .filter(RunStore.RunRow::sessionRole)
-                .filter(run -> ownsRun(run.node(), localHandle))
+                .filter(run -> run.ownedBy(localHandle))
                 .toList();
     if (running.isEmpty()) {
       return agentStatusResponse(project, null, List.of());

--- a/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/StopOperations.java
@@ -225,7 +225,7 @@ public final class StopOperations {
             .findById(runId)
             .orElseThrow(
                 () -> new ApiException(ErrorCode.RUN_NOT_FOUND, "No run '" + runId + "'."));
-    if (!SailOperations.ownsRun(run.node(), localHandle)) {
+    if (!run.ownedBy(localHandle)) {
       var node = Strings.isBlank(run.node()) ? "an unknown node" : run.node();
       throw new ApiException(
           ErrorCode.RUN_ON_OTHER_NODE,

--- a/sail-infra/src/main/java/ai/singlr/sail/api/WatcherRearmer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/WatcherRearmer.java
@@ -116,7 +116,7 @@ public final class WatcherRearmer implements AutoCloseable {
     try {
       var node = localHandle.get();
       for (var run : sessionStore.running()) {
-        if (!SailOperations.ownsRun(run.node(), node) || Strings.isBlank(run.unit())) {
+        if (!run.ownedBy(node) || Strings.isBlank(run.unit())) {
           continue;
         }
         try {


### PR DESCRIPTION
## What

First slice of `sail-orchestration-split` — a small, safe, behavior-preserving DRY win that shrinks the god objects without touching their launch logic.

Ownership was expressed twice, out where it could drift:
- a **static `SailOperations.ownsRun(node, handle)`** reached from **eight** classes (dispatch, stop, presence, tracker, reconciler ×4, rearmer, room-wake)
- a **hand-copied `RoomWakeReactor.ownsSpec`** — the same idea as `DispatchPolicy`'s assignee check, written again

## Change

- **`RunStore.RunRow.ownedBy(localHandle)`** — the one run-ownership predicate (a handled box owns its handle's runs, a blank node fails closed; a standalone box owns its own blank-node runs). Replaces `SailOperations.ownsRun` at all eight call sites; the static is deleted and `isForeign` delegates to it.
- **`SpecStore.SpecRow.assignedTo(localHandle)`** — the spec-assignment predicate (a blank handle owns nothing, unlike run ownership). Replaces `RoomWakeReactor`'s private `ownsSpec` at its four call sites.

`DispatchPolicy` keeps its own storage-agnostic `Spec` type (a deliberate boundary) and is left untouched.

## Testing

- `RunRow.ownedBy` and `SpecRow.assignedTo` unit-tested across match / mismatch / blank-handle / blank-node.
- The predicates are the **exact prior logic** moved onto the rows, so every dispatch/room/reconciler/stop test passes unchanged.
- `mvn clean verify` green — coverage checks met.
