### PR TITLE
refactor: extract the InviteLauncher lane from DispatchOperations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,7 @@
                                         <exclude>ai.singlr.sail.api.RunLauncher</exclude>
                                         <exclude>ai.singlr.sail.api.RunLauncher.*</exclude>
                                         <exclude>ai.singlr.sail.api.RunReservation</exclude>
+                                        <exclude>ai.singlr.sail.api.InviteLauncher</exclude>
                                         <exclude>ai.singlr.sail.api.AgentLogStreamer</exclude>
                                         <exclude>ai.singlr.sail.api.EventStreamClient</exclude>
                                         <exclude>ai.singlr.sail.api.EventStreamClient.StopReadingException</exclude>
@@ -262,6 +263,36 @@
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
                                             <minimum>0.88</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>METHOD</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                                <rule>
+                                    <element>CLASS</element>
+                                    <includes>
+                                        <include>ai.singlr.sail.api.InviteLauncher</include>
+                                    </includes>
+                                    <!--
+                                        The invite lane. Every method is exercised (METHOD 1.0): the
+                                        authorize/reserve/complete paths and the defensive guards (no
+                                        run store, no agent block, empty room) directly by
+                                        InviteLaunchTest. The uncovered lines are defensive-only —
+                                        seedRoomDelivery's empty-ledger guard (InvitePrompt always
+                                        renders at least the prompt, so a full invite's rendered set
+                                        is never empty) and the seed catch (markDelivered would have
+                                        to throw between a won reservation and the ledger write) —
+                                        neither reachable without fault injection. Floored just under
+                                        the actual.
+                                    -->
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.93</minimum>
                                         </limit>
                                         <limit>
                                             <counter>METHOD</counter>

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -12,14 +12,12 @@ import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecCatalog;
 import ai.singlr.sail.config.SpecStatus;
-import ai.singlr.sail.engine.AgentCli;
 import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.AgentTaskPrompt;
 import ai.singlr.sail.engine.AgentUnit;
 import ai.singlr.sail.engine.ContainerExec;
 import ai.singlr.sail.engine.DispatchRepos;
 import ai.singlr.sail.engine.HostInfo;
-import ai.singlr.sail.engine.InvitePrompt;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.SnapshotManager;
 import ai.singlr.sail.engine.WatcherSpawner;
