### PR TITLE
refactor(domain): introduce EngagementMode, unify on the read_only spelling

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/config/Engagement.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/Engagement.java
@@ -13,16 +13,15 @@ import java.util.LinkedHashMap;
  * one compact JSON value so sync merges it atomically — an engagement is set and cleared as a
  * whole, and field-level merging across boxes must never stitch one box's agent to another box's
  * mode. {@code full} is the default mode: conversations produce artifacts (diagrams, drafts,
- * files), so write access is the normal case and {@code read-only} is the explicit narrow choice.
+ * files), so write access is the normal case and {@code read_only} is the explicit narrow choice.
  */
 public record Engagement(String agent, String mode, String model, String engagedAt) {
 
-  public static final String MODE_FULL = "full";
-  public static final String MODE_READ_ONLY = "read-only";
-
   /**
-   * A validated engagement. A blank mode defaults to {@link #MODE_FULL}; a blank model means the
-   * agent's default.
+   * A validated engagement. A blank mode defaults to {@link EngagementMode#FULL}; a blank model
+   * means the agent's default. The mode is normalized to its canonical wire form, so an engagement
+   * stored with the legacy {@code read-only} spelling reads back — and re-serializes — as {@code
+   * read_only}.
    */
   public static Engagement of(String agent, String mode, String model, String engagedAt) {
     if (Strings.isBlank(agent)) {
@@ -31,22 +30,13 @@ public record Engagement(String agent, String mode, String model, String engaged
     if (Strings.isBlank(engagedAt)) {
       throw new IllegalArgumentException("An engagement records when it began; got a blank time.");
     }
-    var effectiveMode = Strings.isBlank(mode) ? MODE_FULL : mode;
-    if (!MODE_FULL.equals(effectiveMode) && !MODE_READ_ONLY.equals(effectiveMode)) {
-      throw new IllegalArgumentException(
-          "Engagement mode must be '"
-              + MODE_FULL
-              + "' or '"
-              + MODE_READ_ONLY
-              + "', got '"
-              + mode
-              + "'.");
-    }
+    var effectiveMode =
+        (Strings.isBlank(mode) ? EngagementMode.FULL : EngagementMode.of(mode)).wire();
     return new Engagement(agent, effectiveMode, Strings.isBlank(model) ? null : model, engagedAt);
   }
 
   public boolean full() {
-    return MODE_FULL.equals(mode);
+    return EngagementMode.FULL.wire().equals(mode);
   }
 
   /** This engagement as the compact JSON the spec row stores. */

--- a/sail-core/src/main/java/ai/singlr/sail/config/EngagementMode.java
+++ b/sail-core/src/main/java/ai/singlr/sail/config/EngagementMode.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.config;
+
+/**
+ * The access level a room agent holds — full write access or read-only. The canonical wire form is
+ * snake_case ({@code full} / {@code read_only}), the spelling most surfaces (the agents endpoint,
+ * invites, and the Mast client) already use; {@link #of} additionally accepts the legacy hyphenated
+ * {@code read-only} an engagement stored before this unification, so old data reads back correctly
+ * and migrates to the canonical form the next time it is written.
+ */
+public enum EngagementMode {
+  FULL("full"),
+  READ_ONLY("read_only");
+
+  private static final String LEGACY_READ_ONLY = "read-only";
+
+  private final String wire;
+
+  EngagementMode(String wire) {
+    this.wire = wire;
+  }
+
+  /** The canonical wire form. */
+  public String wire() {
+    return wire;
+  }
+
+  /** Whether this is the full-access mode. */
+  public boolean isFull() {
+    return this == FULL;
+  }
+
+  /**
+   * The mode for a wire string — the canonical {@code full}/{@code read_only} or the legacy {@code
+   * read-only}. Throws on a blank or unrecognized value; callers apply their own default for an
+   * absent mode.
+   */
+  public static EngagementMode of(String mode) {
+    if (FULL.wire.equals(mode)) {
+      return FULL;
+    }
+    if (READ_ONLY.wire.equals(mode) || LEGACY_READ_ONLY.equals(mode)) {
+      return READ_ONLY;
+    }
+    throw new IllegalArgumentException(
+        "Engagement mode must be '"
+            + FULL.wire
+            + "' or '"
+            + READ_ONLY.wire
+            + "', got '"
+            + mode
+            + "'.");
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/config/EngagementModeTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/EngagementModeTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * EngagementMode is the one spelling of a room agent's access level. Its {@code wire()} is the
+ * canonical snake_case form every surface now emits; {@code of} still accepts the legacy hyphenated
+ * {@code read-only} so a stored engagement written before the unification reads back correctly.
+ */
+class EngagementModeTest {
+
+  @Test
+  void wireIsTheCanonicalSnakeCaseForm() {
+    assertEquals("full", EngagementMode.FULL.wire());
+    assertEquals("read_only", EngagementMode.READ_ONLY.wire());
+  }
+
+  @Test
+  void ofParsesTheCanonicalForms() {
+    assertEquals(EngagementMode.FULL, EngagementMode.of("full"));
+    assertEquals(EngagementMode.READ_ONLY, EngagementMode.of("read_only"));
+  }
+
+  @Test
+  void ofStillAcceptsTheLegacyHyphenatedReadOnly() {
+    assertEquals(EngagementMode.READ_ONLY, EngagementMode.of("read-only"));
+  }
+
+  @Test
+  void ofRejectsBlankOrUnknown() {
+    assertThrows(IllegalArgumentException.class, () -> EngagementMode.of(""));
+    assertThrows(IllegalArgumentException.class, () -> EngagementMode.of(null));
+    assertThrows(IllegalArgumentException.class, () -> EngagementMode.of("halfway"));
+  }
+
+  @Test
+  void isFullDistinguishesTheTwo() {
+    assertTrue(EngagementMode.FULL.isFull());
+    assertFalse(EngagementMode.READ_ONLY.isFull());
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/config/EngagementTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/config/EngagementTest.java
@@ -18,7 +18,7 @@ class EngagementTest {
   @Test
   void fullIsTheDefaultMode() {
     var engagement = Engagement.of("claude-code", null, null, "2026-08-18T00:00:00Z");
-    assertEquals(Engagement.MODE_FULL, engagement.mode());
+    assertEquals(EngagementMode.FULL.wire(), engagement.mode());
     assertTrue(engagement.full());
     assertNull(engagement.model());
   }
@@ -26,9 +26,17 @@ class EngagementTest {
   @Test
   void readOnlyIsTheExplicitNarrowChoice() {
     var engagement =
-        Engagement.of("claude-code", Engagement.MODE_READ_ONLY, "opus", "2026-08-18T00:00:00Z");
+        Engagement.of(
+            "claude-code", EngagementMode.READ_ONLY.wire(), "opus", "2026-08-18T00:00:00Z");
     assertFalse(engagement.full());
     assertEquals("opus", engagement.model());
+  }
+
+  @Test
+  void aLegacyHyphenatedModeNormalizesToTheCanonicalSpelling() {
+    var engagement = Engagement.of("claude-code", "read-only", null, "2026-08-18T00:00:00Z");
+    assertEquals("read_only", engagement.mode());
+    assertEquals("read_only", Engagement.fromJson(engagement.toJson()).mode());
   }
 
   @Test

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.api;
 
 import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.EngagementMode;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecCatalog;
 import ai.singlr.sail.config.YamlUtil;
@@ -429,10 +430,10 @@ public final class SailOperations implements Operations {
                         cli.displayName(),
                         List.of(
                             new AgentModeView(
-                                "read_only",
+                                EngagementMode.READ_ONLY.wire(),
                                 cli.supportsReadOnlyInvite(),
                                 cli.readOnlyInviteRefusal()),
-                            new AgentModeView("full", true, null))))
+                            new AgentModeView(EngagementMode.FULL.wire(), true, null))))
             .toList();
     return Result.success(new AgentsResponse(agents));
   }
@@ -501,7 +502,7 @@ public final class SailOperations implements Operations {
     return new InviteResponse(
         launch.runId(),
         launch.principal(),
-        launch.full() ? "full" : "read_only",
+        launch.full() ? EngagementMode.FULL.wire() : EngagementMode.READ_ONLY.wire(),
         launch.snapshot());
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecEngageCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecEngageCommand.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.SailApiClient;
 import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.EngagementMode;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.NameValidator;
 import java.util.LinkedHashMap;
@@ -75,7 +76,7 @@ public final class ApiSpecEngageCommand implements Runnable {
     var config = connection.resolve();
     var body = new LinkedHashMap<String, Object>();
     body.put("agent", agent);
-    body.put("mode", readOnly ? "read-only" : "full");
+    body.put("mode", (readOnly ? EngagementMode.READ_ONLY : EngagementMode.FULL).wire());
     if (snapshot && !readOnly) {
       body.put("snapshot", true);
     }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
@@ -295,7 +295,7 @@ class EngagementLifecycleTest {
     assertNull(launch.completion(), "nothing is deferred — no payment to make");
     assertEquals("", launch.snapshot());
     var engagement = stored("auth");
-    assertEquals("read-only", engagement.mode());
+    assertEquals("read_only", engagement.mode());
     assertTrue(ofType(Event.WellKnownTypes.SNAPSHOT_CREATED).isEmpty());
     assertEquals(1, ofType(Event.WellKnownTypes.SPEC_ENGAGED).size());
   }


### PR DESCRIPTION
## What

Third enum brick of **sail-domain-types**. A room agent's access level was a bare `String` spelled **two ways** — the engagement domain and the engage CLI wrote `read-only`, while the `/agents` endpoint and the invite response wrote `read_only` — so a client saw a different value depending on which surface answered.

New `enum EngagementMode { FULL, READ_ONLY }` owns one canonical wire form: **`read_only`** (the spelling most of Mast and the agents endpoint already use — per @uday's call). Every surface routes through it.

## Behavior

- **Output unified** (the deliberate change): the engage response/event now emits `read_only`. `Engagement` normalizes its mode, so an engagement stored with the legacy `read-only` reads back — and re-serializes — as `read_only` (storage migrates on next write).
- **Backward compatible on input**: `EngagementMode.of` still accepts the legacy `read-only`, so a request or stored value written before this change is honored.

## TDD

- `EngagementModeTest` pins the canonical forms + legacy acceptance.
- `EngagementTest` gains a normalization case (legacy `read-only` → `read_only`, round-tripped).
- The engage lifecycle test keeps **sending** legacy `read-only` as input (proving backward compat) and asserts the `read_only` it now gets back.

`mvn clean verify` green, all coverage met.

## Coordinated Mast change

Ships alongside in a Mast PR: the client sends/consumes `read_only` everywhere (request payload, the 3 `sail-models` type unions, the mock gateway's codex guard — which was checking the never-matching `read-only`), and its 549 tests pass. `RosterChip` already tolerated either spelling (it only checks `=== "full"`).