### PR TITLE
fix: upgrade SnakeYAML Engine to 3.1.1 to fix the emoji-boundary sync crash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ One binary, zero dependencies, fully declarative. Download it, run `sail host in
 
 - **Java 25** with virtual threads where applicable
 - **picocli** for CLI framework (GraalVM native-image ready)
-- **SnakeYAML Engine 3.0.1** for YAML + JSON parsing (YAML 1.2 is a JSON superset). Zero transitive dependencies.
+- **SnakeYAML Engine 3.1.1** for YAML + JSON parsing (YAML 1.2 is a JSON superset). Zero transitive dependencies.
 - **GraalVM native-image** for AOT compilation to a static Linux binary (<1ms startup)
 - No Spring. No Lombok. No annotation magic beyond picocli's `@Command`/`@Option`/`@Parameters`.
 - Minimal dependencies — two libraries total (picocli, SnakeYAML Engine). No reflection metadata needed.
@@ -84,7 +84,7 @@ Always write modern Java — leverage JDK 25 features, never write old-style cod
 | Dependency | Version | Group ID |
 |-----------|---------|----------|
 | picocli | 4.7.7 | info.picocli |
-| snakeyaml-engine | 3.0.1 | org.snakeyaml |
+| snakeyaml-engine | 3.1.1 | org.snakeyaml |
 | JUnit | 6.0.2 | org.junit |
 | native-maven-plugin | 0.11.4 | org.graalvm.buildtools |
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <picocli-version>4.7.7</picocli-version>
-        <snakeyaml-engine-version>3.0.1</snakeyaml-engine-version>
+        <snakeyaml-engine-version>3.1.1</snakeyaml-engine-version>
         <junit-version>6.0.2</junit-version>
 
         <maven.compiler.source>25</maven.compiler.source>

--- a/sail-core/src/test/java/ai/singlr/sail/config/YamlUtilTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/YamlUtilTest.java
@@ -162,4 +162,21 @@ class YamlUtilTest {
     var result = YamlUtil.dumpToString(Map.of("name", "acme"));
     assertTrue(result.contains("name: acme"));
   }
+
+  @Test
+  void parseMapHandlesANonBmpCharacterOnEveryReaderBufferBoundary() {
+    for (var pad = 1000; pad <= 3100; pad++) {
+      var value = "x".repeat(pad) + "😀tail";
+      var result = YamlUtil.parseMap("{\"body\": \"" + value + "\"}");
+      assertEquals(
+          value, result.get("body"), "emoji straddling the parser buffer window at pad=" + pad);
+    }
+  }
+
+  @Test
+  void parseListHandlesANonBmpCharacterOnTheReaderBufferBoundary() {
+    var value = "x".repeat(1018) + "😀tail";
+    var result = YamlUtil.parseList("[{\"body\": \"" + value + "\"}]");
+    assertEquals(value, result.getFirst().get("body"));
+  }
 }


### PR DESCRIPTION
## The bug

A node's first `sail sync` against a **populated** main crashes with:

```
✗ Sync with sail@<main> failed: Range [1025, 1025 + 1) out of bounds for length 1025
```

## Root cause (reproduced)

`sail sync` parses main's response through `YamlUtil.parseMap` → **SnakeYAML Engine 3.0.1**'s `load.loadFromString`. Its `StreamReader` reads in 1024-code-point windows and **mishandles a non-BMP character (an emoji / surrogate pair) that straddles that boundary**. A local repro nails it, character-for-character:

```
3.0.1: FAIL pad=1018 emoji=😀: Range [1025, 1025 + 1) out of bounds for length 1025
       FAIL pad=2043 …  FAIL pad=3068 …   (every 1024 window)   -> 15 failures / 8404
3.1.1: 0 failures / 8404
```

A node's first sync pulls main's **whole board as one long JSON line**, so an emoji anywhere in main's content — a spec body, a commit message, room chat, a PR title — landing on the ~1024 boundary blows up the parse. It's silent until the content happens to line up, which is why an empty main is fine and a real one isn't. Not version skew, not the join, not the FDE key.

## The fix

Bump the pinned `snakeyaml-engine` **3.0.1 → 3.1.1**, which fixes the `StreamReader` boundary handling. **Drop-in**: same `org.snakeyaml.engine.v2.api` surface sail already uses (no code changes), still **zero transitive dependencies** (verified via `dependency:tree`). Pinned-version docs in `CLAUDE.md` updated to match.

## Testing (TDD)

- New `YamlUtilTest` regression sweeps an emoji across **every 1024-boundary** (pad 1000..3100) through `parseMap`, plus a `parseList` case. Written **first**: on 3.0.1 it fails at `pad=1018` with the exact `Range [1025, 1025 + 1) out of bounds for length 1025`; on 3.1.1 all 2100+ offsets round-trip.
- `mvn clean verify` green — full suite + coverage + spotless pass on the new parser, confirming the upgrade is behavior-safe.

## Rollout

The live boxes get the fix only after a release — both main and the node need the new binary (`sail upgrade`). There's no clean client-side workaround, since the trigger is main's existing data.