@@ -31,7 +29,6 @@ import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -210,6 +207,7 @@ public final class DispatchOperations {
   private final RunReservation runReservation;
   private final AdhocRunner adhocRunner;
   private final RoomWakeLauncher roomWakeLauncher;
+  private final InviteLauncher inviteLauncher;
   private MessageStore messageStore;
   private final EventSink events;
   private final WatcherSpawner watcherSpawner;
@@ -264,6 +262,17 @@ public final class DispatchOperations {
             runReservation,
             runLauncher,
             roomCommitGuard);
+    this.inviteLauncher =
+        new InviteLauncher(
+            specStore,
+            projects,
+            () -> messageStore,
+            runStore,
+            admission,
+            runReservation,
+            runLauncher,
+            this.events,
+            shell);
   }
 
   public DispatchOperations useMessages(MessageStore messages) {
@@ -497,158 +506,8 @@ public final class DispatchOperations {
       String model,
       Actor actor,
       String localHandle) {
-    if (runStore == null) {
-      throw new ApiException(
-          ErrorCode.COMMAND_FAILED,
-          "This box keeps no run aggregate, so an invite cannot be reserved or tracked.");
-    }
-    var spec =
-        specStore
-            .findById(specId)
-            .orElseThrow(
-                () ->
-                    new ApiException(
-                        ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
-    LaunchAdmission.requireAllowed(actor, spec.toSpec(), localHandle);
-    admission.requireTrustedRoster(localHandle);
-    var agentCli = LaunchAdmission.resolveAgent(agentYamlName);
-    var inviteModel = LaunchAdmission.validateModel(model);
-    if (!full) {
-      throw new ApiException(
-          ErrorCode.BAD_REQUEST,
-          "Read-only invites are superseded by engagement: engage the agent in the room instead"
-              + " (POST /v1/specs/{id}/engage, or 'sail spec engage').",
-          "An engaged read-only agent stays in the room and answers every message — the one-shot"
-              + " read-only invite offered strictly less.");
-    }
-    var project = spec.project();
-    var loaded = projects.loadRunning(project);
-    var config = loaded.config();
-    if (config.agent() == null) {
-      throw new ApiException(
-          ErrorCode.AGENT_NOT_CONFIGURED, "No agent configured in sail.yaml's agent block.");
-    }
-    admission.requireInstalled(agentCli, project);
-    var body = specStore.getContent(specId).map(SpecStore.SpecContent::body).orElse("");
-    var room =
-        messageStore == null
-            ? List.<MessageStore.MessageRow>of()
-            : messageStore.list(specId, null, 20);
-    var built = InvitePrompt.build(spec, body.isBlank() ? spec.title() : body, room);
-    var task = built.prompt();
-    var runId = DateTimeUtils.newId().toString();
-    var unit = AgentUnit.forRun(runId);
-    var role = full ? DispatchGate.FULL_INVITE_ROLE : DispatchGate.READ_ONLY_INVITE_ROLE;
-    var targetRepos =
-        full ? DispatchRepos.resolve(config, spec.toSpec(), List.of()) : List.<SailYaml.Repo>of();
-    var repoPaths = targetRepos.stream().map(SailYaml.Repo::path).toList();
-    var branch = full ? Objects.toString(spec.branch(), "") : "";
-    var owner = Strings.isBlank(spec.assignee()) ? localHandle : spec.assignee();
-    var credential =
-        runReservation.reserve(
-            runId,
-            project,
-            specId,
-            localHandle,
-            owner,
-            role,
-            repoPaths,
-            agentCli.yamlName(),
-            Strings.isBlank(branch) ? null : branch,
-            task,
-            unit,
-            config);
-    try {
-      seedRoomDelivery(runId, built.renderedMessages());
-    } catch (RuntimeException e) {
-      runReservation.releaseIfAbsent(runId, project, unit);
-      throw e;
-    }
-    var principal = runStore.findById(runId).map(RunStore.RunRow::principal).orElse("");
-    var snapshot = full && takeSnapshot ? "invite-" + runId : "";
-    Runnable completion =
-        () ->
-            completeInvite(
-                project,
-                config,
-                specId,
-                runId,
-                unit,
-                agentCli,
-                inviteModel,
-                task,
-                branch,
-                targetRepos,
-                repoPaths,
-                credential,
-                role,
-                snapshot);
-    return new InviteLaunch(runId, principal, full, snapshot, completion);
-  }
-
-  /**
-   * The deferred half of an invite, run off the request thread: take the pre-launch snapshot (full
-   * mode) or capture the room baseline (read only), then launch the session. The reservation is
-   * already held. A snapshot or launch failure releases it and publishes {@code snapshot_created}
-   * carrying an {@code error} — there is no caller left to throw to, so the room learns the invite
-   * failed through the stream.
-   */
-  private void completeInvite(
-      String project,
-      SailYaml config,
-      String specId,
-      String runId,
-      AgentUnit unit,
-      AgentCli agentCli,
-      String inviteModel,
-      String task,
-      String branch,
-      List<SailYaml.Repo> targetRepos,
-      List<String> repoPaths,
-      String credential,
-      String role,
-      String snapshot) {
-    try {
-      if (!Strings.isBlank(snapshot)) {
-        inviteSnapshot(project, specId, runId);
-      }
-      var workDir = AgentSession.launchWorkDir(config.sshUser(), targetRepos);
-      var launch =
-          runLauncher.launchSession(
-              new RunLauncher.LaunchSpec(
-                  project,
-                  config,
-                  workDir,
-                  true,
-                  inviteModel,
-                  null,
-                  specId,
-                  agentCli.yamlName(),
-                  task,
-                  branch,
-                  repoPaths,
-                  true,
-                  unit,
-                  runId,
-                  credential,
-                  role,
-                  null));
-      runLauncher.finishLaunch(
-          new RunLauncher.RunContext(project, unit, runId, specId, agentCli.yamlName(), role, true),
-          launch);
-    } catch (RuntimeException e) {
-      runReservation.releaseIfAbsent(runId, project, unit);
-      publishInviteFailed(project, specId, runId, snapshot, e);
-    }
-  }
-
-  private void publishInviteFailed(
-      String project, String specId, String runId, String snapshot, RuntimeException e) {
-    var data = new LinkedHashMap<String, Object>();
-    data.put("label", snapshot);
-    data.put(Event.WellKnownData.RUN_ID, runId);
-    data.put("error", Objects.requireNonNullElse(e.getMessage(), e.toString()));
-    publish(project, specId, Event.WellKnownTypes.SNAPSHOT_CREATED, data);
+    return inviteLauncher.start(
+        specId, agentYamlName, full, takeSnapshot, model, actor, localHandle);
   }
 
   /**
@@ -670,32 +529,6 @@ public final class DispatchOperations {
   /** Delegates to {@link EngagementService}: dismisses the room's engaged agent. */
   public String disengage(String specId, Actor actor, String localHandle) {
     return engagementService.disengage(specId, actor, localHandle);
-  }
-
-  /**
-   * The full invite's mandatory pre-launch snapshot, labeled {@code invite-<runId>} so rollback is
-   * one visible step. Published with the spec id — unlike the container-scoped dispatch snapshot —
-   * so the {@code snapshot_created} event renders in the room the invite was made from. Failure
-   * aborts the invite: the snapshot is the payment for full access, and a YOLO session with no
-   * rollback point must not launch.
-   */
-  private String inviteSnapshot(String project, String specId, String runId) {
-    var label = "invite-" + runId;
-    try {
-      new SnapshotManager(shell).create(project, label, INVITE_SNAPSHOT_TIMEOUT);
-    } catch (Exception e) {
-      throw new ApiException(
-          ErrorCode.SNAPSHOT_FAILED,
-          "Failed to create the pre-invite snapshot, so the invite does not launch.",
-          "Check the host's snapshot capacity (incus storage) and retry.",
-          e);
-    }
-    publish(
-        project,
-        specId,
-        Event.WellKnownTypes.SNAPSHOT_CREATED,
-        Map.of("label", label, Event.WellKnownData.RUN_ID, runId));
-    return label;
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/InviteLauncher.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/InviteLauncher.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.engine.AgentCli;
+import ai.singlr.sail.engine.AgentSession;
+import ai.singlr.sail.engine.AgentUnit;
+import ai.singlr.sail.engine.DispatchRepos;
+import ai.singlr.sail.engine.HostInfo;
+import ai.singlr.sail.engine.InvitePrompt;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.SnapshotManager;
+import ai.singlr.sail.store.DispatchGate;
+import ai.singlr.sail.store.MessageStore;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SpecStore;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * The invite lane — a human explicitly puts an agent in a spec's room in full mode (read-only
+ * invites are superseded by engagement). Reserving is synchronous, but the snapshot payment and the
+ * launch are deferred off the request thread through the returned {@link
+ * DispatchOperations.InviteLaunch}'s completion — a {@code dir}-backend snapshot is a slow full
+ * copy that would blow the client timeout. A thin lane over the three seams: authorize through
+ * {@link LaunchAdmission}, reserve through {@link RunReservation}, launch through {@link
+ * RunLauncher}; on failure the reservation is released and the room learns through a {@code
+ * snapshot_created} event carrying an error, since there is no caller left to throw to.
+ */
+public final class InviteLauncher {
+
+  private static final Duration SNAPSHOT_TIMEOUT = Duration.ofHours(1);
+
+  private final SpecStore specStore;
+  private final ProjectLoader projects;
+  private final Supplier<MessageStore> messageStore;
+  private final RunStore runStore;
+  private final LaunchAdmission admission;
+  private final RunReservation runReservation;
+  private final RunLauncher runLauncher;
+  private final DispatchOperations.EventSink events;
+  private final ShellExec shell;
+
+  public InviteLauncher(
+      SpecStore specStore,
+      ProjectLoader projects,
+      Supplier<MessageStore> messageStore,
+      RunStore runStore,
+      LaunchAdmission admission,
+      RunReservation runReservation,
+      RunLauncher runLauncher,
+      DispatchOperations.EventSink events,
+      ShellExec shell) {
+    this.specStore = specStore;
+    this.projects = projects;
+    this.messageStore = messageStore;
+    this.runStore = runStore;
+    this.admission = admission;
+    this.runReservation = runReservation;
+    this.runLauncher = runLauncher;
+    this.events = events;
+    this.shell = shell;
+  }
+
+  /**
+   * Accepts an invite: authorize the actor, reserve the run synchronously, and return an {@link
+   * DispatchOperations.InviteLaunch} whose {@code completion} pays the pre-launch snapshot (unless
+   * {@code takeSnapshot} waives it) and launches — off the request thread. Requires the dispatch
+   * tier on the spec, exactly like a dispatch.
+   */
+  public DispatchOperations.InviteLaunch start(
+      String specId,
+      String agentYamlName,
+      boolean full,
+      boolean takeSnapshot,
+      String model,
+      Actor actor,
+      String localHandle) {
+    if (runStore == null) {
+      throw new ApiException(
+          ErrorCode.COMMAND_FAILED,
+          "This box keeps no run aggregate, so an invite cannot be reserved or tracked.");
+    }
+    var spec =
+        specStore
+            .findById(specId)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
+    LaunchAdmission.requireAllowed(actor, spec.toSpec(), localHandle);
+    admission.requireTrustedRoster(localHandle);
+    var agentCli = LaunchAdmission.resolveAgent(agentYamlName);
+    var inviteModel = LaunchAdmission.validateModel(model);
+    if (!full) {
+      throw new ApiException(
+          ErrorCode.BAD_REQUEST,
+          "Read-only invites are superseded by engagement: engage the agent in the room instead"
+              + " (POST /v1/specs/{id}/engage, or 'sail spec engage').",
+          "An engaged read-only agent stays in the room and answers every message — the one-shot"
+              + " read-only invite offered strictly less.");
+    }
+    var project = spec.project();
+    var loaded = projects.loadRunning(project);
+    var config = loaded.config();
+    if (config.agent() == null) {
+      throw new ApiException(
+          ErrorCode.AGENT_NOT_CONFIGURED, "No agent configured in sail.yaml's agent block.");
+    }
+    admission.requireInstalled(agentCli, project);
+    var body = specStore.getContent(specId).map(SpecStore.SpecContent::body).orElse("");
+    var messages = messageStore.get();
+    var room =
+        messages == null ? List.<MessageStore.MessageRow>of() : messages.list(specId, null, 20);
+    var built = InvitePrompt.build(spec, body.isBlank() ? spec.title() : body, room);
+    var task = built.prompt();
+    var runId = DateTimeUtils.newId().toString();
+    var unit = AgentUnit.forRun(runId);
+    var role = DispatchGate.FULL_INVITE_ROLE;
+    var targetRepos = DispatchRepos.resolve(config, spec.toSpec(), List.of());
+    var repoPaths = targetRepos.stream().map(SailYaml.Repo::path).toList();
+    var branch = Objects.toString(spec.branch(), "");
+    var owner = Strings.isBlank(spec.assignee()) ? localHandle : spec.assignee();
+    var credential =
+        runReservation.reserve(
+            runId,
+            project,
+            specId,
+            localHandle,
+            owner,
+            role,
+            repoPaths,
+            agentCli.yamlName(),
+            Strings.isBlank(branch) ? null : branch,
+            task,
+            unit,
+            config);
+    try {
+      seedRoomDelivery(runId, built.renderedMessages());
+    } catch (RuntimeException e) {
+      runReservation.releaseIfAbsent(runId, project, unit);
+      throw e;
+    }
+    var principal = runStore.findById(runId).map(RunStore.RunRow::principal).orElse("");
+    var snapshot = takeSnapshot ? "invite-" + runId : "";
+    Runnable completion =
+        () ->
+            completeInvite(
+                project,
+                config,
+                specId,
+                runId,
+                unit,
+                agentCli,
+                inviteModel,
+                task,
+                branch,
+                targetRepos,
+                repoPaths,
+                credential,
+                role,
+                snapshot);
+    return new DispatchOperations.InviteLaunch(runId, principal, full, snapshot, completion);
+  }
+
+  /**
+   * The deferred half of an invite, run off the request thread: take the pre-launch snapshot, then
+   * launch the session. The reservation is already held. A snapshot or launch failure releases it
+   * and publishes {@code snapshot_created} carrying an {@code error} — there is no caller left to
+   * throw to, so the room learns the invite failed through the stream.
+   */
+  private void completeInvite(
+      String project,
+      SailYaml config,
+      String specId,
+      String runId,
+      AgentUnit unit,
+      AgentCli agentCli,
+      String inviteModel,
+      String task,
+      String branch,
+      List<SailYaml.Repo> targetRepos,
+      List<String> repoPaths,
+      String credential,
+      String role,
+      String snapshot) {
+    try {
+      if (!Strings.isBlank(snapshot)) {
+        inviteSnapshot(project, specId, runId);
+      }
+      var workDir = AgentSession.launchWorkDir(config.sshUser(), targetRepos);
+      var launch =
+          runLauncher.launchSession(
+              new RunLauncher.LaunchSpec(
+                  project,
+                  config,
+                  workDir,
+                  true,
+                  inviteModel,
+                  null,
+                  specId,
+                  agentCli.yamlName(),
+                  task,
+                  branch,
+                  repoPaths,
+                  true,
+                  unit,
+                  runId,
+                  credential,
+                  role,
+                  null));
+      runLauncher.finishLaunch(
+          new RunLauncher.RunContext(project, unit, runId, specId, agentCli.yamlName(), role, true),
+          launch);
+    } catch (RuntimeException e) {
+      runReservation.releaseIfAbsent(runId, project, unit);
+      publishInviteFailed(project, specId, runId, snapshot, e);
+    }
+  }
+
+  private void publishInviteFailed(
+      String project, String specId, String runId, String snapshot, RuntimeException e) {
+    var data = new LinkedHashMap<String, Object>();
+    data.put("label", snapshot);
+    data.put(Event.WellKnownData.RUN_ID, runId);
+    data.put("error", Objects.requireNonNullElse(e.getMessage(), e.toString()));
+    publish(project, specId, Event.WellKnownTypes.SNAPSHOT_CREATED, data);
+  }
+
+  /**
+   * The full invite's mandatory pre-launch snapshot, labeled {@code invite-<runId>} so rollback is
+   * one visible step. Published with the spec id — unlike the container-scoped dispatch snapshot —
+   * so the {@code snapshot_created} event renders in the room the invite was made from. Failure
+   * aborts the invite: the snapshot is the payment for full access, and a YOLO session with no
+   * rollback point must not launch.
+   */
+  private String inviteSnapshot(String project, String specId, String runId) {
+    var label = "invite-" + runId;
+    try {
+      new SnapshotManager(shell).create(project, label, SNAPSHOT_TIMEOUT);
+    } catch (Exception e) {
+      throw new ApiException(
+          ErrorCode.SNAPSHOT_FAILED,
+          "Failed to create the pre-invite snapshot, so the invite does not launch.",
+          "Check the host's snapshot capacity (incus storage) and retry.",
+          e);
+    }
+    publish(
+        project,
+        specId,
+        Event.WellKnownTypes.SNAPSHOT_CREATED,
+        Map.of("label", label, Event.WellKnownData.RUN_ID, runId));
+    return label;
+  }
+
+  private void seedRoomDelivery(String runId, List<MessageStore.MessageRow> rendered) {
+    if (runStore == null || rendered.isEmpty()) {
+      return;
+    }
+    runStore.markDelivered(runId, rendered.stream().map(MessageStore.MessageRow::id).toList());
+  }
+
+  private void publish(String project, String specId, String type, Map<String, Object> data) {
+    events.publish(Event.of(project, specId, type, Event.SAIL_AGENT, HostInfo.hostname(), data));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
@@ -83,9 +83,24 @@ class InviteLaunchTest {
     }
   }
 
+  private static final String YAML_NO_AGENT =
+      """
+      name: acme
+      ssh:
+        user: dev
+      repos:
+        - url: https://github.com/acme/app.git
+          path: app
+      """;
+
   private DispatchOperations operations(ShellExec shell) throws IOException {
+    return operations(shell, YAML, true);
+  }
+
+  private DispatchOperations operations(ShellExec shell, String yamlContent, boolean withRunStore)
+      throws IOException {
     var yaml = tempDir.resolve("sail-" + System.nanoTime() + ".yaml");
-    Files.writeString(yaml, YAML);
+    Files.writeString(yaml, yamlContent);
     db = Sqlite.open(tempDir.resolve("invite-" + System.nanoTime() + ".db"));
     new SchemaManager(db).migrate();
     specStore = new SpecStore(db);
@@ -97,7 +112,7 @@ class InviteLaunchTest {
             yaml.toString(),
             specStore,
             new ReviewStore(db),
-            runStore,
+            withRunStore ? runStore : null,
             new FdeStore(db),
             events::add,
             new WatcherSpawner(shell, (command, logPath) -> 4242L),
@@ -109,6 +124,48 @@ class InviteLaunchTest {
             },
             DispatchOperations.Listener.NONE)
         .useMessages(messageStore);
+  }
+
+  @Test
+  void anInviteWithoutARunStoreIsRefused() throws Exception {
+    var ops = operations(liveAgentShell(), YAML, false);
+
+    var ex =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.startInvite(
+                    "auth", "claude-code", true, null, Actor.cliOperator(HANDLE), HANDLE));
+    assertEquals(ErrorCode.COMMAND_FAILED, ex.failure().errorCode());
+  }
+
+  @Test
+  void anInviteWithoutAnAgentBlockIsRefused() throws Exception {
+    var ops = operations(liveAgentShell(), YAML_NO_AGENT, true);
+    seedSpec("auth");
+
+    var ex =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.startInvite(
+                    "auth", "claude-code", true, null, Actor.cliOperator(HANDLE), HANDLE));
+    assertEquals(ErrorCode.AGENT_NOT_CONFIGURED, ex.failure().errorCode());
+  }
+
+  @Test
+  void anInviteWithAnEmptyRoomSeedsNoDelivery() throws Exception {
+    var ops = operations(liveAgentShell());
+    seedSpec("auth");
+
+    var launch =
+        ops.startInvite(
+            "auth", "claude-code", true, false, null, Actor.cliOperator(HANDLE), HANDLE);
+
+    assertNotNull(launch.runId());
+    assertTrue(
+        runStore.deliveredMessageIds(launch.runId()).isEmpty(),
+        "an invite into a room with no messages delivers nothing");
   }
 
   private StubShell liveAgentShell() {


### PR DESCRIPTION
## What

The **third launching lane**. The invite lane — a human explicitly puts an agent in a spec's room in **full mode** (read-only invites are superseded by engagement) — is a thin lane over the three seams: authorize through `LaunchAdmission`, reserve through `RunReservation` synchronously, then defer the snapshot payment + launch off the request thread through `RunLauncher`.

New **`InviteLauncher`** owns `startInvite` and its helpers (`completeInvite`, `publishInviteFailed`, `inviteSnapshot`) over nine collaborators. The late-bound message store is a `Supplier`; `seedRoomDelivery`/`publish` are the trivial shared helpers each lane carries its own copy of. `DispatchOperations` keeps `startInvite` (both overloads) as delegators, so `SailOperations` is unchanged. It drops to **913 lines** — under 1,000, down **60%** from the 2,264 it started at.

## Testing

- **Behavior-preserving** — `InviteLaunchTest` passes unchanged, plus three added cases (no run store, no agent block, empty room) that close the reachable defensive guards.
- The two remaining spots — `seedRoomDelivery`'s empty-ledger guard (a full invite's rendered set is never empty, unlike room-wake) and its seed catch (`markDelivered` would have to throw between a won reservation and the ledger write) — are unreachable without fault injection, gated by a documented per-class rule (LINE 0.93, METHOD 1.0), consistent with `RunLauncher`/`RunReservation`.
- `mvn clean verify` green.

## Next

`BuildDispatch` — the last and largest lane (`claimAndPrepare` + branch checkout + `resolveSpec`) — then slim `SailOperations` and segment the `Operations` port.
