### PR TITLE
refactor(sync): migrate FileStore onto RevisionJournal

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FileStore.java
@@ -6,7 +6,6 @@
 package ai.singlr.sail.store;
 
 import ai.singlr.sail.common.DateTimeUtils;
-import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -32,10 +31,12 @@ public final class FileStore implements ConflictResolver {
 
   private final Sqlite db;
   private final ChangeLog changeLog;
+  private final RevisionJournal journal;
 
   public FileStore(Sqlite db) {
     this.db = db;
     this.changeLog = new ChangeLog(db);
+    this.journal = new RevisionJournal(db, changeLog, new FileSchema());
   }
 
   public record FileRow(String project, String path, String content) {}
@@ -51,7 +52,7 @@ public final class FileStore implements ConflictResolver {
     db.transaction(
         () -> {
           writeRow(row);
-          recordRevision(row, null, "local", false, false);
+          journal.recordRevision(idOf(project, path), "local", false);
         });
   }
 
@@ -63,7 +64,7 @@ public final class FileStore implements ConflictResolver {
           if (row == null) {
             return false;
           }
-          recordRevision(row, null, "local", true, false);
+          journal.recordRevision(idOf(project, path), "local", true);
           db.execute("DELETE FROM project_files WHERE id = ?", idOf(project, path));
           return true;
         });
@@ -105,7 +106,7 @@ public final class FileStore implements ConflictResolver {
   }
 
   public Map<String, Object> comparableSnapshot(String id) {
-    return findRow(id).map(row -> comparable(row.content())).orElse(null);
+    return journal.comparableSnapshot(id);
   }
 
   /** Every file id this box has touched for a project, including tombstoned ones. */
