### PR TITLE
refactor: extract EngagementService from DispatchOperations

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -220,6 +220,7 @@ public final class DispatchOperations {
   private final ReviewStore reviewStore;
   private final RunStore runStore;
   private final LaunchAdmission admission;
+  private final EngagementService engagementService;
   private MessageStore messageStore;
   private final EventSink events;
   private final WatcherSpawner watcherSpawner;
@@ -258,6 +259,8 @@ public final class DispatchOperations {
     this.snapshotter = Objects.requireNonNull(snapshotter, "snapshotter");
     this.launcher = Objects.requireNonNull(launcher, "launcher");
     this.listener = Objects.requireNonNull(listener, "listener");
+    this.engagementService =
+        new EngagementService(specStore, projects, admission, this.events, shell);
   }
 
   public DispatchOperations useMessages(MessageStore messages) {
@@ -843,23 +846,11 @@ public final class DispatchOperations {
     publish(project, specId, Event.WellKnownTypes.SNAPSHOT_CREATED, data);
   }
 
-  /** A prepared engagement: the snapshot label a full mode will pay, and the deferred half. */
-  public record EngageLaunch(String agent, String mode, String snapshot, Runnable completion) {}
-
   /**
-   * Engages an agent in {@code specId}'s room: records the engagement on the spec row (synced,
-   * atomic — one JSON value) so the wake reactor answers every human message with a chat turn until
-   * a human disengages. Mode {@code full} is the default; {@code read-only} is the explicit narrow
-   * choice, offered only where the harness enforces it. A full engagement may take one engage-time
-   * rollback snapshot (never per turn), but the default is none — on the {@code dir} backend a
-   * snapshot is a slow full filesystem copy, so the rollback point is opt-in ({@code takeSnapshot})
-   * and the per-turn repo reservation remains the standing guard. A requested snapshot runs off the
-   * request thread ({@code completion}) because a {@code dir}-backend snapshot would blow the HTTP
-   * timeout; the engagement is then persisted only after the snapshot succeeds — the payment
-   * precedes the access — and a failure publishes {@code spec_engage_failed} into the room instead
-   * of engaging. Requires the dispatch tier on the spec, exactly like an invite.
+   * Delegates to {@link EngagementService}, the launch-free room-engagement lane. Kept on the
+   * dispatch surface so callers reach engagement and dispatch through one operations object.
    */
-  public EngageLaunch engage(
+  public EngagementService.EngageLaunch engage(
       String specId,
       String agentYamlName,
       String mode,
@@ -867,113 +858,13 @@ public final class DispatchOperations {
       boolean takeSnapshot,
       Actor actor,
       String localHandle) {
-    var spec =
-        specStore
-            .findById(specId)
-            .orElseThrow(
-                () ->
-                    new ApiException(
-                        ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
-    LaunchAdmission.requireAllowed(actor, spec.toSpec(), localHandle);
-    admission.requireTrustedRoster(localHandle);
-    var agentCli = LaunchAdmission.resolveAgent(agentYamlName);
-    Engagement engagement;
-    try {
-      engagement =
-          Engagement.of(
-              agentCli.yamlName(),
-              mode,
-              LaunchAdmission.validateModel(model),
-              DateTimeUtils.now().toString());
-    } catch (IllegalArgumentException e) {
-      throw new ApiException(ErrorCode.BAD_REQUEST, e.getMessage());
-    }
-    if (!engagement.full() && !agentCli.supportsRoomLane()) {
-      throw new ApiException(
-          ErrorCode.BAD_REQUEST,
-          agentCli.readOnlyInviteRefusal(),
-          "Engage " + agentCli.yamlName() + " with full access instead.");
-    }
-    var project = spec.project();
-    projects.loadRunning(project);
-    admission.requireInstalled(agentCli, project);
-    if (!engagement.full() || !takeSnapshot) {
-      persistEngagement(specId, engagement, actor);
-      publishEngaged(project, specId, engagement, "");
-      return new EngageLaunch(engagement.agent(), engagement.mode(), "", null);
-    }
-    var label = "engage-" + DateTimeUtils.newId();
-    Runnable completion = () -> completeEngage(project, specId, engagement, label, actor);
-    return new EngageLaunch(engagement.agent(), engagement.mode(), label, completion);
+    return engagementService.engage(
+        specId, agentYamlName, mode, model, takeSnapshot, actor, localHandle);
   }
 
-  private void completeEngage(
-      String project, String specId, Engagement engagement, String label, Actor actor) {
-    try {
-      try {
-        new SnapshotManager(shell).create(project, label, INVITE_SNAPSHOT_TIMEOUT);
-      } catch (Exception e) {
-        throw new ApiException(
-            ErrorCode.SNAPSHOT_FAILED,
-            "Failed to create the engage snapshot, so the engagement does not take effect.",
-            "Check the host's snapshot capacity (incus storage) and retry.",
-            e);
-      }
-      publish(project, specId, Event.WellKnownTypes.SNAPSHOT_CREATED, Map.of("label", label));
-      persistEngagement(specId, engagement, actor);
-      publishEngaged(project, specId, engagement, label);
-    } catch (RuntimeException e) {
-      var data = new LinkedHashMap<String, Object>();
-      data.put("agent", engagement.agent());
-      data.put("label", label);
-      data.put("error", Objects.requireNonNullElse(e.getMessage(), e.toString()));
-      publish(project, specId, Event.WellKnownTypes.SPEC_ENGAGE_FAILED, data);
-    }
-  }
-
-  /** Dismisses the room's engaged agent. Idempotent: dismissing an empty room is a no-op. */
+  /** Delegates to {@link EngagementService}: dismisses the room's engaged agent. */
   public String disengage(String specId, Actor actor, String localHandle) {
-    var spec =
-        specStore
-            .findById(specId)
-            .orElseThrow(
-                () ->
-                    new ApiException(
-                        ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
-    LaunchAdmission.requireAllowed(actor, spec.toSpec(), localHandle);
-    var engagement = Engagement.fromJson(spec.engagement());
-    if (engagement == null) {
-      return null;
-    }
-    specStore.update(spec.withEngagement(null));
-    publish(
-        spec.project(),
-        specId,
-        Event.WellKnownTypes.SPEC_DISENGAGED,
-        Map.of("agent", engagement.agent(), "mode", engagement.mode()));
-    return engagement.agent();
-  }
-
-  private void persistEngagement(String specId, Engagement engagement, Actor actor) {
-    var current =
-        specStore
-            .findById(specId)
-            .orElseThrow(
-                () ->
-                    new ApiException(
-                        ErrorCode.SPEC_NOT_FOUND,
-                        "Spec '" + specId + "' vanished while engaging."));
-    specStore.update(current.withEngagement(engagement.toJson()));
-  }
-
-  private void publishEngaged(String project, String specId, Engagement engagement, String label) {
-    var data = new LinkedHashMap<String, Object>();
-    data.put("agent", engagement.agent());
-    data.put("mode", engagement.mode());
-    if (!Strings.isBlank(label)) {
-      data.put("label", label);
-    }
-    publish(project, specId, Event.WellKnownTypes.SPEC_ENGAGED, data);
+    return engagementService.disengage(specId, actor, localHandle);
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/EngagementService.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/EngagementService.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.Engagement;
+import ai.singlr.sail.engine.HostInfo;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.SnapshotManager;
+import ai.singlr.sail.store.SpecStore;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The room-engagement lane: puts an agent in a spec's room (so the wake reactor answers every human
+ * message with a chat turn until dismissed) and takes it out again. Engagement is pure room state —
+ * one JSON value on the spec row — so this service launches nothing and reserves no container; its
+ * only side effect beyond the spec write is an optional engage-time rollback snapshot a full
+ * engagement may pay for. Kept apart from the launch lanes so the room/spec surface can evolve
+ * without touching dispatch.
+ */
+public final class EngagementService {
+
+  private static final Duration SNAPSHOT_TIMEOUT = Duration.ofHours(1);
+
+  private final SpecStore specStore;
+  private final ProjectLoader projects;
+  private final LaunchAdmission admission;
+  private final DispatchOperations.EventSink events;
+  private final ShellExec shell;
+
+  public EngagementService(
+      SpecStore specStore,
+      ProjectLoader projects,
+      LaunchAdmission admission,
+      DispatchOperations.EventSink events,
+      ShellExec shell) {
+    this.specStore = specStore;
+    this.projects = projects;
+    this.admission = admission;
+    this.events = events;
+    this.shell = shell;
+  }
+
+  /** A prepared engagement: the snapshot label a full mode will pay, and the deferred half. */
+  public record EngageLaunch(String agent, String mode, String snapshot, Runnable completion) {}
+
+  /**
+   * Engages an agent in {@code specId}'s room: records the engagement on the spec row (synced,
+   * atomic — one JSON value) so the wake reactor answers every human message with a chat turn until
+   * a human disengages. Mode {@code full} is the default; {@code read-only} is the explicit narrow
+   * choice, offered only where the harness enforces it. A full engagement may take one engage-time
+   * rollback snapshot (never per turn), but the default is none — on the {@code dir} backend a
+   * snapshot is a slow full filesystem copy, so the rollback point is opt-in ({@code takeSnapshot})
+   * and the per-turn repo reservation remains the standing guard. A requested snapshot runs off the
+   * request thread ({@code completion}) because a {@code dir}-backend snapshot would blow the HTTP
+   * timeout; the engagement is then persisted only after the snapshot succeeds — the payment
+   * precedes the access — and a failure publishes {@code spec_engage_failed} into the room instead
+   * of engaging. Requires the dispatch tier on the spec, exactly like an invite.
+   */
+  public EngageLaunch engage(
+      String specId,
+      String agentYamlName,
+      String mode,
+      String model,
+      boolean takeSnapshot,
+      Actor actor,
+      String localHandle) {
+    var spec =
+        specStore
+            .findById(specId)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
+    LaunchAdmission.requireAllowed(actor, spec.toSpec(), localHandle);
+    admission.requireTrustedRoster(localHandle);
+    var agentCli = LaunchAdmission.resolveAgent(agentYamlName);
+    Engagement engagement;
+    try {
+      engagement =
+          Engagement.of(
+              agentCli.yamlName(),
+              mode,
+              LaunchAdmission.validateModel(model),
+              DateTimeUtils.now().toString());
+    } catch (IllegalArgumentException e) {
+      throw new ApiException(ErrorCode.BAD_REQUEST, e.getMessage());
+    }
+    if (!engagement.full() && !agentCli.supportsRoomLane()) {
+      throw new ApiException(
+          ErrorCode.BAD_REQUEST,
+          agentCli.readOnlyInviteRefusal(),
+          "Engage " + agentCli.yamlName() + " with full access instead.");
+    }
+    var project = spec.project();
+    projects.loadRunning(project);
+    admission.requireInstalled(agentCli, project);
+    if (!engagement.full() || !takeSnapshot) {
+      persistEngagement(specId, engagement);
+      publishEngaged(project, specId, engagement, "");
+      return new EngageLaunch(engagement.agent(), engagement.mode(), "", null);
+    }
+    var label = "engage-" + DateTimeUtils.newId();
+    Runnable completion = () -> completeEngage(project, specId, engagement, label);
+    return new EngageLaunch(engagement.agent(), engagement.mode(), label, completion);
+  }
+
+  private void completeEngage(String project, String specId, Engagement engagement, String label) {
+    try {
+      try {
+        new SnapshotManager(shell).create(project, label, SNAPSHOT_TIMEOUT);
+      } catch (Exception e) {
+        throw new ApiException(
+            ErrorCode.SNAPSHOT_FAILED,
+            "Failed to create the engage snapshot, so the engagement does not take effect.",
+            "Check the host's snapshot capacity (incus storage) and retry.",
+            e);
+      }
+      publish(project, specId, Event.WellKnownTypes.SNAPSHOT_CREATED, Map.of("label", label));
+      persistEngagement(specId, engagement);
+      publishEngaged(project, specId, engagement, label);
+    } catch (RuntimeException e) {
+      var data = new LinkedHashMap<String, Object>();
+      data.put("agent", engagement.agent());
+      data.put("label", label);
+      data.put("error", Objects.requireNonNullElse(e.getMessage(), e.toString()));
+      publish(project, specId, Event.WellKnownTypes.SPEC_ENGAGE_FAILED, data);
+    }
+  }
+
+  /** Dismisses the room's engaged agent. Idempotent: dismissing an empty room is a no-op. */
+  public String disengage(String specId, Actor actor, String localHandle) {
+    var spec =
+        specStore
+            .findById(specId)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
+    LaunchAdmission.requireAllowed(actor, spec.toSpec(), localHandle);
+    var engagement = Engagement.fromJson(spec.engagement());
+    if (engagement == null) {
+      return null;
+    }
+    specStore.update(spec.withEngagement(null));
+    publish(
+        spec.project(),
+        specId,
+        Event.WellKnownTypes.SPEC_DISENGAGED,
+        Map.of("agent", engagement.agent(), "mode", engagement.mode()));
+    return engagement.agent();
+  }
+
+  private void persistEngagement(String specId, Engagement engagement) {
+    var current =
+        specStore
+            .findById(specId)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.SPEC_NOT_FOUND,
+                        "Spec '" + specId + "' vanished while engaging."));
+    specStore.update(current.withEngagement(engagement.toJson()));
+  }
+
+  private void publishEngaged(String project, String specId, Engagement engagement, String label) {
+    var data = new LinkedHashMap<String, Object>();
+    data.put("agent", engagement.agent());
+    data.put("mode", engagement.mode());
+    if (!Strings.isBlank(label)) {
+      data.put("label", label);
+    }
+    publish(project, specId, Event.WellKnownTypes.SPEC_ENGAGED, data);
+  }
+
+  private void publish(String project, String specId, String type, Map<String, Object> data) {
+    events.publish(Event.of(project, specId, type, Event.SAIL_AGENT, HostInfo.hostname(), data));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
@@ -244,6 +244,46 @@ class EngagementLifecycleTest {
   }
 
   @Test
+  void engagingAMissingSpecIsRefusedAsNotFound() throws Exception {
+    var ops = operations(shell());
+
+    var ex =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.engage(
+                    "ghost", "claude-code", null, null, false, Actor.cliOperator(HANDLE), HANDLE));
+    assertEquals(ErrorCode.SPEC_NOT_FOUND, ex.failure().errorCode());
+  }
+
+  @Test
+  void disengagingAMissingSpecIsRefusedAsNotFound() throws Exception {
+    var ops = operations(shell());
+
+    var ex =
+        assertThrows(
+            ApiException.class, () -> ops.disengage("ghost", Actor.cliOperator(HANDLE), HANDLE));
+    assertEquals(ErrorCode.SPEC_NOT_FOUND, ex.failure().errorCode());
+  }
+
+  @Test
+  void aSpecDeletedDuringItsSnapshotPaymentPublishesEngageFailed() throws Exception {
+    var ops = operations(shell());
+    seedSpec("auth");
+
+    var launch =
+        ops.engage("auth", "claude-code", "full", null, true, Actor.cliOperator(HANDLE), HANDLE);
+    specStore.delete("auth");
+    launch.completion().run();
+
+    assertNull(specStore.findById("auth").orElse(null), "the spec is gone");
+    assertTrue(
+        ofType(Event.WellKnownTypes.SPEC_ENGAGED).isEmpty(),
+        "a spec that vanished mid-payment engages nobody");
+    assertEquals(1, ofType(Event.WellKnownTypes.SPEC_ENGAGE_FAILED).size());
+  }
+
+  @Test
   void aReadOnlyEngagePersistsImmediatelyWithNoSnapshot() throws Exception {
     var ops = operations(shell());
     seedSpec("auth");


### PR DESCRIPTION
## What

The **first lane peeled off the `DispatchOperations` god object**, over the `LaunchAdmission` guard seam from #206.

Room engagement launches nothing and reserves no container — it's pure room state (one JSON value on the spec row) plus an optional engage-time rollback snapshot — so it had no business living inside the dispatch launcher.

## Change

New **`EngagementService`** owns `engage` / `completeEngage` / `disengage` and their helpers. It collaborates only with `SpecStore`, `ProjectLoader`, `LaunchAdmission`, the event sink, and (for the snapshot) the shell — **no run launch, no reservation, no run rows**.

- `DispatchOperations` holds one `EngagementService`; its `engage`/`disengage` become thin delegators, so the public surface and all callers (`SailOperations`, the API router) are unchanged.
- Dropped the dead `actor` parameter `persistEngagement` never used.
- `DispatchOperations` sheds ~130 lines.

Isolating engagement here **front-loads the room/spec decouple**: the room's collaboration surface can evolve without touching dispatch.

## Testing

- **Behavior-preserving** — the unchanged `EngagementLifecycleTest` harness drives `EngagementService` through the delegators (full/read-only/failed-snapshot/refusals/disengage-idempotent all pass).
- Added three cases for its defensive not-found paths: engage / disengage a missing spec → `SPEC_NOT_FOUND`, and a spec **deleted mid-snapshot** → `spec_engage_failed`.
- `mvn clean verify` green; `EngagementService` meets the api.* **100% coverage gate** with no exclude.

## Next

`RoomCommitGuard` (also launch-free) is the next peel, then the launching lanes (`InviteLauncher`, `RoomWakeLauncher`, `AdhocRunner`, `BuildDispatch`) over the `RunLauncher` + `LaunchAdmission` seams.
