### PR TITLE
refactor(domain): route the remaining run-role literals through Lane

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -429,7 +429,18 @@ public final class RunStore implements ConflictResolver, SyncedStore {
       String logPath,
       String unit) {
     return createReturningCredential(
-        reviewId, project, specId, node, owner, "review", agent, branch, task, null, null, logPath,
+        reviewId,
+        project,
+        specId,
+        node,
+        owner,
+        Lane.REVIEW.wire(),
+        agent,
+        branch,
+        task,
+        null,
+        null,
+        logPath,
         unit);
   }
 
@@ -869,12 +880,12 @@ public final class RunStore implements ConflictResolver, SyncedStore {
     var base = dash > 0 ? family.substring(0, dash) : family;
     var runId = Objects.requireNonNull(id, "run id");
     var marker =
-        switch (Objects.toString(role, "")) {
-          case "review" -> "review-";
-          case "fix" -> "fix-";
-          case "room" -> "room-";
-          case "invite", "invite-full" -> "invite-";
-          default -> "";
+        switch (Lane.of(role).orElse(null)) {
+          case REVIEW -> "review-";
+          case FIX -> "fix-";
+          case ROOM -> "room-";
+          case INVITE, INVITE_FULL -> "invite-";
+          case null, default -> "";
         };
     return base + "/" + marker + runId;
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/AdhocRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/AdhocRunner.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.api;
 
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.Lane;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.engine.AgentCli;
 import ai.singlr.sail.engine.AgentUnit;
@@ -87,7 +88,7 @@ public final class AdhocRunner {
                   unit,
                   runId,
                   null,
-                  "adhoc",
+                  Lane.ADHOC.wire(),
                   null)));
       return new DispatchOperations.AdhocSession(runId, null, null, Optional.empty());
     }
@@ -114,12 +115,12 @@ public final class AdhocRunner {
                   unit,
                   runId,
                   credential,
-                  "adhoc",
+                  Lane.ADHOC.wire(),
                   null));
       var status =
           runLauncher.finishLaunch(
               new RunLauncher.RunContext(
-                  project, unit, runId, null, agentType, "adhoc", background),
+                  project, unit, runId, null, agentType, Lane.ADHOC.wire(), background),
               launch);
       return new DispatchOperations.AdhocSession(
           runId, status, background ? null : launch.exitCode(), launch.watcher());
