### PR TITLE
refactor(api): segment the local-lane surface out of the Operations port

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
@@ -47,9 +47,9 @@ final class LocalApiRouter implements LocalApiHandler {
           Event.WellKnownTypes.AGENT_TOOL_FINISHED);
 
   private final EventBus bus;
-  private final Operations operations;
+  private final LocalLaneOperations operations;
 
-  LocalApiRouter(EventBus bus, Operations operations) {
+  LocalApiRouter(EventBus bus, LocalLaneOperations operations) {
     this.bus = bus;
     this.operations = operations;
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiSocket.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiSocket.java
@@ -60,7 +60,7 @@ public final class LocalApiSocket implements AutoCloseable {
   private volatile Thread acceptLoop;
   private volatile boolean closed;
 
-  public LocalApiSocket(EventBus bus, Operations operations, Path socketPath) {
+  public LocalApiSocket(EventBus bus, LocalLaneOperations operations, Path socketPath) {
     this(new LocalApiRouter(bus, operations), socketPath, DEFAULT_MAX_IN_FLIGHT);
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/LocalLaneOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/LocalLaneOperations.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SpecStore;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The operations reachable over the in-container local unix socket: the {@code spec} CLI's
+ * global-spec surface and board, spec-room messaging, and a run's own conversation and credential
+ * lane. {@link LocalApiRouter} depends on exactly this narrow surface — never the web lane's
+ * project lifecycle, dispatch, snapshot, or run-control operations — so the in-container caller
+ * cannot reach them and the lane's contract is documented in one place. {@link Operations} composes
+ * this role with the full web surface.
+ */
+public interface LocalLaneOperations {
+
+  /**
+   * Resolves a run credential — the bearer the in-container agent lane presents over the local
+   * socket — to its live run row. Empty for an unknown, revoked, or expired credential, and on
+   * boxes that keep no run aggregate.
+   */
+  default Optional<RunStore.RunRow> runForCredential(String credential) {
+    return Optional.empty();
+  }
+
+  /**
+   * Resolves the box's ambient credential to the FDE actor it stands for, or empty when the
+   * credential is unknown or its handle has left the roster. Serves the local socket's interactive
+   * lane; run credentials are resolved first and never reach this.
+   */
+  default Optional<Actor> boxActorForCredential(String credential) {
+    return Optional.empty();
+  }
+
+  Result<GlobalSpecsListResponse> globalSpecs(SpecStore.SpecFilter filter);
+
+  Result<GlobalSpecDetailResponse> globalSpec(String specId);
+
+  Result<GlobalSpecCreatedResponse> createGlobalSpec(SpecCreateRequest request);
+
+  Result<GlobalSpecUpdatedResponse> updateGlobalSpec(
+      String specId, SpecUpdateRequest request, Actor actor);
+
+  Result<GlobalSpecDeletedResponse> deleteGlobalSpec(String specId, Actor actor);
+
+  Result<GlobalSpecContentResponse> globalSpecContent(String specId);
+
+  Result<GlobalSpecContentResponse> setGlobalSpecContent(
+      String specId, SpecContentRequest request, Actor actor);
+
+  Result<GlobalBoardResponse> globalBoard(String project);
+
+  Result<SpecMessageResponse> postSpecMessage(
+      String specId, SpecMessageRequest request, Actor actor, String author);
+
+  /**
+   * A page of a spec room: {@code before} pages backward from the newest (the default), {@code
+   * after} reads forward past a known message id. The two are exclusive.
+   */
+  Result<SpecMessagesResponse> specMessages(String specId, String before, String after, int limit);
+
+  /**
+   * The run's undelivered room messages: everything on the run's spec absent from the run's
+   * delivery ledger, minus what the run's own principal authored — a run is never told its own
+   * story. Tracked by exact message identity, so a message that synchronized in late is still owed
+   * a delivery no matter how its id sorts. {@code hasMore} reports that the batch was capped and
+   * another read is due. A run with no spec (ad-hoc) has an empty inbox.
+   */
+  Result<RunInboxResponse> runInbox(String runId);
+
+  /**
+   * Acknowledges exactly {@code delivered} — message ids the caller actually showed the run, each
+   * of which must name a message on the run's own spec. The credential names the run and the run
+   * names the spec, so a caller can never mark another run's ledger or point it off-spec.
+   * Idempotent: a replayed acknowledgement is a no-op.
+   */
+  Result<RunAckResponse> ackRunMessages(String runId, List<String> delivered);
+
+  /**
+   * Records the hook-reported identity of the run's agent conversation: the session id (required),
+   * the start source, and the container-side transcript path (both optional, stored null when
+   * blank). Last write wins — a resume, clear, or compact restart re-reports and overwrites, so the
+   * row always names the conversation a human would attach to. The run credential is the write
+   * gate: revocation at run completion is what ends a run's ability to report, so there is no
+   * separate status check. A blank session id is rejected without touching a prior report.
+   */
+  Result<RunSessionResponse> recordRunSession(
+      String runId, String sessionId, String source, String transcriptPath);
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
@@ -5,21 +5,13 @@
 
 package ai.singlr.sail.api;
 
-import ai.singlr.sail.store.RunStore;
-import ai.singlr.sail.store.SpecStore;
-import java.util.List;
-import java.util.Optional;
-
-public interface Operations {
-
-  /**
-   * Resolves a run credential — the bearer the in-container agent lane presents over the local
-   * socket — to its live run row. Empty for an unknown, revoked, or expired credential, and on
-   * boxes that keep no run aggregate.
-   */
-  default Optional<RunStore.RunRow> runForCredential(String credential) {
-    return Optional.empty();
-  }
+/**
+ * The full control-plane surface served over the web API by {@link ApiRouter}. Extends {@link
+ * LocalLaneOperations} so the in-container local-socket surface is one shared contract, and adds
+ * the web-only lanes: project lifecycle, dispatch, snapshots, agent status, run control, events,
+ * and reviews.
+ */
+public interface Operations extends LocalLaneOperations {
 
   Result<ReviewListResponse> reviewsForSpec(String specId);
 
@@ -113,70 +105,8 @@ public interface Operations {
   /** Returns per-subscriber + bus stats for {@code /v1/events/stats}. */
   Result<EventBusStatsResponse> eventBusStats();
 
-  Result<GlobalSpecsListResponse> globalSpecs(SpecStore.SpecFilter filter);
-
-  Result<GlobalSpecDetailResponse> globalSpec(String specId);
-
-  Result<GlobalSpecCreatedResponse> createGlobalSpec(SpecCreateRequest request);
-
   /** Drafts a follow-up spec from the open findings of a spec's latest non-superseded review. */
   Result<FollowupSpecResponse> createFollowupSpec(String specId, FollowupCreateRequest request);
-
-  Result<GlobalSpecUpdatedResponse> updateGlobalSpec(
-      String specId, SpecUpdateRequest request, Actor actor);
-
-  Result<GlobalSpecDeletedResponse> deleteGlobalSpec(String specId, Actor actor);
-
-  Result<GlobalSpecContentResponse> globalSpecContent(String specId);
-
-  Result<GlobalSpecContentResponse> setGlobalSpecContent(
-      String specId, SpecContentRequest request, Actor actor);
-
-  /**
-   * Resolves the box's ambient credential to the FDE actor it stands for, or empty when the
-   * credential is unknown or its handle has left the roster. Serves the local socket's interactive
-   * lane; run credentials are resolved first and never reach this.
-   */
-  default Optional<Actor> boxActorForCredential(String credential) {
-    return Optional.empty();
-  }
-
-  Result<SpecMessageResponse> postSpecMessage(
-      String specId, SpecMessageRequest request, Actor actor, String author);
-
-  /**
-   * A page of a spec room: {@code before} pages backward from the newest (the default), {@code
-   * after} reads forward past a known message id. The two are exclusive.
-   */
-  Result<SpecMessagesResponse> specMessages(String specId, String before, String after, int limit);
-
-  /**
-   * The run's undelivered room messages: everything on the run's spec absent from the run's
-   * delivery ledger, minus what the run's own principal authored — a run is never told its own
-   * story. Tracked by exact message identity, so a message that synchronized in late is still owed
-   * a delivery no matter how its id sorts. {@code hasMore} reports that the batch was capped and
-   * another read is due. A run with no spec (ad-hoc) has an empty inbox.
-   */
-  Result<RunInboxResponse> runInbox(String runId);
-
-  /**
-   * Acknowledges exactly {@code delivered} — message ids the caller actually showed the run, each
-   * of which must name a message on the run's own spec. The credential names the run and the run
-   * names the spec, so a caller can never mark another run's ledger or point it off-spec.
-   * Idempotent: a replayed acknowledgement is a no-op.
-   */
-  Result<RunAckResponse> ackRunMessages(String runId, List<String> delivered);
-
-  /**
-   * Records the hook-reported identity of the run's agent conversation: the session id (required),
-   * the start source, and the container-side transcript path (both optional, stored null when
-   * blank). Last write wins — a resume, clear, or compact restart re-reports and overwrites, so the
-   * row always names the conversation a human would attach to. The run credential is the write
-   * gate: revocation at run completion is what ends a run's ability to report, so there is no
-   * separate status check. A blank session id is rejected without touching a prior report.
-   */
-  Result<RunSessionResponse> recordRunSession(
-      String runId, String sessionId, String source, String transcriptPath);
 
   Result<GlobalSpecHistoryResponse> globalSpecHistory(String specId);
 
@@ -190,6 +120,4 @@ public interface Operations {
       String specId, EngageRequest request, Actor actor, String localHandle);
 
   Result<DisengageResponse> disengageSpec(String specId, Actor actor, String localHandle);
-
-  Result<GlobalBoardResponse> globalBoard(String project);
 }


### PR DESCRIPTION
## What

Segments the fat `Operations` port along its one real consumer boundary.

`Operations` declared all **47** control-plane methods, forcing every consumer to depend on the whole surface. But the in-container local-socket lane (`LocalApiRouter`) uses only **15** of them:

- the `spec` CLI's global-spec surface + board (`globalSpecs`/`globalSpec`/`createGlobalSpec`/`updateGlobalSpec`/`deleteGlobalSpec`/`globalSpecContent`/`setGlobalSpecContent`/`globalBoard`)
- spec-room messaging (`postSpecMessage`/`specMessages`)
- a run's own conversation + credentials (`runInbox`/`ackRunMessages`/`recordRunSession`/`runForCredential`/`boxActorForCredential`)

The other 32 are web-only (project lifecycle, dispatch, snapshots, agent status, run control, events, reviews) and the local lane can never reach them.

## Change

- New `LocalLaneOperations` role interface holds exactly those 15 methods.
- `Operations extends LocalLaneOperations` and declares only the 32 web-only methods.
- `LocalApiRouter` and `LocalApiSocket` now depend on `LocalLaneOperations`, not the full port.

## Why

Interface segregation **with a real consumer** (not speculative). The in-container lane now compiles against exactly its contract — a web-only operation is unreachable from it by construction, a meaningful boundary for the container-facing socket — and the local surface is documented in one interface.

## Safety

No behavior change: the union of `Operations` + `LocalLaneOperations` is identical to the old port (verified — all 47 methods preserved, none dropped). `SailOperations`, `ApiRouter`, and the test doubles are untouched (they still see the full `Operations`). The API lane suite (158 tests) and `mvn clean verify` are green with all coverage checks met.
