### PR TITLE
refactor: extract the RoomWakeLauncher lane from DispatchOperations

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -8,7 +8,6 @@ package ai.singlr.sail.api;
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.BranchPolicy;
-import ai.singlr.sail.config.Engagement;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecCatalog;
@@ -21,7 +20,6 @@ import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.DispatchRepos;
 import ai.singlr.sail.engine.HostInfo;
 import ai.singlr.sail.engine.InvitePrompt;
-import ai.singlr.sail.engine.RoomWakePrompt;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.SnapshotManager;
 import ai.singlr.sail.engine.WatcherSpawner;
@@ -211,6 +209,7 @@ public final class DispatchOperations {
   private final RunLauncher runLauncher;
   private final RunReservation runReservation;
   private final AdhocRunner adhocRunner;
+  private final RoomWakeLauncher roomWakeLauncher;
   private MessageStore messageStore;
   private final EventSink events;
   private final WatcherSpawner watcherSpawner;
@@ -256,6 +255,15 @@ public final class DispatchOperations {
         new RunLauncher(shell, file, launcher, listener, watcherSpawner, runStore, this.events);
     this.runReservation = new RunReservation(runStore, shell, listener);
     this.adhocRunner = new AdhocRunner(projects, runLauncher, runReservation, runStore, listener);
+    this.roomWakeLauncher =
+        new RoomWakeLauncher(
+            projects,
+            specStore,
+            () -> messageStore,
+            runStore,
+            runReservation,
+            runLauncher,
+            roomCommitGuard);
   }
 
   public DispatchOperations useMessages(MessageStore messages) {
@@ -447,129 +455,7 @@ public final class DispatchOperations {
    * Returns the run id.
    */
   public String startRoomRun(String project, String specId, String localHandle) {
-    var loaded = projects.loadRunning(project);
-    var config = loaded.config();
-    if (config.agent() == null) {
-      throw new ApiException(
-          ErrorCode.AGENT_NOT_CONFIGURED, "No agent configured in sail.yaml's agent block.");
-    }
-    if (runStore == null) {
-      throw new ApiException(
-          ErrorCode.COMMAND_FAILED,
-          "This box keeps no run aggregate, so a room wake cannot be reserved or tracked.");
-    }
-    var spec =
-        specStore
-            .findById(specId)
-            .orElseThrow(
-                () ->
-                    new ApiException(
-                        ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
-    var engagement = Engagement.fromJson(spec.engagement());
-    var agentType =
-        engagement != null
-            ? engagement.agent()
-            : spec.agent() != null ? spec.agent() : config.agent().type();
-    var full = engagement != null && engagement.full();
-    if (!full && !AgentCli.fromYamlName(agentType).supportsRoomLane()) {
-      throw new ApiException(
-          ErrorCode.AGENT_NOT_CONFIGURED,
-          "Room wake needs a harness-enforced read-only session, and "
-              + agentType
-              + " has none inside a sail container: its bubblewrap sandbox needs user namespaces,"
-              + " which incus containers block, so its only working mode bypasses all"
-              + " restrictions. Set the spec's agent to claude-code to chat in this room, or"
-              + " answer from the room directly and dispatch when code should change.");
-    }
-    var body = specStore.getContent(specId).map(SpecStore.SpecContent::body).orElse("");
-    var room =
-        messageStore == null
-            ? List.<MessageStore.MessageRow>of()
-            : messageStore.list(specId, null, 20);
-    var resumeSessionId =
-        engagement != null
-            ? engagedSessionId(specId, agentType, localHandle)
-            : resumableSessionId(specId, agentType, localHandle);
-    var built =
-        RoomWakePrompt.build(
-            spec, body.isBlank() ? spec.title() : body, room, resumeSessionId != null, engagement);
-    var task = built.prompt();
-    var runId = DateTimeUtils.newId().toString();
-    var unit = AgentUnit.forRun(runId);
-    var role = full ? DispatchGate.ROOM_FULL_ROLE : DispatchGate.ROOM_ROLE;
-    var targetRepos =
-        full ? DispatchRepos.resolve(config, spec.toSpec(), List.of()) : List.<SailYaml.Repo>of();
-    var repoPaths = targetRepos.stream().map(SailYaml.Repo::path).toList();
-    var branch = full ? Objects.toString(spec.branch(), "") : "";
-    var credential =
-        runReservation.reserve(
-            runId,
-            project,
-            specId,
-            localHandle,
-            Strings.isBlank(spec.assignee()) ? localHandle : spec.assignee(),
-            role,
-            repoPaths,
-            agentType,
-            Strings.isBlank(branch) ? null : branch,
-            task,
-            unit,
-            config);
-    try {
-      seedRoomDelivery(runId, built.renderedMessages());
-      if (!full) {
-        roomCommitGuard.captureRoomBaseline(project, config, runId);
-      }
-      var model =
-          engagement != null && engagement.model() != null ? engagement.model() : spec.model();
-      var workDir =
-          full
-              ? AgentSession.launchWorkDir(config.sshUser(), targetRepos)
-              : "/home/" + config.sshUser() + "/workspace";
-      var launch =
-          runLauncher.launchSession(
-              new RunLauncher.LaunchSpec(
-                  project,
-                  config,
-                  workDir,
-                  full,
-                  model,
-                  spec.reasoningEffort(),
-                  specId,
-                  agentType,
-                  task,
-                  branch,
-                  repoPaths,
-                  true,
-                  unit,
-                  runId,
-                  credential,
-                  role,
-                  resumeSessionId));
-      runLauncher.finishLaunch(
-          new RunLauncher.RunContext(project, unit, runId, specId, agentType, role, true), launch);
-      return runId;
-    } catch (RuntimeException e) {
-      runReservation.releaseIfAbsent(runId, project, unit);
-      throw e;
-    }
-  }
-
-  /**
-   * The engagement's own conversation: the newest chat-turn session of the engaged agent this box
-   * can resume. A build or invite session never qualifies — a working lane's conversation must not
-   * reopen under a chat turn's contract, and the engaged agent's memory is its chat turns.
-   */
-  private String engagedSessionId(String specId, String agentType, String localHandle) {
-    return runStore.listForSpec(specId).stream()
-        .filter(RunStore.RunRow::chatRole)
-        .filter(run -> run.ownedBy(localHandle))
-        .filter(run -> Strings.isNotBlank(run.sessionId()))
-        .filter(run -> agentType.equals(run.agent()))
-        .filter(run -> AgentCli.isSafeSessionId(run.sessionId()))
-        .findFirst()
-        .map(RunStore.RunRow::sessionId)
-        .orElse(null);
+    return roomWakeLauncher.wake(project, specId, localHandle);
   }
 
   /**
@@ -810,24 +696,6 @@ public final class DispatchOperations {
         Event.WellKnownTypes.SNAPSHOT_CREATED,
         Map.of("label", label, Event.WellKnownData.RUN_ID, runId));
     return label;
-  }
-
-  /**
-   * The spec's most recent conversation this box can actually resume: the latest run that recorded
-   * a session id, restricted to runs executed on this node (conversation state lives on the box
-   * that ran it; run rows and session ids replicate fleet-wide), to the same agent (a Claude
-   * session cannot resume under Codex), and to ids safe to place in an argv — session ids are
-   * hook-reported, replicated data.
-   */
-  private String resumableSessionId(String specId, String agentType, String localHandle) {
-    return runStore.listForSpec(specId).stream()
-        .filter(run -> run.ownedBy(localHandle))
-        .filter(run -> Strings.isNotBlank(run.sessionId()))
-        .filter(run -> agentType.equals(run.agent()))
-        .filter(run -> AgentCli.isSafeSessionId(run.sessionId()))
-        .findFirst()
-        .map(RunStore.RunRow::sessionId)
-        .orElse(null);
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeLauncher.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeLauncher.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.Engagement;
+import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.engine.AgentCli;
+import ai.singlr.sail.engine.AgentSession;
+import ai.singlr.sail.engine.AgentUnit;
+import ai.singlr.sail.engine.DispatchRepos;
+import ai.singlr.sail.engine.RoomWakePrompt;
+import ai.singlr.sail.store.DispatchGate;
+import ai.singlr.sail.store.MessageStore;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SpecStore;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * The room-wake lane — the chat lane. A human message posted to a spec's room while no run is live
+ * wakes the agent as a real {@code room}-role run that answers in the room. A thin lane over the
+ * three launch seams: reserve through {@link RunReservation} (an empty repo set — the gate
+ * serializes it only against runs of its own spec), launch through {@link RunLauncher}, and — read
+ * only — capture the {@link RoomCommitGuard} baseline so a worktree-writing chat surfaces. The spec
+ * is never claimed, no branch is checked out, no snapshot is taken; a chat owns no working tree,
+ * and the launch is harness-restricted, never full-permission unless a human engaged the agent in
+ * full mode. When the spec's latest run on this node recorded a resumable session for the chosen
+ * agent, the launch resumes that conversation with the wake prompt as its next turn.
+ */
+public final class RoomWakeLauncher {
+
+  private final ProjectLoader projects;
+  private final SpecStore specStore;
+  private final Supplier<MessageStore> messageStore;
+  private final RunStore runStore;
+  private final RunReservation runReservation;
+  private final RunLauncher runLauncher;
+  private final RoomCommitGuard roomCommitGuard;
+
+  public RoomWakeLauncher(
+      ProjectLoader projects,
+      SpecStore specStore,
+      Supplier<MessageStore> messageStore,
+      RunStore runStore,
+      RunReservation runReservation,
+      RunLauncher runLauncher,
+      RoomCommitGuard roomCommitGuard) {
+    this.projects = projects;
+    this.specStore = specStore;
+    this.messageStore = messageStore;
+    this.runStore = runStore;
+    this.runReservation = runReservation;
+    this.runLauncher = runLauncher;
+    this.roomCommitGuard = roomCommitGuard;
+  }
+
+  /** Launches a room wake for {@code specId}, returning the run id. */
+  public String wake(String project, String specId, String localHandle) {
+    var loaded = projects.loadRunning(project);
+    var config = loaded.config();
+    if (config.agent() == null) {
+      throw new ApiException(
+          ErrorCode.AGENT_NOT_CONFIGURED, "No agent configured in sail.yaml's agent block.");
+    }
+    if (runStore == null) {
+      throw new ApiException(
+          ErrorCode.COMMAND_FAILED,
+          "This box keeps no run aggregate, so a room wake cannot be reserved or tracked.");
+    }
+    var spec =
+        specStore
+            .findById(specId)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
+    var engagement = Engagement.fromJson(spec.engagement());
+    var agentType =
+        engagement != null
+            ? engagement.agent()
+            : spec.agent() != null ? spec.agent() : config.agent().type();
+    var full = engagement != null && engagement.full();
+    if (!full && !AgentCli.fromYamlName(agentType).supportsRoomLane()) {
+      throw new ApiException(
+          ErrorCode.AGENT_NOT_CONFIGURED,
+          "Room wake needs a harness-enforced read-only session, and "
+              + agentType
+              + " has none inside a sail container: its bubblewrap sandbox needs user namespaces,"
+              + " which incus containers block, so its only working mode bypasses all"
+              + " restrictions. Set the spec's agent to claude-code to chat in this room, or"
+              + " answer from the room directly and dispatch when code should change.");
+    }
+    var body = specStore.getContent(specId).map(SpecStore.SpecContent::body).orElse("");
+    var messages = messageStore.get();
+    var room =
+        messages == null ? List.<MessageStore.MessageRow>of() : messages.list(specId, null, 20);
+    var resumeSessionId =
+        engagement != null
+            ? engagedSessionId(specId, agentType, localHandle)
+            : resumableSessionId(specId, agentType, localHandle);
+    var built =
+        RoomWakePrompt.build(
+            spec, body.isBlank() ? spec.title() : body, room, resumeSessionId != null, engagement);
+    var task = built.prompt();
+    var runId = DateTimeUtils.newId().toString();
+    var unit = AgentUnit.forRun(runId);
+    var role = full ? DispatchGate.ROOM_FULL_ROLE : DispatchGate.ROOM_ROLE;
+    var targetRepos =
+        full ? DispatchRepos.resolve(config, spec.toSpec(), List.of()) : List.<SailYaml.Repo>of();
+    var repoPaths = targetRepos.stream().map(SailYaml.Repo::path).toList();
+    var branch = full ? Objects.toString(spec.branch(), "") : "";
+    var credential =
+        runReservation.reserve(
+            runId,
+            project,
+            specId,
+            localHandle,
+            Strings.isBlank(spec.assignee()) ? localHandle : spec.assignee(),
+            role,
+            repoPaths,
+            agentType,
+            Strings.isBlank(branch) ? null : branch,
+            task,
+            unit,
+            config);
+    try {
+      seedRoomDelivery(runId, built.renderedMessages());
+      if (!full) {
+        roomCommitGuard.captureRoomBaseline(project, config, runId);
+      }
+      var model =
+          engagement != null && engagement.model() != null ? engagement.model() : spec.model();
+      var workDir =
+          full
+              ? AgentSession.launchWorkDir(config.sshUser(), targetRepos)
+              : "/home/" + config.sshUser() + "/workspace";
+      var launch =
+          runLauncher.launchSession(
+              new RunLauncher.LaunchSpec(
+                  project,
+                  config,
+                  workDir,
+                  full,
+                  model,
+                  spec.reasoningEffort(),
+                  specId,
+                  agentType,
+                  task,
+                  branch,
+                  repoPaths,
+                  true,
+                  unit,
+                  runId,
+                  credential,
+                  role,
+                  resumeSessionId));
+      runLauncher.finishLaunch(
+          new RunLauncher.RunContext(project, unit, runId, specId, agentType, role, true), launch);
+      return runId;
+    } catch (RuntimeException e) {
+      runReservation.releaseIfAbsent(runId, project, unit);
+      throw e;
+    }
+  }
+
+  /**
+   * The engagement's own conversation: the newest chat-turn session of the engaged agent this box
+   * can resume. A build or invite session never qualifies — a working lane's conversation must not
+   * reopen under a chat turn's contract, and the engaged agent's memory is its chat turns.
+   */
+  private String engagedSessionId(String specId, String agentType, String localHandle) {
+    return runStore.listForSpec(specId).stream()
+        .filter(RunStore.RunRow::chatRole)
+        .filter(run -> run.ownedBy(localHandle))
+        .filter(run -> Strings.isNotBlank(run.sessionId()))
+        .filter(run -> agentType.equals(run.agent()))
+        .filter(run -> AgentCli.isSafeSessionId(run.sessionId()))
+        .findFirst()
+        .map(RunStore.RunRow::sessionId)
+        .orElse(null);
+  }
+
+  private String resumableSessionId(String specId, String agentType, String localHandle) {
+    return runStore.listForSpec(specId).stream()
+        .filter(run -> run.ownedBy(localHandle))
+        .filter(run -> Strings.isNotBlank(run.sessionId()))
+        .filter(run -> agentType.equals(run.agent()))
+        .filter(run -> AgentCli.isSafeSessionId(run.sessionId()))
+        .findFirst()
+        .map(RunStore.RunRow::sessionId)
+        .orElse(null);
+  }
+
+  private void seedRoomDelivery(String runId, List<MessageStore.MessageRow> rendered) {
+    if (runStore == null || rendered.isEmpty()) {
+      return;
+    }
+    runStore.markDelivered(runId, rendered.stream().map(MessageStore.MessageRow::id).toList());
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
@@ -82,9 +82,35 @@ class RoomWakeLaunchTest {
     }
   }
 
+  private static final String YAML_NO_AGENT =
+      """
+      name: acme
+      ssh:
+        user: dev
+      repos:
+        - url: https://github.com/acme/app.git
+          path: app
+      """;
+
   private DispatchOperations operations(ShellExec shell) throws IOException {
+    return operations(
+        shell,
+        YAML,
+        true,
+        command -> {
+          launched.set(command);
+          return 0;
+        });
+  }
+
+  private DispatchOperations operations(
+      ShellExec shell,
+      String yamlContent,
+      boolean withRunStore,
+      DispatchOperations.AgentLauncher launcher)
+      throws IOException {
     var yaml = tempDir.resolve("sail-" + System.nanoTime() + ".yaml");
-    Files.writeString(yaml, YAML);
+    Files.writeString(yaml, yamlContent);
     db = Sqlite.open(tempDir.resolve("wake-" + System.nanoTime() + ".db"));
     new SchemaManager(db).migrate();
     specStore = new SpecStore(db);
@@ -96,17 +122,39 @@ class RoomWakeLaunchTest {
             yaml.toString(),
             specStore,
             new ReviewStore(db),
-            runStore,
+            withRunStore ? runStore : null,
             new FdeStore(db),
             events::add,
             new WatcherSpawner(shell, (command, logPath) -> 4242L),
             (project, config) -> "",
-            command -> {
-              launched.set(command);
-              return 0;
-            },
+            launcher,
             DispatchOperations.Listener.NONE)
         .useMessages(messageStore);
+  }
+
+  @Test
+  void aWakeWithoutAnAgentBlockIsRefused() throws Exception {
+    var ops = operations(liveAgentShell(), YAML_NO_AGENT, true, command -> 0);
+
+    var ex = assertThrows(ApiException.class, () -> ops.startRoomRun("acme", "auth", HANDLE));
+    assertEquals(ErrorCode.AGENT_NOT_CONFIGURED, ex.failure().errorCode());
+  }
+
+  @Test
+  void aWakeWithoutARunStoreIsRefused() throws Exception {
+    var ops = operations(liveAgentShell(), YAML, false, command -> 0);
+
+    var ex = assertThrows(ApiException.class, () -> ops.startRoomRun("acme", "auth", HANDLE));
+    assertEquals(ErrorCode.COMMAND_FAILED, ex.failure().errorCode());
+  }
+
+  @Test
+  void aFailedLaunchReleasesTheReservationAndRethrows() throws Exception {
+    var ops = operations(liveAgentShell(), YAML, true, command -> 1);
+    seedSpec("auth");
+
+    var ex = assertThrows(ApiException.class, () -> ops.startRoomRun("acme", "auth", HANDLE));
+    assertEquals(ErrorCode.AGENT_LAUNCH_FAILED, ex.failure().errorCode());
   }
 
   private static StubShell liveAgentShell() {


### PR DESCRIPTION
## What

The **second launching lane**. The room-wake (chat) lane — a human message to a spec's room while no run is live wakes the agent as a **read-only `room`-role run** that answers in the room — is now a thin lane over the three seams: reserve through `RunReservation` (empty repo set), launch through `RunLauncher`, and capture the `RoomCommitGuard` baseline so a worktree-writing chat surfaces.

New **`RoomWakeLauncher`** owns `startRoomRun` (as `wake`) and its room-only helpers (`engagedSessionId`, `resumableSessionId`) over seven collaborators.

- The message store is **late-bound** via `useMessages`, so it's injected as a `Supplier<MessageStore>` read at wake time.
- `seedRoomDelivery` is a trivial run-store wrapper shared with the build and invite lanes, so `RoomWakeLauncher` carries its own copy (as prior extractions did with `runBookkeeping`); `DispatchOperations` keeps its copy for those lanes.
- `DispatchOperations` keeps `startRoomRun` as a one-line delegator, so the wake seam (`ServerStartCommand`, `RoomWakeReactor`) and `SailOperations` are unchanged. It drops to **1,080 lines** (2,264 at the split's start — down 52%).

## Testing

- **Behavior-preserving** — `RoomWakeLaunchTest` passes unchanged.
- Added three cases that close the lane's defensive guards: **no agent block**, **no run store**, and **launch failure releases the reservation and rethrows** — so the new api class meets the **100% coverage gate with no exclude**.
- `mvn clean verify` green.

## Next

`InviteLauncher` (+ `inviteSnapshot`) → `BuildDispatch`, then slim `SailOperations` and segment the `Operations` port.
