### PR TITLE
refactor(common): extract Secrets.mint for token generation

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/common/Secrets.java
+++ b/sail-core/src/main/java/ai/singlr/sail/common/Secrets.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.common;
+
+import java.security.SecureRandom;
+import java.util.HexFormat;
+
+/**
+ * Mints unguessable secrets — the bearer tokens, credentials, and tickets every store hands out.
+ * One shared, thread-safe {@link SecureRandom} behind a single idiom (random bytes, hex-encoded,
+ * optionally prefixed) so token generation reads identically everywhere instead of each store
+ * hand-rolling the same {@code new byte[]} / {@code nextBytes} / {@code formatHex} dance.
+ */
+public final class Secrets {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+  private static final int DEFAULT_BYTES = 32;
+
+  private Secrets() {}
+
+  /** A {@code <prefix>_<hex>} secret over 32 random bytes — the common bearer-token shape. */
+  public static String mint(String prefix) {
+    return mint(prefix, DEFAULT_BYTES);
+  }
+
+  /** A {@code <prefix>_<hex>} secret over {@code bytes} random bytes. */
+  public static String mint(String prefix, int bytes) {
+    return prefix + "_" + hex(bytes);
+  }
+
+  /** Hex of {@code bytes} random bytes, unprefixed — for values that carry their own framing. */
+  public static String hex(int bytes) {
+    var value = new byte[bytes];
+    RANDOM.nextBytes(value);
+    return HexFormat.of().formatHex(value);
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/AuthSessionStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/AuthSessionStore.java
@@ -6,9 +6,9 @@
 package ai.singlr.sail.store;
 
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Secrets;
 import ai.singlr.sail.webauthn.Hashes;
 import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HexFormat;
@@ -79,9 +79,7 @@ public final class AuthSessionStore {
   }
 
   private static String generateToken() {
-    var bytes = new byte[32];
-    new SecureRandom().nextBytes(bytes);
-    return "sess_" + HexFormat.of().formatHex(bytes);
+    return Secrets.mint("sess");
   }
 
   private static String sha256(String input) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/BoxCredentialStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/BoxCredentialStore.java
@@ -6,9 +6,8 @@
 package ai.singlr.sail.store;
 
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Secrets;
 import ai.singlr.sail.common.Strings;
-import java.security.SecureRandom;
-import java.util.HexFormat;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -32,9 +31,7 @@ public final class BoxCredentialStore {
     if (Strings.isBlank(handle)) {
       throw new IllegalArgumentException("box credential handle is required");
     }
-    var bytes = new byte[32];
-    new SecureRandom().nextBytes(bytes);
-    var credential = "sailbox_" + HexFormat.of().formatHex(bytes);
+    var credential = Secrets.mint("sailbox");
     db.execute(
         """
         INSERT INTO box_credential (id, handle, credential_hash, created_at)

--- a/sail-core/src/main/java/ai/singlr/sail/store/EnrollmentTicketStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/EnrollmentTicketStore.java
@@ -6,9 +6,9 @@
 package ai.singlr.sail.store;
 
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Secrets;
 import ai.singlr.sail.webauthn.Hashes;
 import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HexFormat;
@@ -89,9 +89,7 @@ public final class EnrollmentTicketStore {
   }
 
   private static String generateTicket() {
-    var bytes = new byte[32];
-    new SecureRandom().nextBytes(bytes);
-    return "enr_" + HexFormat.of().formatHex(bytes);
+    return Secrets.mint("enr");
   }
 
   private static String sha256(String input) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/FdeStore.java
@@ -6,11 +6,10 @@
 package ai.singlr.sail.store;
 
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Secrets;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.ssh.SshPublicKey;
-import java.security.SecureRandom;
-import java.util.HexFormat;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -223,8 +222,6 @@ public final class FdeStore {
   }
 
   private static String generateId() {
-    var bytes = new byte[16];
-    new SecureRandom().nextBytes(bytes);
-    return "fde_" + HexFormat.of().formatHex(bytes);
+    return Secrets.mint("fde", 16);
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
@@ -62,7 +62,7 @@ public final class MessageStore implements SyncedStore {
     }
     return db.transaction(
         () -> {
-          var id = Ids.newId().toString();
+          var id = DateTimeUtils.newId().toString();
           var row =
               new MessageRow(
                   id,

--- a/sail-core/src/main/java/ai/singlr/sail/store/PendingChallengeStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/PendingChallengeStore.java
@@ -6,11 +6,10 @@
 package ai.singlr.sail.store;
 
 import ai.singlr.sail.common.DateTimeUtils;
-import java.security.SecureRandom;
+import ai.singlr.sail.common.Secrets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
-import java.util.HexFormat;
 import java.util.Optional;
 
 /**
@@ -83,8 +82,6 @@ public final class PendingChallengeStore {
   private record Resolved(PendingChallenge challenge, String expiresAt) {}
 
   private static String generateId() {
-    var bytes = new byte[16];
-    new SecureRandom().nextBytes(bytes);
-    return "wac_" + HexFormat.of().formatHex(bytes);
+    return Secrets.mint("wac", 16);
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -7,13 +7,12 @@ package ai.singlr.sail.store;
 
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.common.Ids;
+import ai.singlr.sail.common.Secrets;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.YamlUtil;
-import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -857,9 +856,7 @@ public final class RunStore implements ConflictResolver, SyncedStore {
   }
 
   private String mintCredential(String id, Duration maxDuration) {
-    var bytes = new byte[32];
-    new SecureRandom().nextBytes(bytes);
-    var credential = "sailrun_" + HexFormat.of().formatHex(bytes);
+    var credential = Secrets.mint("sailrun");
     var now = DateTimeUtils.now();
     var expiresAt =
         maxDuration == null ? null : now.plus(maxDuration).plus(CREDENTIAL_GRACE).toString();

--- a/sail-core/src/main/java/ai/singlr/sail/store/TokenStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/TokenStore.java
@@ -6,10 +6,10 @@
 package ai.singlr.sail.store;
 
 import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Secrets;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HexFormat;
@@ -114,9 +114,7 @@ public final class TokenStore {
   }
 
   private static String generateToken() {
-    var bytes = new byte[32];
-    new SecureRandom().nextBytes(bytes);
-    return "sail_" + HexFormat.of().formatHex(bytes);
+    return Secrets.mint("sail");
   }
 
   static String sha256(String input) {

--- a/sail-core/src/test/java/ai/singlr/sail/common/SecretsTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/common/SecretsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Minted secrets are prefixed, hex-encoded, of the requested byte length, and unpredictable — the
+ * one seam every store's token/credential generation shares.
+ */
+class SecretsTest {
+
+  @Test
+  void mintPrefixesAndHexEncodesThirtyTwoBytesByDefault() {
+    var token = Secrets.mint("sail");
+
+    assertTrue(token.startsWith("sail_"), "the prefix and separator lead the token");
+    assertEquals(64, token.substring("sail_".length()).length(), "32 bytes render as 64 hex chars");
+    assertTrue(token.matches("sail_[0-9a-f]{64}"), "the body is lowercase hex");
+  }
+
+  @Test
+  void mintHonorsAnExplicitByteLength() {
+    var token = Secrets.mint("wac", 16);
+
+    assertTrue(token.matches("wac_[0-9a-f]{32}"), "16 bytes render as 32 hex chars");
+  }
+
+  @Test
+  void hexEncodesWithoutAPrefix() {
+    var value = Secrets.hex(16);
+
+    assertTrue(value.matches("[0-9a-f]{32}"), "raw hex, no prefix");
+  }
+
+  @Test
+  void everyMintIsUnique() {
+    assertNotEquals(Secrets.mint("sail"), Secrets.mint("sail"));
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/LoopbackCallbackServer.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/LoopbackCallbackServer.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.common.Secrets;
 import ai.singlr.sail.common.Strings;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
@@ -12,9 +13,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
 import java.time.Duration;
-import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -85,9 +84,7 @@ public final class LoopbackCallbackServer implements AutoCloseable {
 
   /** A fresh unguessable {@code state} nonce binding a browser callback to this CLI invocation. */
   public static String newState() {
-    var bytes = new byte[16];
-    new SecureRandom().nextBytes(bytes);
-    return HexFormat.of().formatHex(bytes);
+    return Secrets.hex(16);
   }
 
   public void start() {


### PR DESCRIPTION
## What

Closes the **sail-sync-journal** spec's remaining "adjacent DRY wins."

**`Secrets.mint`** — seven stores hand-rolled the identical secret-minting dance (`new byte[N]` / `SecureRandom.nextBytes` / `"<prefix>_" + HexFormat.formatHex`), each spinning up its own throwaway `SecureRandom`. Consolidated into `Secrets.mint(prefix[, bytes])` + `Secrets.hex(bytes)` over one shared, thread-safe `SecureRandom`:

| Store | Secret |
|---|---|
| TokenStore | `sail_…` |
| BoxCredentialStore | `sailbox_…` |
| EnrollmentTicketStore | `enr_…` |
| PendingChallengeStore | `wac_…` (16b) |
| RunStore | `sailrun_…` |
| FdeStore | `fde_…` (16b) |
| AuthSessionStore | `sess_…` |
| LoopbackCallbackServer | raw hex OAuth state |

The webauthn Base64url challenge (`RelyingParty`) is a different, security-critical idiom — left untouched.

**Id seam** — routed MessageStore's last `Ids.newId()` through `DateTimeUtils.newId()`, so the id seam is uniform repo-wide (`DateTimeUtils.newId` delegates to `Ids`; `IdsTest` still exercises the primitive directly).

## Safety

Behavior-identical — same byte counts, prefixes, hex encoding (a shared `SecureRandom` is the standard, preferred pattern over per-call instances). `SecretsTest` covers prefix/length/hex/uniqueness. `mvn clean verify` green, all coverage met.
