### PR TITLE
fix(rooms): harden bricks 0/1 against the adversarial review findings

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/DataMigrations.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/DataMigrations.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.store;
+
+import java.util.List;
+
+/**
+ * The one canonical registry of data migrations, shared by every lane that converges a database —
+ * the {@code sail migrate} CLI, server start, and the sync engine — so a migration added in one
+ * place can never silently be skipped by another.
+ */
+public final class DataMigrations {
+
+  public static final List<DataMigration> ALL =
+      List.of(new LegacyDataMigration(), new RoomsBackfillMigration());
+
+  private DataMigrations() {}
+
+  /** Whether any registered migration has not yet been applied to {@code db}. */
+  public static boolean anyPending(Sqlite db) {
+    return ALL.stream()
+        .anyMatch(
+            migration ->
+                db.queryOne(
+                        "SELECT 1 FROM data_migrations WHERE name = ?",
+                        row -> row.integer(0),
+                        migration.name())
+                    .isEmpty());
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/store/RoomStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RoomStore.java
@@ -82,23 +82,78 @@ public final class RoomStore implements ConflictResolver, SyncedStore {
         });
   }
 
-  /** Updates a room's mutable fields as a local edit; creation identity is immutable. */
-  public void update(RoomRow room) {
+  /**
+   * Seats a new roster as a local edit — a single-column write, so a concurrent wake edit is never
+   * clobbered by a stale full-row rewrite.
+   */
+  public void updateRoster(String id, String roster, String actor) {
+    db.transaction(
+        () -> {
+          db.execute(
+              "UPDATE rooms SET roster = ?, updated_at = ?, updated_by = ? WHERE id = ?",
+              roster,
+              DateTimeUtils.now().toString(),
+              actor,
+              id);
+          journal.recordRevision(id, "local", false);
+        });
+  }
+
+  /** Stores a new wake mode as a local edit — single-column, mirror of {@link #updateRoster}. */
+  public void updateWake(String id, String wake, String actor) {
+    db.transaction(
+        () -> {
+          db.execute(
+              "UPDATE rooms SET wake = ?, updated_at = ?, updated_by = ? WHERE id = ?",
+              wake,
+              DateTimeUtils.now().toString(),
+              actor,
+              id);
+          journal.recordRevision(id, "local", false);
+        });
+  }
+
+  /** Tombstones a room so the deletion propagates; a no-op if it is already absent. */
+  public boolean delete(String id) {
+    return db.transaction(
+        () -> {
+          if (findById(id).isEmpty()) {
+            return false;
+          }
+          journal.recordRevision(id, "local", true);
+          db.execute("DELETE FROM rooms WHERE id = ?", id);
+          return true;
+        });
+  }
+
+  /**
+   * Writes a row verbatim — timestamps included — and journals it as a LOCAL revision with no
+   * synced ancestor. The backfill's write: every field derives from the synced spec row, so each
+   * box mints a byte-identical revision, and a room main never minted pushes up on first sync
+   * instead of reading as a remote deletion (which a synced-ancestor write would).
+   */
+  public void createJournaled(RoomRow room) {
+    Strings.requireNonBlank(room.id(), "A room needs an id");
+    Strings.requireNonBlank(room.title(), "A room needs a title");
+    Strings.requireNonBlank(room.createdAt(), "A journaled create carries its creation time");
+    Strings.requireNonBlank(room.updatedAt(), "A journaled create carries its update time");
     db.transaction(
         () -> {
           db.execute(
               """
-              UPDATE rooms SET project = ?, title = ?, assignee = ?, wake = ?, roster = ?,
-                  updated_at = ?, updated_by = ?
-              WHERE id = ?""",
+              INSERT INTO rooms (id, project, title, assignee, wake, roster, created_by,
+                  created_at, updated_at, updated_by)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+              room.id(),
               room.project(),
               room.title(),
               room.assignee(),
               room.wake(),
               room.roster(),
-              DateTimeUtils.now().toString(),
-              room.updatedBy(),
-              room.id());
+              room.createdBy(),
+              room.createdAt(),
+              room.updatedAt(),
+              room.updatedBy());
           journal.recordRevision(room.id(), "local", false);
         });
   }
