### PR TITLE
feat(rooms): the rooms membership API (decouple brick 1b)

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -788,6 +788,31 @@ record DisengageResponse(String agent) implements Mappable {
   }
 }
 
+/** Response of {@code GET /v1/rooms/{id}/members}: the room's roster, room-first. */
+record RoomMembersResponse(List<ai.singlr.sail.config.Engagement> members) implements Mappable {
+  @Override
+  public Map<String, Object> toMap() {
+    var m = new LinkedHashMap<String, Object>();
+    m.put(
+        "members",
+        members.stream()
+            .map(
+                member -> {
+                  var one = new LinkedHashMap<String, Object>();
+                  one.put("agent", member.agent());
+                  one.put("mode", member.mode());
+                  if (member.model() != null) {
+                    one.put("model", member.model());
+                  }
+                  one.put("engaged_at", member.engagedAt());
+                  return one;
+                })
+            .toList());
+    m.put("count", members.size());
+    return m;
+  }
+}
+
 record InviteRequest(String agent, String model, boolean full, boolean snapshot) {
   static InviteRequest fromMap(Map<String, Object> map) {
     return new InviteRequest(

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -60,6 +60,8 @@ public final class ApiRouter implements HttpHandler {
   private static final String MESSAGES = "messages";
   private static final String INVITE = "invite";
   private static final String ENGAGE = "engage";
+  private static final String ROOMS = "rooms";
+  private static final String MEMBERS = "members";
   private static final String DISENGAGE = "disengage";
   private static final String AGENTS = "agents";
   private static final String SNAPSHOTS = "snapshots";
@@ -191,6 +193,10 @@ public final class ApiRouter implements HttpHandler {
       return routeGlobalSpecs(exchange, request);
     }
 
+    if (request.hasRoomsPrefix()) {
+      return routeRooms(exchange, request);
+    }
+
     if (request.hasReviewsPrefix()) {
       return routeReviews(exchange, request);
     }
@@ -301,6 +307,33 @@ public final class ApiRouter implements HttpHandler {
         Objects.toString(exchange.getAttribute("token.fde"), null),
         Role.fromAttribute(exchange.getAttribute("token.role")),
         Actor.Lane.API);
+  }
+
+  /**
+   * Routes the rooms membership surface — {@code GET|POST|DELETE /v1/rooms/{id}/members}. A room id
+   * is a spec id while rooms and specs share identity; the write forms reuse the engage shapes and
+   * semantics, so the spec-shaped doors can retire without a behavior change.
+   */
+  private ApiResponse routeRooms(HttpExchange exchange, RouteRequest request) throws IOException {
+    if (request.size() != 4 || !MEMBERS.equals(request.segments().get(3))) {
+      throw notFound();
+    }
+    var roomId = request.segments().get(2);
+    NameValidator.requireValidSpecId(roomId);
+    return switch (request.method()) {
+      case GET -> ApiResponse.from(operations.roomMembers(roomId));
+      case POST ->
+          ApiResponse.from(
+              operations.addRoomMember(
+                  roomId,
+                  EngageRequest.fromMap(JsonBody.readMap(exchange)),
+                  actorOf(exchange),
+                  nodeHandle.get()));
+      case DELETE ->
+          ApiResponse.from(
+              operations.removeRoomMember(roomId, actorOf(exchange), nodeHandle.get()));
+      default -> throw methodNotAllowed();
+    };
   }
 
   private ApiResponse routeGlobalSpecs(HttpExchange exchange, RouteRequest request)
@@ -772,6 +805,10 @@ public final class ApiRouter implements HttpHandler {
 
     boolean hasGlobalSpecsPrefix() {
       return segments.size() >= 2 && V1.equals(segments.get(0)) && SPECS.equals(segments.get(1));
+    }
+
+    boolean hasRoomsPrefix() {
+      return segments.size() >= 2 && V1.equals(segments.get(0)) && ROOMS.equals(segments.get(1));
     }
 
     boolean hasReviewsPrefix() {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -389,6 +389,11 @@ public final class DispatchOperations {
     return membership.disengage(specId, actor, localHandle);
   }
 
+  /** The members of {@code roomId}'s roster, room-first. */
+  public List<ai.singlr.sail.config.Engagement> roomMembers(String roomId) {
+    return membership.members(roomId);
+  }
+
   /**
    * Delegates to {@link RoomCommitGuard}: the read-only room contract's backstop, run when a room
    * run stops. Kept on the dispatch surface so the server and the wake reactor reach it here.

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MembershipService.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MembershipService.java
@@ -72,10 +72,35 @@ public final class MembershipService {
   public static RoomState stateOf(RoomStore rooms, SpecStore.SpecRow spec) {
     var room = rooms == null ? null : rooms.findById(spec.id()).orElse(null);
     if (room == null) {
-      return new RoomState(spec.wake(), Engagement.fromJson(spec.engagement()));
+      return new RoomState(spec.wake(), rosterOf(null, spec).standing());
     }
     var wake = room.wake() != null ? room.wake() : spec.wake();
     return new RoomState(wake, Roster.fromJson(room.roster()).standing());
+  }
+
+  /**
+   * The full membership of a spec's room — the room row's roster when one exists (authoritative,
+   * even when empty), else the spec's legacy engagement column as a one-member roster.
+   */
+  public static Roster rosterOf(RoomStore rooms, SpecStore.SpecRow spec) {
+    var room = rooms == null ? null : rooms.findById(spec.id()).orElse(null);
+    if (room != null) {
+      return Roster.fromJson(room.roster());
+    }
+    var legacy = Engagement.fromJson(spec.engagement());
+    return legacy == null ? Roster.EMPTY : Roster.solo(legacy);
+  }
+
+  /** The members of {@code roomId}'s roster, room-first. The room's spec must exist. */
+  public java.util.List<Engagement> members(String roomId) {
+    var spec =
+        specStore
+            .findById(roomId)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.SPEC_NOT_FOUND, "Room '" + roomId + "' was not found."));
+    return rosterOf(rooms.get(), spec).members();
   }
 
   /** A prepared membership: the snapshot label a full mode will pay, and the deferred half. */

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
@@ -120,4 +120,11 @@ public interface Operations extends LocalLaneOperations {
       String specId, EngageRequest request, Actor actor, String localHandle);
 
   Result<DisengageResponse> disengageSpec(String specId, Actor actor, String localHandle);
+
+  Result<RoomMembersResponse> roomMembers(String roomId);
+
+  Result<EngageResponse> addRoomMember(
+      String roomId, EngageRequest request, Actor actor, String localHandle);
+
+  Result<DisengageResponse> removeRoomMember(String roomId, Actor actor, String localHandle);
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -487,6 +487,24 @@ public final class SailOperations implements Operations {
   }
 
   @Override
+  public Result<RoomMembersResponse> roomMembers(String roomId) {
+    freshenForRead();
+    return safe(() -> new RoomMembersResponse(dispatchOps.roomMembers(roomId)));
+  }
+
+  @Override
+  public Result<EngageResponse> addRoomMember(
+      String roomId, EngageRequest request, Actor actor, String localHandle) {
+    return engageToSpec(roomId, request, actor, localHandle);
+  }
+
+  @Override
+  public Result<DisengageResponse> removeRoomMember(
+      String roomId, Actor actor, String localHandle) {
+    return disengageSpec(roomId, actor, localHandle);
+  }
+
+  @Override
   public Result<DisengageResponse> disengageSpec(String specId, Actor actor, String localHandle) {
     freshenForRead();
     var result =

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -1065,6 +1065,46 @@ class ApiRouterTest {
   }
 
   @Test
+  void roomMembersRoutesReadAddAndRemoveThroughThePort() throws Exception {
+    var ops = new FakeOperations();
+    try (var server = serverWith(ops, true)) {
+      var listed = get(server, "/v1/rooms/auth-flow/members", "token");
+      assertEquals(200, listed.statusCode());
+      assertTrue(listed.body().contains("\"agent\": \"claude-code\""));
+      assertTrue(listed.body().contains("\"count\": 1"));
+      assertTrue(listed.body().contains("\"model\": \"opus-x\""));
+      assertEquals("auth-flow", ops.lastMembersRoom);
+
+      var added =
+          post(
+              server,
+              "/v1/rooms/auth-flow/members",
+              "token",
+              "{\"agent\": \"claude-code\", \"mode\": \"read_only\"}");
+      assertEquals(200, added.statusCode());
+      assertTrue(added.body().contains("\"mode\": \"read_only\""));
+      assertEquals("auth-flow", ops.lastAddMember.specId());
+      assertEquals("read_only", ops.lastAddMember.request().mode());
+
+      var removed = delete(server, "/v1/rooms/auth-flow/members", "token");
+      assertEquals(200, removed.statusCode());
+      assertTrue(removed.body().contains("\"disengaged\": true"));
+      assertEquals("auth-flow", ops.lastRemoveMember);
+    }
+  }
+
+  @Test
+  void theRoomsSurfaceRefusesUnknownShapesAndMethods() throws Exception {
+    var ops = new FakeOperations();
+    try (var server = serverWith(ops, true)) {
+      assertEquals(404, get(server, "/v1/rooms", "token").statusCode());
+      assertEquals(404, get(server, "/v1/rooms/auth-flow", "token").statusCode());
+      assertEquals(404, get(server, "/v1/rooms/auth-flow/messages", "token").statusCode());
+      assertEquals(405, put(server, "/v1/rooms/auth-flow/members", "token", "{}").statusCode());
+    }
+  }
+
+  @Test
   void engageRequiresPostAndDisengageRoutesTheSpec() throws Exception {
     var ops = new FakeOperations();
     try (var server = serverWith(ops, true)) {
@@ -1511,6 +1551,9 @@ class ApiRouterTest {
 
     Engage lastEngage;
     String lastDisengage;
+    String lastMembersRoom;
+    Engage lastAddMember;
+    String lastRemoveMember;
 
     record Engage(String specId, EngageRequest request, String localHandle) {}
 
@@ -1523,6 +1566,32 @@ class ApiRouterTest {
               request.agent(),
               request.mode() == null ? "full" : request.mode(),
               request.snapshot() ? "engage-1" : ""));
+    }
+
+    @Override
+    public Result<RoomMembersResponse> roomMembers(String roomId) {
+      lastMembersRoom = roomId;
+      return Result.success(
+          new RoomMembersResponse(
+              java.util.List.of(
+                  ai.singlr.sail.config.Engagement.of(
+                      "claude-code", "full", "opus-x", "2026-08-23T00:00:00Z"))));
+    }
+
+    @Override
+    public Result<EngageResponse> addRoomMember(
+        String roomId, EngageRequest request, Actor actor, String localHandle) {
+      lastAddMember = new Engage(roomId, request, localHandle);
+      return Result.success(
+          new EngageResponse(
+              request.agent(), request.mode() == null ? "full" : request.mode(), ""));
+    }
+
+    @Override
+    public Result<DisengageResponse> removeRoomMember(
+        String roomId, Actor actor, String localHandle) {
+      lastRemoveMember = roomId;
+      return Result.success(new DisengageResponse("claude-code"));
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
@@ -387,6 +387,26 @@ class EngagementLifecycleTest {
               HANDLE);
       assertTrue(refused instanceof Result.Failure<EngageResponse>);
 
+      var membersAdd =
+          sailOps.addRoomMember(
+              "auth",
+              new EngageRequest("claude-code", "read_only", null, false),
+              Actor.cliOperator(HANDLE),
+              HANDLE);
+      assertTrue(membersAdd instanceof Result.Success<EngageResponse>);
+      assertEquals("read_only", ((Result.Success<EngageResponse>) membersAdd).value().mode());
+      var listed = sailOps.roomMembers("auth");
+      assertTrue(listed instanceof Result.Success<RoomMembersResponse>);
+      assertEquals(1, ((Result.Success<RoomMembersResponse>) listed).value().members().size());
+      var removed = sailOps.removeRoomMember("auth", Actor.cliOperator(HANDLE), HANDLE);
+      assertTrue(removed instanceof Result.Success<DisengageResponse>);
+      assertEquals("claude-code", ((Result.Success<DisengageResponse>) removed).value().agent());
+      sailOps.engageToSpec(
+          "auth",
+          new EngageRequest("claude-code", null, null, true),
+          Actor.cliOperator(HANDLE),
+          HANDLE);
+
       var dismissed = sailOps.disengageSpec("auth", Actor.cliOperator(HANDLE), HANDLE);
       assertTrue(dismissed instanceof Result.Success<DisengageResponse>);
       assertEquals("claude-code", ((Result.Success<DisengageResponse>) dismissed).value().agent());
@@ -488,6 +508,25 @@ class EngagementLifecycleTest {
     assertNull(
         roomStore.findById("auth").orElseThrow().roster(),
         "an empty roster stores as null, matching the engagement convention");
+  }
+
+  @Test
+  void membersReadsTheRosterRoomFirstThroughTheLifecycle() throws Exception {
+    var ops = operations(shell());
+    seedSpec("auth");
+    assertTrue(ops.roomMembers("auth").isEmpty(), "a fresh room seats nobody");
+
+    ops.engage("auth", "claude-code", "read-only", null, false, Actor.cliOperator(HANDLE), HANDLE);
+    var members = ops.roomMembers("auth");
+    assertEquals(1, members.size());
+    assertEquals("claude-code", members.getFirst().agent());
+    assertEquals("read_only", members.getFirst().mode());
+
+    ops.disengage("auth", Actor.cliOperator(HANDLE), HANDLE);
+    assertTrue(ops.roomMembers("auth").isEmpty(), "dismissal empties the roster");
+
+    var missing = assertThrows(ApiException.class, () -> ops.roomMembers("ghost"));
+    assertEquals(ErrorCode.SPEC_NOT_FOUND, missing.failure().errorCode());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -96,6 +96,24 @@ class TestOperations implements Operations {
   }
 
   @Override
+  public Result<RoomMembersResponse> roomMembers(String roomId) {
+    return Result.success(new RoomMembersResponse(java.util.List.of()));
+  }
+
+  @Override
+  public Result<EngageResponse> addRoomMember(
+      String roomId, EngageRequest request, Actor actor, String localHandle) {
+    return Result.success(
+        new EngageResponse(request.agent(), request.mode() == null ? "full" : request.mode(), ""));
+  }
+
+  @Override
+  public Result<DisengageResponse> removeRoomMember(
+      String roomId, Actor actor, String localHandle) {
+    return Result.success(new DisengageResponse(null));
+  }
+
+  @Override
   public Result<ProjectResponse> project(String project) {
     return Result.success(new ProjectResponse(project, "running", null));
   }


### PR DESCRIPTION
Brick 1b of `room-spec-decouple`: the rooms membership API — the room-shaped door onto the membership service Brick 1a moved to the room row. Pure surface addition; zero behavior change to any existing endpoint.

## What

- **`GET|POST|DELETE /v1/rooms/{id}/members`** on the web lane:
  - `GET` lists the roster room-first (`RoomMembersResponse`: members with agent/mode/model/engaged_at + count).
  - `POST` adds a member — the exact engage semantics and shapes (`EngageRequest`/`EngageResponse`), same admission, same snapshot payment, same events.
  - `DELETE` removes the standing member — the exact disengage semantics (`DisengageResponse`), idempotent.
- **`Operations` port** grows the three methods; `SailOperations.addRoomMember`/`removeRoomMember` delegate to the engage/disengage implementations verbatim — one service, two doors, so Brick 6 can retire the spec-shaped door with no behavior change. A room id is a spec id while identity holds (Brick 3 breaks that); ids are validated the same way.
- **`MembershipService.rosterOf`** — the full-roster read seam beside `stateOf`: a present room row is authoritative (even empty), a missing row falls back to the legacy engagement column as a one-member roster.
- `LocalLaneOperations` (the in-container surface) deliberately untouched.

## Tests

- `ApiRouterTest` +2: the three methods route through the port with payloads intact; unknown shapes 404, wrong method 405. `FakeOperations`/`TestOperations` extended.
- `EngagementLifecycleTest` +1: roster read through the full lifecycle — empty fresh, seated after engage (mode normalized), empty after dismissal, room-first, `SPEC_NOT_FOUND` for a ghost room.
