### PR TITLE
refactor(sync): extract RevisionJournal, migrate SpecStore onto it

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/EntitySchema.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/EntitySchema.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import java.util.Map;
+
+/**
+ * The store-specific half of a synced entity, supplied to {@link RevisionJournal}. The journal owns
+ * the sync <em>protocol</em> — rev minting, {@code base_rev}/tombstone bookkeeping, the
+ * compare-and-set commit, and three-way conflict resolution — identically for every mutable synced
+ * store; this strategy supplies the handful of things that genuinely differ: the entity's name, its
+ * table (which must carry {@code id}, {@code rev}, and {@code base_rev} columns), how a row
+ * projects to and from a snapshot, and who a local revision is attributed to.
+ *
+ * <p>Implemented by the five mutable synced stores (specs, runs, reviews, projects, files).
+ * Immutable or specially-authorized entities (e.g. messages) keep their own bespoke logic and do
+ * not ride this journal.
+ */
+public interface EntitySchema {
+
+  /** The {@code change_log.entity_type} discriminator for this entity, e.g. {@code "spec"}. */
+  String entityType();
+
+  /** The row table, which must have {@code id}, {@code rev}, and {@code base_rev} columns. */
+  String table();
+
+  /** Whether a live row exists for {@code id} (a tombstone is not a live row). */
+  boolean exists(String id);
+
+  /** The full current snapshot of {@code id} as a JSON-serializable map, or null if absent. */
+  Map<String, Object> snapshotMap(String id);
+
+  /**
+   * The author a <em>local</em> revision of {@code id} is attributed to in the journal — the row's
+   * own last writer (e.g. a spec's {@code updated_by}, a run's node). Null when the entity carries
+   * no per-row author.
+   */
+  String author(String id);
+
+  /**
+   * Upserts {@code id} from an authoritative {@code snapshot}, injecting the surrogate key and
+   * resolving the snapshot's {@code _actor} into the row's own author field. Runs inside the
+   * journal's transaction.
+   */
+  void apply(String id, Map<String, Object> snapshot);
+
+  /**
+   * Projects a full snapshot onto the subset that carries an FDE's actual work — the fields
+   * conflict detection compares — plus the reserved {@code _actor} attribution key, which {@link
+   * ConflictDetector} ignores. Excludes surrogate keys and timestamps so two boxes never falsely
+   * conflict on metadata.
+   */
+  Map<String, Object> comparable(Map<String, Object> full);
+
+  /**
+   * Deletes the live row for {@code id} (and any child rows). Runs inside the journal's
+   * transaction.
+   */
+  void deleteRow(String id);
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/RevisionJournal.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RevisionJournal.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.YamlUtil;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * The sync protocol every mutable synced store shares, in one place. Given an {@link EntitySchema}
+ * for a particular entity it mints revisions, keeps each row's {@code base_rev} and tombstone
+ * bookkeeping, journals every post-state into the {@link ChangeLog} within the mutating transaction
+ * (the no-lost-work spine), performs the main-side compare-and-set commit, and resolves a parked
+ * conflict by rebasing onto main and writing the chosen state.
+ *
+ * <p>Extracted from the byte-for-byte copies that lived in {@link SpecStore}, {@link RunStore},
+ * {@link ReviewStore}, {@link ProjectStore}, and {@link FileStore}: each now holds one journal and
+ * supplies only its schema. Conflict detection ignores the reserved {@code _actor} key, so
+ * per-actor attribution rides through every revision without ever causing a false conflict.
+ */
+public final class RevisionJournal implements ConflictResolver {
+
+  private static final String TOMBSTONE_BASE = "_base_rev";
+  private static final String EMPTY_SNAPSHOT = "{}";
+
+  private final Sqlite db;
+  private final ChangeLog changeLog;
+  private final EntitySchema schema;
+
+  public RevisionJournal(Sqlite db, ChangeLog changeLog, EntitySchema schema) {
+    this.db = Objects.requireNonNull(db, "db");
+    this.changeLog = Objects.requireNonNull(changeLog, "changeLog");
+    this.schema = Objects.requireNonNull(schema, "schema");
+  }
+
+  /** Every entity id this replica knows of, including those present only as a tombstone. */
+  public Set<String> entityIds() {
+    return new LinkedHashSet<>(
+        db.query(
+            "SELECT DISTINCT entity_id FROM change_log WHERE entity_type = ?",
+            row -> row.text(0),
+            schema.entityType()));
+  }
+
+  /** Comparable snapshot of the current state, or null if the entity is absent/deleted. */
+  public Map<String, Object> comparableSnapshot(String id) {
+    var map = schema.snapshotMap(id);
+    return map == null ? null : schema.comparable(map);
+  }
+
+  /** Comparable snapshot recorded at a given revision (the merge base), or null if not recorded. */
+  public Map<String, Object> comparableAtRev(String id, String rev) {
+    if (Strings.isBlank(rev)) {
+      return null;
+    }
+    return changeLog
+        .at(schema.entityType(), id, rev)
+        .map(e -> schema.comparable(YamlUtil.parseMap(e.snapshot())))
+        .orElse(null);
+  }
+
+  /** The current revision of a live row, or null if the row is absent. */
+  public String revOf(String id) {
+    var rev = currentRev(id);
+    return rev.isBlank() ? null : rev;
+  }
+
+  /** The latest revision recorded for an entity, including a tombstone; null if never recorded. */
+  public String latestRev(String id) {
+    var history = changeLog.history(schema.entityType(), id);
+    return history.isEmpty() ? null : history.getLast().rev();
+  }
+
+  /**
+   * The revision this row last synced from main. For a live row it is the {@code base_rev} column;
+   * for a locally deleted entity the row is gone, so it is recovered from the {@code _base_rev}
+   * embedded in the tombstone — without which a local delete could not be told apart from a
+   * delete-vs-edit conflict.
+   */
+  public String baseRevOf(String id) {
+    if (schema.exists(id)) {
+      return rawBaseRev(id);
+    }
+    var tombstone = changeLog.history(schema.entityType(), id);
+    if (tombstone.isEmpty()) {
+      return null;
+    }
+    return Snapshots.text(YamlUtil.parseMap(tombstone.getLast().snapshot()), TOMBSTONE_BASE);
+  }
+
+  /** Appends a revision for the current state of {@code id}, minting a rev from the counter. */
+  public String recordRevision(String id, String origin, boolean deleted) {
+    return recordRevision(id, null, origin, deleted, false);
+  }
+
+  /**
+   * Appends a revision for the current state of {@code id}. With {@code explicitRev} null the rev
+   * is minted from the current counter; otherwise the caller-supplied rev is used verbatim (sync
+   * adopting main's authoritative rev). {@code setBaseRev} records that this revision is the new
+   * synced ancestor — set only when adopting from main, never on a local edit.
+   */
+  public String recordRevision(
+      String id, String explicitRev, String origin, boolean deleted, boolean setBaseRev) {
+    var map = schema.snapshotMap(id);
+    if (map == null) {
+      return null;
+    }
+    if (deleted) {
+      map.put(TOMBSTONE_BASE, rawBaseRev(id));
+    }
+    var snapshot = YamlUtil.dumpJson(map);
+    var rev = explicitRev != null ? explicitRev : Revisions.next(currentRev(id), snapshot);
+    if (!deleted) {
+      if (setBaseRev) {
+        db.execute(
+            "UPDATE " + schema.table() + " SET rev = ?, base_rev = ? WHERE id = ?", rev, rev, id);
+      } else {
+        db.execute("UPDATE " + schema.table() + " SET rev = ? WHERE id = ?", rev, id);
+      }
+    }
+    changeLog.append(schema.entityType(), id, rev, schema.author(id), origin, deleted, snapshot);
+    return rev;
+  }
+
+  /**
+   * Writes an authoritative state from main at its exact revision (no minting), marking it the new
+   * synced ancestor ({@code base_rev = rev}). A null snapshot adopts a deletion. Used by the sync
+   * engine; the revision is journaled with origin {@code sync}.
+   */
+  public void applyRevision(String id, Map<String, Object> snapshot, String rev) {
+    db.transaction(
+        () -> {
+          if (snapshot == null) {
+            if (schema.exists(id)) {
+              recordRevision(id, rev, "sync", true, false);
+              schema.deleteRow(id);
+            } else {
+              changeLog.append(schema.entityType(), id, rev, null, "sync", true, EMPTY_SNAPSHOT);
+            }
+          } else {
+            schema.apply(id, snapshot);
+            recordRevision(id, rev, "sync", false, true);
+          }
+          return null;
+        });
+  }
+
+  /**
+   * Compare-and-set commit as main: mints a new authoritative rev only if {@code expectedRev} still
+   * equals the entity's current rev (a brand-new entity expects {@code null}); otherwise returns
+   * {@link PushOutcome.Stale} with main's present state, never overwriting a concurrent change. A
+   * null snapshot commits a deletion. The check and the write share one transaction, so two nodes
+   * pushing the same row can never both win. Used by the sync engine on the main side.
+   */
+  public PushOutcome commitRevision(String id, Map<String, Object> snapshot, String expectedRev) {
+    return db.immediateTransaction(
+        () -> {
+          if (!Objects.equals(latestRev(id), expectedRev)) {
+            return new PushOutcome.Stale(latestRev(id), comparableSnapshot(id));
+          }
+          if (snapshot == null) {
+            if (!schema.exists(id)) {
+              return new PushOutcome.Accepted(latestRev(id));
+            }
+            var rev = recordRevision(id, null, "sync", true, false);
+            schema.deleteRow(id);
+            return new PushOutcome.Accepted(rev);
+          }
+          schema.apply(id, snapshot);
+          return new PushOutcome.Accepted(recordRevision(id, null, "sync", false, false));
+        });
+  }
+
+  /**
+   * Resolves an open conflict locally by rebasing the row onto main's conflicting content {@code
+   * remote} — recorded as the new merge base, so the next sync can never re-raise the same conflict
+   * (base now equals remote) — and then writing {@code chosen} as the resolved state. When {@code
+   * chosen} differs from {@code remote} the row becomes a forward local edit the next sync pushes;
+   * when they match the row simply adopts main's value, and the earlier local version is still in
+   * the {@link ChangeLog}. A {@code null} side is a deletion. Returns the rev the row now carries.
+   * No work is ever lost: every state is journaled.
+   */
+  @Override
+  public String resolveConflict(String id, Map<String, Object> chosen, Map<String, Object> remote) {
+    return db.transaction(
+        () -> {
+          var baseRev = adoptBase(id, remote);
+          if (sameContent(chosen, remote)) {
+            return baseRev;
+          }
+          return writeChosen(id, chosen);
+        });
+  }
+
+  private String adoptBase(String id, Map<String, Object> remote) {
+    if (remote == null) {
+      if (schema.exists(id)) {
+        var rev = recordRevision(id, null, "sync", true, false);
+        schema.deleteRow(id);
+        return rev;
+      }
+      var rev = Revisions.next(currentRev(id), EMPTY_SNAPSHOT);
+      changeLog.append(schema.entityType(), id, rev, null, "sync", true, EMPTY_SNAPSHOT);
+      return rev;
+    }
+    schema.apply(id, remote);
+    return recordRevision(id, null, "sync", false, true);
+  }
+
+  private String writeChosen(String id, Map<String, Object> chosen) {
+    if (chosen == null) {
+      if (!schema.exists(id)) {
+        return latestRev(id);
+      }
+      var rev = recordRevision(id, null, "resolve", true, false);
+      schema.deleteRow(id);
+      return rev;
+    }
+    schema.apply(id, chosen);
+    return recordRevision(id, null, "resolve", false, false);
+  }
+
+  private static boolean sameContent(Map<String, Object> a, Map<String, Object> b) {
+    if (a == null || b == null) {
+      return a == b;
+    }
+    var keys = new LinkedHashSet<String>();
+    keys.addAll(a.keySet());
+    keys.addAll(b.keySet());
+    return keys.stream()
+        .filter(key -> !key.startsWith("_"))
+        .allMatch(key -> Objects.equals(a.get(key), b.get(key)));
+  }
+
+  private String rawBaseRev(String id) {
+    var value =
+        db.queryOne(
+                "SELECT COALESCE(base_rev, '') FROM " + schema.table() + " WHERE id = ?",
+                row -> row.text(0),
+                id)
+            .orElse("");
+    return value.isBlank() ? null : value;
+  }
+
+  private String currentRev(String id) {
+    return db.queryOne(
+            "SELECT COALESCE(rev, '') FROM " + schema.table() + " WHERE id = ?",
+            row -> row.text(0),
+            id)
+        .orElse("");
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -12,10 +12,8 @@ import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.config.YamlUtil;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -33,10 +31,12 @@ public final class SpecStore implements ConflictResolver {
 
   private final Sqlite db;
   private final ChangeLog changeLog;
+  private final RevisionJournal journal;
 
   public SpecStore(Sqlite db) {
     this.db = db;
     this.changeLog = new ChangeLog(db);
+    this.journal = new RevisionJournal(db, changeLog, new SpecSchema());
   }
 
   public record SpecRow(
@@ -493,52 +493,7 @@ public final class SpecStore implements ConflictResolver {
   }
 
   String recordRevision(String id, String origin, boolean deleted) {
-    return recordRevision(id, null, origin, deleted, false);
-  }
-
-  /**
-   * Appends a revision for the current state of {@code id}. With {@code explicitRev} null the rev
-   * is minted from the current counter; otherwise the caller-supplied rev is used verbatim (sync
-   * adopting main's authoritative rev). {@code setBaseRev} records that this revision is the new
-   * synced ancestor — set only when adopting from main, never on a local edit.
-   */
-  private String recordRevision(
-      String id, String explicitRev, String origin, boolean deleted, boolean setBaseRev) {
-    var spec = findById(id).orElse(null);
-    if (spec == null) {
-      return null;
-    }
-    var map = snapshotMap(spec);
-    if (deleted) {
-      map.put("_base_rev", rawBaseRev(id));
-    }
-    var snapshot = YamlUtil.dumpJson(map);
-    var rev = explicitRev != null ? explicitRev : Revisions.next(currentRev(id), snapshot);
-    if (!deleted) {
-      if (setBaseRev) {
-        db.execute("UPDATE specs SET rev = ?, base_rev = ? WHERE id = ?", rev, rev, id);
-      } else {
-        db.execute("UPDATE specs SET rev = ? WHERE id = ?", rev, id);
-      }
-    }
-    changeLog.append(ENTITY, id, rev, spec.updatedBy(), origin, deleted, snapshot);
-    return rev;
-  }
-
-  private String rawBaseRev(String id) {
-    var value =
-        db.queryOne("SELECT COALESCE(base_rev, '') FROM specs WHERE id = ?", row -> row.text(0), id)
-            .orElse("");
-    return value.isBlank() ? null : value;
-  }
-
-  private String currentRev(String id) {
-    return db.queryOne("SELECT COALESCE(rev, '') FROM specs WHERE id = ?", row -> row.text(0), id)
-        .orElse("");
-  }
-
-  private String snapshotJson(SpecRow spec) {
-    return YamlUtil.dumpJson(snapshotMap(spec));
+    return journal.recordRevision(id, origin, deleted);
   }
 
   private Map<String, Object> snapshotMap(SpecRow spec) {
@@ -695,38 +650,23 @@ public final class SpecStore implements ConflictResolver {
     return m;
   }
 
-  /**
-   * Reserved metadata key carrying the author of a revision through the sync protocol. It rides
-   * inside the comparable snapshot but {@link ConflictDetector} ignores reserved ({@code
-   * _}-prefixed) keys, so attribution propagates without ever causing a false conflict. The
-   * receiving side reads it to attribute the synced row to its real author instead of {@code sync}.
-   */
-
   /** Comparable snapshot of the current state, or null if the spec is absent/deleted. */
   public Map<String, Object> comparableSnapshot(String id) {
-    return findById(id).map(this::snapshotMap).map(SpecStore::comparable).orElse(null);
+    return journal.comparableSnapshot(id);
   }
 
   /** Comparable snapshot recorded at a given revision (the merge base), or null if not recorded. */
   public Map<String, Object> comparableAtRev(String id, String rev) {
-    if (Strings.isBlank(rev)) {
-      return null;
-    }
-    return changeLog
-        .at(ENTITY, id, rev)
-        .map(e -> comparable(YamlUtil.parseMap(e.snapshot())))
-        .orElse(null);
+    return journal.comparableAtRev(id, rev);
   }
 
   public String revOf(String id) {
-    var rev = currentRev(id);
-    return rev.isBlank() ? null : rev;
+    return journal.revOf(id);
   }
 
   /** The latest revision recorded for an entity, including a tombstone; null if never recorded. */
   public String latestRev(String id) {
-    var history = changeLog.history(ENTITY, id);
-    return history.isEmpty() ? null : history.getLast().rev();
+    return journal.latestRev(id);
   }
 
   /**
@@ -736,24 +676,12 @@ public final class SpecStore implements ConflictResolver {
    * delete-vs-edit conflict.
    */
   public String baseRevOf(String id) {
-    if (findById(id).isPresent()) {
-      return rawBaseRev(id);
-    }
-    var tombstone = changeLog.history(ENTITY, id);
-    if (tombstone.isEmpty()) {
-      return null;
-    }
-    var baseRev = YamlUtil.parseMap(tombstone.getLast().snapshot()).get("_base_rev");
-    return baseRev == null ? null : baseRev.toString();
+    return journal.baseRevOf(id);
   }
 
   /** Every entity id this replica knows of, including those only present as a tombstone. */
   public Set<String> syncEntityIds() {
-    return new LinkedHashSet<>(
-        db.query(
-            "SELECT DISTINCT entity_id FROM change_log WHERE entity_type = ?",
-            row -> row.text(0),
-            ENTITY));
+    return journal.entityIds();
   }
 
   /** Attributes a spec solely for the retained versioned 0.14 data migration. */
@@ -780,23 +708,7 @@ public final class SpecStore implements ConflictResolver {
    * engine; the revision is journaled with origin {@code sync}.
    */
   public void applyRevision(String id, Map<String, Object> snapshot, String rev) {
-    db.transaction(
-        () -> {
-          if (snapshot == null) {
-            if (findById(id).isPresent()) {
-              recordRevision(id, rev, "sync", true, false);
-              db.execute("DELETE FROM specs WHERE id = ?", id);
-            } else {
-              changeLog.append(ENTITY, id, rev, null, "sync", true, "{}");
-            }
-          } else {
-            var full = new LinkedHashMap<>(snapshot);
-            full.put("id", id);
-            full.put("updated_by", Snapshots.actor(snapshot));
-            applySnapshot(id, full);
-            recordRevision(id, rev, "sync", false, true);
-          }
-        });
+    journal.applyRevision(id, snapshot, rev);
   }
 
   /**
@@ -807,25 +719,7 @@ public final class SpecStore implements ConflictResolver {
    * pushing the same row can never both win. Used by the sync engine on the main side.
    */
   public PushOutcome commitRevision(String id, Map<String, Object> snapshot, String expectedRev) {
-    return db.immediateTransaction(
-        () -> {
-          if (!Objects.equals(latestRev(id), expectedRev)) {
-            return new PushOutcome.Stale(latestRev(id), comparableSnapshot(id));
-          }
-          if (snapshot == null) {
-            if (findById(id).isEmpty()) {
-              return new PushOutcome.Accepted(latestRev(id));
-            }
-            var rev = recordRevision(id, null, "sync", true, false);
-            db.execute("DELETE FROM specs WHERE id = ?", id);
-            return new PushOutcome.Accepted(rev);
-          }
-          var full = new LinkedHashMap<>(snapshot);
-          full.put("id", id);
-          full.put("updated_by", Snapshots.actor(snapshot));
-          applySnapshot(id, full);
-          return new PushOutcome.Accepted(recordRevision(id, null, "sync", false, false));
-        });
+    return journal.commitRevision(id, snapshot, expectedRev);
   }
 
   /**
@@ -837,43 +731,9 @@ public final class SpecStore implements ConflictResolver {
    * earlier local version is still in the {@link ChangeLog}. A {@code null} side is a deletion.
    * Returns the rev the row now carries. No work is ever lost: every state is journaled.
    */
+  @Override
   public String resolveConflict(String id, Map<String, Object> chosen, Map<String, Object> remote) {
-    return db.transaction(
-        () -> {
-          var baseRev = adoptBase(id, remote);
-          if (sameContent(chosen, remote)) {
-            return baseRev;
-          }
-          return writeChosen(id, chosen);
-        });
-  }
-
-  private String adoptBase(String id, Map<String, Object> remote) {
-    if (remote == null) {
-      if (findById(id).isPresent()) {
-        var rev = recordRevision(id, null, "sync", true, false);
-        db.execute("DELETE FROM specs WHERE id = ?", id);
-        return rev;
-      }
-      var rev = Revisions.next(currentRev(id), "{}");
-      changeLog.append(ENTITY, id, rev, null, "sync", true, "{}");
-      return rev;
-    }
-    applySnapshot(id, withSync(id, remote));
-    return recordRevision(id, null, "sync", false, true);
-  }
-
-  private String writeChosen(String id, Map<String, Object> chosen) {
-    if (chosen == null) {
-      if (findById(id).isEmpty()) {
-        return latestRev(id);
-      }
-      var rev = recordRevision(id, null, "resolve", true, false);
-      db.execute("DELETE FROM specs WHERE id = ?", id);
-      return rev;
-    }
-    applySnapshot(id, withSync(id, chosen));
-    return recordRevision(id, null, "resolve", false, false);
+    return journal.resolveConflict(id, chosen, remote);
   }
 
   private static Map<String, Object> withSync(String id, Map<String, Object> snapshot) {
@@ -883,16 +743,48 @@ public final class SpecStore implements ConflictResolver {
     return full;
   }
 
-  private static boolean sameContent(Map<String, Object> a, Map<String, Object> b) {
-    if (a == null || b == null) {
-      return a == b;
+  /** The spec's store-specific half of the shared {@link RevisionJournal} sync protocol. */
+  private final class SpecSchema implements EntitySchema {
+
+    @Override
+    public String entityType() {
+      return ENTITY;
     }
-    var keys = new LinkedHashSet<String>();
-    keys.addAll(a.keySet());
-    keys.addAll(b.keySet());
-    return keys.stream()
-        .filter(key -> !key.startsWith("_"))
-        .allMatch(key -> Objects.equals(a.get(key), b.get(key)));
+
+    @Override
+    public String table() {
+      return "specs";
+    }
+
+    @Override
+    public boolean exists(String id) {
+      return findById(id).isPresent();
+    }
+
+    @Override
+    public Map<String, Object> snapshotMap(String id) {
+      return findById(id).map(SpecStore.this::snapshotMap).orElse(null);
+    }
+
+    @Override
+    public String author(String id) {
+      return findById(id).map(SpecRow::updatedBy).orElse(null);
+    }
+
+    @Override
+    public void apply(String id, Map<String, Object> snapshot) {
+      applySnapshot(id, withSync(id, snapshot));
+    }
+
+    @Override
+    public Map<String, Object> comparable(Map<String, Object> full) {
+      return SpecStore.comparable(full);
+    }
+
+    @Override
+    public void deleteRow(String id) {
+      db.execute("DELETE FROM specs WHERE id = ?", id);
+    }
   }
 
   public Optional<SpecContent> getContent(String specId) {

--- a/sail-core/src/test/java/ai/singlr/sail/store/RevisionJournalTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RevisionJournalTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The sync protocol in isolation, driven through a minimal {@code widget} entity so the journal's
+ * behavior is asserted directly rather than only through a store: rev minting, adopting an
+ * authoritative revision, the compare-and-set commit (accept on a matching expected rev, reject as
+ * stale otherwise), conflict resolution (take-remote vs keep-local), and {@code base_rev} recovery
+ * from a tombstone after a local delete.
+ */
+class RevisionJournalTest {
+
+  @TempDir Path tempDir;
+
+  private Sqlite db;
+  private RevisionJournal journal;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("journal.db"));
+    new SchemaManager(db).migrate();
+    db.execute(
+        "CREATE TABLE widgets (id TEXT PRIMARY KEY, value TEXT, updated_by TEXT, rev TEXT,"
+            + " base_rev TEXT)");
+    journal = new RevisionJournal(db, new ChangeLog(db), new WidgetSchema(db));
+  }
+
+  private void createWidget(String id, String value, String author) {
+    db.transaction(
+        () -> {
+          db.execute(
+              "INSERT INTO widgets (id, value, updated_by) VALUES (?, ?, ?)", id, value, author);
+          journal.recordRevision(id, "local", false);
+          return null;
+        });
+  }
+
+  private static Map<String, Object> snapshot(String value, String actor) {
+    var m = new LinkedHashMap<String, Object>();
+    m.put("value", value);
+    m.put(Snapshots.ACTOR, actor);
+    return m;
+  }
+
+  @Test
+  void recordRevisionMintsARevAndJournalsTheState() {
+    createWidget("w1", "hello", "uday");
+
+    assertEquals(journal.revOf("w1"), journal.latestRev("w1"));
+    assertEquals("hello", journal.comparableSnapshot("w1").get("value"));
+    assertEquals("uday", journal.comparableSnapshot("w1").get(Snapshots.ACTOR));
+    assertTrue(journal.entityIds().contains("w1"));
+  }
+
+  @Test
+  void applyRevisionAdoptsRemoteAtItsExactRevAndSetsTheBase() {
+    journal.applyRevision("w2", snapshot("remote", "bob"), "5-abc");
+
+    assertEquals("remote", journal.comparableSnapshot("w2").get("value"));
+    assertEquals("bob", journal.comparableSnapshot("w2").get(Snapshots.ACTOR));
+    assertEquals("5-abc", journal.latestRev("w2"));
+    assertEquals("5-abc", journal.baseRevOf("w2"));
+  }
+
+  @Test
+  void applyRevisionWithNullDeletesAndRecoversBaseFromTheTombstone() {
+    journal.applyRevision("w3", snapshot("v", "bob"), "3-aaa");
+
+    journal.applyRevision("w3", null, "4-bbb");
+
+    assertFalse(new WidgetSchema(db).exists("w3"));
+    assertEquals("4-bbb", journal.latestRev("w3"));
+    assertEquals("3-aaa", journal.baseRevOf("w3"));
+    assertNull(journal.comparableSnapshot("w3"));
+    assertTrue(journal.entityIds().contains("w3"));
+  }
+
+  @Test
+  void commitRevisionAcceptsWhenTheExpectedRevMatches() {
+    createWidget("w4", "one", "uday");
+    var current = journal.latestRev("w4");
+
+    var outcome = journal.commitRevision("w4", snapshot("two", "uday"), current);
+
+    var accepted = assertInstanceOf(PushOutcome.Accepted.class, outcome);
+    assertNotEquals(current, accepted.rev());
+    assertEquals("two", journal.comparableSnapshot("w4").get("value"));
+  }
+
+  @Test
+  void commitRevisionRejectsAStaleExpectedRevWithoutOverwriting() {
+    createWidget("w5", "kept", "uday");
+    var current = journal.latestRev("w5");
+
+    var outcome = journal.commitRevision("w5", snapshot("clobber", "bob"), "0-stale");
+
+    var stale = assertInstanceOf(PushOutcome.Stale.class, outcome);
+    assertEquals(current, stale.currentRev());
+    assertEquals("kept", journal.comparableSnapshot("w5").get("value"));
+  }
+
+  @Test
+  void commitRevisionForABrandNewEntityExpectsNull() {
+    var outcome = journal.commitRevision("w6", snapshot("fresh", "uday"), null);
+
+    assertInstanceOf(PushOutcome.Accepted.class, outcome);
+    assertEquals("fresh", journal.comparableSnapshot("w6").get("value"));
+  }
+
+  @Test
+  void resolveConflictTakingRemoteAdoptsTheBaseAndKeepsNoForwardEdit() {
+    createWidget("w7", "mine", "uday");
+    var remote = snapshot("theirs", "bob");
+
+    var rev = journal.resolveConflict("w7", remote, remote);
+
+    assertEquals("theirs", journal.comparableSnapshot("w7").get("value"));
+    assertEquals(rev, journal.baseRevOf("w7"));
+    assertEquals(rev, journal.latestRev("w7"));
+  }
+
+  @Test
+  void resolveConflictKeepingLocalRebasesOntoRemoteThenWritesTheChosenState() {
+    createWidget("w8", "original", "uday");
+    var remote = snapshot("theirs", "bob");
+    var chosen = snapshot("mine-wins", "uday");
+
+    var rev = journal.resolveConflict("w8", chosen, remote);
+
+    assertEquals("mine-wins", journal.comparableSnapshot("w8").get("value"));
+    assertEquals(rev, journal.latestRev("w8"));
+    assertNotEquals(rev, journal.baseRevOf("w8"));
+  }
+
+  @Test
+  void resolveConflictWithBothSidesDeletedTombstonesTheRow() {
+    createWidget("w9", "doomed", "uday");
+
+    journal.resolveConflict("w9", null, null);
+
+    assertFalse(new WidgetSchema(db).exists("w9"));
+    assertNull(journal.comparableSnapshot("w9"));
+  }
+
+  @Test
+  void comparableAtRevReadsTheHistoricalStateNotTheCurrentOne() {
+    createWidget("w10", "first", "uday");
+    var firstRev = journal.latestRev("w10");
+    db.transaction(
+        () -> {
+          db.execute("UPDATE widgets SET value = ? WHERE id = ?", "second", "w10");
+          journal.recordRevision("w10", "local", false);
+          return null;
+        });
+
+    assertEquals("first", journal.comparableAtRev("w10", firstRev).get("value"));
+    assertEquals("second", journal.comparableSnapshot("w10").get("value"));
+    assertNull(journal.comparableAtRev("w10", null));
+  }
+
+  private static final class WidgetSchema implements EntitySchema {
+
+    private final Sqlite db;
+
+    WidgetSchema(Sqlite db) {
+      this.db = db;
+    }
+
+    @Override
+    public String entityType() {
+      return "widget";
+    }
+
+    @Override
+    public String table() {
+      return "widgets";
+    }
+
+    @Override
+    public boolean exists(String id) {
+      return db.queryOne("SELECT 1 FROM widgets WHERE id = ?", row -> row.integer(0), id)
+          .isPresent();
+    }
+
+    @Override
+    public Map<String, Object> snapshotMap(String id) {
+      return db.queryOne(
+              "SELECT id, value, updated_by FROM widgets WHERE id = ?",
+              row -> {
+                var m = new LinkedHashMap<String, Object>();
+                m.put("id", row.text(0));
+                m.put("value", row.text(1));
+                m.put("updated_by", row.text(2));
+                return m;
+              },
+              id)
+          .orElse(null);
+    }
+
+    @Override
+    public String author(String id) {
+      return db.queryOne("SELECT updated_by FROM widgets WHERE id = ?", row -> row.text(0), id)
+          .orElse(null);
+    }
+
+    @Override
+    public void apply(String id, Map<String, Object> snapshot) {
+      var value = Snapshots.text(snapshot, "value");
+      var author = Snapshots.actor(snapshot);
+      if (exists(id)) {
+        db.execute("UPDATE widgets SET value = ?, updated_by = ? WHERE id = ?", value, author, id);
+      } else {
+        db.execute(
+            "INSERT INTO widgets (id, value, updated_by) VALUES (?, ?, ?)", id, value, author);
+      }
+    }
+
+    @Override
+    public Map<String, Object> comparable(Map<String, Object> full) {
+      var m = new LinkedHashMap<String, Object>();
+      if (full.containsKey("value")) {
+        m.put("value", full.get("value"));
+      }
+      var author = full.get("updated_by");
+      if (author != null) {
+        m.put(Snapshots.ACTOR, author);
+      }
+      return m;
+    }
+
+    @Override
+    public void deleteRow(String id) {
+      db.execute("DELETE FROM widgets WHERE id = ?", id);
+    }
+  }
+}


### PR DESCRIPTION
## What

The core of the **sail-sync-journal** spec: extract the revision-journal / three-way-merge / CAS / tombstone protocol — duplicated byte-for-byte across the mutable synced stores — into one `RevisionJournal`, and migrate the first store (SpecStore) onto it.

## Design

`RevisionJournal` owns the sync **protocol** (identical for every mutable synced store):
- rev minting + `base_rev`/tombstone bookkeeping, journaling every post-state in the mutating transaction (the no-lost-work spine)
- the main-side compare-and-set `commitRevision`
- conflict resolution: adopt-base → same-content → write-chosen

An `EntitySchema` strategy supplies only what genuinely differs per store: the entity name, its table (with `id`/`rev`/`base_rev` columns), how a row projects to/from a snapshot, and — the one that really varies — **who a local revision is attributed to** in the changelog (a spec's `updated_by`, a run's `node`, a review's spec id).

SpecStore keeps its CRUD + a small nested `SpecSchema` and delegates its eight sync methods to the journal, shedding **~160 lines** (1068 → 949) of the hardest, incident-prone code in the repo — the `run_principals` divergence the spec cites lived in exactly these copies.

## TDD

New `RevisionJournalTest` drives the merge matrix **directly** through a minimal `widget` entity — behavior previously only tested indirectly, per store:
- rev minting + journaling
- adopt-at-exact-rev (sets base)
- CAS commit: accept on matching expected rev, reject stale without overwriting, new-entity-expects-null
- conflict resolution: take-remote (adopt base) vs keep-local (rebase then forward-edit) vs both-deleted
- `base_rev` recovery from a tombstone after a local delete
- `comparableAtRev` reads history, not current

## Safety

Behavior-preserving extraction. SpecStore's full suite, `SpecSyncTest`, `SyncEngineTest`, and the conflict/merge tests pass **unchanged**; `mvn clean verify` is green with all coverage checks met. The reserved `_actor` attribution key still rides through every revision untouched (conflict detection ignores it).

## Next

Migrate `RunStore`, `ReviewStore`, `ProjectStore`, `FileStore` (each ~150 lines lighter), then collapse the six near-verbatim sync replicas into one generic `StoreReplica`. `MessageStore` stays bespoke (immutable, custom authorization — it shares only the method names, not the bodies).