@@ -109,13 +164,16 @@ public final class RoomStore implements ConflictResolver, SyncedStore {
    */
   public RoomRow ensureFor(
       String id, String project, String title, String assignee, String wake, String actor) {
-    return findById(id)
-        .orElseGet(
-            () -> {
-              create(
-                  new RoomRow(id, project, title, assignee, wake, null, actor, null, null, actor));
-              return findById(id).orElseThrow();
-            });
+    return db.immediateTransaction(
+        () ->
+            findById(id)
+                .orElseGet(
+                    () -> {
+                      create(
+                          new RoomRow(
+                              id, project, title, assignee, wake, null, actor, null, null, actor));
+                      return findById(id).orElseThrow();
+                    }));
   }
 
   /** Every room with at least one member — the rooms the engagement sweeper walks. */

--- a/sail-core/src/main/java/ai/singlr/sail/store/RoomsBackfillMigration.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RoomsBackfillMigration.java
@@ -5,10 +5,10 @@
 
 package ai.singlr.sail.store;
 
+import ai.singlr.sail.config.Engagement;
 import ai.singlr.sail.config.ProjectRegistry;
-import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.config.Roster;
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.List;
 
 /**
@@ -16,11 +16,12 @@ import java.util.List;
  * conversation-side state (wake, engagement-as-roster, assignee) onto the new rooms table. Runs
  * exactly once per database via the {@code data_migrations} marker.
  *
- * <p>Every field of the backfilled snapshot — including its revision — is derived solely from the
- * spec row, so two boxes that hold the same synced spec mint a byte-identical room at an identical
- * content-hash rev, recorded as its own synced ancestor ({@code base_rev = rev}). The first fleet
- * sync after an upgrade therefore converges every backfilled room with zero pushes, pulls, or
- * conflicts; rooms diverge only where the underlying specs had genuinely diverged, which sync then
+ * <p>Every field of the backfilled row — and therefore its content-hash revision — derives solely
+ * from the spec row, so two boxes holding the same synced spec mint a byte-identical room at an
+ * identical rev. The write is journaled as LOCAL with no synced ancestor: boxes that both
+ * backfilled a room converge as a no-op (equal revs), and a room main never minted — a spec that
+ * reached main only by sync — pushes up on the first round instead of reading back as a remote
+ * deletion. Rooms diverge only where the underlying specs had genuinely diverged, which sync
  * surfaces through the ordinary conflict path.
  */
 public final class RoomsBackfillMigration implements DataMigration {
@@ -39,7 +40,7 @@ public final class RoomsBackfillMigration implements DataMigration {
         db.query(
             """
             SELECT id, project, title, assignee, wake, engagement, created_by, created_at,
-                updated_by
+                updated_by, updated_at
             FROM specs ORDER BY id""",
             row ->
                 Arrays.asList(
@@ -51,39 +52,40 @@ public final class RoomsBackfillMigration implements DataMigration {
                     text(row, 5),
                     text(row, 6),
                     text(row, 7),
-                    text(row, 8)));
+                    text(row, 8),
+                    text(row, 9)));
     var created = 0;
     for (var spec : specs) {
       var id = spec.get(0);
       if (rooms.findById(id).isPresent()) {
         continue;
       }
-      var snapshot = roomSnapshot(spec);
-      rooms.applyRevision(id, snapshot, Revisions.next(null, YamlUtil.dumpJson(snapshot)));
+      rooms.createJournaled(roomRow(spec));
       created++;
     }
     return new Report(created, 0, 0, List.of());
   }
 
   /**
-   * The comparable-shaped snapshot sync itself would deliver: the room's work-carrying fields plus
-   * the {@code _actor} attribution resolved into {@code updated_by} on apply. Field values come
-   * from the spec row verbatim; the engagement JSON object becomes the roster's one-element array.
+   * The room row a spec backfills to, every field taken from the spec row verbatim — timestamps
+   * included — so each box mints a byte-identical local revision with no synced ancestor. The
+   * engagement column rides through {@link Engagement#fromJson}'s corruption tolerance before
+   * becoming the roster's genesis value: a corrupt or blank engagement backfills as no members,
+   * exactly as it already read.
    */
-  private static LinkedHashMap<String, Object> roomSnapshot(List<String> spec) {
-    var engagement = spec.get(5);
-    var snapshot = new LinkedHashMap<String, Object>();
-    snapshot.put("project", spec.get(1));
-    snapshot.put("title", spec.get(2));
-    snapshot.put("assignee", spec.get(3));
-    snapshot.put("wake", spec.get(4));
-    snapshot.put("roster", engagement == null ? null : "[" + engagement + "]");
-    snapshot.put("created_by", spec.get(6));
-    snapshot.put("created_at", spec.get(7));
-    if (spec.get(8) != null) {
-      snapshot.put(Snapshots.ACTOR, spec.get(8));
-    }
-    return snapshot;
+  private static RoomStore.RoomRow roomRow(List<String> spec) {
+    var member = Engagement.fromJson(spec.get(5));
+    return new RoomStore.RoomRow(
+        spec.get(0),
+        spec.get(1),
+        spec.get(2),
+        spec.get(3),
+        spec.get(4),
+        member == null ? null : Roster.solo(member).toJson(),
+        spec.get(6),
+        spec.get(7),
+        spec.get(9),
+        spec.get(8));
   }
 
   private static String text(Sqlite.Row row, int index) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -378,6 +378,33 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
         });
   }
 
