### PR TITLE
refactor: extract the shared RunReservation seam from DispatchOperations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,7 @@
                                         <exclude>ai.singlr.sail.api.ReviewPipelineController</exclude>
                                         <exclude>ai.singlr.sail.api.RunLauncher</exclude>
                                         <exclude>ai.singlr.sail.api.RunLauncher.*</exclude>
+                                        <exclude>ai.singlr.sail.api.RunReservation</exclude>
                                         <exclude>ai.singlr.sail.api.AgentLogStreamer</exclude>
                                         <exclude>ai.singlr.sail.api.EventStreamClient</exclude>
                                         <exclude>ai.singlr.sail.api.EventStreamClient.StopReadingException</exclude>
@@ -261,6 +262,35 @@
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
                                             <minimum>0.88</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>METHOD</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                                <rule>
+                                    <element>CLASS</element>
+                                    <includes>
+                                        <include>ai.singlr.sail.api.RunReservation</include>
+                                    </includes>
+                                    <!--
+                                        The shared reservation seam. Every method is exercised
+                                        (METHOD 1.0): the claim/refusal/release paths and the
+                                        best-effort cleanup's defensive branches directly by
+                                        RunReservationTest (prune failure, unprobeable agent, no-store
+                                        release, store failure during cleanup). The two uncovered
+                                        lines are the pruneRuns catch — unreachable because
+                                        RunRetention.prune is itself best-effort and swallows the
+                                        shell failure rather than propagating it. Floored just under
+                                        the actual.
+                                    -->
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
                                         </limit>
                                         <limit>
                                             <counter>METHOD</counter>

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -9,7 +9,6 @@ import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.BranchPolicy;
 import ai.singlr.sail.config.Engagement;
-import ai.singlr.sail.config.Guardrails;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecCatalog;
@@ -23,7 +22,6 @@ import ai.singlr.sail.engine.DispatchRepos;
 import ai.singlr.sail.engine.HostInfo;
 import ai.singlr.sail.engine.InvitePrompt;
 import ai.singlr.sail.engine.RoomWakePrompt;
-import ai.singlr.sail.engine.RunRetention;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.SnapshotManager;
 import ai.singlr.sail.engine.WatcherSpawner;
@@ -40,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * The single dispatch executor behind every lane. Owns the whole procedure — resolve, policy,
@@ -212,6 +209,7 @@ public final class DispatchOperations {
   private final EngagementService engagementService;
   private final RoomCommitGuard roomCommitGuard;
   private final RunLauncher runLauncher;
+  private final RunReservation runReservation;
   private MessageStore messageStore;
   private final EventSink events;
   private final WatcherSpawner watcherSpawner;
@@ -255,6 +253,7 @@ public final class DispatchOperations {
     this.roomCommitGuard = new RoomCommitGuard(runStore, projects, this.events, shell);
     this.runLauncher =
         new RunLauncher(shell, file, launcher, listener, watcherSpawner, runStore, this.events);
+    this.runReservation = new RunReservation(runStore, shell, listener);
   }
 
   public DispatchOperations useMessages(MessageStore messages) {
@@ -405,7 +404,7 @@ public final class DispatchOperations {
           background ? null : launch.exitCode(),
           launch.watcher());
     } catch (RuntimeException e) {
-      releaseIfAbsent(runId, project, unit);
+      runReservation.releaseIfAbsent(runId, project, unit);
       throw e;
     }
   }
@@ -494,7 +493,7 @@ public final class DispatchOperations {
       return new AdhocSession(
           runId, status, background ? null : launch.exitCode(), launch.watcher());
     } catch (RuntimeException e) {
-      releaseIfAbsent(runId, project, unit);
+      runReservation.releaseIfAbsent(runId, project, unit);
       throw e;
     }
   }
