### PR TITLE
refactor(domain): introduce RunStatus enum, one definition of terminal

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/config/RunStatus.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/RunStatus.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.config;
+
+import java.util.Optional;
+
+/**
+ * The lifecycle state of a run — the canonical type behind the {@code runs.status} column that the
+ * store, the sync narrator, and the missed-stop reconciler each once matched as a bare string. A
+ * run begins {@link #RUNNING}, may pass through {@link #STOPPING} while a stop is honored, and
+ * settles in one terminal state: {@link #STOPPED}, {@link #COMPLETED}, or {@link #FAILED}. (A
+ * cancel records the run as {@code STOPPED} and the spec as cancelled — cancellation is a spec
+ * state, never a run one.)
+ *
+ * <p>{@link #isTerminal} is the one definition of "finished." Note it is broader than the set the
+ * missed-stop reconciler replays to <em>advance</em> a spec: a failed run is terminal but its spec
+ * surfaces for triage rather than advancing, so that narrower rule lives with the reconciler.
+ */
+public enum RunStatus {
+  RUNNING("running"),
+  STOPPING("stopping"),
+  STOPPED("stopped"),
+  COMPLETED("completed"),
+  FAILED("failed");
+
+  private final String wire;
+
+  RunStatus(String wire) {
+    this.wire = wire;
+  }
+
+  /** The stored/transmitted status string for this state. */
+  public String wire() {
+    return wire;
+  }
+
+  /** The status for a wire string, or empty for an unknown or null value. */
+  public static Optional<RunStatus> of(String status) {
+    for (var value : values()) {
+      if (value.wire.equals(status)) {
+        return Optional.of(value);
+      }
+    }
+    return Optional.empty();
+  }
+
+  /** Whether this state is terminal — the run has finished, however it finished. */
+  public boolean isTerminal() {
+    return this == STOPPED || this == COMPLETED || this == FAILED;
+  }
+
+  /** Whether {@code status} names a terminal state — null and unknown values are not terminal. */
+  public static boolean isTerminal(String status) {
+    return of(status).map(RunStatus::isTerminal).orElse(false);
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/MissedStops.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MissedStops.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.config.RunStatus;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
@@ -33,7 +34,14 @@ import java.util.Set;
  */
 public final class MissedStops {
 
-  private static final Set<String> TERMINAL = Set.of("stopped", "completed");
+  /**
+   * The finished states whose missed stop should be replayed to <em>advance</em> the spec.
+   * Deliberately narrower than {@link RunStatus#isTerminal}: a {@link RunStatus#FAILED} run is
+   * terminal too, but a failed spec surfaces for triage rather than advancing, so replaying its
+   * stop would only duplicate the failure — it is excluded here on purpose.
+   */
+  private static final Set<String> TERMINAL =
+      Set.of(RunStatus.STOPPED.wire(), RunStatus.COMPLETED.wire());
 
   /** What one reconciliation pass should do for a spec's latest session. */
   public sealed interface Outcome {

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -10,6 +10,7 @@ import ai.singlr.sail.common.Ids;
 import ai.singlr.sail.common.Secrets;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.Lane;
+import ai.singlr.sail.config.RunStatus;
 import ai.singlr.sail.config.YamlUtil;
 import java.time.Duration;
 import java.time.Instant;
@@ -1083,14 +1084,14 @@ public final class RunStore implements ConflictResolver, SyncedStore {
               "UPDATE runs SET status = ?, completed_at = ?, exit_code = COALESCE(?, exit_code)"
                   + " WHERE id = ? AND status = ?",
               status,
-              TERMINAL_STATUSES.contains(status) ? DateTimeUtils.now().toString() : null,
+              RunStatus.isTerminal(status) ? DateTimeUtils.now().toString() : null,
               exitCode != null ? exitCode.longValue() : null,
               id,
               expected);
           if (db.changes() == 0) {
             return false;
           }
-          if (TERMINAL_STATUSES.contains(status)) {
+          if (RunStatus.isTerminal(status)) {
             revokeCredential(id);
           }
           alongside.run();
@@ -1127,8 +1128,6 @@ public final class RunStore implements ConflictResolver, SyncedStore {
           return true;
         });
   }
-
-  private static final Set<String> TERMINAL_STATUSES = Set.of("completed", "stopped", "failed");
 
   /** Marks a run finished with its final status and the agent process's exit code (nullable). */
   public void complete(String id, String status, Integer exitCode) {

--- a/sail-core/src/test/java/ai/singlr/sail/config/RunStatusTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/RunStatusTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * RunStatus is the canonical run-lifecycle vocabulary — the wire strings the {@code runs.status}
+ * column stored and matched as bare text, with {@code isTerminal} as the single definition of
+ * "finished" that the run store, the sync narrator, and the missed-stop reconciler once each kept
+ * their own copy of.
+ */
+class RunStatusTest {
+
+  @Test
+  void wireMatchesTheStoredStatusStrings() {
+    assertEquals("running", RunStatus.RUNNING.wire());
+    assertEquals("stopping", RunStatus.STOPPING.wire());
+    assertEquals("stopped", RunStatus.STOPPED.wire());
+    assertEquals("completed", RunStatus.COMPLETED.wire());
+    assertEquals("failed", RunStatus.FAILED.wire());
+  }
+
+  @Test
+  void ofRoundTripsEveryWireForm() {
+    for (var status : RunStatus.values()) {
+      assertEquals(Optional.of(status), RunStatus.of(status.wire()));
+    }
+  }
+
+  @Test
+  void ofIsEmptyForUnknownOrNull() {
+    assertEquals(Optional.empty(), RunStatus.of("gone"));
+    assertEquals(Optional.empty(), RunStatus.of(null));
+  }
+
+  @Test
+  void terminalIsStoppedCompletedOrFailed() {
+    assertTrue(RunStatus.STOPPED.isTerminal());
+    assertTrue(RunStatus.COMPLETED.isTerminal());
+    assertTrue(RunStatus.FAILED.isTerminal());
+    assertFalse(RunStatus.RUNNING.isTerminal());
+    assertFalse(RunStatus.STOPPING.isTerminal());
+  }
+
+  @Test
+  void terminalByWireIsTheSingleSourceTheStringSetsReplace() {
+    assertTrue(RunStatus.isTerminal("completed"));
+    assertTrue(RunStatus.isTerminal("stopped"));
+    assertTrue(RunStatus.isTerminal("failed"));
+    assertFalse(RunStatus.isTerminal("running"));
+    assertFalse(RunStatus.isTerminal(null));
+    assertFalse(RunStatus.isTerminal("nonsense"));
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MissedStopReconciler.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.api;
 
 import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.RunStatus;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.AgentUnit;
@@ -74,8 +75,6 @@ public final class MissedStopReconciler implements AutoCloseable {
 
   private static final SpecStore.SpecFilter REVIEW =
       new SpecStore.SpecFilter(null, "review", null, null, null);
-
-  private static final Set<String> TERMINAL_RUN_STATUSES = Set.of("completed", "stopped", "failed");
 
   /** Answers whether a run's recorded agent identity is still active. */
   @FunctionalInterface
@@ -358,7 +357,7 @@ public final class MissedStopReconciler implements AutoCloseable {
             .filter(RunStore.RunRow::buildRole)
             .findFirst()
             .filter(run -> run.ownedBy(node))
-            .filter(run -> TERMINAL_RUN_STATUSES.contains(run.status()));
+            .filter(run -> RunStatus.isTerminal(run.status()));
     if (latest.isEmpty() || unitStillActive(spec, latest.get())) {
       return false;
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SyncTransitionEvents.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SyncTransitionEvents.java
@@ -5,13 +5,13 @@
 
 package ai.singlr.sail.api;
 
+import ai.singlr.sail.config.RunStatus;
 import ai.singlr.sail.sync.SyncTransition;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -29,7 +29,6 @@ import java.util.function.Function;
 public final class SyncTransitionEvents {
 
   private static final String IN_PROGRESS = "in_progress";
-  private static final Set<String> TERMINAL_RUN_STATUSES = Set.of("completed", "stopped", "failed");
   private static final List<String> SEVERITY_ORDER = List.of("critical", "high", "medium", "low");
 
   private SyncTransitionEvents() {}
@@ -143,7 +142,7 @@ public final class SyncTransitionEvents {
   }
 
   private static boolean isTerminal(String status) {
-    return status != null && TERMINAL_RUN_STATUSES.contains(status);
+    return RunStatus.isTerminal(status);
   }
 
   private static List<Event> reviewEvents(


### PR DESCRIPTION
## What

Second enum brick of **sail-domain-types**. Run status was a bare `String` (while `SpecStatus` is already an enum), and "is this run finished?" was hand-copied in **three** places — `RunStore`, `SyncTransitionEvents`, `MissedStopReconciler` — each `Set.of("completed", "stopped", "failed")`.

New `enum RunStatus { RUNNING, STOPPING, STOPPED, COMPLETED, FAILED }` owns the wire strings + `isTerminal()`; all three sets become `RunStatus.isTerminal(status)`.

## Rigor: verified, not assumed

The spec's premise for this brick was partly wrong, and checking it prevented a regression:

- **Runs never carry `cancelled`** — a cancel records the run `STOPPED` and the *spec* cancelled (cancellation is a spec state). So the enum is **five** values, not the six the spec listed.
- **`MissedStops.TERMINAL = {stopped, completed}` is not drift.** Tracing the semantics: a `failed` run is terminal, but a failed spec **surfaces for triage rather than advancing**, so `MissedStops` deliberately excludes it — its set means *"finished in a way that should replay to **advance** the spec"*, a genuinely narrower predicate. Folding it into `isTerminal()` would have made the reconciler wrongly advance failed specs. It now sources its wire strings from `RunStatus` and **documents the exclusion**, instead of being unified away.

## Safety

Behavior-preserving. `RunStatusTest` pins `wire`/`of`/`isTerminal`; the run, missed-stop (`MissedStopsTest`, `MissedStopReconcilerTest`), and sync-narrator (`SyncTransitionEventsTest`) suites and `mvn clean verify` pass **unchanged**.

## Next

`enum EngagementMode` (the `read-only`/`read_only` wire unification, with a Mast cross-check) and the `SpecStatus` lifecycle consolidation. The `Spec` unification stays gated on `room-spec-decouple`.