### PR TITLE
refactor(store): extract Snapshots map-coercion helper

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ProjectStore.java
@@ -188,7 +188,7 @@ public final class ProjectStore implements ConflictResolver {
             adoptDeletion(id, rev);
           } else {
             var definition = definitionOf(snapshot);
-            writeRow(id, definition, actorOf(snapshot));
+            writeRow(id, definition, Snapshots.actor(snapshot));
             recordRevision(id, definition, rev, "sync", false, true);
           }
         });
@@ -226,7 +226,7 @@ public final class ProjectStore implements ConflictResolver {
             return new PushOutcome.Accepted(rev);
           }
           var definition = definitionOf(snapshot);
-          writeRow(id, definition, actorOf(snapshot));
+          writeRow(id, definition, Snapshots.actor(snapshot));
           return new PushOutcome.Accepted(
               recordRevision(id, definition, null, "sync", false, false));
         });
@@ -256,7 +256,7 @@ public final class ProjectStore implements ConflictResolver {
       return adoptBaseDeletion(id);
     }
     var definition = definitionOf(remote);
-    writeRow(id, definition, actorOf(remote));
+    writeRow(id, definition, Snapshots.actor(remote));
     return recordRevision(id, definition, null, "sync", false, true);
   }
 
@@ -386,11 +386,6 @@ public final class ProjectStore implements ConflictResolver {
    * versioned 0.14 migration can journal a project row that predates attribution. Read on the
    * receiving side so a current snapshot is attributed to the engineer who actually edited it.
    */
-  private static String actorOf(Map<String, Object> snapshot) {
-    var actor = snapshot == null ? null : snapshot.get(ACTOR);
-    return actor == null ? "sync" : actor.toString();
-  }
-
   private String rawBaseRev(String id) {
     var value =
         db.queryOne(
@@ -427,12 +422,10 @@ public final class ProjectStore implements ConflictResolver {
   private static Map<String, Object> comparable(String definition, String actor) {
     var map = comparable(definition);
     if (actor != null) {
-      map.put(ACTOR, actor);
+      map.put(Snapshots.ACTOR, actor);
     }
     return map;
   }
-
-  private static final String ACTOR = "_actor";
 
   private static final String SELECT =
       "SELECT name, definition, created_by, created_at, updated_by, updated_at FROM projects";

--- a/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/ReviewStore.java
@@ -858,14 +858,14 @@ public final class ReviewStore implements ConflictResolver {
             decided_by, superseded_at, error)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         id,
-        text(snapshot, "spec_id"),
-        integer(snapshot, "iteration"),
-        text(snapshot, "status"),
-        text(snapshot, "created_at"),
-        text(snapshot, "completed_at"),
-        text(snapshot, "decided_by"),
-        text(snapshot, "superseded_at"),
-        text(snapshot, "error"));
+        Snapshots.text(snapshot, "spec_id"),
+        Snapshots.integer(snapshot, "iteration"),
+        Snapshots.text(snapshot, "status"),
+        Snapshots.text(snapshot, "created_at"),
+        Snapshots.text(snapshot, "completed_at"),
+        Snapshots.text(snapshot, "decided_by"),
+        Snapshots.text(snapshot, "superseded_at"),
+        Snapshots.text(snapshot, "error"));
     var stages = (List<Map<String, Object>>) snapshot.get("stages");
     if (stages != null) {
       for (var stage : stages) {
@@ -875,15 +875,15 @@ public final class ReviewStore implements ConflictResolver {
             INSERT INTO review_stages (id, review_id, name, stage_type, status, reviewer,
                 started_at, completed_at, error, finding_counts)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            text(stage, "id"),
+            Snapshots.text(stage, "id"),
             id,
-            text(stage, "name"),
-            text(stage, "stage_type"),
-            text(stage, "status"),
-            text(stage, "reviewer"),
-            text(stage, "started_at"),
-            text(stage, "completed_at"),
-            text(stage, "error"),
+            Snapshots.text(stage, "name"),
+            Snapshots.text(stage, "stage_type"),
+            Snapshots.text(stage, "status"),
+            Snapshots.text(stage, "reviewer"),
+            Snapshots.text(stage, "started_at"),
+            Snapshots.text(stage, "completed_at"),
+            Snapshots.text(stage, "error"),
             counts == null ? null : YamlUtil.dumpJson((Map<String, Object>) counts));
       }
     }
@@ -929,16 +929,6 @@ public final class ReviewStore implements ConflictResolver {
   private String currentRev(String id) {
     return db.queryOne("SELECT COALESCE(rev, '') FROM reviews WHERE id = ?", row -> row.text(0), id)
         .orElse("");
-  }
-
-  private static String text(Map<String, Object> map, String key) {
-    var value = map.get(key);
-    return value == null ? null : value.toString();
-  }
-
-  private static Integer integer(Map<String, Object> map, String key) {
-    var value = map.get(key);
-    return value instanceof Number n ? n.intValue() : null;
   }
 
   private ReviewRow mapReview(Sqlite.Row row) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -833,8 +833,9 @@ public final class RunStore implements ConflictResolver {
   }
 
   private void recordPrincipals(String id, Map<String, Object> snapshot) {
-    stringList(snapshot, "principals").forEach(principal -> recordPrincipal(id, principal));
-    recordPrincipal(id, text(snapshot, "principal"));
+    Snapshots.stringList(snapshot, "principals")
+        .forEach(principal -> recordPrincipal(id, principal));
+    recordPrincipal(id, Snapshots.text(snapshot, "principal"));
   }
 
   private static String principalHandle(String agent, String role, String id) {
@@ -1444,48 +1445,29 @@ public final class RunStore implements ConflictResolver {
   private static RunRow rowFrom(String id, Map<String, Object> snapshot) {
     return new RunRow(
         Ids.requireUuid(id),
-        text(snapshot, "project"),
-        text(snapshot, "spec_id"),
-        text(snapshot, "node"),
-        text(snapshot, "role"),
-        text(snapshot, "agent"),
-        text(snapshot, "branch"),
-        text(snapshot, "task"),
-        integer(snapshot, "pid"),
-        integer(snapshot, "watcher_pid"),
-        text(snapshot, "status"),
-        integer(snapshot, "exit_code"),
-        text(snapshot, "log_path"),
-        text(snapshot, "unit"),
-        text(snapshot, "started_at"),
-        text(snapshot, "completed_at"),
-        stringList(snapshot, "repos"),
-        longValue(snapshot, "pid_ticks"),
-        text(snapshot, "principal"),
-        text(snapshot, "owner"),
-        text(snapshot, "session_id"),
-        text(snapshot, "session_source"),
-        text(snapshot, "transcript_path"),
-        text(snapshot, "last_activity_at"));
-  }
-
-  private static String text(Map<String, Object> map, String key) {
-    var value = map.get(key);
-    return value == null ? null : value.toString();
-  }
-
-  private static List<String> stringList(Map<String, Object> map, String key) {
-    return map.get(key) instanceof List<?> list
-        ? list.stream().map(String::valueOf).toList()
-        : List.of();
-  }
-
-  private static Integer integer(Map<String, Object> map, String key) {
-    return map.get(key) instanceof Number n ? n.intValue() : null;
-  }
-
-  private static Long longValue(Map<String, Object> map, String key) {
-    return map.get(key) instanceof Number n ? n.longValue() : null;
+        Snapshots.text(snapshot, "project"),
+        Snapshots.text(snapshot, "spec_id"),
+        Snapshots.text(snapshot, "node"),
+        Snapshots.text(snapshot, "role"),
+        Snapshots.text(snapshot, "agent"),
+        Snapshots.text(snapshot, "branch"),
+        Snapshots.text(snapshot, "task"),
+        Snapshots.integer(snapshot, "pid"),
+        Snapshots.integer(snapshot, "watcher_pid"),
+        Snapshots.text(snapshot, "status"),
+        Snapshots.integer(snapshot, "exit_code"),
+        Snapshots.text(snapshot, "log_path"),
+        Snapshots.text(snapshot, "unit"),
+        Snapshots.text(snapshot, "started_at"),
+        Snapshots.text(snapshot, "completed_at"),
+        Snapshots.stringList(snapshot, "repos"),
+        Snapshots.longValue(snapshot, "pid_ticks"),
+        Snapshots.text(snapshot, "principal"),
+        Snapshots.text(snapshot, "owner"),
+        Snapshots.text(snapshot, "session_id"),
+        Snapshots.text(snapshot, "session_source"),
+        Snapshots.text(snapshot, "transcript_path"),
+        Snapshots.text(snapshot, "last_activity_at"));
   }
 
   private String rawBaseRev(String id) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/Snapshots.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/Snapshots.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Coerces one key of a decoded JSON snapshot into the typed value a synced row's field wants.
+ * Snapshots round-trip through {@code YamlUtil} as {@code Map<String, Object>} with loose types
+ * (numbers as {@code Number}, lists as {@code List<?>}), so every store reads its rows back through
+ * the same handful of null-tolerant coercions. Shared here so the revision journal and each store's
+ * {@code fromSnapshot} decode identically rather than each hand-rolling the idiom.
+ */
+public final class Snapshots {
+
+  /** Reserved metadata key carrying the author of a revision through the sync protocol. */
+  public static final String ACTOR = "_actor";
+
+  private Snapshots() {}
+
+  /** The string form of a present value, or null when the key is absent. */
+  public static String text(Map<String, Object> map, String key) {
+    var value = map.get(key);
+    return value == null ? null : value.toString();
+  }
+
+  /** A numeric value narrowed to {@code int}, or null when absent or not a number. */
+  public static Integer integer(Map<String, Object> map, String key) {
+    return map.get(key) instanceof Number n ? n.intValue() : null;
+  }
+
+  /** A numeric value widened to {@code long}, or null when absent or not a number. */
+  public static Long longValue(Map<String, Object> map, String key) {
+    return map.get(key) instanceof Number n ? n.longValue() : null;
+  }
+
+  /** Each element of a list value in string form, or an empty list when absent or not a list. */
+  public static List<String> stringList(Map<String, Object> map, String key) {
+    return map.get(key) instanceof List<?> list
+        ? list.stream().map(String::valueOf).toList()
+        : List.of();
+  }
+
+  /**
+   * The author a synced snapshot attributes its revision to — the reserved {@link #ACTOR} key — or
+   * {@code sync} when absent (or the snapshot itself is null), so a row that arrived with no
+   * attribution is still recorded as a sync write rather than crashing.
+   */
+  public static String actor(Map<String, Object> snapshot) {
+    var actor = snapshot == null ? null : snapshot.get(ACTOR);
+    return actor == null ? "sync" : actor.toString();
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -623,11 +623,11 @@ public final class SpecStore implements ConflictResolver {
         INSERT INTO spec_content (spec_id, body, plan, updated_at) VALUES (?, ?, ?, ?)
         ON CONFLICT(spec_id) DO UPDATE SET body = ?, plan = ?, updated_at = ?""",
         id,
-        text(snapshot, "body"),
-        text(snapshot, "plan"),
+        Snapshots.text(snapshot, "body"),
+        Snapshots.text(snapshot, "plan"),
         now,
-        text(snapshot, "body"),
-        text(snapshot, "plan"),
+        Snapshots.text(snapshot, "body"),
+        Snapshots.text(snapshot, "plan"),
         now);
   }
 
@@ -635,29 +635,24 @@ public final class SpecStore implements ConflictResolver {
   private static SpecRow specFromSnapshot(Map<String, Object> s) {
     var priority = s.get("priority");
     return new SpecRow(
-        text(s, "id"),
-        text(s, "project"),
-        text(s, "title"),
-        SpecStatus.fromWire(text(s, "status")),
-        text(s, "assignee"),
-        text(s, "agent"),
-        text(s, "model"),
-        text(s, "reasoning_effort"),
-        text(s, "branch"),
+        Snapshots.text(s, "id"),
+        Snapshots.text(s, "project"),
+        Snapshots.text(s, "title"),
+        SpecStatus.fromWire(Snapshots.text(s, "status")),
+        Snapshots.text(s, "assignee"),
+        Snapshots.text(s, "agent"),
+        Snapshots.text(s, "model"),
+        Snapshots.text(s, "reasoning_effort"),
+        Snapshots.text(s, "branch"),
         priority instanceof Number n ? n.intValue() : 0,
-        text(s, "created_by"),
-        text(s, "created_at"),
-        text(s, "updated_at"),
-        text(s, "updated_by"),
+        Snapshots.text(s, "created_by"),
+        Snapshots.text(s, "created_at"),
+        Snapshots.text(s, "updated_at"),
+        Snapshots.text(s, "updated_by"),
         (List<String>) s.getOrDefault("depends_on", List.of()),
         (List<String>) s.getOrDefault("repos", List.of()),
-        text(s, "wake"),
-        text(s, "engagement"));
-  }
-
-  private static String text(Map<String, Object> map, String key) {
-    var value = map.get(key);
-    return value == null ? null : value.toString();
+        Snapshots.text(s, "wake"),
+        Snapshots.text(s, "engagement"));
   }
 
   private static final Set<String> SYNC_FIELDS =
@@ -695,7 +690,7 @@ public final class SpecStore implements ConflictResolver {
     }
     var author = full.get("updated_by");
     if (author != null) {
-      m.put(ACTOR, author);
+      m.put(Snapshots.ACTOR, author);
     }
     return m;
   }
@@ -706,12 +701,6 @@ public final class SpecStore implements ConflictResolver {
    * _}-prefixed) keys, so attribution propagates without ever causing a false conflict. The
    * receiving side reads it to attribute the synced row to its real author instead of {@code sync}.
    */
-  private static final String ACTOR = "_actor";
-
-  private static String authorOf(Map<String, Object> snapshot) {
-    var author = snapshot.get(ACTOR);
-    return author == null ? "sync" : author.toString();
-  }
 
   /** Comparable snapshot of the current state, or null if the spec is absent/deleted. */
   public Map<String, Object> comparableSnapshot(String id) {
@@ -803,7 +792,7 @@ public final class SpecStore implements ConflictResolver {
           } else {
             var full = new LinkedHashMap<>(snapshot);
             full.put("id", id);
-            full.put("updated_by", authorOf(snapshot));
+            full.put("updated_by", Snapshots.actor(snapshot));
             applySnapshot(id, full);
             recordRevision(id, rev, "sync", false, true);
           }
@@ -833,7 +822,7 @@ public final class SpecStore implements ConflictResolver {
           }
           var full = new LinkedHashMap<>(snapshot);
           full.put("id", id);
-          full.put("updated_by", authorOf(snapshot));
+          full.put("updated_by", Snapshots.actor(snapshot));
           applySnapshot(id, full);
           return new PushOutcome.Accepted(recordRevision(id, null, "sync", false, false));
         });
@@ -890,7 +879,7 @@ public final class SpecStore implements ConflictResolver {
   private static Map<String, Object> withSync(String id, Map<String, Object> snapshot) {
     var full = new LinkedHashMap<>(snapshot);
     full.put("id", id);
-    full.put("updated_by", authorOf(snapshot));
+    full.put("updated_by", Snapshots.actor(snapshot));
     return full;
   }
 

--- a/sail-core/src/test/java/ai/singlr/sail/store/SnapshotsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SnapshotsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The snapshot-coercion helpers every synced store reads its rows back through: JSON snapshots
+ * decode to {@code Map<String, Object>} with loose types (numbers as {@code Long}/{@code Integer},
+ * lists as {@code List<?>}), and these turn one key into the typed value a row field wants — null
+ * for an absent or wrong-typed value, never a class-cast.
+ */
+class SnapshotsTest {
+
+  @Test
+  void textReturnsTheStringFormOfAnyPresentValue() {
+    assertEquals("hello", Snapshots.text(Map.of("k", "hello"), "k"));
+    assertEquals("42", Snapshots.text(Map.of("k", 42), "k"));
+    assertEquals("true", Snapshots.text(Map.of("k", true), "k"));
+  }
+
+  @Test
+  void textIsNullForAnAbsentKey() {
+    assertNull(Snapshots.text(Map.of(), "missing"));
+  }
+
+  @Test
+  void integerCoercesAnyNumberToItsIntValue() {
+    assertEquals(7, Snapshots.integer(Map.of("k", 7L), "k"));
+    assertEquals(3, Snapshots.integer(Map.of("k", 3.9), "k"));
+  }
+
+  @Test
+  void integerIsNullForAbsentOrNonNumeric() {
+    assertNull(Snapshots.integer(Map.of(), "k"));
+    assertNull(Snapshots.integer(Map.of("k", "notanumber"), "k"));
+  }
+
+  @Test
+  void longValueCoercesAnyNumberToItsLongValue() {
+    assertEquals(9_000_000_000L, Snapshots.longValue(Map.of("k", 9_000_000_000L), "k"));
+    assertEquals(4L, Snapshots.longValue(Map.of("k", 4), "k"));
+  }
+
+  @Test
+  void longValueIsNullForAbsentOrNonNumeric() {
+    assertNull(Snapshots.longValue(Map.of(), "k"));
+    assertNull(Snapshots.longValue(Map.of("k", "x"), "k"));
+  }
+
+  @Test
+  void stringListMapsEveryElementToItsStringForm() {
+    assertEquals(List.of("a", "b"), Snapshots.stringList(Map.of("k", List.of("a", "b")), "k"));
+    assertEquals(List.of("1", "2"), Snapshots.stringList(Map.of("k", List.of(1, 2)), "k"));
+  }
+
+  @Test
+  void stringListIsEmptyForAbsentOrNonList() {
+    assertTrue(Snapshots.stringList(Map.of(), "k").isEmpty());
+    assertTrue(Snapshots.stringList(Map.of("k", "notalist"), "k").isEmpty());
+  }
+
+  @Test
+  void actorReadsTheReservedKeyAndDefaultsToSync() {
+    assertEquals("uday", Snapshots.actor(Map.of("_actor", "uday")));
+    assertEquals("sync", Snapshots.actor(Map.of("title", "no author here")));
+    assertEquals("sync", Snapshots.actor(null));
+  }
+}


### PR DESCRIPTION
## What

First slice of the **sail-sync-journal** spec — the shared primitives the revision-journal extraction will lean on. Extracts the snapshot-read idiom into one `Snapshots` utility.

Turning one key of a decoded JSON snapshot into a typed row field (null-tolerant of absent or wrong-typed values) was hand-rolled **byte-for-byte** across the synced stores:

- `text` / `integer` / `longValue` / `stringList` — copied in `SpecStore`, `RunStore`, `ReviewStore`
- the `_actor` author lookup — copied as `authorOf` (`SpecStore`) and `actorOf` (`ProjectStore`), plus per-store `ACTOR = "_actor"` constants

## Change

- New `Snapshots` utility holds the five coercions + the reserved `ACTOR` key.
- `SpecStore`, `RunStore`, `ReviewStore`, `ProjectStore` route through it; their private `ACTOR` constants fold onto `Snapshots.ACTOR`.
- `Snapshots.actor` is the **null-safe superset** of both prior copies (a null snapshot yields `"sync"` rather than throwing), so no behavior is lost.

## Why

The revision journal's `fromSnapshot` decoding (next slice) will decode identically through this one seam instead of each store re-deriving the idiom — and it removes ~7 duplicated helper definitions today.

## Safety

Pure de-duplication, behavior-preserving. New `SnapshotsTest` covers the coercion matrix (present/absent/wrong-type for each, `_actor` default-to-sync incl. null). The full sync suite (`SpecSync`/`RunSync`/`ReviewSync`/`ProjectSync`/`FileSync`/`MessageSync`) and `mvn clean verify` are green with all coverage checks met.
