### PR TITLE
fix: a host without ufw skips the firewall step instead of aborting sail init

### DIFF
--- a/sail-core/src/test/java/ai/singlr/sail/engine/ScriptedShellExecutor.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/ScriptedShellExecutor.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.engine;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -23,6 +24,7 @@ import java.util.Set;
 public final class ScriptedShellExecutor implements ShellExec {
 
   private final Map<String, Result> scripts = new LinkedHashMap<>();
+  private final Map<String, IOException> throwing = new LinkedHashMap<>();
   private final Set<String> consumable = new HashSet<>();
   private final Set<String> consumed = new HashSet<>();
   private final List<String> invocations = new ArrayList<>();
@@ -57,6 +59,16 @@ public final class ScriptedShellExecutor implements ShellExec {
     return on(pattern, new Result(1, "", stderr));
   }
 
+  /**
+   * Command containing pattern throws — modeling a missing binary, where the real {@link
+   * ShellExecutor} fails at {@code ProcessBuilder.start} with {@link IOException} rather than
+   * returning a non-zero result.
+   */
+  public ScriptedShellExecutor onThrow(String pattern, IOException exception) {
+    throwing.put(pattern, exception);
+    return this;
+  }
+
   /** Shorthand: command containing pattern fails once, then falls through to default on reuse. */
   public ScriptedShellExecutor onceOnFail(String pattern, String stderr) {
     consumable.add(pattern);
@@ -77,14 +89,19 @@ public final class ScriptedShellExecutor implements ShellExec {
   }
 
   @Override
-  public Result exec(List<String> command) {
+  public Result exec(List<String> command) throws IOException {
     return exec(command, null, Duration.ZERO);
   }
 
   @Override
-  public Result exec(List<String> command, Path workDir, Duration timeout) {
+  public Result exec(List<String> command, Path workDir, Duration timeout) throws IOException {
     var joined = String.join(" ", command);
     invocations.add(joined);
+    for (var entry : throwing.entrySet()) {
+      if (joined.contains(entry.getKey())) {
+        throw entry.getValue();
+      }
+    }
     for (var entry : scripts.entrySet()) {
       if (joined.contains(entry.getKey())) {
         if (consumed.contains(entry.getKey())) {

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/HostProvisioner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/HostProvisioner.java
@@ -340,7 +340,13 @@ public final class HostProvisioner {
       throws IOException, InterruptedException, TimeoutException {
     step(8, "Configuring UFW firewall rules...");
 
-    var status = shell.exec(List.of("ufw", "status"));
+    ShellExec.Result status;
+    try {
+      status = shell.exec(List.of("ufw", "status"));
+    } catch (IOException e) {
+      stepSkipped(8, "UFW not installed");
+      return;
+    }
     if (!status.ok() || !status.stdout().contains("Status: active")) {
       stepSkipped(8, "UFW not active");
       return;

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/HostProvisionerTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/HostProvisionerTest.java
@@ -389,18 +389,25 @@ class HostProvisionerTest {
   }
 
   @Test
-  void ufwNotInstalledSkipsFirewallStep() throws Exception {
+  void ufwNotInstalledSkipsFirewallStepInsteadOfCrashing() {
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
             .onOk("incus version", "6.3")
-            .onFail("ufw status", "command not found");
+            .onThrow(
+                "ufw",
+                new IOException("Cannot run program \"ufw\": error=2, No such file or directory"));
 
     var steps = new ArrayList<String>();
     var provisioner = new HostProvisioner(shell, new RecordingListener(steps));
 
-    provisioner.provision("dir", null, "devpool", "incusbr0", null, tempDir.resolve("host.yaml"));
-
-    assertTrue(steps.stream().anyMatch(s -> s.contains("skipped:8/8:UFW not active")));
+    assertDoesNotThrow(
+        () ->
+            provisioner.provision(
+                "dir", null, "devpool", "incusbr0", null, tempDir.resolve("host.yaml")),
+        "a host without ufw must skip the firewall step, not abort init");
+    assertTrue(
+        steps.stream().anyMatch(s -> s.contains("skipped:8/8:UFW not installed")),
+        "step 8 skipped as not installed; steps=" + steps);
   }
 
   @Test


### PR DESCRIPTION
## The bug

`sail init` on a minimal host (e.g. a fresh Hetzner box) crashed at the very end:

```
java.io.IOException: Cannot run program "ufw": error=2 (No such file or directory)
    at ai.singlr.sail.engine.HostProvisioner.configureFirewall(HostProvisioner.java:343)
```

The firewall step assumed `ufw` exists and only guarded against it being **inactive** — a non-zero *exit code*. But a **missing** binary makes `ProcessBuilder.start()` throw `IOException` (errno 2 = ENOENT) *before* any exit code, and that propagated out and aborted the whole init. Many minimal cloud images ship without UFW.

## The fix

`configureFirewall` now catches that `IOException` and skips step 8 as **"UFW not installed"**, exactly as it already skips an inactive ufw. A host with no ufw simply gets no bridge rules — which is correct; there's no firewall to configure.

## Why it slipped through — and the test-double fix

The existing `ufwNotInstalledSkipsFirewallStep` test "passed" for the **wrong reason**: `ScriptedShellExecutor` returns a *non-zero Result* for an unknown command, but the real `ShellExecutor` **throws `IOException`** on a missing binary. The double didn't model reality, so the crash path was never exercised.

- Gave the double an **`onThrow(pattern, IOException)`** that models a missing binary the way the real executor fails.
- Rewrote the test to use it (**TDD**): it now **reproduces the crash (red)**, and the `catch` fixes it (green). It also asserts the distinct "UFW not installed" skip message, separate from the "UFW not active" case (kept in its own test).

## Testing

- `HostProvisionerTest` (22 tests) green, including the corrected missing-binary case.
- `mvn clean verify` green — coverage checks met.

Companion to the emoji-boundary sync fix (#209) — both are "fresh-node install on a minimal host" papercuts.