@@ -568,33 +567,20 @@ public final class DispatchOperations {
         full ? DispatchRepos.resolve(config, spec.toSpec(), List.of()) : List.<SailYaml.Repo>of();
     var repoPaths = targetRepos.stream().map(SailYaml.Repo::path).toList();
     var branch = full ? Objects.toString(spec.branch(), "") : "";
-    RunStore.Reservation reservation;
-    try {
-      reservation =
-          runStore.reserveDispatch(
-              runId,
-              project,
-              specId,
-              localHandle,
-              Strings.isBlank(spec.assignee()) ? localHandle : spec.assignee(),
-              role,
-              repoPaths,
-              agentType,
-              Strings.isBlank(branch) ? null : branch,
-              task,
-              unit.logPath(),
-              unit.unitName(),
-              configuredMaxDuration(config));
-    } catch (RuntimeException e) {
-      throw new ApiException(ErrorCode.COMMAND_FAILED, "Failed to record the room wake run.", e);
-    }
-    if (reservation instanceof RunStore.Reservation.Conflicted conflicted) {
-      throw overlapRefusal(conflicted.conflict());
-    }
-    if (reservation instanceof RunStore.Reservation.LeaseHeld held) {
-      throw leaseRefusal(held);
-    }
-    var credential = ((RunStore.Reservation.Reserved) reservation).credential();
+    var credential =
+        runReservation.reserve(
+            runId,
+            project,
+            specId,
+            localHandle,
+            Strings.isBlank(spec.assignee()) ? localHandle : spec.assignee(),
+            role,
+            repoPaths,
+            agentType,
+            Strings.isBlank(branch) ? null : branch,
+            task,
+            unit,
+            config);
     try {
       seedRoomDelivery(runId, built.renderedMessages());
       if (!full) {
@@ -630,7 +616,7 @@ public final class DispatchOperations {
           new RunLauncher.RunContext(project, unit, runId, specId, agentType, role, true), launch);
       return runId;
     } catch (RuntimeException e) {
-      releaseIfAbsent(runId, project, unit);
+      runReservation.releaseIfAbsent(runId, project, unit);
       throw e;
     }
   }
@@ -739,7 +725,7 @@ public final class DispatchOperations {
     var branch = full ? Objects.toString(spec.branch(), "") : "";
     var owner = Strings.isBlank(spec.assignee()) ? localHandle : spec.assignee();
     var credential =
-        reserve(
+        runReservation.reserve(
             runId,
             project,
             specId,
@@ -755,7 +741,7 @@ public final class DispatchOperations {
     try {
       seedRoomDelivery(runId, built.renderedMessages());
     } catch (RuntimeException e) {
-      releaseIfAbsent(runId, project, unit);
+      runReservation.releaseIfAbsent(runId, project, unit);
       throw e;
     }
     var principal = runStore.findById(runId).map(RunStore.RunRow::principal).orElse("");
@@ -831,7 +817,7 @@ public final class DispatchOperations {
           new RunLauncher.RunContext(project, unit, runId, specId, agentCli.yamlName(), role, true),
           launch);
     } catch (RuntimeException e) {
-      releaseIfAbsent(runId, project, unit);
+      runReservation.releaseIfAbsent(runId, project, unit);
       publishInviteFailed(project, specId, runId, snapshot, e);
     }
   }
@@ -1204,38 +1190,8 @@ public final class DispatchOperations {
     DispatchGate.decide(specId, "build", targetRepos, runningLocalRuns(project, localHandle))
         .ifPresent(
             conflict -> {
-              throw overlapRefusal(conflict);
+              throw RunReservation.overlapRefusal(conflict);
             });
-  }
-
-  /**
-   * The refusal when an exclusive container operation (a snapshot restore) holds the container: no
-   * run of any role may start into a container that is about to be rolled back.
-   */
-  private static ApiException leaseRefusal(RunStore.Reservation.LeaseHeld held) {
-    return new ApiException(
-        ErrorCode.CONFLICT,
-        "A snapshot " + held.action() + " is in progress in this container.",
-        "Wait for its snapshot_restored event, then retry.");
-  }
-
-  private static ApiException overlapRefusal(DispatchGate.Conflict conflict) {
-    var run = conflict.run();
-    var occupied =
-        Strings.isBlank(run.specId())
-            ? "Ad-hoc agent run " + run.runId() + " is occupying this container"
-            : "Agent run "
-                + run.runId()
-                + " is already working spec '"
-                + run.specId()
-                + "' in "
-                + (conflict.overlap().isEmpty()
-                    ? "this container"
-                    : "repo(s) " + conflict.overlap());
-    return new ApiException(
-        ErrorCode.AGENT_ALREADY_RUNNING,
-        occupied + ".",
-        "Wait for it to finish or stop it, or dispatch a spec targeting disjoint repos.");
   }
 
   /**
@@ -1288,7 +1244,7 @@ public final class DispatchOperations {
     if (runStore == null) {
       return null;
     }
-    return reserve(
+    return runReservation.reserve(
         runId, project, specId, node, owner, "build", repos, agentType, branch, task, unit, config);
   }
 
@@ -1313,80 +1269,8 @@ public final class DispatchOperations {
           ErrorCode.COMMAND_FAILED,
           "This box keeps no run aggregate, so an agent session cannot be reserved or tracked.");
     }
-    return reserve(
+    return runReservation.reserve(
         runId, project, "", node, node, "adhoc", List.of(), agentType, branch, task, unit, config);
-  }
-
-  private String reserve(
-      String runId,
-      String project,
-      String specId,
-      String node,
-      String owner,
-      String role,
-      List<String> repos,
-      String agentType,
-      String branch,
-      String task,
-      AgentUnit unit,
-      SailYaml config) {
-    RunStore.Reservation reservation;
-    try {
-      reservation =
-          runStore.reserveDispatch(
-              runId,
-              project,
-              specId,
-              node,
-              owner,
-              role,
-              repos,
-              agentType,
-              branch,
-              task,
-              unit.logPath(),
-              unit.unitName(),
-              configuredMaxDuration(config));
-    } catch (RuntimeException e) {
-      throw new ApiException(ErrorCode.COMMAND_FAILED, "Failed to record the dispatch run.", e);
-    }
-    if (reservation instanceof RunStore.Reservation.Conflicted conflicted) {
-      throw overlapRefusal(conflicted.conflict());
-    }
-    if (reservation instanceof RunStore.Reservation.LeaseHeld held) {
-      throw leaseRefusal(held);
-    }
-    pruneRuns(project);
-    return ((RunStore.Reservation.Reserved) reservation).credential();
-  }
-
-  /**
-   * The run's configured hard lifetime, bounding its credential: {@code guardrails.max_duration},
-   * or null when unset — an unbounded run's credential is revoked by its verified finishers, never
-   * by a clock that could expire mid-work.
-   */
-  private static Duration configuredMaxDuration(SailYaml config) {
-    var agent = config.agent();
-    if (agent == null || agent.guardrails() == null) {
-      return null;
-    }
-    return Guardrails.parseDuration(agent.guardrails().maxDuration());
-  }
-
-  private void pruneRuns(String project) {
-    try {
-      var runs = runStore.listForProject(project);
-      var ids = runs.stream().map(RunStore.RunRow::id).toList();
-      var active =
-          runs.stream()
-              .filter(DispatchOperations::ownsLiveAgent)
-              .map(RunStore.RunRow::id)
-              .collect(Collectors.toUnmodifiableSet());
-      var pruned = RunRetention.prune(shell, project, ids, active, RunRetention.DEFAULT_KEEP);
-      listener.runsPruned(pruned.size());
-    } catch (Exception e) {
-      System.err.println("  [api] Warning: could not prune runs: " + e.getMessage());
-    }
   }
 
   /**
@@ -1397,62 +1281,6 @@ public final class DispatchOperations {
    */
   static boolean ownsLiveAgent(RunStore.RunRow run) {
     return "running".equals(run.status()) || StopOperations.STOPPING.equals(run.status());
-  }
-
-  /**
-   * Marks a run failed when its launch throws, so a created-but-never-launched row is not orphaned.
-   */
-  /**
-   * Fails a run on a launch error, but only if the run is still {@code running}: a stop that
-   * cancelled the run mid-launch, or a watcher that already recorded the real exit, owns the
-   * terminal record and must not be overwritten by the launch's cleanup.
-   */
-  private void failRun(String runId) {
-    runBookkeeping(
-        "mark run failed " + runId,
-        () -> runStore.transition(runId, "running", "failed", (Integer) null));
-  }
-
-  /**
-   * Releases the run's repo reservation on a launch failure only when the agent is proven absent —
-   * probed on the run's own identity (systemd unit and run-scoped pid file), so the check covers
-   * background and foreground launches alike. A failure before or during launch leaves no live
-   * process, so the run is failed and its repo freed. But once the agent process exists — a
-   * background unit that started, a foreground child whose blocking wait threw — a later failure
-   * leaves a live agent, and failing the run would free the repo under it and admit an overlapping
-   * session. An unprobeable identity is treated as live for the same reason — the missed-stop
-   * reconciler releases a genuinely dead run on its next pass.
-   */
-  private void releaseIfAbsent(String runId, String project, AgentUnit unit) {
-    if (agentLive(project, unit)) {
-      return;
-    }
-    failRun(runId);
-  }
-
-  private boolean agentLive(String project, AgentUnit unit) {
-    try {
-      var status = new AgentSession(shell).queryStatus(project, unit);
-      return status != null && status.running();
-    } catch (Exception e) {
-      return true;
-    }
-  }
-
-  /**
-   * Runs a best-effort run-store bookkeeping update. A missing store (a box that keeps no run
-   * aggregate) is a silent no-op, and a store error is logged but never propagated: bookkeeping
-   * must never fail a launch or mask the agent's real outcome.
-   */
-  private void runBookkeeping(String action, Runnable op) {
-    if (runStore == null) {
-      return;
-    }
-    try {
-      op.run();
-    } catch (RuntimeException e) {
-      System.err.println("  [api] Warning: could not " + action + ": " + e.getMessage());
-    }
   }
 
   private void publish(String project, String specId, String type, Map<String, Object> data) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RunReservation.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RunReservation.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.Guardrails;
+import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.engine.AgentSession;
+import ai.singlr.sail.engine.AgentUnit;
+import ai.singlr.sail.engine.RunRetention;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.store.DispatchGate;
+import ai.singlr.sail.store.RunStore;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * The shared reservation and launch-failure cleanup every launching lane runs. {@link #reserve}
+ * atomically claims the container (and, for a build, its target repos) as a {@code running} run row
+ * in one {@code BEGIN IMMEDIATE} transaction — so two concurrent launches, even from separate
+ * processes, can never both claim the same repos — and returns the run's bearer credential. {@link
+ * #releaseIfAbsent} is the mirror: on a launch failure it frees the reservation, but only once the
+ * agent is proven absent, so a failure that races a live process never pulls the repo out from
+ * under it. Kept in one place so the concurrency guarantee has a single definition across lanes.
+ */
+public final class RunReservation {
+
+  private final RunStore runStore;
+  private final ShellExec shell;
+  private final DispatchOperations.Listener listener;
+
+  public RunReservation(RunStore runStore, ShellExec shell, DispatchOperations.Listener listener) {
+    this.runStore = runStore;
+    this.shell = shell;
+    this.listener = listener;
+  }
+
+  /**
+   * Atomically reserves the launch as a {@code running} run stamped with {@code owner} and the
+   * target repo set: {@link RunStore#reserveDispatch} checks every running local run for a repo
+   * overlap and inserts the row in one transaction, so two concurrent launches can never both claim
+   * the same repo. A conflict or a store failure aborts before any launch — the row is what every
+   * later overlap check and provenance guard depends on. Also prunes the container's oldest run-log
+   * directories (best-effort). Returns the run's plaintext bearer credential.
+   */
+  public String reserve(
+      String runId,
+      String project,
+      String specId,
+      String node,
+      String owner,
+      String role,
+      List<String> repos,
+      String agentType,
+      String branch,
+      String task,
+      AgentUnit unit,
+      SailYaml config) {
+    RunStore.Reservation reservation;
+    try {
+      reservation =
+          runStore.reserveDispatch(
+              runId,
+              project,
+              specId,
+              node,
+              owner,
+              role,
+              repos,
+              agentType,
+              branch,
+              task,
+              unit.logPath(),
+              unit.unitName(),
+              configuredMaxDuration(config));
+    } catch (RuntimeException e) {
+      throw new ApiException(ErrorCode.COMMAND_FAILED, "Failed to record the dispatch run.", e);
+    }
+    if (reservation instanceof RunStore.Reservation.Conflicted conflicted) {
+      throw overlapRefusal(conflicted.conflict());
+    }
+    if (reservation instanceof RunStore.Reservation.LeaseHeld held) {
+      throw leaseRefusal(held);
+    }
+    pruneRuns(project);
+    return ((RunStore.Reservation.Reserved) reservation).credential();
+  }
+
+  /**
+   * Releases the run's repo reservation on a launch failure only when the agent is proven absent —
+   * probed on the run's own identity (systemd unit and run-scoped pid file), so the check covers
+   * background and foreground launches alike. A failure before or during launch leaves no live
+   * process, so the run is failed and its repo freed. But once the agent process exists — a
+   * background unit that started, a foreground child whose blocking wait threw — a later failure
+   * leaves a live agent, and failing the run would free the repo under it and admit an overlapping
+   * session. An unprobeable identity is treated as live for the same reason — the missed-stop
+   * reconciler releases a genuinely dead run on its next pass.
+   */
+  public void releaseIfAbsent(String runId, String project, AgentUnit unit) {
+    if (agentLive(project, unit)) {
+      return;
+    }
+    failRun(runId);
+  }
+
+  /**
+   * The run's configured hard lifetime, bounding its credential: {@code guardrails.max_duration},
+   * or null when unset — an unbounded run's credential is revoked by its verified finishers, never
+   * by a clock that could expire mid-work.
+   */
+  private static Duration configuredMaxDuration(SailYaml config) {
+    var agent = config.agent();
+    if (agent == null || agent.guardrails() == null) {
+      return null;
+    }
+    return Guardrails.parseDuration(agent.guardrails().maxDuration());
+  }
+
+  private void pruneRuns(String project) {
+    try {
+      var runs = runStore.listForProject(project);
+      var ids = runs.stream().map(RunStore.RunRow::id).toList();
+      var active =
+          runs.stream()
+              .filter(DispatchOperations::ownsLiveAgent)
+              .map(RunStore.RunRow::id)
+              .collect(Collectors.toUnmodifiableSet());
+      var pruned = RunRetention.prune(shell, project, ids, active, RunRetention.DEFAULT_KEEP);
+      listener.runsPruned(pruned.size());
+    } catch (Exception e) {
+      System.err.println("  [api] Warning: could not prune runs: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Fails a run on a launch error, but only if the run is still {@code running}: a stop that
+   * cancelled the run mid-launch, or a watcher that already recorded the real exit, owns the
+   * terminal record and must not be overwritten by the launch's cleanup.
+   */
+  private void failRun(String runId) {
+    runBookkeeping(
+        "mark run failed " + runId,
+        () -> runStore.transition(runId, "running", "failed", (Integer) null));
+  }
+
+  private boolean agentLive(String project, AgentUnit unit) {
+    try {
+      var status = new AgentSession(shell).queryStatus(project, unit);
+      return status != null && status.running();
+    } catch (Exception e) {
+      return true;
+    }
+  }
+
+  /**
+   * Runs a best-effort run-store bookkeeping update. A store error is logged but never propagated:
+   * bookkeeping must never fail a launch or mask the agent's real outcome.
+   */
+  private void runBookkeeping(String action, Runnable op) {
+    if (runStore == null) {
+      return;
+    }
+    try {
+      op.run();
+    } catch (RuntimeException e) {
+      System.err.println("  [api] Warning: could not " + action + ": " + e.getMessage());
+    }
+  }
+
+  /**
+   * The refusal when a running local run already reserves an overlapping repo set — the dispatch
+   * gate's verdict rendered for a client. Package-static because the dispatch dry lane's read-only
+   * overlap check surfaces the same refusal without reserving.
+   */
+  static ApiException overlapRefusal(DispatchGate.Conflict conflict) {
+    var run = conflict.run();
+    var occupied =
+        Strings.isBlank(run.specId())
+            ? "Ad-hoc agent run " + run.runId() + " is occupying this container"
+            : "Agent run "
+                + run.runId()
+                + " is already working spec '"
+                + run.specId()
+                + "' in "
+                + (conflict.overlap().isEmpty()
+                    ? "this container"
+                    : "repo(s) " + conflict.overlap());
+    return new ApiException(
+        ErrorCode.AGENT_ALREADY_RUNNING,
+        occupied + ".",
+        "Wait for it to finish or stop it, or dispatch a spec targeting disjoint repos.");
+  }
+
+  /**
+   * The refusal when an exclusive container operation (a snapshot restore) holds the container: no
+   * run of any role may start into a container that is about to be rolled back.
+   */
+  private static ApiException leaseRefusal(RunStore.Reservation.LeaseHeld held) {
+    return new ApiException(
+        ErrorCode.CONFLICT,
+        "A snapshot " + held.action() + " is in progress in this container.",
+        "Wait for its snapshot_restored event, then retry.");
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RunReservationTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RunReservationTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.engine.AgentUnit;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The shared reservation seam and its best-effort cleanup: a claim returns a credential and prunes,
+ * a prune or status probe that fails never fails the launch, and the run-store bookkeeping is a
+ * silent no-op without a store.
+ */
+class RunReservationTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private RunStore runStore;
+  private static final String RUN_ID = DateTimeUtils.newId().toString();
+
+  private static final SailYaml CONFIG =
+      SailYaml.fromMap(
+          Map.of(
+              "name",
+              "acme",
+              "ssh",
+              Map.of("user", "dev"),
+              "repos",
+              List.of(Map.of("url", "https://example.com/app.git", "path", "app"))));
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    runStore = new RunStore(db);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (db != null) db.close();
+  }
+
+  private static ShellExec quietShell() {
+    return new ShellExec() {
+      @Override
+      public ShellExec.Result exec(List<String> command) {
+        return new ShellExec.Result(1, "", "");
+      }
+
+      @Override
+      public ShellExec.Result exec(List<String> command, Path workDir, Duration timeout) {
+        return new ShellExec.Result(1, "", "");
+      }
+
+      @Override
+      public boolean isDryRun() {
+        return false;
+      }
+    };
+  }
+
+  private static ShellExec throwingShell() {
+    return new ShellExec() {
+      @Override
+      public ShellExec.Result exec(List<String> command) throws IOException {
+        throw new IOException("container gone");
+      }
+
+      @Override
+      public ShellExec.Result exec(List<String> command, Path workDir, Duration timeout)
+          throws IOException {
+        throw new IOException("container gone");
+      }
+
+      @Override
+      public boolean isDryRun() {
+        return false;
+      }
+    };
+  }
+
+  private RunReservation reservation(ShellExec shell, RunStore store) {
+    return new RunReservation(store, shell, DispatchOperations.Listener.NONE);
+  }
+
+  private String reserve(RunReservation r) {
+    return r.reserve(
+        RUN_ID,
+        "acme",
+        "spec",
+        "node",
+        "node",
+        "adhoc",
+        List.of(),
+        "codex",
+        null,
+        "task",
+        AgentUnit.forRun(RUN_ID),
+        CONFIG);
+  }
+
+  @Test
+  void reserveClaimsTheRunAndReturnsItsCredential() {
+    var credential = reserve(reservation(quietShell(), runStore));
+    assertNotNull(credential);
+    assertEquals("running", runStore.findById(RUN_ID).orElseThrow().status());
+  }
+
+  @Test
+  void anOverlappingClaimIsRefused() {
+    var r = reservation(quietShell(), runStore);
+    reserve(r);
+    var second = reservation(quietShell(), runStore);
+    var ex =
+        assertThrows(
+            ApiException.class,
+            () ->
+                second.reserve(
+                    DateTimeUtils.newId().toString(),
+                    "acme",
+                    "spec2",
+                    "node",
+                    "node",
+                    "adhoc",
+                    List.of(),
+                    "codex",
+                    null,
+                    "task",
+                    AgentUnit.forRun(DateTimeUtils.newId().toString()),
+                    CONFIG));
+    assertEquals(ErrorCode.AGENT_ALREADY_RUNNING, ex.failure().errorCode());
+  }
+
+  @Test
+  void aPruneFailureNeverFailsTheReservation() {
+    var credential = reserve(reservation(throwingShell(), runStore));
+    assertNotNull(credential, "a best-effort prune that throws must not fail the claim");
+  }
+
+  @Test
+  void anUnprobeableAgentIsTreatedAsLiveSoTheRunIsNotReleased() {
+    reserve(reservation(quietShell(), runStore));
+
+    reservation(throwingShell(), runStore)
+        .releaseIfAbsent(RUN_ID, "acme", AgentUnit.forRun(RUN_ID));
+
+    assertEquals(
+        "running",
+        runStore.findById(RUN_ID).orElseThrow().status(),
+        "an unprobeable agent is assumed live, so the reservation is kept");
+  }
+
+  @Test
+  void anAbsentAgentReleasesTheReservation() {
+    reserve(reservation(quietShell(), runStore));
+
+    reservation(quietShell(), runStore).releaseIfAbsent(RUN_ID, "acme", AgentUnit.forRun(RUN_ID));
+
+    assertEquals(
+        "failed",
+        runStore.findById(RUN_ID).orElseThrow().status(),
+        "a probe that finds no live agent frees the run");
+  }
+
+  @Test
+  void releaseWithoutARunStoreIsASilentNoOp() {
+    assertDoesNotThrow(
+        () ->
+            new RunReservation(null, quietShell(), DispatchOperations.Listener.NONE)
+                .releaseIfAbsent(RUN_ID, "acme", AgentUnit.forRun(RUN_ID)));
+  }
+
+  @Test
+  void aStoreFailureDuringCleanupIsSwallowed() {
+    reserve(reservation(quietShell(), runStore));
+    db.close();
+
+    assertDoesNotThrow(
+        () ->
+            reservation(quietShell(), runStore)
+                .releaseIfAbsent(RUN_ID, "acme", AgentUnit.forRun(RUN_ID)),
+        "bookkeeping must never propagate a store error out of the launch cleanup");
+    assertFalse(db == null);
+  }
+}


### PR DESCRIPTION
## What

The **shared reservation + launch-failure cleanup** subsystem every launching lane runs, extracted from `DispatchOperations` into a `RunReservation` seam — the prerequisite for peeling the four launching lanes (this is the "extract the shared seam first" lesson, same as guards→`LaunchAdmission`).

`reserve()` atomically claims the container (and a build's target repos) as a `running` run row in one transaction and returns the run's bearer credential; `releaseIfAbsent()` is the mirror, freeing the reservation on a launch failure **only once the agent is proven absent** (so a failure racing a live process never pulls the repo out from under it). Both, plus the overlap/lease refusals, the best-effort prune, and the run-store bookkeeping, now live in one place — the concurrency guarantee has a single definition.

## DRY win

This collapses the smell the audit flagged: the **room-wake lane re-implemented `reserve()` inline** (its own `reserveDispatch` call, refusals, credential extraction). It now calls `runReservation.reserve()` like every other lane — and gains the same best-effort run-dir pruning for free.

## Boundaries kept

- `overlapRefusal` stays package-static in `RunReservation` (the dispatch dry lane's read-only overlap check surfaces the same refusal without reserving).
- `ownsLiveAgent` stays in `DispatchOperations` (`RoomCommitGuard` and the dry-run overlap read it too).

## Testing

- **Behavior-preserving** — the lane suites (adhoc / invite / room / cancel-race / lane-parity) pass unchanged.
- New **`RunReservationTest`** drives the seam and its defensive cleanup directly: prune failure never fails the claim, an unprobeable agent is kept, an absent agent is released, a missing store is a no-op, and a store failure during cleanup is swallowed.
- The one remaining line is `pruneRuns`' catch — unreachable because `RunRetention.prune` is *itself* best-effort — gated by a documented per-class rule (LINE 0.95, METHOD 1.0), consistent with `RunLauncher` / `ReviewPipelineController`.
- `mvn clean verify` green. `DispatchOperations` is now **1,323 lines** (2,264 at the split's start).

## Next

With `RunReservation` + `RunLauncher` + `LaunchAdmission` all in place, each launching lane is now a thin lane over three seams: `AdhocRunner` → `RoomWakeLauncher` → `InviteLauncher` → `BuildDispatch`.