@@ -144,7 +145,18 @@ public final class AdhocRunner {
           "This box keeps no run aggregate, so an agent session cannot be reserved or tracked.");
     }
     return runReservation.reserve(
-        runId, project, "", node, node, "adhoc", List.of(), agentType, branch, task, unit, config);
+        runId,
+        project,
+        "",
+        node,
+        node,
+        Lane.ADHOC.wire(),
+        List.of(),
+        agentType,
+        branch,
+        task,
+        unit,
+        config);
   }
 
   private static String adhocWorkDir(SailYaml config, String path) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/BuildDispatch.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/BuildDispatch.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.api;
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.BranchPolicy;
+import ai.singlr.sail.config.Lane;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecCatalog;
@@ -211,7 +212,7 @@ public final class BuildDispatch {
       var status =
           runLauncher.finishLaunch(
               new RunLauncher.RunContext(
-                  project, unit, runId, nextSpec.id(), agentType, "build", background),
+                  project, unit, runId, nextSpec.id(), agentType, Lane.BUILD.wire(), background),
               launch);
       return new DispatchOperations.Dispatched(
           taskSpec,
@@ -437,7 +438,8 @@ public final class BuildDispatch {
    */
   private void requireNoRepoOverlap(
       String project, String localHandle, String specId, List<String> targetRepos) {
-    DispatchGate.decide(specId, "build", targetRepos, runningLocalRuns(project, localHandle))
+    DispatchGate.decide(
+            specId, Lane.BUILD.wire(), targetRepos, runningLocalRuns(project, localHandle))
         .ifPresent(
             conflict -> {
               throw RunReservation.overlapRefusal(conflict);
@@ -482,7 +484,18 @@ public final class BuildDispatch {
       return null;
     }
     return runReservation.reserve(
-        runId, project, specId, node, owner, "build", repos, agentType, branch, task, unit, config);
+        runId,
+        project,
+        specId,
+        node,
+        owner,
+        Lane.BUILD.wire(),
+        repos,
+        agentType,
+        branch,
+        task,
+        unit,
+        config);
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ContainerReviewAgentRunner.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ContainerReviewAgentRunner.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.config.Lane;
 import ai.singlr.sail.engine.AgentCli;
 import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.AgentUnit;
@@ -108,7 +109,8 @@ final class ContainerReviewAgentRunner implements ReviewAgentRunner {
       throws Exception {
     var cli = AgentCli.fromYamlName(agent);
     var unit = stage(project, prompt, reviewId);
-    session.writeSession(project, prompt, branch, "", agent, reviewId, "fix", repos, unit);
+    session.writeSession(
+        project, prompt, branch, "", agent, reviewId, Lane.FIX.wire(), repos, unit);
     return launch(project, cli, agent, unit, runCredential, reviewId, model, reasoningEffort);
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.api;
 
 import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.Lane;
 import ai.singlr.sail.config.ReviewPipelineConfig;
 import ai.singlr.sail.config.ReviewPipelineConfig.StageConfig;
 import ai.singlr.sail.config.ReviewPipelineConfig.StageType;
@@ -428,7 +429,8 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
               branch, repos, stageConfig.categories(), roomMessages(specId), carried);
 
       var credential =
-          startReviewRun(stage.reviewId(), project, specId, agent, branch, prompt, "review");
+          startReviewRun(
+              stage.reviewId(), project, specId, agent, branch, prompt, Lane.REVIEW.wire());
       var effort = spec.map(SpecStore.SpecRow::reasoningEffort).orElse(null);
       var output =
           agentRunner.run(project, agent, prompt, stage.reviewId(), credential, null, effort);
@@ -664,7 +666,8 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
     try {
       var agent = spec.get().agent() != null ? spec.get().agent() : "claude-code";
       var credential =
-          startReviewRun(reviewId, project, specId, agent, spec.get().branch(), fixTask, "fix");
+          startReviewRun(
+              reviewId, project, specId, agent, spec.get().branch(), fixTask, Lane.FIX.wire());
       seedRoomDelivery(reviewId, built.renderedMessages());
       agentRunner.runFix(
           project,

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RunLauncher.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RunLauncher.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.api;
 
 import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.Lane;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.engine.AgentCli;
@@ -133,7 +134,7 @@ public final class RunLauncher {
             unit,
             runId,
             runCredential,
-            "build",
+            Lane.BUILD.wire(),
             null));
   }
 


### PR DESCRIPTION
## What

Completes the **Lane** brick's acceptance criterion — *no raw run-role string literals remain in production*.

The launch, dispatch, and review paths still passed bare role strings; every one now flows through `Lane`:

| Site | Was | Now |
|---|---|---|
| BuildDispatch, RunLauncher | `"build"` | `Lane.BUILD.wire()` |
| AdhocRunner | `"adhoc"` | `Lane.ADHOC.wire()` |
| ReviewPipelineController, RunStore.createReview, ContainerReviewAgentRunner | `"review"` / `"fix"` | `Lane.REVIEW.wire()` / `Lane.FIX.wire()` |
| RunStore principal-handle marker | `switch` on literal cases | `switch` on `Lane` values (`case null, default` preserves the build/adhoc/room-full fall-through to `""`) |

Non-role look-alikes deliberately left untouched: board-bucket keys, the spec-status `"review"` filter, the `/invite` route constant, snapshot labels.

## Safety

Behavior-preserving — wire strings are byte-identical. The dispatch/adhoc/review suites (`AdhocDispatchTest`, `DispatchLaneParityTest`, `ReviewPipelineControllerTest`, `RunStoreTest`) and `mvn clean verify` pass unchanged.