+  /**
+   * Composes writes across stores sharing this database into one atomic transaction — nested store
+   * transactions join the outermost scope (see {@link Sqlite#transaction}), the same seam {@code
+   * StoreReplica.atomically} rides. Lets a caller pair a room write with its spec mirror so a crash
+   * can never persist one half.
+   */
+  public <T> T atomically(java.util.function.Supplier<T> work) {
+    return db.transaction(work);
+  }
+
+  /**
+   * Stores a new engagement mirror as a local edit — a single-column write, so it can never revert
+   * a concurrent status transition or reassignment the way a full-row rewrite from a stale read
+   * would.
+   */
+  public void updateEngagement(String id, String engagement) {
+    db.transaction(
+        () -> {
+          db.execute(
+              "UPDATE specs SET engagement = ?, updated_at = ? WHERE id = ?",
+              engagement,
+              DateTimeUtils.now().toString(),
+              id);
+          recordRevision(id, "local", false);
+        });
+  }
+
   public void updateStatus(String id, SpecStatus status) {
     db.transaction(
         () -> {

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncDatabase.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncDatabase.java
@@ -6,13 +6,11 @@
 package ai.singlr.sail.sync;
 
 import ai.singlr.sail.store.DataMigration;
-import ai.singlr.sail.store.LegacyDataMigration;
+import ai.singlr.sail.store.DataMigrations;
 import ai.singlr.sail.store.MigrationRunner;
-import ai.singlr.sail.store.RoomsBackfillMigration;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Path;
-import java.util.List;
 
 /**
  * The only database handle a sync path may run on: constructing one converges the schema and
@@ -45,19 +43,8 @@ public final class SyncDatabase implements AutoCloseable {
     var db = Sqlite.open(dbPath);
     try {
       new SchemaManager(db).migrate();
-      var pending = List.of(LegacyDataMigration.NAME, RoomsBackfillMigration.NAME);
-      if (pending.stream()
-          .anyMatch(
-              name ->
-                  db.queryOne(
-                          "SELECT 1 FROM data_migrations WHERE name = ?",
-                          row -> row.integer(0),
-                          name)
-                      .isEmpty())) {
-        MigrationRunner.applyAll(
-            db,
-            List.of(new LegacyDataMigration(), new RoomsBackfillMigration()),
-            DataMigration.Prompter.NON_INTERACTIVE);
+      if (DataMigrations.anyPending(db)) {
+        MigrationRunner.applyAll(db, DataMigrations.ALL, DataMigration.Prompter.NON_INTERACTIVE);
       }
     } catch (SchemaManager.PreFloorException e) {
       db.close();

--- a/sail-core/src/test/java/ai/singlr/sail/store/RoomStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RoomStoreTest.java
@@ -87,33 +87,58 @@ class RoomStoreTest {
   }
 
   @Test
-  void updateJournalsANewRevisionAndKeepsCreationIdentity() {
+  void narrowUpdatesTouchOnlyTheirColumnAndJournalARevision() {
     rooms.create(room("auth"));
     var created = rooms.findById("auth").orElseThrow();
     var firstRev = rooms.latestRev("auth");
 
-    rooms.update(
-        new RoomStore.RoomRow(
-            "auth",
-            "acme",
-            "Auth design v2",
-            "sam",
-            "mention",
-            null,
-            "ignored",
-            null,
-            null,
-            "sam"));
-
-    var updated = rooms.findById("auth").orElseThrow();
-    assertEquals("Auth design v2", updated.title());
-    assertEquals("sam", updated.assignee());
-    assertEquals("mention", updated.wake());
-    assertNull(updated.roster());
-    assertEquals("sam", updated.updatedBy());
-    assertEquals(created.createdBy(), updated.createdBy());
-    assertEquals(created.createdAt(), updated.createdAt());
+    rooms.updateRoster("auth", null, "sam");
+    var afterRoster = rooms.findById("auth").orElseThrow();
+    assertNull(afterRoster.roster());
+    assertEquals(created.wake(), afterRoster.wake(), "a roster write never touches wake");
+    assertEquals(created.title(), afterRoster.title());
+    assertEquals("sam", afterRoster.updatedBy());
     assertFalse(firstRev.equals(rooms.latestRev("auth")), "an edit mints a new revision");
+
+    rooms.updateWake("auth", "mention", "ada");
+    var afterWake = rooms.findById("auth").orElseThrow();
+    assertEquals("mention", afterWake.wake());
+    assertNull(afterWake.roster(), "a wake write never resurrects the roster");
+    assertEquals(created.createdAt(), afterWake.createdAt());
+  }
+
+  @Test
+  void deleteTombstonesTheRoomSoTheDeletionPropagates() {
+    rooms.create(room("auth"));
+
+    assertTrue(rooms.delete("auth"));
+
+    assertTrue(rooms.findById("auth").isEmpty());
+    assertNotNull(rooms.latestRev("auth"), "the tombstone stays journaled for sync");
+    assertTrue(rooms.syncEntityIds().contains("auth"));
+    assertFalse(rooms.delete("auth"), "deleting an absent room is a no-op");
+  }
+
+  @Test
+  void createJournaledWritesVerbatimTimestampsWithNoSyncedAncestor() {
+    rooms.createJournaled(
+        new RoomStore.RoomRow(
+            "seed",
+            "acme",
+            "Seeded",
+            "uday",
+            "on",
+            null,
+            "uday",
+            "t-created",
+            "t-updated",
+            "uday"));
+
+    var row = rooms.findById("seed").orElseThrow();
+    assertEquals("t-created", row.createdAt());
+    assertEquals("t-updated", row.updatedAt());
+    assertNotNull(rooms.latestRev("seed"));
+    assertNull(rooms.baseRevOf("seed"), "a local genesis has no synced ancestor");
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/RoomsBackfillMigrationTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RoomsBackfillMigrationTest.java
@@ -70,17 +70,17 @@ class RoomsBackfillMigrationTest {
     assertEquals("acme", auth.project());
     assertEquals("uday", auth.assignee());
     assertEquals("on", auth.wake());
-    assertEquals(
-        "[{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}]",
-        auth.roster(),
-        "the engagement object becomes the roster's one-element array");
+    var seated = ai.singlr.sail.config.Roster.fromJson(auth.roster()).standing();
+    assertEquals("claude-code", seated.agent(), "the engagement becomes the roster's one member");
+    assertEquals("full", seated.mode());
+    assertEquals("t0", seated.engagedAt());
     assertEquals("2026-08-01T00:00:00Z", auth.createdAt());
     assertEquals("uday", auth.updatedBy());
     assertNull(rooms.findById("billing").orElseThrow().roster(), "no engagement, empty roster");
-    assertEquals(
-        rooms.latestRev("auth"),
+    assertNull(
         rooms.baseRevOf("auth"),
-        "a backfilled room is its own synced ancestor");
+        "a backfilled room is a local genesis, so a room main lacks pushes up instead of"
+            + " reading back as a remote deletion");
   }
 
   @Test
@@ -142,6 +142,51 @@ class RoomsBackfillMigrationTest {
 
       assertEquals(0, report.total(), "the first fleet sync after backfill moves nothing");
     }
+  }
+
+  @Test
+  void aRoomMainNeverMintedPushesUpOnFirstSyncInsteadOfBeingDeleted() {
+    try (var node = Sqlite.open(tempDir.resolve("node.db"))) {
+      new SchemaManager(node).migrate();
+      seedSpec(node, "node-only", null);
+      backfill(node);
+      backfill(db);
+
+      var mainRooms = new RoomStore(db);
+      var nodeRooms = new RoomStore(node);
+      var report =
+          new SyncEngine()
+              .reconcile(
+                  new StoreReplica(
+                      "node",
+                      nodeRooms,
+                      new ChangeLog(node),
+                      new SyncConflicts(node),
+                      new SyncState(node)),
+                  new StoreReplica(
+                      "main",
+                      mainRooms,
+                      new ChangeLog(db),
+                      new SyncConflicts(db),
+                      new SyncState(db)));
+
+      assertEquals(1, report.pushed(), "the node's room reaches main");
+      assertTrue(nodeRooms.findById("node-only").isPresent(), "the node keeps its room");
+      assertTrue(mainRooms.findById("node-only").isPresent());
+    }
+  }
+
+  @Test
+  void aCorruptEngagementBackfillsAsNoMembersNeverAPoisonedRoster() {
+    seedSpec(db, "corrupt", "not json {{{");
+    seedSpec(db, "blank", "");
+
+    backfill(db);
+
+    var rooms = new RoomStore(db);
+    assertNull(rooms.findById("corrupt").orElseThrow().roster());
+    assertNull(rooms.findById("blank").orElseThrow().roster(), "blank never mints roster='[]'");
+    assertTrue(rooms.listEngaged().isEmpty(), "no empty room counts as engaged");
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
@@ -8,6 +8,8 @@ package ai.singlr.sail.store;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -627,6 +629,26 @@ class SpecStoreTest {
 
     assertEquals(List.of("auth"), store.findById("billing").orElseThrow().dependsOn());
     assertTrue(store.findById("auth").isEmpty(), "the dependency need not exist");
+  }
+
+  @Test
+  void updateEngagementTouchesOnlyTheMirrorColumnAndJournals() {
+    store.create(spec("auth", "OAuth", "draft"));
+    store.updateStatus("auth", SpecStatus.IN_PROGRESS);
+    var before = store.findById("auth").orElseThrow();
+    var rev = store.revOf("auth");
+
+    store.updateEngagement("auth", "{\"agent\":\"claude-code\",\"engaged_at\":\"t0\"}");
+
+    var after = store.findById("auth").orElseThrow();
+    assertEquals(SpecStatus.IN_PROGRESS, after.status(), "a mirror write never touches status");
+    assertEquals(before.assignee(), after.assignee());
+    assertEquals(before.title(), after.title());
+    assertNotNull(after.engagement());
+    assertNotEquals(rev, store.revOf("auth"), "the mirror write journals a revision");
+
+    store.updateEngagement("auth", null);
+    assertNull(store.findById("auth").orElseThrow().engagement());
   }
 
   @Test

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/SailRoomRelay.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/SailRoomRelay.java
@@ -65,9 +65,12 @@ public final class SailRoomRelay {
       # batch retries next check, so the worst case is a duplicate delivery,
       # never a lost one.
       # Every unexpected condition exits 0 silently: delivery is best-effort and
-      # must never break a build. An interval stamp under the run dir keeps the
+      # must never break a build. The hook payload on stdin is drained before
+      # any guard can exit, so the hook writer never takes an EPIPE. An interval stamp under the run dir keeps the
       # relay to at most one API round-trip per __CHECK_INTERVAL__ seconds.
       set -u
+
+      cat >/dev/null 2>&1 || true
 
       RUN_ID="${SAIL_RUN_ID:-}"
       [ -n "$RUN_ID" ] || exit 0

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/SailSessionReport.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/SailSessionReport.java
@@ -54,8 +54,11 @@ public final class SailSessionReport {
       # sessions are inert. Last write wins server-side: a resume, clear, or
       # compact restart simply re-reports the new conversation.
       # Every unexpected condition exits 0 silently: a session report must
-      # never block or fail an agent.
+      # never block or fail an agent. Stdin is drained before any guard can
+      # exit, so the hook writer never takes an EPIPE from an early return.
       set -u
+
+      PAYLOAD="$(cat 2>/dev/null || true)"
 
       RUN_ID="${SAIL_RUN_ID:-}"
       [ -n "$RUN_ID" ] || exit 0
@@ -66,7 +69,7 @@ public final class SailSessionReport {
       command -v curl >/dev/null 2>&1 || exit 0
       command -v python3 >/dev/null 2>&1 || exit 0
 
-      BODY="$(python3 -c '
+      BODY="$(printf '%s' "$PAYLOAD" | python3 -c '
       import json, sys, urllib.parse
       try:
           payload = json.load(sys.stdin)

--- a/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
@@ -231,18 +231,7 @@ final class GlobalSpecOperations {
             updated.wake(),
             request.updatedBy());
     if (!Objects.equals(room.wake(), updated.wake())) {
-      store.update(
-          new RoomStore.RoomRow(
-              room.id(),
-              room.project(),
-              room.title(),
-              room.assignee(),
-              updated.wake(),
-              room.roster(),
-              room.createdBy(),
-              room.createdAt(),
-              null,
-              request.updatedBy()));
+      store.updateWake(updated.id(), updated.wake(), request.updatedBy());
     }
   }
 
@@ -280,7 +269,15 @@ final class GlobalSpecOperations {
     requireStore();
     var existing = findOrThrow(specId);
     SpecPolicy.mutate(actor, existing.id(), existing.assignee(), existing.createdBy()).enforce();
-    specStore.delete(specId);
+    var store = rooms.get();
+    specStore.atomically(
+        () -> {
+          specStore.delete(specId);
+          if (store != null) {
+            store.delete(specId);
+          }
+          return null;
+        });
     publishBoardUpdated(existing.project(), specId, Event.SAIL_AGENT);
     return new GlobalSpecDeletedResponse(specId);
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MembershipService.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MembershipService.java
@@ -231,23 +231,15 @@ public final class MembershipService {
   private void writeRoster(SpecStore.SpecRow spec, Roster roster, Actor actor) {
     var store = requireRooms();
     var handle = actor == null ? spec.updatedBy() : actor.handle();
-    var room =
-        store.ensureFor(
-            spec.id(), spec.project(), spec.title(), spec.assignee(), spec.wake(), handle);
-    store.update(
-        new RoomStore.RoomRow(
-            room.id(),
-            room.project(),
-            room.title(),
-            room.assignee(),
-            room.wake(),
-            roster.toJson(),
-            room.createdBy(),
-            room.createdAt(),
-            null,
-            handle));
     var standing = roster.standing();
-    specStore.update(spec.withEngagement(standing == null ? null : standing.toJson()));
+    specStore.atomically(
+        () -> {
+          store.ensureFor(
+              spec.id(), spec.project(), spec.title(), spec.assignee(), spec.wake(), handle);
+          store.updateRoster(spec.id(), roster.toJson(), handle);
+          specStore.updateEngagement(spec.id(), standing == null ? null : standing.toJson());
+          return null;
+        });
   }
 
   private RoomStore requireRooms() {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
@@ -324,15 +324,18 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
    * lost event, or a turn deferred behind a build must never strand a conversation.
    */
   public void sweepEngagedRooms() {
-    for (var room : roomStore.listEngaged()) {
+    var engaged = new java.util.LinkedHashSet<String>();
+    roomStore.listEngaged().forEach(room -> engaged.add(room.id()));
+    specStore.listEngaged().forEach(spec -> engaged.add(spec.id()));
+    for (var id : engaged) {
       try {
-        var spec = specStore.findById(room.id()).orElse(null);
+        var spec = specStore.findById(id).orElse(null);
         if (spec != null && spec.assignedTo(localHandle.get())) {
           refireOwedTurn(spec.id());
         }
       } catch (RuntimeException e) {
         System.err.println(
-            "room-wake: engagement sweep of room " + room.id() + " failed: " + e.getMessage());
+            "room-wake: engagement sweep of room " + id + " failed: " + e.getMessage());
       }
     }
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ConflictsCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ConflictsCommand.java
@@ -12,6 +12,7 @@ import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.store.ConflictResolver;
 import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.ProjectStore;
+import ai.singlr.sail.store.RoomStore;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import ai.singlr.sail.store.SyncConflicts;
@@ -119,6 +120,7 @@ public final class ConflictsCommand implements Callable<Integer> {
       case SPEC -> new SpecStore(db);
       case FILE -> new FileStore(db);
       case PROJECT -> new ProjectStore(db);
+      case "room" -> new RoomStore(db);
       default -> throw new IllegalStateException("Unknown conflict entity type: " + entityType);
     };
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -18,12 +18,11 @@ import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.Spinner;
 import ai.singlr.sail.engine.SshIdentityProvisioner;
 import ai.singlr.sail.store.DataMigration;
+import ai.singlr.sail.store.DataMigrations;
 import ai.singlr.sail.store.DataMigrator;
 import ai.singlr.sail.store.FileStore;
-import ai.singlr.sail.store.LegacyDataMigration;
 import ai.singlr.sail.store.MigrationRunner;
 import ai.singlr.sail.store.ProjectStore;
-import ai.singlr.sail.store.RoomsBackfillMigration;
 import ai.singlr.sail.store.Sqlite;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -54,8 +53,7 @@ import picocli.CommandLine.Spec;
 public final class MigrateCommand implements Runnable {
 
   /** Every one-shot data migration tracked in {@code data_migrations}. Add new ones at the end. */
-  public static final List<DataMigration> REGISTRY =
-      List.of(new LegacyDataMigration(), new RoomsBackfillMigration());
+  public static final List<DataMigration> REGISTRY = DataMigrations.ALL;
 
   @Option(
       names = "--non-interactive",

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
@@ -511,6 +511,27 @@ class EngagementLifecycleTest {
   }
 
   @Test
+  void anEngageNeverRevertsAConcurrentStatusTransition() throws Exception {
+    var ops = operations(shell());
+    seedSpec("auth");
+    var launch =
+        ops.engage("auth", "claude-code", "full", null, true, Actor.cliOperator(HANDLE), HANDLE);
+    specStore.compareAndSetStatus(
+        "auth",
+        ai.singlr.sail.config.SpecStatus.DRAFT,
+        ai.singlr.sail.config.SpecStatus.IN_PROGRESS);
+
+    launch.completion().run();
+
+    var after = specStore.findById("auth").orElseThrow();
+    assertEquals(
+        ai.singlr.sail.config.SpecStatus.IN_PROGRESS,
+        after.status(),
+        "the engagement mirror is a single-column write — it cannot clobber a status race");
+    assertNotNull(Engagement.fromJson(after.engagement()));
+  }
+
+  @Test
   void membersReadsTheRosterRoomFirstThroughTheLifecycle() throws Exception {
     var ops = operations(shell());
     seedSpec("auth");
@@ -535,9 +556,7 @@ class EngagementLifecycleTest {
     seedSpec("auth");
     ops.engage("auth", "claude-code", "read-only", null, false, Actor.cliOperator(HANDLE), HANDLE);
     var spec = specStore.findById("auth").orElseThrow();
-    roomStore.update(
-        new RoomStore.RoomRow(
-            "auth", "acme", "OAuth flow", HANDLE, null, null, HANDLE, null, null, HANDLE));
+    roomStore.updateRoster("auth", null, HANDLE);
 
     assertNotNull(Engagement.fromJson(spec.engagement()), "the legacy column is now stale");
     assertNull(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
@@ -743,6 +743,29 @@ class GlobalSpecOperationsTest {
   }
 
   @Test
+  void deleteTombstonesTheIdentityRoomAndAReusedIdGetsAFreshRoom() {
+    var rooms = new RoomStore(db);
+    var withRooms = new GlobalSpecOperations(specStore, reviewStore, null, null, () -> rooms);
+    withRooms.create(
+        SpecCreateRequest.fromMap(
+                java.util.Map.of("id", "reused", "title", "First life", "project", "acme"))
+            .withCreatedBy("uday"));
+    rooms.updateRoster(
+        "reused", "[{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}]", "uday");
+
+    withRooms.delete("reused", ADMIN);
+    assertTrue(rooms.findById("reused").isEmpty(), "the identity room dies with its spec");
+
+    withRooms.create(
+        SpecCreateRequest.fromMap(
+                java.util.Map.of("id", "reused", "title", "Second life", "project", "acme"))
+            .withCreatedBy("uday"));
+    var reborn = rooms.findById("reused").orElseThrow();
+    assertEquals("Second life", reborn.title(), "a reused id mints a fresh room");
+    assertNull(reborn.roster(), "no ghost member resurrects from the first life");
+  }
+
+  @Test
   void anExplicitWakeEditDualWritesTheRoomRow() {
     var rooms = new RoomStore(db);
     var withRooms = new GlobalSpecOperations(specStore, reviewStore, null, null, () -> rooms);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
@@ -181,20 +181,8 @@ class RoomWakeReactorTest {
     var spec = specStore.findById(id).orElseThrow();
     var member = ai.singlr.sail.config.Engagement.of(agent, mode, null, now.get().toString());
     specStore.update(spec.withEngagement(member.toJson()));
-    var room =
-        roomStore.ensureFor(id, spec.project(), spec.title(), spec.assignee(), spec.wake(), "uday");
-    roomStore.update(
-        new RoomStore.RoomRow(
-            room.id(),
-            room.project(),
-            room.title(),
-            room.assignee(),
-            room.wake(),
-            ai.singlr.sail.config.Roster.solo(member).toJson(),
-            room.createdBy(),
-            room.createdAt(),
-            null,
-            "uday"));
+    roomStore.ensureFor(id, spec.project(), spec.title(), spec.assignee(), spec.wake(), "uday");
+    roomStore.updateRoster(id, ai.singlr.sail.config.Roster.solo(member).toJson(), "uday");
   }
 
   private String chatRun(String specId, String role, String status, Instant startedAt) {
@@ -974,21 +962,26 @@ class RoomWakeReactorTest {
   }
 
   @Test
+  void theSweepStillRescuesALegacyColumnEngagementWithNoRoomRow() {
+    seed("legacy", "in_progress", "uday", "on");
+    var spec = specStore.findById("legacy").orElseThrow();
+    specStore.update(
+        spec.withEngagement(
+            ai.singlr.sail.config.Engagement.of("claude-code", "full", null, now.get().toString())
+                .toJson()));
+    messageStore.append("legacy", "uday", "anyone there?", null);
+
+    reactor().sweepEngagedRooms();
+
+    assertEquals(1, launcher.woken.size(), "the sweep unions the legacy column until it retires");
+  }
+
+  @Test
   void aMemberRecordedOnlyOnTheRoomRowWakesTheAgent() {
     seed("auth", "in_progress", "uday", "off");
     roomStore.ensureFor("auth", "acme", "auth", "uday", "off", "uday");
-    roomStore.update(
-        new RoomStore.RoomRow(
-            "auth",
-            "acme",
-            "auth",
-            "uday",
-            "off",
-            "[{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}]",
-            "uday",
-            null,
-            null,
-            "uday"));
+    roomStore.updateRoster(
+        "auth", "[{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}]", "uday");
 
     var reactor = reactor();
     reactor.onEvent(message("auth", "uday", "hello"));
@@ -1000,19 +993,7 @@ class RoomWakeReactorTest {
   void aDismissalRecordedOnTheRoomWinsOverAStaleSpecColumn() {
     seed("auth", "in_progress", "uday", "off");
     engage("auth", "claude-code", "full");
-    var room = roomStore.findById("auth").orElseThrow();
-    roomStore.update(
-        new RoomStore.RoomRow(
-            room.id(),
-            room.project(),
-            room.title(),
-            room.assignee(),
-            room.wake(),
-            null,
-            room.createdBy(),
-            room.createdAt(),
-            null,
-            "uday"));
+    roomStore.updateRoster("auth", null, "uday");
 
     var reactor = reactor();
     reactor.onEvent(message("auth", "uday", "hello"));

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/ConflictsCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/ConflictsCommandTest.java
@@ -17,6 +17,7 @@ import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.store.FileStore;
 import ai.singlr.sail.store.ProjectStore;
+import ai.singlr.sail.store.RoomStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
@@ -221,6 +222,7 @@ class ConflictsCommandTest {
     assertInstanceOf(FileStore.class, ConflictsCommand.resolverFor(db, "file"));
     assertInstanceOf(SpecStore.class, ConflictsCommand.resolverFor(db, "spec"));
     assertInstanceOf(ProjectStore.class, ConflictsCommand.resolverFor(db, "project"));
+    assertInstanceOf(RoomStore.class, ConflictsCommand.resolverFor(db, "room"));
   }
 
   @Test


### PR DESCRIPTION
Hardening for decouple Bricks 0/1, driven by an adversarial code review of `v0.30.0..main` (7 confirmed + 2 plausible correctness findings + 1 structural cleanup — all verified against code before fixing). Nothing here is released; the bricks are merged but the fleet is on 0.30.0, so every fix — including rewriting the backfill migration itself — lands before first field exposure.

## Correctness fixes (each with a regression test)

1. **Spec delete now tombstones the identity room** (atomically with the spec delete). Regression test proves the resurrection bug is dead: delete an engaged spec, re-create the same id → a *fresh* room, no ghost member, no stale wake.
2. **The engagement mirror is a single-column write** — new `SpecStore.updateEngagement` replaces the full-row rewrite from a possibly-stale read; test proves an engage completing after a concurrent status CAS can no longer revert the transition.
3. **The dual-write is atomic** — `writeRoster` composes room write + spec mirror inside one transaction via a new `SpecStore.atomically` seam (nested store transactions join the outer scope; the `StoreReplica.atomically` precedent). A crash can no longer persist one half.
4. **Room-row writes are column-narrow** — `RoomStore.updateRoster`/`updateWake` replace the removed wholesale `update`, so a concurrent engage and wake edit can no longer clobber each other's column.
5. **`ensureFor` is atomic** (`BEGIN IMMEDIATE` check-then-insert) — concurrent engages on a roomless spec no longer race to a PRIMARY KEY 500.
6. **Backfill rewritten to local-genesis journaled writes** (`RoomStore.createJournaled`: verbatim timestamps, deterministic content-hash rev, `base_rev = null`). Fixes the confirmed sync bug where a room main never minted read back as a remote deletion — new test proves that room now *pushes up* on first sync; the two-box zero-churn test still passes (identical revs, no-op reconcile).
7. **Backfill routes the engagement through `Engagement.fromJson`'s corruption tolerance** — a corrupt or blank column mints no members (test), never a poisoned genesis revision or a `'[]'` roster that counts as engaged.
8. **`sail conflicts resolve` handles rooms** — `resolverFor` gained the `room` case (folded into the existing resolver-dispatch test).
9. **The engagement sweep unions both homes** — `roomStore.listEngaged()` ∪ `specStore.listEngaged()`, so a spec engaged via the legacy column with no room row (sync round that died between the spec and room lanes) is still rescued; test proves it.

## Cleanup

10. **One canonical data-migration registry** — new `store.DataMigrations.ALL` (+ `anyPending`) shared by `MigrateCommand`, `ServerStartCommand`, and `SyncDatabase`; the triply-maintained lists and the hand-rolled applied-check are gone.

## Addendum: hook-writer EPIPE (found by this PR's CI, root-caused structurally)

`SessionReportDeliveryIT.aDeadSocketLeavesTheReportSilent` failed on the multi-node lane with `IOException: Broken pipe` — in the *writer*. Root cause read straight from the script: `sail-session-report`'s guards (`[ -S "$SOCKET" ] || exit 0` etc.) exit **before stdin is ever read**, so whenever the script wins the race the hook writer takes an EPIPE — on a hook whose contract is "must never block or fail an agent." A latent production defect, present since #188; main's green lane history was timing luck, and this branch merely lost the coin flip. Audit of every generated hook script:

- `sail-session-report`: **fixed** — the payload is drained before any guard can exit.
- `sail-room-relay`: **fixed** — it never drained the hook payload at all, and its interval guard exits unread on nearly every tool call; now drains first.
- stop gate: already correct (`INPUT="$(cat …)"` precedes every guard).
- event helper / agent-session scripts: take no hook stdin; not affected.

Per the no-flaky-reruns rule: no rerun was requested until the defect was fixed structurally.
