### PR TITLE
refactor: extract the shared LaunchAdmission guards from DispatchOperations

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -219,7 +219,7 @@ public final class DispatchOperations {
   private final SpecStore specStore;
   private final ReviewStore reviewStore;
   private final RunStore runStore;
-  private final FdeStore fdeStore;
+  private final LaunchAdmission admission;
   private MessageStore messageStore;
   private final EventSink events;
   private final WatcherSpawner watcherSpawner;
@@ -252,7 +252,7 @@ public final class DispatchOperations {
     this.specStore = specStore;
     this.reviewStore = reviewStore;
     this.runStore = runStore;
-    this.fdeStore = fdeStore;
+    this.admission = new LaunchAdmission(shell, fdeStore);
     this.events = Objects.requireNonNull(events, "events");
     this.watcherSpawner = Objects.requireNonNull(watcherSpawner, "watcherSpawner");
     this.snapshotter = Objects.requireNonNull(snapshotter, "snapshotter");
@@ -297,7 +297,7 @@ public final class DispatchOperations {
     if (Strings.isBlank(localHandle)) {
       throw refusal(DispatchPolicy.nodeHandleUnset());
     }
-    requireTrustedRoster(localHandle);
+    admission.requireTrustedRoster(localHandle);
     if (loaded.config().agent() == null) {
       throw new ApiException(
           ErrorCode.AGENT_NOT_CONFIGURED, "No agent configured in sail.yaml's agent block.");
@@ -702,10 +702,10 @@ public final class DispatchOperations {
                 () ->
                     new ApiException(
                         ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
-    requireAllowed(actor, spec.toSpec(), localHandle);
-    requireTrustedRoster(localHandle);
-    var agentCli = inviteAgent(agentYamlName);
-    var inviteModel = inviteModel(model);
+    LaunchAdmission.requireAllowed(actor, spec.toSpec(), localHandle);
+    admission.requireTrustedRoster(localHandle);
+    var agentCli = LaunchAdmission.resolveAgent(agentYamlName);
+    var inviteModel = LaunchAdmission.validateModel(model);
     if (!full) {
       throw new ApiException(
           ErrorCode.BAD_REQUEST,
@@ -721,7 +721,7 @@ public final class DispatchOperations {
       throw new ApiException(
           ErrorCode.AGENT_NOT_CONFIGURED, "No agent configured in sail.yaml's agent block.");
     }
-    requireInstalled(agentCli, project);
+    admission.requireInstalled(agentCli, project);
     var body = specStore.getContent(specId).map(SpecStore.SpecContent::body).orElse("");
     var room =
         messageStore == null
@@ -843,55 +843,6 @@ public final class DispatchOperations {
     publish(project, specId, Event.WellKnownTypes.SNAPSHOT_CREATED, data);
   }
 
-  /**
-   * Validates the invite's model exactly like a spec write, refusing shell-unsafe values as a
-   * client error before any reservation or snapshot — the model rides the agent command through
-   * {@code bash -l -c}, so only a single safe token may reach it.
-   */
-  private static String inviteModel(String model) {
-    try {
-      return Spec.validatedModel(model);
-    } catch (IllegalArgumentException e) {
-      throw new ApiException(ErrorCode.INVALID_REQUEST, e.getMessage());
-    }
-  }
-
-  /**
-   * Refuses the invite before any reservation or snapshot when the chosen agent's binary is not on
-   * the container's PATH — sail.yaml's agent block declares what a project apply installed, but the
-   * container is the authority on what can actually launch.
-   */
-  private void requireInstalled(AgentCli agentCli, String project) {
-    var found =
-        exec(
-            ContainerExec.asDevUser(
-                project,
-                List.of("bash", "-lc", "command -v -- \"$1\"", "bash", agentCli.binaryName())));
-    if (!found.ok()) {
-      throw new ApiException(
-          ErrorCode.AGENT_NOT_CONFIGURED,
-          "Agent '" + agentCli.yamlName() + "' is not installed in project '" + project + "'.",
-          "Add "
-              + agentCli.yamlName()
-              + " to sail.yaml's agent.install list and run 'sail project apply'.");
-    }
-  }
-
-  /** Resolves the invite's agent, refusing an unknown or missing name as a client error. */
-  private static AgentCli inviteAgent(String agentYamlName) {
-    if (Strings.isBlank(agentYamlName)) {
-      throw new ApiException(
-          ErrorCode.BAD_REQUEST,
-          "An invite must name the agent to launch.",
-          "Pass agent: claude-code or codex.");
-    }
-    try {
-      return AgentCli.fromYamlName(agentYamlName);
-    } catch (IllegalArgumentException e) {
-      throw new ApiException(ErrorCode.BAD_REQUEST, e.getMessage());
-    }
-  }
-
   /** A prepared engagement: the snapshot label a full mode will pay, and the deferred half. */
   public record EngageLaunch(String agent, String mode, String snapshot, Runnable completion) {}
 
@@ -923,14 +874,17 @@ public final class DispatchOperations {
                 () ->
                     new ApiException(
                         ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
-    requireAllowed(actor, spec.toSpec(), localHandle);
-    requireTrustedRoster(localHandle);
-    var agentCli = inviteAgent(agentYamlName);
+    LaunchAdmission.requireAllowed(actor, spec.toSpec(), localHandle);
+    admission.requireTrustedRoster(localHandle);
+    var agentCli = LaunchAdmission.resolveAgent(agentYamlName);
     Engagement engagement;
     try {
       engagement =
           Engagement.of(
-              agentCli.yamlName(), mode, inviteModel(model), DateTimeUtils.now().toString());
+              agentCli.yamlName(),
+              mode,
+              LaunchAdmission.validateModel(model),
+              DateTimeUtils.now().toString());
     } catch (IllegalArgumentException e) {
       throw new ApiException(ErrorCode.BAD_REQUEST, e.getMessage());
     }
@@ -942,7 +896,7 @@ public final class DispatchOperations {
     }
     var project = spec.project();
     projects.loadRunning(project);
-    requireInstalled(agentCli, project);
+    admission.requireInstalled(agentCli, project);
     if (!engagement.full() || !takeSnapshot) {
       persistEngagement(specId, engagement, actor);
       publishEngaged(project, specId, engagement, "");
@@ -986,7 +940,7 @@ public final class DispatchOperations {
                 () ->
                     new ApiException(
                         ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
-    requireAllowed(actor, spec.toSpec(), localHandle);
+    LaunchAdmission.requireAllowed(actor, spec.toSpec(), localHandle);
     var engagement = Engagement.fromJson(spec.engagement());
     if (engagement == null) {
       return null;
@@ -1436,10 +1390,10 @@ public final class DispatchOperations {
       if (next == null) {
         return SpecResolution.none();
       }
-      requireAllowed(actor, next, localHandle);
+      LaunchAdmission.requireAllowed(actor, next, localHandle);
       return SpecResolution.of(next);
     }
-    requireAllowed(actor, spec, localHandle);
+    LaunchAdmission.requireAllowed(actor, spec, localHandle);
     return switch (RestartResolution.decide(specId, spec, restart)) {
       case RestartResolution.Refused refused -> throw refusal(refused);
       case RestartResolution.NotRestarted ignored -> {
@@ -1454,30 +1408,6 @@ public final class DispatchOperations {
       case RestartResolution.Restarted restarted ->
           SpecResolution.restarted(spec, restarted.previousStatus());
     };
-  }
-
-  private static void requireAllowed(Actor actor, Spec spec, String localHandle) {
-    if (DispatchPolicy.check(actor, spec, localHandle)
-        instanceof DispatchDecision.Refused refused) {
-      throw refusal(refused);
-    }
-  }
-
-  /**
-   * Refuses dispatch when this box's FDE handle is missing from the synced roster: an unauthorized
-   * handle means the specs assigned to it cannot be trusted. Enforced on every lane; a box that
-   * keeps no roster ({@code fdeStore == null}) skips the check.
-   */
-  private void requireTrustedRoster(String localHandle) {
-    if (fdeStore == null || fdeStore.byHandle(localHandle).isPresent()) {
-      return;
-    }
-    throw new ApiException(
-        ErrorCode.FDE_NOT_IN_ROSTER,
-        "FDE '"
-            + localHandle
-            + "' is not in this box's roster, so its assigned specs cannot be trusted.",
-        "Run 'sail sync' to pull the roster from main, or get authorized there first.");
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/LaunchAdmission.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/LaunchAdmission.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.Spec;
+import ai.singlr.sail.engine.AgentCli;
+import ai.singlr.sail.engine.ContainerExec;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.store.FdeStore;
+import java.util.List;
+
+/**
+ * The pre-launch admission checks every run lane runs before it reserves a container or takes a
+ * snapshot: is the actor allowed to act on this spec from this box, is the box's FDE in the synced
+ * roster, is the chosen agent a known name actually installed in the container, and is the model a
+ * shell-safe token. Each refusal is an {@link ApiException} thrown before any side effect, so a
+ * rejected launch never leaves a half-provisioned run. Shared by the dispatch, ad-hoc, room,
+ * invite, and engagement lanes so admission is decided in exactly one place.
+ */
+public final class LaunchAdmission {
+
+  private final ShellExec shell;
+  private final FdeStore fdeStore;
+
+  public LaunchAdmission(ShellExec shell, FdeStore fdeStore) {
+    this.shell = shell;
+    this.fdeStore = fdeStore;
+  }
+
+  /**
+   * Refuses when the actor may not act on {@code spec} from the box identified by {@code
+   * localHandle}.
+   */
+  public static void requireAllowed(Actor actor, Spec spec, String localHandle) {
+    if (DispatchPolicy.check(actor, spec, localHandle)
+        instanceof DispatchDecision.Refused refused) {
+      throw new ApiException(refused.code(), refused.message(), refused.fix());
+    }
+  }
+
+  /**
+   * Refuses dispatch when this box's FDE handle is missing from the synced roster: an unauthorized
+   * handle means the specs assigned to it cannot be trusted. A box that keeps no roster ({@code
+   * fdeStore == null}) skips the check.
+   */
+  public void requireTrustedRoster(String localHandle) {
+    if (fdeStore == null || fdeStore.byHandle(localHandle).isPresent()) {
+      return;
+    }
+    throw new ApiException(
+        ErrorCode.FDE_NOT_IN_ROSTER,
+        "FDE '"
+            + localHandle
+            + "' is not in this box's roster, so its assigned specs cannot be trusted.",
+        "Run 'sail sync' to pull the roster from main, or get authorized there first.");
+  }
+
+  /**
+   * Refuses the launch before any reservation or snapshot when the chosen agent's binary is not on
+   * the container's PATH — sail.yaml's agent block declares what a project apply installed, but the
+   * container is the authority on what can actually launch.
+   */
+  public void requireInstalled(AgentCli agentCli, String project) {
+    var found =
+        exec(
+            ContainerExec.asDevUser(
+                project,
+                List.of("bash", "-lc", "command -v -- \"$1\"", "bash", agentCli.binaryName())));
+    if (!found.ok()) {
+      throw new ApiException(
+          ErrorCode.AGENT_NOT_CONFIGURED,
+          "Agent '" + agentCli.yamlName() + "' is not installed in project '" + project + "'.",
+          "Add "
+              + agentCli.yamlName()
+              + " to sail.yaml's agent.install list and run 'sail project apply'.");
+    }
+  }
+
+  /** Resolves the agent to launch, refusing an unknown or missing name as a client error. */
+  public static AgentCli resolveAgent(String agentYamlName) {
+    if (Strings.isBlank(agentYamlName)) {
+      throw new ApiException(
+          ErrorCode.BAD_REQUEST,
+          "An invite must name the agent to launch.",
+          "Pass agent: claude-code or codex.");
+    }
+    try {
+      return AgentCli.fromYamlName(agentYamlName);
+    } catch (IllegalArgumentException e) {
+      throw new ApiException(ErrorCode.BAD_REQUEST, e.getMessage());
+    }
+  }
+
+  /**
+   * Validates the model exactly like a spec write, refusing shell-unsafe values as a client error
+   * before any reservation or snapshot — the model rides the agent command through {@code bash -l
+   * -c}, so only a single safe token may reach it.
+   */
+  public static String validateModel(String model) {
+    try {
+      return Spec.validatedModel(model);
+    } catch (IllegalArgumentException e) {
+      throw new ApiException(ErrorCode.INVALID_REQUEST, e.getMessage());
+    }
+  }
+
+  private ShellExec.Result exec(List<String> command) {
+    try {
+      return shell.exec(command);
+    } catch (Exception e) {
+      throw new ApiException(ErrorCode.COMMAND_FAILED, "A sail system command failed.", e);
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/LaunchAdmissionTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/LaunchAdmissionTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ai.singlr.sail.config.Spec;
+import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.engine.AgentCli;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** The pre-launch admission guards every run lane runs before any reservation or side effect. */
+class LaunchAdmissionTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private FdeStore fdeStore;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    fdeStore = new FdeStore(db);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  private static Spec spec(String assignee) {
+    return new Spec(
+        "auth",
+        "acme",
+        "Add auth",
+        SpecStatus.PENDING,
+        assignee,
+        List.of(),
+        List.of(),
+        null,
+        null,
+        null,
+        null);
+  }
+
+  private static ShellExec shellExiting(int exitCode) {
+    return new ShellExec() {
+      @Override
+      public ShellExec.Result exec(List<String> command) {
+        return new ShellExec.Result(exitCode, "", "");
+      }
+
+      @Override
+      public ShellExec.Result exec(List<String> command, Path workDir, Duration timeout) {
+        return new ShellExec.Result(exitCode, "", "");
+      }
+
+      @Override
+      public boolean isDryRun() {
+        return false;
+      }
+    };
+  }
+
+  private static ShellExec throwingShell() {
+    return new ShellExec() {
+      @Override
+      public ShellExec.Result exec(List<String> command) throws IOException {
+        throw new IOException("boom");
+      }
+
+      @Override
+      public ShellExec.Result exec(List<String> command, Path workDir, Duration timeout)
+          throws IOException {
+        throw new IOException("boom");
+      }
+
+      @Override
+      public boolean isDryRun() {
+        return false;
+      }
+    };
+  }
+
+  @Test
+  void requireAllowedAdmitsTheAssignee() {
+    assertDoesNotThrow(
+        () -> LaunchAdmission.requireAllowed(Actor.cliOperator("uday"), spec("uday"), "uday"));
+  }
+
+  @Test
+  void requireAllowedRefusesAMemberActingOnAnothersSpec() {
+    var ex =
+        assertThrows(
+            ApiException.class,
+            () ->
+                LaunchAdmission.requireAllowed(
+                    new Actor("mady", Role.MEMBER, Actor.Lane.API), spec("uday"), "uday"));
+    assertEquals(ErrorCode.NOT_YOUR_SPEC, ex.failure().errorCode());
+  }
+
+  @Test
+  void requireTrustedRosterSkipsWhenTheBoxKeepsNoRoster() {
+    var admission = new LaunchAdmission(shellExiting(0), null);
+    assertDoesNotThrow(() -> admission.requireTrustedRoster("anyone"));
+  }
+
+  @Test
+  void requireTrustedRosterAdmitsARosteredHandle() {
+    fdeStore.add("uday", "Uday", "uday@x");
+    var admission = new LaunchAdmission(shellExiting(0), fdeStore);
+    assertDoesNotThrow(() -> admission.requireTrustedRoster("uday"));
+  }
+
+  @Test
+  void requireTrustedRosterRefusesAnUnrosteredHandle() {
+    var admission = new LaunchAdmission(shellExiting(0), fdeStore);
+    var ex = assertThrows(ApiException.class, () -> admission.requireTrustedRoster("ghost"));
+    assertEquals(ErrorCode.FDE_NOT_IN_ROSTER, ex.failure().errorCode());
+  }
+
+  @Test
+  void requireInstalledAdmitsWhenTheBinaryIsOnThePath() {
+    var admission = new LaunchAdmission(shellExiting(0), fdeStore);
+    assertDoesNotThrow(() -> admission.requireInstalled(AgentCli.CLAUDE_CODE, "acme"));
+  }
+
+  @Test
+  void requireInstalledRefusesWhenTheBinaryIsMissing() {
+    var admission = new LaunchAdmission(shellExiting(1), fdeStore);
+    var ex =
+        assertThrows(
+            ApiException.class, () -> admission.requireInstalled(AgentCli.CLAUDE_CODE, "acme"));
+    assertEquals(ErrorCode.AGENT_NOT_CONFIGURED, ex.failure().errorCode());
+  }
+
+  @Test
+  void requireInstalledWrapsAShellFailure() {
+    var admission = new LaunchAdmission(throwingShell(), fdeStore);
+    var ex =
+        assertThrows(
+            ApiException.class, () -> admission.requireInstalled(AgentCli.CLAUDE_CODE, "acme"));
+    assertEquals(ErrorCode.COMMAND_FAILED, ex.failure().errorCode());
+  }
+
+  @Test
+  void resolveAgentReturnsTheNamedAgent() {
+    assertEquals(AgentCli.CLAUDE_CODE, LaunchAdmission.resolveAgent("claude-code"));
+  }
+
+  @Test
+  void resolveAgentRejectsABlankName() {
+    var ex = assertThrows(ApiException.class, () -> LaunchAdmission.resolveAgent("  "));
+    assertEquals(ErrorCode.BAD_REQUEST, ex.failure().errorCode());
+  }
+
+  @Test
+  void resolveAgentRejectsAnUnknownName() {
+    var ex = assertThrows(ApiException.class, () -> LaunchAdmission.resolveAgent("not-an-agent"));
+    assertEquals(ErrorCode.BAD_REQUEST, ex.failure().errorCode());
+  }
+
+  @Test
+  void validateModelReturnsASafeModel() {
+    assertEquals("opus-5", LaunchAdmission.validateModel("opus-5"));
+  }
+
+  @Test
+  void validateModelRejectsAShellUnsafeModel() {
+    var ex = assertThrows(ApiException.class, () -> LaunchAdmission.validateModel("bad model!"));
+    assertEquals(ErrorCode.INVALID_REQUEST, ex.failure().errorCode());
+  }
+}


### PR DESCRIPTION
## What

The shared-guards extraction that **unblocks the `DispatchOperations` lane split**. Before peeling the six lane services out of the 2,264-line god object, their shared pre-launch checks had to move somewhere neutral — otherwise every lane service just re-couples through the same private helpers.

## Change

New **`LaunchAdmission`** collaborator (`ai.singlr.sail.api`) — the one place that decides whether a launch is admitted, each refusal an `ApiException` thrown *before* any reservation or snapshot:

- `requireAllowed(actor, spec, localHandle)` — dispatch authorization (via `DispatchPolicy`)
- `requireTrustedRoster(localHandle)` — the box's FDE must be in the synced roster
- `requireInstalled(agentCli, project)` — the agent binary must be on the container's PATH
- `resolveAgent(name)` — resolve/validate the agent name
- `validateModel(model)` — refuse shell-unsafe model tokens

The three **pure** checks (`requireAllowed`, `resolveAgent`, `validateModel`) are `static`, so the pure static `resolveSpec` keeps calling them; the two **stateful** ones (`requireTrustedRoster` over `FdeStore`, `requireInstalled` over the container) are instance methods. `DispatchOperations` now holds one `LaunchAdmission` and delegates — its `fdeStore` field is gone, and it drops from 2,264 → 2,200 lines with five helpers removed.

## Testing

- **Behavior-preserving** — identical refusal codes and messages, verified by the unchanged dispatch / ad-hoc / room / invite / engagement lane tests.
- New `LaunchAdmissionTest` — **13 cases covering every branch** (admit + each refusal, the null-roster skip, the shell-failure wrap), so the new api class meets the 100% coverage gate with no exclude.
- `mvn clean verify` green.

## Next

With admission decided in one place, the lane services (`EngagementService` first — it launches nothing — then `RoomCommitGuard`, `InviteLauncher`, …) peel out over this guard seam + the `RunLauncher` seam from #205, one behavior-preserving PR each.
