### PR TITLE
refactor(domain): introduce Lane enum, unify the run-lane classifications

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/config/Lane.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/Lane.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.config;
+
+import java.util.Optional;
+
+/**
+ * The lane a run executes in — the canonical type behind what the {@code runs.role} column stores
+ * and every reactor, gate, and store once matched as a bare string. Each constant owns its wire
+ * form and the classifications that used to live as hand-copied string checks: whether a lane's
+ * stop triggers the review pipeline, whether it is a chat or invite turn, whether it is an agent
+ * session (as opposed to a review execution), and whether it runs under the read-only room
+ * contract. One source, so the two classifications that once drifted with no compiler help cannot.
+ */
+public enum Lane {
+  BUILD("build"),
+  ADHOC("adhoc"),
+  ROOM("room"),
+  ROOM_FULL("room-full"),
+  INVITE("invite"),
+  INVITE_FULL("invite-full"),
+  REVIEW("review"),
+  FIX("fix");
+
+  private final String wire;
+
+  Lane(String wire) {
+    this.wire = wire;
+  }
+
+  /** The stored/transmitted role string for this lane. */
+  public String wire() {
+    return wire;
+  }
+
+  /** The lane for a role string, or empty for an unknown or null role. */
+  public static Optional<Lane> of(String role) {
+    for (var lane : values()) {
+      if (lane.wire.equals(role)) {
+        return Optional.of(lane);
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Whether {@code role} is this lane's wire form — the null-safe check the string compares were.
+   */
+  public boolean matches(String role) {
+    return wire.equals(role);
+  }
+
+  /**
+   * Whether a stop in this lane hands the spec to the review pipeline. Only a dispatch build and an
+   * ad-hoc run do; every chat, invite, and review execution stays out of the loop.
+   */
+  public boolean triggersReview() {
+    return this == BUILD || this == ADHOC;
+  }
+
+  /** A conversational turn of the room lane, either mode — a wake or an engaged agent's turn. */
+  public boolean isChat() {
+    return this == ROOM || this == ROOM_FULL;
+  }
+
+  /** An invited agent session, either mode. */
+  public boolean isInvite() {
+    return this == INVITE || this == INVITE_FULL;
+  }
+
+  /**
+   * An agent session the run-scoped machinery owns — a build, ad-hoc, chat, or invite — as opposed
+   * to a pipeline-driven review execution. These are the rows the stop, status, log, reaper, and
+   * missed-stop lanes address.
+   */
+  public boolean isSession() {
+    return this == BUILD || this == ADHOC || isChat() || isInvite();
+  }
+
+  /**
+   * Whether this lane runs under the read-only room contract — a room wake or a read-only invite:
+   * viewer-tier credential, harness tool cut, no repo reservation.
+   */
+  public boolean readOnly() {
+    return this == ROOM || this == INVITE;
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/DispatchGate.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/DispatchGate.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.config.Lane;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,7 +32,7 @@ public final class DispatchGate {
   private DispatchGate() {}
 
   /** The chat lane: a run that reserves no repos and conflicts only with runs of its own spec. */
-  public static final String ROOM_ROLE = "room";
+  public static final String ROOM_ROLE = Lane.ROOM.wire();
 
   /**
    * The read-only invite lane: a consultant a human explicitly invited into the room. It reserves
@@ -40,10 +41,10 @@ public final class DispatchGate {
    * lane's purpose. The same-spec backstop stays for {@link #ROOM_ROLE} wakes, which fire
    * automatically and must never race a live run.
    */
-  public static final String READ_ONLY_INVITE_ROLE = "invite";
+  public static final String READ_ONLY_INVITE_ROLE = Lane.INVITE.wire();
 
   /** The full invite lane: reserves like a build, so one writer per repo always holds. */
-  public static final String FULL_INVITE_ROLE = "invite-full";
+  public static final String FULL_INVITE_ROLE = Lane.INVITE_FULL.wire();
 
   /**
    * The full chat lane: an engaged agent's turn with write access. It reserves the spec's repos
@@ -51,7 +52,7 @@ public final class DispatchGate {
    * exactly as for builds — a full turn defers on a live build through the ordinary repo rule and
    * frees when the build's stop re-evaluates the room.
    */
-  public static final String ROOM_FULL_ROLE = "room-full";
+  public static final String ROOM_FULL_ROLE = Lane.ROOM_FULL.wire();
 
   /**
    * One running local run of the project: its id, the spec it works, its role, and its reserved

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -9,9 +9,11 @@ import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.common.Ids;
 import ai.singlr.sail.common.Secrets;
 import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.Lane;
 import ai.singlr.sail.config.YamlUtil;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -20,6 +22,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * The Run aggregate on SQLite: one dispatch execution of a spec. Records where it ran ({@code node}
@@ -199,19 +203,33 @@ public final class RunStore implements ConflictResolver, SyncedStore {
           null);
     }
 
+    /** This row's lane, or empty for an unrecognized role. */
+    public Optional<Lane> lane() {
+      return Lane.of(role);
+    }
+
+    /**
+     * Whether this run's own stop hands its spec to the review pipeline — only a build or ad-hoc
+     * does. A row-less or unrecognized role is treated as a normal triggering stop, matching the
+     * role-marker path.
+     */
+    public boolean triggersReview() {
+      return lane().map(Lane::triggersReview).orElse(true);
+    }
+
     /** Whether this row is a build attempt of a spec. */
     public boolean buildRole() {
-      return "build".equals(role);
+      return Lane.BUILD.matches(role);
     }
 
     /** Whether this row is an ad-hoc session — an engineer-initiated run that works no spec. */
     public boolean adhocRole() {
-      return "adhoc".equals(role);
+      return Lane.ADHOC.matches(role);
     }
 
     /** Whether this row is a room wake — a chat-lane run that answers in its spec's room. */
     public boolean roomRole() {
-      return DispatchGate.ROOM_ROLE.equals(role);
+      return Lane.ROOM.matches(role);
     }
 
     /**
@@ -220,7 +238,7 @@ public final class RunStore implements ConflictResolver, SyncedStore {
      * per spec.
      */
     public boolean chatRole() {
-      return roomRole() || DispatchGate.ROOM_FULL_ROLE.equals(role);
+      return lane().map(Lane::isChat).orElse(false);
     }
 
     /**
@@ -229,8 +247,7 @@ public final class RunStore implements ConflictResolver, SyncedStore {
      * stays anchored to dispatch.
      */
     public boolean inviteRole() {
-      return DispatchGate.READ_ONLY_INVITE_ROLE.equals(role)
-          || DispatchGate.FULL_INVITE_ROLE.equals(role);
+      return lane().map(Lane::isInvite).orElse(false);
     }
 
     /**
@@ -240,7 +257,7 @@ public final class RunStore implements ConflictResolver, SyncedStore {
      * says.
      */
     public boolean readOnlyLane() {
-      return roomRole() || DispatchGate.READ_ONLY_INVITE_ROLE.equals(role);
+      return lane().map(Lane::readOnly).orElse(false);
     }
 
     /**
@@ -249,7 +266,7 @@ public final class RunStore implements ConflictResolver, SyncedStore {
      * this as the fallback when a stop signal lost its role marker.
      */
     public boolean reviewRole() {
-      return "review".equals(role);
+      return Lane.REVIEW.matches(role);
     }
 
     /**
@@ -260,7 +277,7 @@ public final class RunStore implements ConflictResolver, SyncedStore {
      * reaped and stoppable like any other.
      */
     public boolean sessionRole() {
-      return buildRole() || adhocRole() || chatRole() || inviteRole();
+      return lane().map(Lane::isSession).orElse(false);
     }
 
     /**
@@ -275,11 +292,18 @@ public final class RunStore implements ConflictResolver, SyncedStore {
     }
   }
 
-  private static final String SESSION_ROLES =
-      "role IN ('build', 'adhoc', 'room', 'room-full', 'invite', 'invite-full')";
+  private static final String SESSION_ROLES = roleIn(Lane::isSession);
 
   private static final String PROJECT_SESSION_ROLES =
-      "role IN ('build', 'adhoc', 'room', 'room-full')";
+      roleIn(lane -> lane.isSession() && !lane.isInvite());
+
+  /** A {@code role IN (...)} clause over the lanes matching {@code which}, in enum order. */
+  private static String roleIn(Predicate<Lane> which) {
+    return Arrays.stream(Lane.values())
+        .filter(which)
+        .map(lane -> "'" + lane.wire() + "'")
+        .collect(Collectors.joining(", ", "role IN (", ")"));
+  }
 
   private static final String COLUMNS =
       "id, project, spec_id, node, role, agent, branch, task, pid, watcher_pid, status,"

--- a/sail-core/src/test/java/ai/singlr/sail/config/LaneTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/LaneTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Lane is the canonical run-lane vocabulary: its {@code wire()} strings are the exact role values
+ * stored and matched today, and its classifications ({@code triggersReview}, {@code isChat}, {@code
+ * isInvite}, {@code isSession}, {@code readOnly}) are the single source the reactors and stores
+ * consult — so the "does this lane trigger review?" decision can no longer drift between two
+ * hand-maintained copies.
+ */
+class LaneTest {
+
+  @Test
+  void wireMatchesTheStoredRoleStrings() {
+    assertEquals("build", Lane.BUILD.wire());
+    assertEquals("adhoc", Lane.ADHOC.wire());
+    assertEquals("room", Lane.ROOM.wire());
+    assertEquals("room-full", Lane.ROOM_FULL.wire());
+    assertEquals("invite", Lane.INVITE.wire());
+    assertEquals("invite-full", Lane.INVITE_FULL.wire());
+    assertEquals("review", Lane.REVIEW.wire());
+    assertEquals("fix", Lane.FIX.wire());
+  }
+
+  @Test
+  void ofRoundTripsEveryWireForm() {
+    for (var lane : Lane.values()) {
+      assertEquals(Optional.of(lane), Lane.of(lane.wire()));
+    }
+  }
+
+  @Test
+  void ofIsEmptyForAnUnknownOrNullRole() {
+    assertEquals(Optional.empty(), Lane.of("nope"));
+    assertEquals(Optional.empty(), Lane.of(null));
+  }
+
+  @Test
+  void matchesIsTheNullSafeStringCheckItReplaces() {
+    assertTrue(Lane.BUILD.matches("build"));
+    assertFalse(Lane.BUILD.matches("adhoc"));
+    assertFalse(Lane.BUILD.matches(null));
+  }
+
+  @Test
+  void onlyBuildAndAdhocTriggerReview() {
+    assertTrue(Lane.BUILD.triggersReview());
+    assertTrue(Lane.ADHOC.triggersReview());
+    for (var lane : Lane.values()) {
+      if (lane != Lane.BUILD && lane != Lane.ADHOC) {
+        assertFalse(lane.triggersReview(), lane + " must not trigger review");
+      }
+    }
+  }
+
+  @Test
+  void chatIsTheTwoRoomModes() {
+    assertTrue(Lane.ROOM.isChat());
+    assertTrue(Lane.ROOM_FULL.isChat());
+    assertFalse(Lane.INVITE.isChat());
+    assertFalse(Lane.BUILD.isChat());
+  }
+
+  @Test
+  void inviteIsTheTwoInviteModes() {
+    assertTrue(Lane.INVITE.isInvite());
+    assertTrue(Lane.INVITE_FULL.isInvite());
+    assertFalse(Lane.ROOM.isInvite());
+  }
+
+  @Test
+  void sessionIsEveryAgentSessionButNotAReviewExecution() {
+    for (var lane : Lane.values()) {
+      var expected =
+          lane == Lane.BUILD
+              || lane == Lane.ADHOC
+              || lane == Lane.ROOM
+              || lane == Lane.ROOM_FULL
+              || lane == Lane.INVITE
+              || lane == Lane.INVITE_FULL;
+      assertEquals(expected, lane.isSession(), lane + " session classification");
+    }
+    assertFalse(Lane.REVIEW.isSession());
+    assertFalse(Lane.FIX.isSession());
+  }
+
+  @Test
+  void readOnlyIsAWakeOrAReadOnlyInvite() {
+    assertTrue(Lane.ROOM.readOnly());
+    assertTrue(Lane.INVITE.readOnly());
+    assertFalse(Lane.ROOM_FULL.readOnly());
+    assertFalse(Lane.INVITE_FULL.readOnly());
+    assertFalse(Lane.BUILD.readOnly());
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.api;
 
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.Lane;
 import ai.singlr.sail.config.YamlUtil;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
@@ -196,45 +197,39 @@ public record Event(
     public static final String RUN_ROLE = "run_role";
 
     /** {@link #RUN_ROLE} value: a room wake — a chat that must never trigger a review. */
-    public static final String RUN_ROLE_ROOM = "room";
+    public static final String RUN_ROLE_ROOM = Lane.ROOM.wire();
 
     /**
      * {@link #RUN_ROLE} value: an engaged agent's full-access chat turn. A conversation, not a
      * task: never a review trigger, and its clean stop is turn plumbing, not news.
      */
-    public static final String RUN_ROLE_ROOM_FULL =
-        ai.singlr.sail.store.DispatchGate.ROOM_FULL_ROLE;
+    public static final String RUN_ROLE_ROOM_FULL = Lane.ROOM_FULL.wire();
 
     /** {@link #RUN_ROLE} value: a reviewer run — its own stop must never re-enter the pipeline. */
-    public static final String RUN_ROLE_REVIEW = "review";
+    public static final String RUN_ROLE_REVIEW = Lane.REVIEW.wire();
 
     /** {@link #RUN_ROLE} value: a fix run — its own stop must never re-enter the pipeline. */
-    public static final String RUN_ROLE_FIX = "fix";
+    public static final String RUN_ROLE_FIX = Lane.FIX.wire();
 
     /** {@link #RUN_ROLE} value: a read-only invited consultant — chat only, never a review. */
-    public static final String RUN_ROLE_INVITE = "invite";
+    public static final String RUN_ROLE_INVITE = Lane.INVITE.wire();
 
     /**
      * {@link #RUN_ROLE} value: a full-access invited agent. Its stop never triggers the review
      * pipeline — the review loop stays anchored to dispatch; commits it pushed surface in the room
      * and the next build's review sees them.
      */
-    public static final String RUN_ROLE_INVITE_FULL = "invite-full";
+    public static final String RUN_ROLE_INVITE_FULL = Lane.INVITE_FULL.wire();
 
     /**
-     * Whether a run role names a lane whose own stop must never drive the review pipeline: a {@link
-     * #RUN_ROLE_ROOM} chat, an invited agent ({@link #RUN_ROLE_INVITE} / {@link
-     * #RUN_ROLE_INVITE_FULL}), or the pipeline's own {@link #RUN_ROLE_REVIEW} / {@link
-     * #RUN_ROLE_FIX} run. Reactors on {@code agent_session_stopped} drop such stops by role so the
-     * loop can never re-enter on its own agents. Null (a role-less stop) is a normal build stop.
+     * Whether a run role names a lane whose own stop must never drive the review pipeline — every
+     * lane except a dispatch build and an ad-hoc run. Reactors on {@code agent_session_stopped}
+     * drop such stops by role so the loop can never re-enter on its own agents. Null (a role-less
+     * stop), like an unrecognized role, is treated as a normal triggering stop. Delegates to {@link
+     * Lane} so this classification and {@code RunRow}'s share one source.
      */
     public static boolean nonTriggeringLane(String role) {
-      return RUN_ROLE_ROOM.equals(role)
-          || RUN_ROLE_ROOM_FULL.equals(role)
-          || RUN_ROLE_REVIEW.equals(role)
-          || RUN_ROLE_FIX.equals(role)
-          || RUN_ROLE_INVITE.equals(role)
-          || RUN_ROLE_INVITE_FULL.equals(role);
+      return Lane.of(role).map(lane -> !lane.triggersReview()).orElse(false);
     }
 
     private WellKnownData() {}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -1041,10 +1041,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     var runId = Objects.toString(event.data().get(Event.WellKnownData.RUN_ID), null);
     return runId != null
         && !runId.isBlank()
-        && runStore
-            .findById(runId)
-            .map(row -> row.chatRole() || row.reviewRole() || row.inviteRole())
-            .orElse(false);
+        && runStore.findById(runId).map(row -> !row.triggersReview()).orElse(false);
   }
 
   private static Integer exitCodeOf(Event event) {


### PR DESCRIPTION
## What

First brick of **sail-domain-types**: give the run *lane* a canonical type and unify the classifications that could silently drift.

The lane lived as bare role strings matched in parallel across `DispatchGate`, `RunStore`, and `Event`, and the *"does this lane's stop trigger review?"* decision was maintained **twice** — `Event.nonTriggeringLane` vs `RunRow`'s `chat/review/invite` predicates — with no compiler help keeping them aligned.

## Change

New `enum Lane { BUILD, ADHOC, ROOM, ROOM_FULL, INVITE, INVITE_FULL, REVIEW, FIX }` owning each lane's `wire()` string and its classifications (`triggersReview`, `isChat`, `isInvite`, `isSession`, `readOnly`). Consumers routed through it:

- `RunRow`'s eight role predicates + new `lane()` / `triggersReview()` consult `Lane`; `SESSION_ROLES` / `PROJECT_SESSION_ROLES` SQL now **derives from `Lane.values()`** (byte-identical `IN`-list, can't drift).
- `DispatchGate`'s role constants and `Event`'s `RUN_ROLE_*` values become `Lane.wire()` — one source for the wire strings.
- `Event.nonTriggeringLane` **and** `ReviewPipelineController`'s lost-marker fallback both delegate to `Lane.triggersReview()` — collapsing the two classifications into one.

## Safety

Behavior-preserving. Wire strings are byte-identical; every classification matches its prior string checks. I verified the one subtle case: a fix run's **row** role is `"review"` (only events/logs use `"fix"`), so the unified fallback yields the same result for every actual role — the divergence was latent fragility, not a live bug, and it's now impossible by construction.

New `LaneTest` pins the wire forms + each classification (a mistyped lane is now a compile error). The reactor/pipeline suite — `ReviewPipelineControllerTest`, `SlackReactorTest`, `SpecLifecycleReactorTest`, `RoomWakeReactorTest`, `SyncTransitionEventsTest` (201 tests) — and `mvn clean verify` pass **unchanged**.

## Next in this spec

Sweep the remaining raw role literals (`DispatchOperations`, `ContainerReviewAgentRunner`, `LaunchSpec.role`); then the independent `RunStatus` and `EngagementMode` enums. The `Spec` unification stays gated on `room-spec-decouple`.