@@ -138,76 +139,31 @@ public final class FileStore implements ConflictResolver {
   }
 
   public Map<String, Object> comparableAtRev(String id, String rev) {
-    if (Strings.isBlank(rev)) {
-      return null;
-    }
-    return changeLog
-        .at(ENTITY, id, rev)
-        .map(e -> comparable((String) YamlUtil.parseMap(e.snapshot()).get("content")))
-        .orElse(null);
+    return journal.comparableAtRev(id, rev);
   }
 
   public String latestRev(String id) {
-    var history = changeLog.history(ENTITY, id);
-    return history.isEmpty() ? null : history.getLast().rev();
+    return journal.latestRev(id);
   }
 
   public String baseRevOf(String id) {
-    if (findRow(id).isPresent()) {
-      return rawBaseRev(id);
-    }
-    var tombstone = changeLog.history(ENTITY, id);
-    if (tombstone.isEmpty()) {
-      return null;
-    }
-    var baseRev = YamlUtil.parseMap(tombstone.getLast().snapshot()).get("_base_rev");
-    return baseRev == null ? null : baseRev.toString();
+    return journal.baseRevOf(id);
   }
 
   public LinkedHashSet<String> syncEntityIds() {
-    return new LinkedHashSet<>(
-        db.query(
-            "SELECT DISTINCT entity_id FROM change_log WHERE entity_type = ?",
-            row -> row.text(0),
-            ENTITY));
+    return new LinkedHashSet<>(journal.entityIds());
   }
 
   /**
    * Adopts main's authoritative state at its exact rev (no minting), as the new synced ancestor.
    */
   public void applyRevision(String id, Map<String, Object> snapshot, String rev) {
-    db.transaction(
-        () -> {
-          if (snapshot == null) {
-            adoptDeletion(id, rev);
-          } else {
-            var row = rowFrom(id, snapshot);
-            writeRow(row);
-            recordRevision(row, rev, "sync", false, true);
-          }
-        });
+    journal.applyRevision(id, snapshot, rev);
   }
 
   /** Compare-and-set commit as main: accepts only if {@code expectedRev} still matches. */
   public PushOutcome commitRevision(String id, Map<String, Object> snapshot, String expectedRev) {
-    return db.immediateTransaction(
-        () -> {
-          if (!Objects.equals(latestRev(id), expectedRev)) {
-            return new PushOutcome.Stale(latestRev(id), comparableSnapshot(id));
-          }
-          if (snapshot == null) {
-            var present = findRow(id).orElse(null);
-            if (present == null) {
-              return new PushOutcome.Accepted(latestRev(id));
-            }
-            var rev = recordRevision(present, null, "sync", true, false);
-            db.execute("DELETE FROM project_files WHERE id = ?", id);
-            return new PushOutcome.Accepted(rev);
-          }
-          var row = rowFrom(id, snapshot);
-          writeRow(row);
-          return new PushOutcome.Accepted(recordRevision(row, null, "sync", false, false));
-        });
+    return journal.commitRevision(id, snapshot, expectedRev);
   }
 
   /**
@@ -220,87 +176,7 @@ public final class FileStore implements ConflictResolver {
    */
   @Override
   public String resolveConflict(String id, Map<String, Object> chosen, Map<String, Object> remote) {
-    return db.transaction(
-        () -> {
-          var baseRev = adoptBase(id, remote);
-          if (Objects.equals(contentOf(chosen), contentOf(remote))) {
-            return baseRev;
-          }
-          return writeChosen(id, chosen);
-        });
-  }
-
-  private String adoptBase(String id, Map<String, Object> remote) {
-    if (remote == null) {
-      return adoptBaseDeletion(id);
-    }
-    var row = rowFrom(id, remote);
-    writeRow(row);
-    return recordRevision(row, null, "sync", false, true);
-  }
-
-  private String adoptBaseDeletion(String id) {
-    var present = findRow(id).orElse(null);
-    if (present == null) {
-      var rev = Revisions.next(currentRev(id), "{}");
-      changeLog.append(ENTITY, id, rev, null, "sync", true, "{}");
-      return rev;
-    }
-    var rev = recordRevision(present, null, "sync", true, false);
-    db.execute("DELETE FROM project_files WHERE id = ?", id);
-    return rev;
-  }
-
-  private String writeChosen(String id, Map<String, Object> chosen) {
-    if (chosen == null) {
-      var present = findRow(id).orElse(null);
-      if (present == null) {
-        return latestRev(id);
-      }
-      var rev = recordRevision(present, null, "resolve", true, false);
-      db.execute("DELETE FROM project_files WHERE id = ?", id);
-      return rev;
-    }
-    var row = rowFrom(id, chosen);
-    writeRow(row);
-    return recordRevision(row, null, "resolve", false, false);
-  }
-
-  private static String contentOf(Map<String, Object> snapshot) {
-    return snapshot == null ? null : (String) snapshot.get("content");
-  }
-
-  private void adoptDeletion(String id, String rev) {
-    var present = findRow(id).orElse(null);
-    if (present == null) {
-      changeLog.append(ENTITY, id, rev, null, "sync", true, "{}");
-      return;
-    }
-    recordRevision(present, rev, "sync", true, false);
-    db.execute("DELETE FROM project_files WHERE id = ?", id);
-  }
-
-  private String recordRevision(
-      FileRow row, String explicitRev, String origin, boolean deleted, boolean setBaseRev) {
-    var id = idOf(row.project(), row.path());
-    var map = new LinkedHashMap<String, Object>();
-    map.put("project", row.project());
-    map.put("path", row.path());
-    map.put("content", row.content());
-    if (deleted) {
-      map.put("_base_rev", rawBaseRev(id));
-    }
-    var snapshot = YamlUtil.dumpJson(map);
-    var rev = explicitRev != null ? explicitRev : Revisions.next(currentRev(id), snapshot);
-    if (!deleted) {
-      if (setBaseRev) {
-        db.execute("UPDATE project_files SET rev = ?, base_rev = ? WHERE id = ?", rev, rev, id);
-      } else {
-        db.execute("UPDATE project_files SET rev = ? WHERE id = ?", rev, id);
-      }
-    }
-    changeLog.append(ENTITY, id, rev, null, origin, deleted, snapshot);
-    return rev;
+    return journal.resolveConflict(id, chosen, remote);
   }
 
   private void writeRow(FileRow row) {
@@ -333,25 +209,62 @@ public final class FileStore implements ConflictResolver {
     return new FileRow(row.text(0), row.text(1), row.text(2));
   }
 
-  private String rawBaseRev(String id) {
-    var value =
-        db.queryOne(
-                "SELECT COALESCE(base_rev, '') FROM project_files WHERE id = ?",
-                row -> row.text(0),
-                id)
-            .orElse("");
-    return value.isBlank() ? null : value;
-  }
-
-  private String currentRev(String id) {
-    return db.queryOne(
-            "SELECT COALESCE(rev, '') FROM project_files WHERE id = ?", row -> row.text(0), id)
-        .orElse("");
-  }
-
   private static Map<String, Object> comparable(String content) {
     var map = new LinkedHashMap<String, Object>();
     map.put("content", content);
     return map;
+  }
+
+  /** The file's store-specific half of the shared {@link RevisionJournal} sync protocol. */
+  private final class FileSchema implements EntitySchema {
+
+    @Override
+    public String entityType() {
+      return ENTITY;
+    }
+
+    @Override
+    public String table() {
+      return "project_files";
+    }
+
+    @Override
+    public boolean exists(String id) {
+      return findRow(id).isPresent();
+    }
+
+    @Override
+    public Map<String, Object> snapshotMap(String id) {
+      return findRow(id)
+          .map(
+              row -> {
+                var map = new LinkedHashMap<String, Object>();
+                map.put("project", row.project());
+                map.put("path", row.path());
+                map.put("content", row.content());
+                return (Map<String, Object>) map;
+              })
+          .orElse(null);
+    }
+
+    @Override
+    public String author(String id) {
+      return null;
+    }
+
+    @Override
+    public void apply(String id, Map<String, Object> snapshot) {
+      writeRow(rowFrom(id, snapshot));
+    }
+
+    @Override
+    public Map<String, Object> comparable(Map<String, Object> full) {
+      return FileStore.comparable(Snapshots.text(full, "content"));
+    }
+
+    @Override
+    public void deleteRow(String id) {
+      db.execute("DELETE FROM project_files WHERE id = ?", id);
+    }
   }
 }


### PR DESCRIPTION
## What

Fourth store onto the shared `RevisionJournal` (after Spec #220, Run #221, Review #222).

FileStore is the **clean symmetric case**: a content blob keyed by `project/path`, **no per-row author** (revisions attribute to null), and a `comparable` that projects to `content` alone — identical for the current row and any historical revision, so no attribution asymmetry to reconcile.

FileStore keeps its row/content helpers + a small nested `FileSchema` and delegates its sync methods to the journal, dropping the duplicated protocol: **357 → 270 lines**.

## Safety

Behavior-preserving. FileStore's suite (20 tests) and `FileSyncTest` pass **unchanged**; `mvn clean verify` green, all coverage met.

## Status of the arc

Four of the five mutable synced stores now ride one journal: Spec, Run, Review, File. **ProjectStore** is the remaining one — it carries genuinely store-specific sync semantics (a rename *resurrection-blocking* tombstone marker, and an `_actor` attribution path) that need care, so it gets its own focused pass rather than being forced to fit. `MessageStore` stays bespoke (immutable + custom authorization). After ProjectStore: collapse the six near-verbatim sync replicas into one generic `StoreReplica`.
