### PR TITLE
refactor: extract the AdhocRunner lane from DispatchOperations

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/AdhocRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/AdhocRunner.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.engine.AgentCli;
+import ai.singlr.sail.engine.AgentUnit;
+import ai.singlr.sail.store.RunStore;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The ad-hoc lane — {@code sail agent run --task}: launch one operator-supplied agent session as a
+ * first-class run. No spec, so no policy — the session reserves the whole container through the
+ * same {@link RunReservation} the dispatch lane uses, so an ad-hoc run and a dispatched agent are
+ * mutually exclusive by the one atomic mechanism. A thin lane over the three launch seams: reserve
+ * through {@link RunReservation}, launch through {@link RunLauncher}, and release the reservation
+ * through {@link RunReservation} if the launch fails.
+ */
+public final class AdhocRunner {
+
+  private final ProjectLoader projects;
+  private final RunLauncher runLauncher;
+  private final RunReservation runReservation;
+  private final RunStore runStore;
+  private final DispatchOperations.Listener listener;
+
+  public AdhocRunner(
+      ProjectLoader projects,
+      RunLauncher runLauncher,
+      RunReservation runReservation,
+      RunStore runStore,
+      DispatchOperations.Listener listener) {
+    this.projects = projects;
+    this.runLauncher = runLauncher;
+    this.runReservation = runReservation;
+    this.runStore = runStore;
+    this.listener = listener;
+  }
+
+  /**
+   * Launches one ad-hoc agent session as a first-class run: a minted run id, {@code role='adhoc'}
+   * with no spec, a run-scoped unit and file set, and a whole-container reservation through the
+   * same transaction that gates dispatches. Background launches get the same run-addressed
+   * guardrail watcher as dispatches. No spec means no policy: unlike dispatch, a blank node handle
+   * is allowed — the reservation is stamped with whatever identity the box has. The {@code
+   * preparer} runs strictly after the reservation is won and before anything is staged or launched,
+   * so a refused launch leaves the workspace untouched. A dry run mints the id and announces the
+   * launch command but reserves, prepares, writes, and executes nothing.
+   */
+  public DispatchOperations.AdhocSession start(
+      String project,
+      DispatchOperations.AdhocRequest request,
+      String localHandle,
+      DispatchOperations.AdhocPreparer preparer) {
+    var loaded = projects.loadRunning(project);
+    var config = loaded.config();
+    var agentType =
+        config.agent() != null ? config.agent().type() : AgentCli.CLAUDE_CODE.yamlName();
+    var runId = DateTimeUtils.newId().toString();
+    var unit = AgentUnit.forRun(runId);
+    var background = request.background();
+    var workDir = adhocWorkDir(config, request.path());
+    var fullPermissions = adhocFullPermissions(config);
+    if (request.dryRun()) {
+      listener.launching(
+          background,
+          RunLauncher.launchCommand(
+              new RunLauncher.LaunchSpec(
+                  project,
+                  config,
+                  workDir,
+                  fullPermissions,
+                  null,
+                  null,
+                  "",
+                  agentType,
+                  request.task(),
+                  request.branch(),
+                  List.of(),
+                  background,
+                  unit,
+                  runId,
+                  null,
+                  "adhoc",
+                  null)));
+      return new DispatchOperations.AdhocSession(runId, null, null, Optional.empty());
+    }
+    var credential =
+        reserveAdhocRun(
+            runId, project, localHandle, agentType, request.branch(), request.task(), unit, config);
+    try {
+      prepare(preparer);
+      var launch =
+          runLauncher.launchSession(
+              new RunLauncher.LaunchSpec(
+                  project,
+                  config,
+                  workDir,
+                  fullPermissions,
+                  null,
+                  null,
+                  "",
+                  agentType,
+                  request.task(),
+                  request.branch(),
+                  List.of(),
+                  background,
+                  unit,
+                  runId,
+                  credential,
+                  "adhoc",
+                  null));
+      var status =
+          runLauncher.finishLaunch(
+              new RunLauncher.RunContext(
+                  project, unit, runId, null, agentType, "adhoc", background),
+              launch);
+      return new DispatchOperations.AdhocSession(
+          runId, status, background ? null : launch.exitCode(), launch.watcher());
+    } catch (RuntimeException e) {
+      runReservation.releaseIfAbsent(runId, project, unit);
+      throw e;
+    }
+  }
+
+  private String reserveAdhocRun(
+      String runId,
+      String project,
+      String node,
+      String agentType,
+      String branch,
+      String task,
+      AgentUnit unit,
+      SailYaml config) {
+    if (runStore == null) {
+      throw new ApiException(
+          ErrorCode.COMMAND_FAILED,
+          "This box keeps no run aggregate, so an agent session cannot be reserved or tracked.");
+    }
+    return runReservation.reserve(
+        runId, project, "", node, node, "adhoc", List.of(), agentType, branch, task, unit, config);
+  }
+
+  private static String adhocWorkDir(SailYaml config, String path) {
+    var workDir = "/home/" + config.sshUser() + "/workspace";
+    return Strings.isBlank(path) ? workDir : workDir + "/" + path;
+  }
+
+  private static boolean adhocFullPermissions(SailYaml config) {
+    return config.agent() != null
+        && config.agent().config() != null
+        && "full".equals(config.agent().config().get("permissions"));
+  }
+
+  private static void prepare(DispatchOperations.AdhocPreparer preparer) {
+    try {
+      preparer.prepare();
+    } catch (Exception e) {
+      throw new ApiException(
+          ErrorCode.AGENT_LAUNCH_FAILED, "Failed to prepare the agent session.", e);
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -210,6 +210,7 @@ public final class DispatchOperations {
   private final RoomCommitGuard roomCommitGuard;
   private final RunLauncher runLauncher;
   private final RunReservation runReservation;
+  private final AdhocRunner adhocRunner;
   private MessageStore messageStore;
   private final EventSink events;
   private final WatcherSpawner watcherSpawner;
@@ -254,6 +255,7 @@ public final class DispatchOperations {
     this.runLauncher =
         new RunLauncher(shell, file, launcher, listener, watcherSpawner, runStore, this.events);
     this.runReservation = new RunReservation(runStore, shell, listener);
+    this.adhocRunner = new AdhocRunner(projects, runLauncher, runReservation, runStore, listener);
   }
 
   public DispatchOperations useMessages(MessageStore messages) {
@@ -427,75 +429,7 @@ public final class DispatchOperations {
 
   public AdhocSession startAdhoc(
       String project, AdhocRequest request, String localHandle, AdhocPreparer preparer) {
-    var loaded = projects.loadRunning(project);
-    var config = loaded.config();
-    var agentType =
-        config.agent() != null ? config.agent().type() : AgentCli.CLAUDE_CODE.yamlName();
-    var runId = DateTimeUtils.newId().toString();
-    var unit = AgentUnit.forRun(runId);
-    var background = request.background();
-    var workDir = adhocWorkDir(config, request.path());
-    var fullPermissions = adhocFullPermissions(config);
-    if (request.dryRun()) {
-      listener.launching(
-          background,
-          RunLauncher.launchCommand(
-              new RunLauncher.LaunchSpec(
-                  project,
-                  config,
-                  workDir,
-                  fullPermissions,
-                  null,
-                  null,
-                  "",
-                  agentType,
-                  request.task(),
-                  request.branch(),
-                  List.of(),
-                  background,
-                  unit,
-                  runId,
-                  null,
-                  "adhoc",
-                  null)));
-      return new AdhocSession(runId, null, null, Optional.empty());
-    }
-    var credential =
-        reserveAdhocRun(
-            runId, project, localHandle, agentType, request.branch(), request.task(), unit, config);
-    try {
-      prepare(preparer);
-      var launch =
-          runLauncher.launchSession(
-              new RunLauncher.LaunchSpec(
-                  project,
-                  config,
-                  workDir,
-                  fullPermissions,
-                  null,
-                  null,
-                  "",
-                  agentType,
-                  request.task(),
-                  request.branch(),
-                  List.of(),
-                  background,
-                  unit,
-                  runId,
-                  credential,
-                  "adhoc",
-                  null));
-      var status =
-          runLauncher.finishLaunch(
-              new RunLauncher.RunContext(
-                  project, unit, runId, null, agentType, "adhoc", background),
-              launch);
-      return new AdhocSession(
-          runId, status, background ? null : launch.exitCode(), launch.watcher());
-    } catch (RuntimeException e) {
-      runReservation.releaseIfAbsent(runId, project, unit);
-      throw e;
-    }
+    return adhocRunner.start(project, request, localHandle, preparer);
   }
 
   /**
@@ -904,26 +838,6 @@ public final class DispatchOperations {
     roomCommitGuard.guardRoomRun(project, runId);
   }
 
-  private static void prepare(AdhocPreparer preparer) {
-    try {
-      preparer.prepare();
-    } catch (Exception e) {
-      throw new ApiException(
-          ErrorCode.AGENT_LAUNCH_FAILED, "Failed to prepare the agent session.", e);
-    }
-  }
-
-  private static String adhocWorkDir(SailYaml config, String path) {
-    var workDir = "/home/" + config.sshUser() + "/workspace";
-    return Strings.isBlank(path) ? workDir : workDir + "/" + path;
-  }
-
-  private static boolean adhocFullPermissions(SailYaml config) {
-    return config.agent() != null
-        && config.agent().config() != null
-        && "full".equals(config.agent().config().get("permissions"));
-  }
-
   /** What the claim/branch phase produced: the snapshot label and whether a branch was set up. */
   private record PreparedClaim(String snapshot, boolean branchCreated) {}
 
@@ -1246,31 +1160,6 @@ public final class DispatchOperations {
     }
     return runReservation.reserve(
         runId, project, specId, node, owner, "build", repos, agentType, branch, task, unit, config);
-  }
-
-  /**
-   * Reserves an ad-hoc session through the identical transaction: {@code role='adhoc'}, no spec,
-   * and an empty repo set — which the gate reads as the whole project, so the session excludes and
-   * is excluded by every dispatch atomically. Unlike dispatch, an absent run store is a refusal,
-   * not a skip: the reservation is the only thing standing between two agents in one container, and
-   * an ad-hoc session without a row would also be invisible to stop, status, and retention.
-   */
-  private String reserveAdhocRun(
-      String runId,
-      String project,
-      String node,
-      String agentType,
-      String branch,
-      String task,
-      AgentUnit unit,
-      SailYaml config) {
-    if (runStore == null) {
-      throw new ApiException(
-          ErrorCode.COMMAND_FAILED,
-          "This box keeps no run aggregate, so an agent session cannot be reserved or tracked.");
-    }
-    return runReservation.reserve(
-        runId, project, "", node, node, "adhoc", List.of(), agentType, branch, task, unit, config);
   }
 
   /**


### PR DESCRIPTION
## What

The **first launching lane** peeled off `DispatchOperations`, now that the three seams (`LaunchAdmission` + `RunLauncher` + `RunReservation`) are in place. The ad-hoc lane (`sail agent run --task`) is now a thin lane over them.

New **`AdhocRunner`** owns `startAdhoc` and its helpers (`reserveAdhocRun`, `adhocWorkDir`, `adhocFullPermissions`, `prepare`) over five collaborators — `projects`, `runLauncher`, `runReservation`, `runStore`, `listener`. Its whole flow is: reserve the container through `RunReservation`, launch through `RunLauncher`, and release the reservation through `RunReservation` if the launch fails.

`DispatchOperations` keeps `startAdhoc` as a two-line delegator, so the public surface and callers (`AgentSweepCommand`, `RunCommand`) are unchanged. It drops to **1,212 lines** (2,264 at the split's start — a 1,052-line reduction, less than half its original size).

## Testing

- **Behavior-preserving** — `AdhocDispatchTest` passes unchanged.
- It already covers every `AdhocRunner` branch (dry run, live launch, no-store refusal, prepare failure, full/limited permissions), so the new api class meets the **100% coverage gate with no exclude and no new test** — the payoff of the seams: the lane is thin enough to be fully covered by the existing suite.
- `mvn clean verify` green.

## Next

`RoomWakeLauncher` → `InviteLauncher` → `BuildDispatch`, then slim `SailOperations` and segment the `Operations` port.
