### PR TITLE
feat(rooms): introduce the rooms entity, synced and backfilled, dark (decouple brick 0)

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/RoomStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RoomStore.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.common.Strings;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Rooms on SQLite: the durable collaboration surface an FDE and their agents converse in. A room
+ * carries the conversation-side state that previously lived on the spec row — the agent roster, the
+ * wake policy, the waker-box assignee — while a spec remains the work-item. In this brick the table
+ * exists and replicates but nothing reads it yet; the conversation write paths move here in the
+ * following bricks.
+ *
+ * <p>{@code roster} is one compact JSON array of agent members ({@code [{agent, mode, model,
+ * engaged_at}, …]}) so sync merges the membership atomically — many members by schema even while
+ * the UI adds one. Each mutation journals the room's full post-state through the shared {@link
+ * RevisionJournal} under entity type {@code room}, so rooms get the same revision/CAS/conflict
+ * machinery — and org-wide replication — as specs.
+ */
+public final class RoomStore implements ConflictResolver, SyncedStore {
+
+  private static final String ENTITY = "room";
+
+  private static final Set<String> SYNC_FIELDS =
+      Set.of("project", "title", "assignee", "wake", "roster", "created_by", "created_at");
+
+  private final Sqlite db;
+  private final ChangeLog changeLog;
+  private final RevisionJournal journal;
+
+  public RoomStore(Sqlite db) {
+    this.db = db;
+    this.changeLog = new ChangeLog(db);
+    this.journal = new RevisionJournal(db, changeLog, new RoomSchema());
+  }
+
+  public record RoomRow(
+      String id,
+      String project,
+      String title,
+      String assignee,
+      String wake,
+      String roster,
+      String createdBy,
+      String createdAt,
+      String updatedAt,
+      String updatedBy) {}
+
+  /** Creates a room as a local edit, stamping creation and update times. */
+  public void create(RoomRow room) {
+    Strings.requireNonBlank(room.id(), "A room needs an id");
+    Strings.requireNonBlank(room.title(), "A room needs a title");
+    var now = DateTimeUtils.now().toString();
+    db.transaction(
+        () -> {
+          db.execute(
+              """
+              INSERT INTO rooms (id, project, title, assignee, wake, roster, created_by,
+                  created_at, updated_at, updated_by)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+              room.id(),
+              room.project(),
+              room.title(),
+              room.assignee(),
+              room.wake(),
+              room.roster(),
+              room.createdBy(),
+              now,
+              now,
+              room.updatedBy());
+          journal.recordRevision(room.id(), "local", false);
+        });
+  }
+
+  /** Updates a room's mutable fields as a local edit; creation identity is immutable. */
+  public void update(RoomRow room) {
+    db.transaction(
+        () -> {
+          db.execute(
+              """
+              UPDATE rooms SET project = ?, title = ?, assignee = ?, wake = ?, roster = ?,
+                  updated_at = ?, updated_by = ?
+              WHERE id = ?""",
+              room.project(),
+              room.title(),
+              room.assignee(),
+              room.wake(),
+              room.roster(),
+              DateTimeUtils.now().toString(),
+              room.updatedBy(),
+              room.id());
+          journal.recordRevision(room.id(), "local", false);
+        });
+  }
+
+  public Optional<RoomRow> findById(String id) {
+    return db.queryOne(
+        """
+        SELECT id, project, title, assignee, wake, roster, created_by, created_at,
+            updated_at, updated_by
+        FROM rooms WHERE id = ?""",
+        RoomStore::mapRoom,
+        id);
+  }
+
+  /** Every current room of a project, newest activity last by creation order. */
+  public List<RoomRow> list(String project) {
+    return db.query(
+        """
+        SELECT id, project, title, assignee, wake, roster, created_by, created_at,
+            updated_at, updated_by
+        FROM rooms WHERE project = ? ORDER BY created_at, id""",
+        RoomStore::mapRoom,
+        project);
+  }
+
+  @Override
+  public String entityType() {
+    return ENTITY;
+  }
+
+  @Override
+  public Map<String, Object> comparableSnapshot(String id) {
+    return journal.comparableSnapshot(id);
+  }
+
+  @Override
+  public Map<String, Object> comparableAtRev(String id, String rev) {
+    return journal.comparableAtRev(id, rev);
+  }
+
+  @Override
+  public String latestRev(String id) {
+    return journal.latestRev(id);
+  }
+
+  @Override
+  public String baseRevOf(String id) {
+    return journal.baseRevOf(id);
+  }
+
+  @Override
+  public Set<String> syncEntityIds() {
+    return new LinkedHashSet<>(journal.entityIds());
+  }
+
+  /**
+   * Adopts main's authoritative state at its exact rev (no minting), as the new synced ancestor.
+   */
+  @Override
+  public void applyRevision(String id, Map<String, Object> snapshot, String rev) {
+    journal.applyRevision(id, snapshot, rev);
+  }
+
+  /** Compare-and-set commit as main: accepts only if {@code expectedRev} still matches. */
+  @Override
+  public PushOutcome commitRevision(String id, Map<String, Object> snapshot, String expectedRev) {
+    return journal.commitRevision(id, snapshot, expectedRev);
+  }
+
+  /**
+   * Resolves an open room conflict locally: rebases onto main's conflicting content as the new
+   * merge base, then writes {@code chosen} as the resolved state. Every state stays in the {@link
+   * ChangeLog}, so no choice loses work.
+   */
+  @Override
+  public String resolveConflict(String id, Map<String, Object> chosen, Map<String, Object> remote) {
+    return journal.resolveConflict(id, chosen, remote);
+  }
+
+  private static RoomRow mapRoom(Sqlite.Row row) {
+    return new RoomRow(
+        row.text(0),
+        row.text(1),
+        row.text(2),
+        row.text(3),
+        row.text(4),
+        row.text(5),
+        row.text(6),
+        row.text(7),
+        row.text(8),
+        row.text(9));
+  }
+
+  private Map<String, Object> snapshotMap(RoomRow room) {
+    var map = new LinkedHashMap<String, Object>();
+    map.put("id", room.id());
+    map.put("project", room.project());
+    map.put("title", room.title());
+    map.put("assignee", room.assignee());
+    map.put("wake", room.wake());
+    map.put("roster", room.roster());
+    map.put("created_by", room.createdBy());
+    map.put("created_at", room.createdAt());
+    map.put("updated_by", room.updatedBy());
+    map.put("updated_at", room.updatedAt());
+    return map;
+  }
+
+  /** The room's store-specific half of the shared {@link RevisionJournal} sync protocol. */
+  private final class RoomSchema implements EntitySchema {
+
+    @Override
+    public String entityType() {
+      return ENTITY;
+    }
+
+    @Override
+    public String table() {
+      return "rooms";
+    }
+
+    @Override
+    public boolean exists(String id) {
+      return findById(id).isPresent();
+    }
+
+    @Override
+    public Map<String, Object> snapshotMap(String id) {
+      return findById(id).map(RoomStore.this::snapshotMap).orElse(null);
+    }
+
+    @Override
+    public String author(String id) {
+      return findById(id).map(RoomRow::updatedBy).orElse(null);
+    }
+
+    @Override
+    public void apply(String id, Map<String, Object> snapshot) {
+      var now = DateTimeUtils.now().toString();
+      var createdAt = Snapshots.text(snapshot, "created_at");
+      db.execute(
+          """
+          INSERT INTO rooms (id, project, title, assignee, wake, roster, created_by,
+              created_at, updated_at, updated_by)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET project = excluded.project, title = excluded.title,
+              assignee = excluded.assignee, wake = excluded.wake, roster = excluded.roster,
+              updated_at = excluded.updated_at, updated_by = excluded.updated_by""",
+          id,
+          Snapshots.text(snapshot, "project"),
+          Snapshots.text(snapshot, "title"),
+          Snapshots.text(snapshot, "assignee"),
+          Snapshots.text(snapshot, "wake"),
+          Snapshots.text(snapshot, "roster"),
+          Snapshots.text(snapshot, "created_by"),
+          Strings.isBlank(createdAt) ? now : createdAt,
+          now,
+          Snapshots.actor(snapshot));
+    }
+
+    @Override
+    public Map<String, Object> comparable(Map<String, Object> full) {
+      if (full == null) {
+        return null;
+      }
+      var m = new LinkedHashMap<String, Object>();
+      for (var field : full.keySet()) {
+        if (SYNC_FIELDS.contains(field)) {
+          m.put(field, full.get(field));
+        }
+      }
+      var author = full.get("updated_by");
+      if (author != null) {
+        m.put(Snapshots.ACTOR, author);
+      }
+      return m;
+    }
+
+    @Override
+    public void deleteRow(String id) {
+      db.execute("DELETE FROM rooms WHERE id = ?", id);
+    }
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/RoomsBackfillMigration.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RoomsBackfillMigration.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import ai.singlr.sail.config.ProjectRegistry;
+import ai.singlr.sail.config.YamlUtil;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/**
+ * Mints one room per existing spec with the room id equal to the spec id, carrying the spec's
+ * conversation-side state (wake, engagement-as-roster, assignee) onto the new rooms table. Runs
+ * exactly once per database via the {@code data_migrations} marker.
+ *
+ * <p>Every field of the backfilled snapshot — including its revision — is derived solely from the
+ * spec row, so two boxes that hold the same synced spec mint a byte-identical room at an identical
+ * content-hash rev, recorded as its own synced ancestor ({@code base_rev = rev}). The first fleet
+ * sync after an upgrade therefore converges every backfilled room with zero pushes, pulls, or
+ * conflicts; rooms diverge only where the underlying specs had genuinely diverged, which sync then
+ * surfaces through the ordinary conflict path.
+ */
+public final class RoomsBackfillMigration implements DataMigration {
+
+  public static final String NAME = "rooms-from-specs-v1";
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public Report apply(Sqlite db, ProjectRegistry projects, Prompter prompter) {
+    var rooms = new RoomStore(db);
+    var specs =
+        db.query(
+            """
+            SELECT id, project, title, assignee, wake, engagement, created_by, created_at,
+                updated_by
+            FROM specs ORDER BY id""",
+            row ->
+                Arrays.asList(
+                    text(row, 0),
+                    text(row, 1),
+                    text(row, 2),
+                    text(row, 3),
+                    text(row, 4),
+                    text(row, 5),
+                    text(row, 6),
+                    text(row, 7),
+                    text(row, 8)));
+    var created = 0;
+    for (var spec : specs) {
+      var id = spec.get(0);
+      if (rooms.findById(id).isPresent()) {
+        continue;
+      }
+      var snapshot = roomSnapshot(spec);
+      rooms.applyRevision(id, snapshot, Revisions.next(null, YamlUtil.dumpJson(snapshot)));
+      created++;
+    }
+    return new Report(created, 0, 0, List.of());
+  }
+
+  /**
+   * The comparable-shaped snapshot sync itself would deliver: the room's work-carrying fields plus
+   * the {@code _actor} attribution resolved into {@code updated_by} on apply. Field values come
+   * from the spec row verbatim; the engagement JSON object becomes the roster's one-element array.
+   */
+  private static LinkedHashMap<String, Object> roomSnapshot(List<String> spec) {
+    var engagement = spec.get(5);
+    var snapshot = new LinkedHashMap<String, Object>();
+    snapshot.put("project", spec.get(1));
+    snapshot.put("title", spec.get(2));
+    snapshot.put("assignee", spec.get(3));
+    snapshot.put("wake", spec.get(4));
+    snapshot.put("roster", engagement == null ? null : "[" + engagement + "]");
+    snapshot.put("created_by", spec.get(6));
+    snapshot.put("created_at", spec.get(7));
+    if (spec.get(8) != null) {
+      snapshot.put(Snapshots.ACTOR, spec.get(8));
+    }
+    return snapshot;
+  }
+
+  private static String text(Sqlite.Row row, int index) {
+    return row.text(index);
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -375,7 +375,22 @@ public final class SchemaManager {
           "ALTER TABLE review_findings_v3 RENAME TO review_findings",
           "CREATE INDEX idx_review_findings_stage ON review_findings(stage_id)",
           "CREATE INDEX idx_review_findings_severity ON review_findings(severity)",
-          BACKFILL_SHIPPED_RESIDUE);
+          BACKFILL_SHIPPED_RESIDUE,
+          """
+          CREATE TABLE rooms (
+              id TEXT PRIMARY KEY,
+              project TEXT,
+              title TEXT NOT NULL,
+              assignee TEXT,
+              wake TEXT CHECK (wake IN ('on', 'mention', 'off')),
+              roster TEXT,
+              created_by TEXT,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              updated_by TEXT,
+              rev TEXT,
+              base_rev TEXT
+          )""");
 
   /** The schema version this binary converges every database to. */
   static final int CURRENT_VERSION = V1_VERSION + MIGRATIONS.size();

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncDatabase.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncDatabase.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.sync;
 import ai.singlr.sail.store.DataMigration;
 import ai.singlr.sail.store.LegacyDataMigration;
 import ai.singlr.sail.store.MigrationRunner;
+import ai.singlr.sail.store.RoomsBackfillMigration;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Path;
@@ -44,13 +45,19 @@ public final class SyncDatabase implements AutoCloseable {
     var db = Sqlite.open(dbPath);
     try {
       new SchemaManager(db).migrate();
-      if (db.queryOne(
-              "SELECT 1 FROM data_migrations WHERE name = ?",
-              row -> row.integer(0),
-              LegacyDataMigration.NAME)
-          .isEmpty()) {
+      var pending = List.of(LegacyDataMigration.NAME, RoomsBackfillMigration.NAME);
+      if (pending.stream()
+          .anyMatch(
+              name ->
+                  db.queryOne(
+                          "SELECT 1 FROM data_migrations WHERE name = ?",
+                          row -> row.integer(0),
+                          name)
+                      .isEmpty())) {
         MigrationRunner.applyAll(
-            db, List.of(new LegacyDataMigration()), DataMigration.Prompter.NON_INTERACTIVE);
+            db,
+            List.of(new LegacyDataMigration(), new RoomsBackfillMigration()),
+            DataMigration.Prompter.NON_INTERACTIVE);
       }
     } catch (SchemaManager.PreFloorException e) {
       db.close();

--- a/sail-core/src/test/java/ai/singlr/sail/store/RoomStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RoomStoreTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RoomStoreTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+  private RoomStore rooms;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    rooms = new RoomStore(db);
+  }
+
+  @AfterEach
+  void tearDown() {
+    db.close();
+  }
+
+  private static RoomStore.RoomRow room(String id) {
+    return new RoomStore.RoomRow(
+        id,
+        "acme",
+        "Auth design",
+        "uday",
+        "on",
+        "[{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}]",
+        "uday",
+        null,
+        null,
+        "uday");
+  }
+
+  @Test
+  void createRoundTripsAndJournalsARevision() {
+    rooms.create(room("auth"));
+
+    var found = rooms.findById("auth").orElseThrow();
+    assertEquals("acme", found.project());
+    assertEquals("Auth design", found.title());
+    assertEquals("uday", found.assignee());
+    assertEquals("on", found.wake());
+    assertTrue(found.roster().contains("claude-code"));
+    assertNotNull(found.createdAt());
+    assertNotNull(found.updatedAt());
+    assertNotNull(rooms.latestRev("auth"));
+    assertNull(rooms.baseRevOf("auth"), "a local creation has no synced ancestor");
+    assertTrue(rooms.syncEntityIds().contains("auth"));
+  }
+
+  @Test
+  void createRequiresIdAndTitle() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            rooms.create(
+                new RoomStore.RoomRow(
+                    " ", "acme", "t", null, null, null, "uday", null, null, "uday")));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            rooms.create(
+                new RoomStore.RoomRow(
+                    "id", "acme", "", null, null, null, "uday", null, null, "uday")));
+  }
+
+  @Test
+  void updateJournalsANewRevisionAndKeepsCreationIdentity() {
+    rooms.create(room("auth"));
+    var created = rooms.findById("auth").orElseThrow();
+    var firstRev = rooms.latestRev("auth");
+
+    rooms.update(
+        new RoomStore.RoomRow(
+            "auth",
+            "acme",
+            "Auth design v2",
+            "sam",
+            "mention",
+            null,
+            "ignored",
+            null,
+            null,
+            "sam"));
+
+    var updated = rooms.findById("auth").orElseThrow();
+    assertEquals("Auth design v2", updated.title());
+    assertEquals("sam", updated.assignee());
+    assertEquals("mention", updated.wake());
+    assertNull(updated.roster());
+    assertEquals("sam", updated.updatedBy());
+    assertEquals(created.createdBy(), updated.createdBy());
+    assertEquals(created.createdAt(), updated.createdAt());
+    assertFalse(firstRev.equals(rooms.latestRev("auth")), "an edit mints a new revision");
+  }
+
+  @Test
+  void applyRevisionAdoptsRemoteStateAsTheSyncedAncestor() {
+    var snapshot = new LinkedHashMap<String, Object>();
+    snapshot.put("project", "acme");
+    snapshot.put("title", "Synced room");
+    snapshot.put("assignee", "uday");
+    snapshot.put("wake", "on");
+    snapshot.put("roster", null);
+    snapshot.put("created_by", "uday");
+    snapshot.put("created_at", "2026-08-01T00:00:00Z");
+    snapshot.put(Snapshots.ACTOR, "sam");
+
+    rooms.applyRevision("synced", snapshot, "3-abc");
+
+    var found = rooms.findById("synced").orElseThrow();
+    assertEquals("Synced room", found.title());
+    assertEquals("2026-08-01T00:00:00Z", found.createdAt(), "adoption preserves creation time");
+    assertEquals("sam", found.updatedBy(), "the _actor key resolves into the row's author");
+    assertEquals("3-abc", rooms.latestRev("synced"));
+    assertEquals("3-abc", rooms.baseRevOf("synced"), "adopting from main sets the merge base");
+  }
+
+  @Test
+  void commitRevisionRejectsAStaleRev() {
+    rooms.create(room("auth"));
+    var current = rooms.latestRev("auth");
+
+    var stale = rooms.commitRevision("auth", rooms.comparableSnapshot("auth"), "0-stale");
+    assertInstanceOf(PushOutcome.Stale.class, stale);
+    assertEquals(current, ((PushOutcome.Stale) stale).currentRev());
+
+    var accepted = rooms.commitRevision("auth", rooms.comparableSnapshot("auth"), current);
+    assertInstanceOf(PushOutcome.Accepted.class, accepted);
+  }
+
+  @Test
+  void aRemoteDeletionTombstonesTheRow() {
+    rooms.create(room("auth"));
+
+    rooms.applyRevision("auth", null, "4-gone");
+
+    assertTrue(rooms.findById("auth").isEmpty());
+    assertNull(rooms.comparableSnapshot("auth"));
+    assertNotNull(rooms.latestRev("auth"), "the tombstone stays journaled");
+    assertTrue(rooms.syncEntityIds().contains("auth"), "a tombstoned id remains visible to sync");
+  }
+
+  @Test
+  void comparableSnapshotCarriesWorkFieldsAndActorButNoTimestampMetadata() {
+    rooms.create(room("auth"));
+
+    Map<String, Object> comparable = rooms.comparableSnapshot("auth");
+
+    assertEquals("Auth design", comparable.get("title"));
+    assertEquals("on", comparable.get("wake"));
+    assertTrue(comparable.containsKey("roster"));
+    assertEquals("uday", comparable.get(Snapshots.ACTOR));
+    assertFalse(comparable.containsKey("updated_at"));
+    assertFalse(comparable.containsKey("updated_by"));
+    assertFalse(comparable.containsKey("id"));
+  }
+
+  @Test
+  void listReturnsOnlyTheProjectsRooms() {
+    rooms.create(room("auth"));
+    rooms.create(
+        new RoomStore.RoomRow(
+            "other", "beta", "Beta room", null, null, null, "sam", null, null, "sam"));
+
+    var acme = rooms.list("acme");
+
+    assertEquals(1, acme.size());
+    assertEquals("auth", acme.getFirst().id());
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/RoomsBackfillMigrationTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RoomsBackfillMigrationTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.config.ProjectRegistry;
+import ai.singlr.sail.sync.StoreReplica;
+import ai.singlr.sail.sync.SyncEngine;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RoomsBackfillMigrationTest {
+
+  @TempDir Path tempDir;
+  private Sqlite db;
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(tempDir.resolve("main.db"));
+    new SchemaManager(db).migrate();
+  }
+
+  @AfterEach
+  void tearDown() {
+    db.close();
+  }
+
+  private static void seedSpec(Sqlite target, String id, String engagement) {
+    target.execute(
+        """
+        INSERT INTO specs (id, project, title, status, assignee, wake, engagement, created_by,
+            created_at, updated_at, updated_by)
+        VALUES (?, 'acme', ?, 'done', 'uday', 'on', ?, 'uday',
+            '2026-08-01T00:00:00Z', '2026-08-02T00:00:00Z', 'uday')""",
+        id,
+        "Spec " + id,
+        engagement);
+  }
+
+  private DataMigration.Report backfill(Sqlite target) {
+    return new RoomsBackfillMigration()
+        .apply(target, noProjects(), DataMigration.Prompter.NON_INTERACTIVE);
+  }
+
+  private ProjectRegistry noProjects() {
+    return ProjectRegistry.loadFromDisk(tempDir.resolve("no-projects"));
+  }
+
+  @Test
+  void mintsOneRoomPerSpecWithIdentityIdCarryingConversationState() {
+    seedSpec(db, "auth", "{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}");
+    seedSpec(db, "billing", null);
+
+    var report = backfill(db);
+
+    assertEquals(2, report.applied());
+    var rooms = new RoomStore(db);
+    var auth = rooms.findById("auth").orElseThrow();
+    assertEquals("Spec auth", auth.title());
+    assertEquals("acme", auth.project());
+    assertEquals("uday", auth.assignee());
+    assertEquals("on", auth.wake());
+    assertEquals(
+        "[{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}]",
+        auth.roster(),
+        "the engagement object becomes the roster's one-element array");
+    assertEquals("2026-08-01T00:00:00Z", auth.createdAt());
+    assertEquals("uday", auth.updatedBy());
+    assertNull(rooms.findById("billing").orElseThrow().roster(), "no engagement, empty roster");
+    assertEquals(
+        rooms.latestRev("auth"),
+        rooms.baseRevOf("auth"),
+        "a backfilled room is its own synced ancestor");
+  }
+
+  @Test
+  void skipsSpecsThatAlreadyHaveARoomAndReportsOnlyFreshOnes() {
+    seedSpec(db, "auth", null);
+    backfill(db);
+
+    seedSpec(db, "billing", null);
+    var second = backfill(db);
+
+    assertEquals(1, second.applied());
+    assertEquals(2, new RoomStore(db).list("acme").size());
+  }
+
+  @Test
+  void runsExactlyOncePerDatabaseThroughTheDataMigrator() {
+    seedSpec(db, "auth", null);
+    var migrator = new DataMigrator(db, List.of(new RoomsBackfillMigration()));
+
+    var first = migrator.run(noProjects(), DataMigration.Prompter.NON_INTERACTIVE);
+    var second = migrator.run(noProjects(), DataMigration.Prompter.NON_INTERACTIVE);
+
+    assertEquals(1, first.getFirst().report().applied());
+    assertTrue(second.getFirst().alreadyApplied());
+  }
+
+  @Test
+  void twoBoxesBackfillIdenticalRevsSoTheFirstSyncIsANoop() {
+    try (var node = Sqlite.open(tempDir.resolve("node.db"))) {
+      new SchemaManager(node).migrate();
+      seedSpec(db, "auth", "{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}");
+      seedSpec(node, "auth", "{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}");
+
+      backfill(db);
+      backfill(node);
+
+      var mainRooms = new RoomStore(db);
+      var nodeRooms = new RoomStore(node);
+      assertEquals(
+          mainRooms.latestRev("auth"),
+          nodeRooms.latestRev("auth"),
+          "identical spec content mints an identical content-hash rev on every box");
+
+      var report =
+          new SyncEngine()
+              .reconcile(
+                  new StoreReplica(
+                      "node",
+                      nodeRooms,
+                      new ChangeLog(node),
+                      new SyncConflicts(node),
+                      new SyncState(node)),
+                  new StoreReplica(
+                      "main",
+                      mainRooms,
+                      new ChangeLog(db),
+                      new SyncConflicts(db),
+                      new SyncState(db)));
+
+      assertEquals(0, report.total(), "the first fleet sync after backfill moves nothing");
+    }
+  }
+
+  @Test
+  void divergedSpecsStillConvergeThroughTheOrdinarySyncPath() {
+    try (var node = Sqlite.open(tempDir.resolve("node.db"))) {
+      new SchemaManager(node).migrate();
+      seedSpec(db, "auth", "{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}");
+      seedSpec(node, "auth", null);
+
+      backfill(db);
+      backfill(node);
+
+      var mainRooms = new RoomStore(db);
+      var nodeRooms = new RoomStore(node);
+      var report =
+          new SyncEngine()
+              .reconcile(
+                  new StoreReplica(
+                      "node",
+                      nodeRooms,
+                      new ChangeLog(node),
+                      new SyncConflicts(node),
+                      new SyncState(node)),
+                  new StoreReplica(
+                      "main",
+                      mainRooms,
+                      new ChangeLog(db),
+                      new SyncConflicts(db),
+                      new SyncState(db)));
+
+      assertTrue(report.total() > 0, "genuine divergence is reconciled, never silently equal");
+      assertEquals(
+          mainRooms.findById("auth").orElseThrow().roster(),
+          nodeRooms.findById("auth").orElseThrow().roster(),
+          "the boxes converge on main's authoritative roster");
+    }
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -360,6 +360,11 @@ class SchemaManagerTest {
             .contains("spec_messages"));
     assertTrue(
         db.query(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'rooms'",
+                r -> r.text(0))
+            .contains("rooms"));
+    assertTrue(
+        db.query(
                 "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'box_credential'",
                 r -> r.text(0))
             .contains("box_credential"));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -23,6 +23,7 @@ import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.LegacyDataMigration;
 import ai.singlr.sail.store.MigrationRunner;
 import ai.singlr.sail.store.ProjectStore;
+import ai.singlr.sail.store.RoomsBackfillMigration;
 import ai.singlr.sail.store.Sqlite;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -53,7 +54,8 @@ import picocli.CommandLine.Spec;
 public final class MigrateCommand implements Runnable {
 
   /** Every one-shot data migration tracked in {@code data_migrations}. Add new ones at the end. */
-  public static final List<DataMigration> REGISTRY = List.of(new LegacyDataMigration());
+  public static final List<DataMigration> REGISTRY =
+      List.of(new LegacyDataMigration(), new RoomsBackfillMigration());
 
   @Option(
       names = "--non-interactive",

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
@@ -25,6 +25,7 @@ import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RoomStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.SyncConflicts;
@@ -131,10 +132,12 @@ public final class SyncCommand implements Callable<Integer> {
     var fileStore = new FileStore(db);
     var projectStore = new ProjectStore(db);
     var specStore = new SpecStore(db);
+    var roomStore = new RoomStore(db);
     var messageStore = new MessageStore(db);
     var runStore = new RunStore(db);
     return new Boxes(
         new StoreReplica(host, specStore, changeLog, conflicts, syncState),
+        new StoreReplica(host, roomStore, changeLog, conflicts, syncState),
         new StoreReplica(host, fileStore, changeLog, conflicts, syncState),
         new StoreReplica(host, projectStore, changeLog, conflicts, syncState),
         new StoreReplica(
@@ -155,6 +158,7 @@ public final class SyncCommand implements Callable<Integer> {
 
   private record Boxes(
       StoreReplica spec,
+      StoreReplica room,
       StoreReplica file,
       StoreReplica project,
       StoreReplica run,
@@ -240,6 +244,7 @@ public final class SyncCommand implements Callable<Integer> {
     try (var channel = SshSyncChannel.open(target);
         var session = new SyncSession(channel.reader(), channel.writer())) {
       var specReport = new SyncEngine().reconcile(boxes.spec(), session.replica("spec"));
+      var roomReport = new SyncEngine().reconcile(boxes.room(), session.replica("room"));
       var fileReport = new SyncEngine().reconcile(boxes.file(), session.replica("file"));
       var projectReport = new SyncEngine().reconcile(boxes.project(), session.replica("project"));
       var runReport = new SyncEngine().reconcile(boxes.run(), session.replica("run"));
@@ -264,7 +269,9 @@ public final class SyncCommand implements Callable<Integer> {
       return new Round(
           combine(
               combine(
-                  combine(combine(combine(specReport, fileReport), projectReport), runReport),
+                  combine(
+                      combine(combine(combine(specReport, roomReport), fileReport), projectReport),
+                      runReport),
                   reviewReport),
               messageReport),
           pulledMessages);

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncServerCommand.java
@@ -20,6 +20,7 @@ import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RoomStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
@@ -100,6 +101,7 @@ public final class SyncServerCommand implements Callable<Integer> {
     var replicas =
         Map.<String, MainReplica>of(
             "spec", new StoreReplica(mainId, new SpecStore(db), changeLog, conflicts, syncState),
+            "room", new StoreReplica(mainId, new RoomStore(db), changeLog, conflicts, syncState),
             "file", new StoreReplica(mainId, new FileStore(db), changeLog, conflicts, syncState),
             "project",
                 new StoreReplica(mainId, new ProjectStore(db), changeLog, conflicts, syncState),


### PR DESCRIPTION
Brick 0 of `room-spec-decouple` (spec has the full arc): the `rooms` table and `RoomStore` exist, replicate, and are backfilled — and nothing reads them yet. Behavior-preserving by construction.

## What

- **`rooms` table** (append-only schema migration): `id, project, title, assignee, wake, roster, created_by/at, updated_by/at, rev, base_rev`. `roster` is one compact JSON **array** of agent members (`[{agent, mode, model, engaged_at}, …]`) — many members by schema, per the approved interaction model, even while the UI adds one.
- **`RoomStore`**: journal-backed synced store on the shared `RevisionJournal`/`EntitySchema` machinery — same revision/CAS/tombstone/conflict protocol as specs, zero new sync code. Registered as entity `room` in both sync lanes (`SyncCommand` node side, `SyncServerCommand` main side).
- **`RoomsBackfillMigration`** (`data_migrations`-tracked, runs once per box): mints one room per existing spec with **`room.id = spec.id`**, carrying the spec's conversation-side state (wake, engagement → one-element roster, assignee, attribution).

## The zero-churn migration

Every backfilled field — including the revision — derives solely from the spec row, and revs are content-hashed (`Revisions`). Two boxes holding the same synced spec therefore mint a **byte-identical room at an identical rev**, recorded as its own synced ancestor (`base_rev = rev`). Proven by test: the first fleet sync after upgrade reconciles the backfilled rooms with **zero pushes, pulls, or conflicts**; rooms diverge only where the specs had genuinely diverged, and that surfaces through the ordinary conflict path (also tested).

## Deliberate scope cuts

- **`specs.room_id` is deferred to Brick 3.** Adding it now would change the synced spec snapshot shape: a pre-split box's `applySnapshot` drops the unknown key and pushes the row back without it — a silent null-back loop. Until Brick 3 (which bumps the sync upgrade floor with the message re-key), room id ≡ spec id by the identity migration, so the column adds nothing dark.
- **Mixed-version fleet**: a pre-split peer already refuses the `room` entity cleanly (`SyncWire.Failed: Unknown entity type`) — defined behavior, no corruption; the existing `V1_UPGRADE_FLOOR` handshake stays untouched this brick.

## Tests

- `RoomStoreTest` (8): CRUD + validation, journal revs, adopt-as-ancestor with `_actor` attribution, CAS staleness, remote-deletion tombstones, comparable-snapshot metadata exclusion.
- `RoomsBackfillMigrationTest` (5): identity ids + roster/wake/attribution carry-over, skip-existing, once-per-database via `DataMigrator`, **two-box identical-rev + first-sync-is-a-noop**, diverged-spec convergence.
- `SchemaManagerTest`: rooms table asserted on the upgrade path.
