### PR TITLE
feat(rooms): re-key messages to the room, bump the sync floor (decouple brick 2)

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
@@ -20,13 +20,13 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-/** Append-only messages attached to specs and journaled as independently synced records. */
+/** Append-only messages attached to rooms and journaled as independently synced records. */
 public final class MessageStore implements SyncedStore {
 
   public static final int MAX_BODY_BYTES = 64 * 1024;
   private static final String ENTITY = "message";
   private static final String COLUMNS =
-      "id, spec_id, author, body, reply_to, created_at, rev, base_rev, question";
+      "id, room_id, author, body, reply_to, created_at, rev, base_rev, question";
 
   private final Sqlite db;
   private final ChangeLog changeLog;
@@ -38,7 +38,7 @@ public final class MessageStore implements SyncedStore {
 
   public record MessageRow(
       String id,
-      String specId,
+      String roomId,
       String author,
       String body,
       String replyTo,
@@ -47,12 +47,12 @@ public final class MessageStore implements SyncedStore {
       String baseRev,
       boolean question) {}
 
-  public MessageRow append(String specId, String author, String body, String replyTo) {
-    return append(specId, author, body, replyTo, false);
+  public MessageRow append(String roomId, String author, String body, String replyTo) {
+    return append(roomId, author, body, replyTo, false);
   }
 
   public MessageRow append(
-      String specId, String author, String body, String replyTo, boolean question) {
+      String roomId, String author, String body, String replyTo, boolean question) {
     requireBody(body);
     if (Strings.isBlank(author)) {
       throw new IllegalArgumentException("message author is required");
@@ -66,7 +66,7 @@ public final class MessageStore implements SyncedStore {
           var row =
               new MessageRow(
                   id,
-                  specId,
+                  roomId,
                   author.strip(),
                   body,
                   replyTo,
@@ -84,7 +84,7 @@ public final class MessageStore implements SyncedStore {
         });
   }
 
-  public List<MessageRow> list(String specId, String before, int limit) {
+  public List<MessageRow> list(String roomId, String before, int limit) {
     if (before != null) {
       Ids.requireUuid(before);
     }
@@ -96,18 +96,18 @@ public final class MessageStore implements SyncedStore {
             ? db.query(
                 "SELECT "
                     + COLUMNS
-                    + " FROM spec_messages WHERE spec_id = ?"
+                    + " FROM room_messages WHERE room_id = ?"
                     + " ORDER BY id DESC LIMIT ?",
                 MessageStore::map,
-                specId,
+                roomId,
                 limit)
             : db.query(
                 "SELECT "
                     + COLUMNS
-                    + " FROM spec_messages WHERE spec_id = ? AND id < ?"
+                    + " FROM room_messages WHERE room_id = ? AND id < ?"
                     + " ORDER BY id DESC LIMIT ?",
                 MessageStore::map,
-                specId,
+                roomId,
                 before,
                 limit);
     var oldest = new ArrayList<>(newest);
@@ -116,12 +116,12 @@ public final class MessageStore implements SyncedStore {
   }
 
   /**
-   * Messages of {@code specId} strictly newer than {@code after} (a message id, or null for all),
+   * Messages of {@code roomId} strictly newer than {@code after} (a message id, or null for all),
    * oldest first, capped at {@code limit}. Ids are UUIDv7 strings, so {@code id > ?} is mint-time
    * order — a forward paging cursor for room reads. Not a delivery primitive: mint order is not
    * arrival order across synced boxes, so delivery goes through {@link #listUndelivered}.
    */
-  public List<MessageRow> listAfter(String specId, String after, int limit) {
+  public List<MessageRow> listAfter(String roomId, String after, int limit) {
     if (after != null) {
       Ids.requireUuid(after);
     }
@@ -130,56 +130,56 @@ public final class MessageStore implements SyncedStore {
     }
     if (after == null) {
       return db.query(
-          "SELECT " + COLUMNS + " FROM spec_messages WHERE spec_id = ? ORDER BY id ASC LIMIT ?",
+          "SELECT " + COLUMNS + " FROM room_messages WHERE room_id = ? ORDER BY id ASC LIMIT ?",
           MessageStore::map,
-          specId,
+          roomId,
           limit);
     }
     return db.query(
         "SELECT "
             + COLUMNS
-            + " FROM spec_messages WHERE spec_id = ? AND id > ? ORDER BY id ASC LIMIT ?",
+            + " FROM room_messages WHERE room_id = ? AND id > ? ORDER BY id ASC LIMIT ?",
         MessageStore::map,
-        specId,
+        roomId,
         after,
         limit);
   }
 
   /**
-   * Messages of {@code specId} absent from {@code runId}'s delivery ledger and not authored by
+   * Messages of {@code roomId} absent from {@code runId}'s delivery ledger and not authored by
    * {@code excludeAuthor} (a run is never told its own story), oldest first, capped at {@code
    * limit}. Delivery is by exact identity, so a message that synchronized in with an older id after
    * newer messages were already delivered still appears here.
    */
   public List<MessageRow> listUndelivered(
-      String specId, String runId, String excludeAuthor, int limit) {
+      String roomId, String runId, String excludeAuthor, int limit) {
     if (limit <= 0) {
       throw new IllegalArgumentException("limit must be positive");
     }
     return db.query(
         "SELECT "
             + COLUMNS
-            + " FROM spec_messages WHERE spec_id = ? AND author != ?"
+            + " FROM room_messages WHERE room_id = ? AND author != ?"
             + " AND NOT EXISTS (SELECT 1 FROM run_delivered_messages"
-            + " WHERE run_id = ? AND message_id = spec_messages.id)"
+            + " WHERE run_id = ? AND message_id = room_messages.id)"
             + " ORDER BY id ASC LIMIT ?",
         MessageStore::map,
-        specId,
+        roomId,
         excludeAuthor,
         runId,
         limit);
   }
 
   /** The id of the room's newest message, or empty for a silent room. */
-  public Optional<String> newestId(String specId) {
+  public Optional<String> newestId(String roomId) {
     return db.queryOne(
-        "SELECT id FROM spec_messages WHERE spec_id = ? ORDER BY id DESC LIMIT 1",
+        "SELECT id FROM room_messages WHERE room_id = ? ORDER BY id DESC LIMIT 1",
         row -> row.text(0),
-        specId);
+        roomId);
   }
 
   /**
-   * Each spec whose latest agent-authored question is still unanswered, mapped to that question's
+   * Each room whose latest agent-authored question is still unanswered, mapped to that question's
    * message id — one aggregate query. A question is answered by any later human message in the
    * room; the author classes are structural, mirroring {@code RoomWakePolicy.humanAuthor}: an agent
    * principal always carries a {@code /}, the orchestrator posts as the literal {@code sail}, and
@@ -198,12 +198,12 @@ public final class MessageStore implements SyncedStore {
     var open = new LinkedHashMap<String, String>();
     for (var entry :
         db.query(
-            "SELECT q.spec_id, MAX(q.id) FROM spec_messages q"
+            "SELECT q.room_id, MAX(q.id) FROM room_messages q"
                 + " WHERE q.question != 0 AND q.author LIKE '%/%'"
-                + " AND NOT EXISTS (SELECT 1 FROM spec_messages h"
-                + " WHERE h.spec_id = q.spec_id AND h.id > q.id"
+                + " AND NOT EXISTS (SELECT 1 FROM room_messages h"
+                + " WHERE h.room_id = q.room_id AND h.id > q.id"
                 + " AND h.author NOT LIKE '%/%' AND h.author != 'sail')"
-                + " GROUP BY q.spec_id",
+                + " GROUP BY q.room_id",
             row -> Map.entry(row.text(0), row.text(1)))) {
       open.put(entry.getKey(), entry.getValue());
     }
@@ -211,11 +211,11 @@ public final class MessageStore implements SyncedStore {
   }
 
   /** Each room's newest message timestamp — one aggregate query, keyed by spec id. */
-  public Map<String, String> latestBySpec() {
+  public Map<String, String> latestByRoom() {
     var latest = new LinkedHashMap<String, String>();
     for (var entry :
         db.query(
-            "SELECT spec_id, MAX(created_at) FROM spec_messages GROUP BY spec_id",
+            "SELECT room_id, MAX(created_at) FROM room_messages GROUP BY room_id",
             row -> Map.entry(row.text(0), row.text(1)))) {
       latest.put(entry.getKey(), entry.getValue());
     }
@@ -224,7 +224,7 @@ public final class MessageStore implements SyncedStore {
 
   public Optional<MessageRow> findById(String id) {
     return db.queryOne(
-        "SELECT " + COLUMNS + " FROM spec_messages WHERE id = ?", MessageStore::map, id);
+        "SELECT " + COLUMNS + " FROM room_messages WHERE id = ?", MessageStore::map, id);
   }
 
   @Override
@@ -306,7 +306,7 @@ public final class MessageStore implements SyncedStore {
           var rev = Revisions.next(null, json);
           var row = fromSnapshot(id, snapshot);
           var peer = SyncPeer.current();
-          if (!mayPostAs(peer, row.author(), row.specId())) {
+          if (!mayPostAs(peer, row.author(), row.roomId())) {
             throw new IllegalArgumentException(
                 "sync principal '" + peer + "' may not post as '" + row.author() + "'");
           }
@@ -317,7 +317,7 @@ public final class MessageStore implements SyncedStore {
         });
   }
 
-  private boolean mayPostAs(String peer, String author, String specId) {
+  private boolean mayPostAs(String peer, String author, String roomId) {
     if (peer == null) {
       return false;
     }
@@ -329,7 +329,7 @@ public final class MessageStore implements SyncedStore {
                         + " WHERE rp.run_id = r.id AND rp.principal = ?)) LIMIT 1",
                     row -> true,
                     peer,
-                    specId,
+                    roomId,
                     author,
                     author)
                 .orElse(false);
@@ -337,13 +337,13 @@ public final class MessageStore implements SyncedStore {
       return false;
     }
     return db.queryOne(
-            "SELECT 1 FROM specs s LEFT JOIN fdes f ON f.handle = ? "
+            "SELECT 1 FROM rooms s LEFT JOIN fdes f ON f.handle = ? "
                 + "WHERE s.id = ? AND (lower(coalesce(f.role, '')) = 'admin' "
                 + "OR s.assignee = ? OR "
                 + "(trim(coalesce(s.assignee, '')) = '' AND s.created_by = ?)) LIMIT 1",
             row -> true,
             peer,
-            specId,
+            roomId,
             peer,
             peer)
         .orElse(false);
@@ -352,12 +352,12 @@ public final class MessageStore implements SyncedStore {
   private void write(MessageRow row, String rev, String baseRev) {
     db.execute(
         """
-        INSERT INTO spec_messages
-            (id, spec_id, author, body, reply_to, created_at, rev, base_rev, question)
+        INSERT INTO room_messages
+            (id, room_id, author, body, reply_to, created_at, rev, base_rev, question)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET rev = excluded.rev, base_rev = excluded.base_rev""",
         row.id(),
-        row.specId(),
+        row.roomId(),
         row.author(),
         row.body(),
         row.replyTo(),
@@ -370,10 +370,10 @@ public final class MessageStore implements SyncedStore {
   private void requireReplyTarget(MessageRow row) {
     if (row.replyTo() != null
         && findById(row.replyTo())
-            .filter(parent -> parent.specId().equals(row.specId()))
+            .filter(parent -> parent.roomId().equals(row.roomId()))
             .isEmpty()) {
       throw new IllegalArgumentException(
-          "reply_to must reference a message on spec '" + row.specId() + "'");
+          "reply_to must reference a message in room '" + row.roomId() + "'");
     }
   }
 
@@ -391,7 +391,7 @@ public final class MessageStore implements SyncedStore {
     }
     return new MessageRow(
         id,
-        required(snapshot, "spec_id"),
+        roomIdOf(snapshot),
         author,
         body,
         replyTo,
@@ -401,9 +401,19 @@ public final class MessageStore implements SyncedStore {
         Boolean.parseBoolean(Objects.toString(snapshot.get("question"), "false")));
   }
 
+  /**
+   * The room a snapshot belongs to: {@code room_id}, falling back to the {@code spec_id} key that
+   * pre-rename journal entries and pre-rename revisions carry — rooms kept the spec's id at the
+   * split, so the value is the same room either way.
+   */
+  private static String roomIdOf(Map<String, Object> snapshot) {
+    var roomId = Objects.toString(snapshot.get("room_id"), null);
+    return roomId != null ? roomId : required(snapshot, "spec_id");
+  }
+
   private static Map<String, Object> snapshot(MessageRow row) {
     var map = new LinkedHashMap<String, Object>();
-    map.put("spec_id", row.specId());
+    map.put("room_id", row.roomId());
     map.put("author", row.author());
     map.put("body", row.body());
     if (row.replyTo() != null) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -390,7 +390,11 @@ public final class SchemaManager {
               updated_by TEXT,
               rev TEXT,
               base_rev TEXT
-          )""");
+          )""",
+          "ALTER TABLE spec_messages RENAME TO room_messages",
+          "ALTER TABLE room_messages RENAME COLUMN spec_id TO room_id",
+          "DROP INDEX idx_spec_messages_page",
+          "CREATE INDEX idx_room_messages_page ON room_messages(room_id, id DESC)");
 
   /** The schema version this binary converges every database to. */
   static final int CURRENT_VERSION = V1_VERSION + MIGRATIONS.size();

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncWire.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncWire.java
@@ -45,12 +45,13 @@ public final class SyncWire {
 
   /**
    * The fleet floor both sides must advertise before exchanging rows: the release that carries the
-   * v1 schema baseline. Bumped from {@code 0.14.0} with the baseline because a pre-baseline peer's
-   * schema lacks post-floor columns and must not receive v1 snapshots — the refusal names 'sail
-   * upgrade' as the remedy. Bump again only when a change makes older peers unsafe, never for a
-   * routine release.
+   * v1 schema baseline. Bumped from {@code 0.14.0} with the baseline, and from {@code 0.15.0} to
+   * {@code 0.31.0} with the room-spec decouple's message re-key: message snapshots now carry {@code
+   * room_id} and a pre-split peer would corrupt or refuse them mid-exchange, so it must be refused
+   * up front — the refusal names 'sail upgrade' as the remedy. Bump again only when a change makes
+   * older peers unsafe, never for a routine release.
    */
-  public static final String V1_UPGRADE_FLOOR = "0.15.0";
+  public static final String V1_UPGRADE_FLOOR = "0.31.0";
 
   /**
    * Hard ceiling on one framed message, bounding the memory a single read can claim. A sync message

--- a/sail-core/src/test/java/ai/singlr/sail/store/MessageStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/MessageStoreTest.java
@@ -32,7 +32,7 @@ class MessageStoreTest {
     new SchemaManager(db).migrate();
     db.execute(
         """
-        INSERT INTO specs (id, title, project, created_at, updated_at)
+        INSERT INTO rooms (id, title, project, created_at, updated_at)
         VALUES ('room', 'Room', 'acme', 'now', 'now')""");
     messages = new MessageStore(db);
   }
@@ -86,31 +86,31 @@ class MessageStoreTest {
 
   @Test
   void latestBySpecReportsEachRoomsNewestMessageTime() {
-    assertEquals(Map.of(), messages.latestBySpec());
+    assertEquals(Map.of(), messages.latestByRoom());
 
     messages.append("room", "uday", "first", null);
     var second = messages.append("room", "uday", "second", null);
     db.execute(
         """
-        INSERT INTO specs (id, title, project, created_at, updated_at)
+        INSERT INTO rooms (id, title, project, created_at, updated_at)
         VALUES ('other', 'Other', 'acme', 'now', 'now')""");
     var other = messages.append("other", "uday", "solo", null);
 
     assertEquals(
-        Map.of("room", second.createdAt(), "other", other.createdAt()), messages.latestBySpec());
+        Map.of("room", second.createdAt(), "other", other.createdAt()), messages.latestByRoom());
   }
 
   @Test
-  void acceptsTheExactByteCapAndSurvivesSpecLifecycleChanges() {
+  void acceptsTheExactByteCapAndSurvivesRoomRowChanges() {
     var row = messages.append("room", "ada", "x".repeat(MessageStore.MAX_BODY_BYTES), null);
-    db.execute("UPDATE specs SET status = 'archived' WHERE id = 'room'");
+    db.execute("UPDATE rooms SET title = 'Renamed', assignee = 'ada' WHERE id = 'room'");
     assertEquals(row.id(), messages.list("room", null, 10).getFirst().id());
 
-    db.execute("DELETE FROM specs WHERE id = 'room'");
+    db.execute("DELETE FROM rooms WHERE id = 'room'");
     assertEquals(row.id(), messages.findById(row.id()).orElseThrow().id());
     db.execute(
         """
-        INSERT INTO specs (id, title, project, created_at, updated_at)
+        INSERT INTO rooms (id, title, project, created_at, updated_at)
         VALUES ('room', 'Room restored', 'acme', 'later', 'later')""");
     assertEquals(row.id(), messages.list("room", null, 10).getFirst().id());
   }

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -301,7 +301,51 @@ class SchemaManagerTest {
     assertTrue(indexes.contains("idx_events_timestamp"));
     assertTrue(indexes.contains("idx_runs_project"));
     assertTrue(indexes.contains("idx_runs_spec"));
-    assertTrue(indexes.contains("idx_spec_messages_page"));
+    assertTrue(indexes.contains("idx_room_messages_page"));
+  }
+
+  @Test
+  void theMessageRekeyCarriesRowsAndTheDeliveryLedgerAcrossTheRename() {
+    var staged = SchemaManager.CURRENT_VERSION - 4;
+    stageAtBaseline();
+    for (var v = SchemaManager.V1_VERSION + 1; v <= staged; v++) {
+      db.execute(SchemaManager.MIGRATIONS.get(v - SchemaManager.V1_VERSION - 1));
+      db.execute("INSERT INTO schema_version (version, applied_at) VALUES (?, 'staged')", v);
+    }
+    db.execute(
+        "INSERT INTO spec_messages (id, spec_id, author, body, created_at, rev, question)"
+            + " VALUES ('0195a2f0-0000-7000-8000-00000000000a', 'auth', 'uday', 'hi', 't0',"
+            + " '1-a', 1)");
+    db.execute(
+        "INSERT INTO runs (id, project, agent, status, started_at)"
+            + " VALUES ('r-keep', 'acme', 'claude-code', 'completed', 't0')");
+    db.execute(
+        "INSERT INTO run_delivered_messages (run_id, message_id)"
+            + " VALUES ('r-keep', '0195a2f0-0000-7000-8000-00000000000a')");
+
+    new SchemaManager(db).migrate();
+
+    assertEquals(
+        "auth",
+        db.queryOne(
+                "SELECT room_id FROM room_messages"
+                    + " WHERE id = '0195a2f0-0000-7000-8000-00000000000a'",
+                r -> r.text(0))
+            .orElseThrow(),
+        "the re-key is a pure rename: rows carry over with the same room id");
+    assertEquals(
+        1,
+        db.queryOne(
+                "SELECT question FROM room_messages"
+                    + " WHERE id = '0195a2f0-0000-7000-8000-00000000000a'",
+                r -> r.integer(0))
+            .orElseThrow());
+    db.execute("PRAGMA foreign_keys = ON");
+    db.execute("DELETE FROM room_messages WHERE id = '0195a2f0-0000-7000-8000-00000000000a'");
+    assertEquals(
+        0,
+        db.query("SELECT run_id FROM run_delivered_messages", r -> r.text(0)).size(),
+        "the delivery ledger's FK followed the rename and still cascades");
   }
 
   private void stageAtVersion(int version) {
@@ -355,9 +399,9 @@ class SchemaManagerTest {
             .contains("run_delivered_messages"));
     assertTrue(
         db.query(
-                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'spec_messages'",
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'room_messages'",
                 r -> r.text(0))
-            .contains("spec_messages"));
+            .contains("room_messages"));
     assertTrue(
         db.query(
                 "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'rooms'",
@@ -610,7 +654,7 @@ class SchemaManagerTest {
         0L,
         (long)
             db.queryOne(
-                    "SELECT question FROM spec_messages"
+                    "SELECT question FROM room_messages"
                         + " WHERE id = '0195a2f0-0000-7000-8000-000000000002'",
                     r -> r.integer(0))
                 .orElseThrow(),

--- a/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
@@ -42,7 +42,7 @@ class MessageSyncTest {
       new SchemaManager(db).migrate();
       db.execute(
           """
-          INSERT INTO specs (id, title, project, created_at, updated_at)
+          INSERT INTO rooms (id, title, project, created_at, updated_at)
           VALUES ('room', 'Room', 'acme', 'now', 'now')""");
       messages = new MessageStore(db);
       replica =
@@ -91,7 +91,7 @@ class MessageSyncTest {
   @Test
   void theQuestionFlagSurvivesSyncAndDerivesTheSameAnswerEverywhere() {
     var runId = "019fee00-0000-7000-8000-0000000000bb";
-    main.db.execute("UPDATE specs SET assignee = 'node' WHERE id = 'room'");
+    main.db.execute("UPDATE rooms SET assignee = 'node' WHERE id = 'room'");
     var runs = new ai.singlr.sail.store.RunStore(main.db);
     runs.createReview(runId, "acme", "room", "node", "node", "codex", "b", "t", "/log", "unit");
     var principal = runs.findById(runId).orElseThrow().principal();
@@ -112,7 +112,7 @@ class MessageSyncTest {
 
   @Test
   void syncedMessagesCannotBeChangedOrDeleted() {
-    main.db.execute("UPDATE specs SET assignee = 'node' WHERE id = 'room'");
+    main.db.execute("UPDATE rooms SET assignee = 'node' WHERE id = 'room'");
     var row = node.messages.append("room", "node", "original", null);
     SyncPeer.with("node", () -> new SyncEngine().reconcile(node.replica, main.replica));
     var changed = new LinkedHashMap<>(main.messages.comparableSnapshot(row.id()));
@@ -129,7 +129,7 @@ class MessageSyncTest {
   @Test
   void aMessageAuthoredBeforePrincipalRotationStillSyncs() {
     var reviewId = "019fee00-0000-7000-8000-0000000000aa";
-    main.db.execute("UPDATE specs SET assignee = 'node' WHERE id = 'room'");
+    main.db.execute("UPDATE rooms SET assignee = 'node' WHERE id = 'room'");
     var runs = new ai.singlr.sail.store.RunStore(main.db);
     runs.createReview(reviewId, "acme", "room", "node", "node", "codex", "b", "t", "/log", "unit");
     var reviewerPrincipal = runs.findById(reviewId).orElseThrow().principal();
@@ -169,7 +169,7 @@ class MessageSyncTest {
 
   @Test
   void authenticatedPeerCannotPostToForeignOrMissingSpec() {
-    main.db.execute("UPDATE specs SET assignee = 'ada', created_by = 'ada' WHERE id = 'room'");
+    main.db.execute("UPDATE rooms SET assignee = 'ada', created_by = 'ada' WHERE id = 'room'");
 
     assertThrows(
         IllegalArgumentException.class,
@@ -197,7 +197,7 @@ class MessageSyncTest {
 
   @Test
   void authenticatedPeerMayPostAsItsRunPrincipalOnlyOnThatRunsSpec() {
-    main.db.execute("UPDATE specs SET assignee = 'node' WHERE id = 'room'");
+    main.db.execute("UPDATE rooms SET assignee = 'node' WHERE id = 'room'");
     main.db.execute(
         """
         INSERT INTO runs
@@ -216,7 +216,7 @@ class MessageSyncTest {
 
     main.db.execute(
         """
-        INSERT INTO specs (id, title, project, created_at, updated_at)
+        INSERT INTO rooms (id, title, project, created_at, updated_at)
         VALUES ('other-room', 'Other room', 'acme', 'now', 'now')""");
     assertThrows(
         IllegalArgumentException.class,

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -1144,7 +1144,7 @@ record SpecMessageView(
   static SpecMessageView from(MessageStore.MessageRow row) {
     return new SpecMessageView(
         row.id(),
-        row.specId(),
+        row.roomId(),
         row.author(),
         row.body(),
         row.replyTo(),

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -315,25 +315,58 @@ public final class ApiRouter implements HttpHandler {
    * semantics, so the spec-shaped doors can retire without a behavior change.
    */
   private ApiResponse routeRooms(HttpExchange exchange, RouteRequest request) throws IOException {
-    if (request.size() != 4 || !MEMBERS.equals(request.segments().get(3))) {
+    if (request.size() != 4) {
       throw notFound();
     }
     var roomId = request.segments().get(2);
     NameValidator.requireValidSpecId(roomId);
-    return switch (request.method()) {
-      case GET -> ApiResponse.from(operations.roomMembers(roomId));
-      case POST ->
-          ApiResponse.from(
-              operations.addRoomMember(
+    var sub = request.segments().get(3);
+    if (MEMBERS.equals(sub)) {
+      return switch (request.method()) {
+        case GET -> ApiResponse.from(operations.roomMembers(roomId));
+        case POST ->
+            ApiResponse.from(
+                operations.addRoomMember(
+                    roomId,
+                    EngageRequest.fromMap(JsonBody.readMap(exchange)),
+                    actorOf(exchange),
+                    nodeHandle.get()));
+        case DELETE ->
+            ApiResponse.from(
+                operations.removeRoomMember(roomId, actorOf(exchange), nodeHandle.get()));
+        default -> throw methodNotAllowed();
+      };
+    }
+    if (MESSAGES.equals(sub)) {
+      return switch (request.method()) {
+        case GET -> {
+          var params = QueryParameters.from(request.uri()).values();
+          yield ApiResponse.from(
+              operations.roomMessages(
                   roomId,
-                  EngageRequest.fromMap(JsonBody.readMap(exchange)),
-                  actorOf(exchange),
-                  nodeHandle.get()));
-      case DELETE ->
-          ApiResponse.from(
-              operations.removeRoomMember(roomId, actorOf(exchange), nodeHandle.get()));
-      default -> throw methodNotAllowed();
-    };
+                  params.get("before"),
+                  params.get("after"),
+                  clampedLimit(params.get(LIMIT), DEFAULT_MESSAGES, MAX_MESSAGES)));
+        }
+        case POST -> {
+          var principal = actorOf(exchange);
+          if (principal.handle() == null) {
+            throw new ApiException(
+                ErrorCode.FORBIDDEN,
+                "Room messages require an FDE-bound credential so authorship can be"
+                    + " synchronized.");
+          }
+          yield ApiResponse.fromCreated(
+              operations.postRoomMessage(
+                  roomId,
+                  SpecMessageRequest.fromMap(JsonBody.readMessageMap(exchange)),
+                  principal,
+                  principal.handle()));
+        }
+        default -> throw methodNotAllowed();
+      };
+    }
+    throw notFound();
   }
 
   private ApiResponse routeGlobalSpecs(HttpExchange exchange, RouteRequest request)

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
@@ -123,6 +123,11 @@ public interface Operations extends LocalLaneOperations {
 
   Result<RoomMembersResponse> roomMembers(String roomId);
 
+  Result<SpecMessagesResponse> roomMessages(String roomId, String before, String after, int limit);
+
+  Result<SpecMessageResponse> postRoomMessage(
+      String roomId, SpecMessageRequest request, Actor principal, String authorHandle);
+
   Result<EngageResponse> addRoomMember(
       String roomId, EngageRequest request, Actor actor, String localHandle);
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -487,6 +487,18 @@ public final class SailOperations implements Operations {
   }
 
   @Override
+  public Result<SpecMessagesResponse> roomMessages(
+      String roomId, String before, String after, int limit) {
+    return specMessages(roomId, before, after, limit);
+  }
+
+  @Override
+  public Result<SpecMessageResponse> postRoomMessage(
+      String roomId, SpecMessageRequest request, Actor principal, String authorHandle) {
+    return postSpecMessage(roomId, request, principal, authorHandle);
+  }
+
+  @Override
   public Result<RoomMembersResponse> roomMembers(String roomId) {
     freshenForRead();
     return safe(() -> new RoomMembersResponse(dispatchOps.roomMembers(roomId)));
@@ -1164,7 +1176,7 @@ public final class SailOperations implements Operations {
           return new GlobalSpecsListResponse(
               listed.specs(),
               listed.total(),
-              messageStore.latestBySpec(),
+              messageStore.latestByRoom(),
               messageStore.openQuestions());
         });
   }
@@ -1320,7 +1332,7 @@ public final class SailOperations implements Operations {
                 !Strings.isBlank(messageId)
                     && store
                         .findById(messageId)
-                        .filter(message -> message.specId().equals(run.specId()))
+                        .filter(message -> message.roomId().equals(run.specId()))
                         .isPresent();
             if (!onSpec) {
               throw new ApiException(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
@@ -295,12 +295,12 @@ public final class SyncCommand implements Callable<Integer> {
         .map(
             row ->
                 specs
-                    .findById(row.specId())
+                    .findById(row.roomId())
                     .map(
                         spec ->
                             SyncTransitionEvents.messagePosted(
                                 spec.project(),
-                                row.specId(),
+                                row.roomId(),
                                 row.id(),
                                 row.author(),
                                 row.body(),

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -1094,12 +1094,42 @@ class ApiRouterTest {
   }
 
   @Test
+  void roomMessagesRouteReadAndPostThroughThePort() throws Exception {
+    var ops = new FakeOperations();
+    try (var server = serverWithOwnedToken(ops, true)) {
+      var listed = get(server, "/v1/rooms/auth-flow/messages?limit=10", "token");
+      assertEquals(200, listed.statusCode());
+      assertEquals("auth-flow", ops.lastRoomMessagesRoom);
+
+      var posted =
+          post(server, "/v1/rooms/auth-flow/messages", "token", "{\"body\": \"hello room\"}");
+      assertEquals(201, posted.statusCode());
+      assertEquals("auth-flow:hello room", ops.lastRoomPost);
+
+      assertEquals(405, delete(server, "/v1/rooms/auth-flow/messages", "token").statusCode());
+    }
+  }
+
+  @Test
+  void roomMessagePostsRejectUnownedCredentialsLikeTheSpecDoor() throws Exception {
+    var ops = new FakeOperations();
+    try (var server = serverWith(ops, true)) {
+      var response =
+          post(server, "/v1/rooms/auth-flow/messages", "token", "{\"body\":\"progress\"}");
+
+      assertEquals(403, response.statusCode());
+      assertTrue(response.body().contains("FDE-bound credential"));
+      assertNull(ops.lastRoomPost);
+    }
+  }
+
+  @Test
   void theRoomsSurfaceRefusesUnknownShapesAndMethods() throws Exception {
     var ops = new FakeOperations();
     try (var server = serverWith(ops, true)) {
       assertEquals(404, get(server, "/v1/rooms", "token").statusCode());
       assertEquals(404, get(server, "/v1/rooms/auth-flow", "token").statusCode());
-      assertEquals(404, get(server, "/v1/rooms/auth-flow/messages", "token").statusCode());
+      assertEquals(404, get(server, "/v1/rooms/auth-flow/bogus", "token").statusCode());
       assertEquals(405, put(server, "/v1/rooms/auth-flow/members", "token", "{}").statusCode());
     }
   }
@@ -1592,6 +1622,32 @@ class ApiRouterTest {
         String roomId, Actor actor, String localHandle) {
       lastRemoveMember = roomId;
       return Result.success(new DisengageResponse("claude-code"));
+    }
+
+    String lastRoomMessagesRoom;
+    String lastRoomPost;
+
+    @Override
+    public Result<SpecMessagesResponse> roomMessages(
+        String roomId, String before, String after, int limit) {
+      lastRoomMessagesRoom = roomId;
+      return Result.success(new SpecMessagesResponse(roomId, java.util.List.of()));
+    }
+
+    @Override
+    public Result<SpecMessageResponse> postRoomMessage(
+        String roomId, SpecMessageRequest request, Actor principal, String authorHandle) {
+      lastRoomPost = roomId + ":" + request.body();
+      return Result.success(
+          new SpecMessageResponse(
+              new SpecMessageView(
+                  "00000000-0000-7000-8000-000000000001",
+                  roomId,
+                  "uday",
+                  request.body(),
+                  null,
+                  "2026-08-23T00:00:00Z",
+                  false)));
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
@@ -398,6 +398,16 @@ class EngagementLifecycleTest {
       var listed = sailOps.roomMembers("auth");
       assertTrue(listed instanceof Result.Success<RoomMembersResponse>);
       assertEquals(1, ((Result.Success<RoomMembersResponse>) listed).value().members().size());
+      var posted =
+          sailOps.postRoomMessage(
+              "auth",
+              new SpecMessageRequest("hello room", null, false),
+              Actor.cliOperator(HANDLE),
+              HANDLE);
+      assertTrue(posted instanceof Result.Success<SpecMessageResponse>);
+      var roomList = sailOps.roomMessages("auth", null, null, 10);
+      assertTrue(roomList instanceof Result.Success<SpecMessagesResponse>);
+      assertEquals(1, ((Result.Success<SpecMessagesResponse>) roomList).value().messages().size());
       var removed = sailOps.removeRoomMember("auth", Actor.cliOperator(HANDLE), HANDLE);
       assertTrue(removed instanceof Result.Success<DisengageResponse>);
       assertEquals("claude-code", ((Result.Success<DisengageResponse>) removed).value().agent());

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
@@ -738,13 +738,13 @@ class RoomWakeReactorTest {
     reactor(new DirectExecutorService(), null).onEvent(roomStop("chat", run));
     assertTrue(launcher.woken.isEmpty(), "no message store, no owed check");
 
-    db.execute("UPDATE spec_messages SET created_at = 'garbage' WHERE id = ?", second.id());
-    db.execute("UPDATE spec_messages SET created_at = 'garbage' WHERE spec_id = 'chat'");
+    db.execute("UPDATE room_messages SET created_at = 'garbage' WHERE id = ?", second.id());
+    db.execute("UPDATE room_messages SET created_at = 'garbage' WHERE room_id = 'chat'");
     reactor().onEvent(roomStop("chat", run));
     assertTrue(launcher.woken.isEmpty(), "an unparseable timestamp is never owed");
 
     db.execute(
-        "UPDATE spec_messages SET created_at = ? WHERE spec_id = 'chat'", now.get().toString());
+        "UPDATE room_messages SET created_at = ? WHERE room_id = 'chat'", now.get().toString());
     reactor().onEvent(roomStop("chat", run));
     assertEquals(List.of("acme/chat"), launcher.woken, "the newest of several messages decides");
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -101,6 +101,18 @@ class TestOperations implements Operations {
   }
 
   @Override
+  public Result<SpecMessagesResponse> roomMessages(
+      String roomId, String before, String after, int limit) {
+    return Result.success(new SpecMessagesResponse(roomId, java.util.List.of()));
+  }
+
+  @Override
+  public Result<SpecMessageResponse> postRoomMessage(
+      String roomId, SpecMessageRequest request, Actor principal, String authorHandle) {
+    return Result.failure(ErrorCode.COMMAND_FAILED, "not supported in this fake");
+  }
+
+  @Override
   public Result<EngageResponse> addRoomMember(
       String roomId, EngageRequest request, Actor actor, String localHandle) {
     return Result.success(


### PR DESCRIPTION
Brick 2 of `room-spec-decouple`: messages are re-keyed to the room — `spec_messages` → `room_messages`, `spec_id` → `room_id` — and message-post authorization moves to the room row. **This is the sync-floor-bump brick**: it must be RELEASED SOLO and the fleet upgraded lockstep before later bricks ship.

## What

- **Schema** (append-only migrations): `RENAME TO room_messages`, `RENAME COLUMN spec_id → room_id`, index rebuilt as `idx_room_messages_page`. Zero data rewrite — rooms kept spec ids at the split, so every existing row's value is already its room id. A dedicated migration test seeds the pre-rename shape with data and a delivery-ledger row, migrates, and proves the rows carry over **and the `run_delivered_messages` FK followed the rename and still cascades**.
- **`MessageStore`**: fully room-keyed (`MessageRow.roomId`, all queries, `latestByRoom`). Snapshot wire key becomes `room_id` with a **read fallback to `spec_id`** for pre-rename journal entries and revisions (`roomIdOf`). `mayPostAs` now authorizes against **`rooms.assignee`/`created_by`** — the conversation surface owns posting rights; the run-principal ownership rule is unchanged and deliberately still joins `runs.spec_id` (runs don't move until Brick 4).
- **`SyncWire.V1_UPGRADE_FLOOR` bumped `0.15.0` → `0.31.0`** — exactly the case the constant's contract reserves the bump for: message snapshots now carry `room_id`, and a pre-split peer must be refused up front with the `sail upgrade` remedy rather than corrupt or reject rows mid-exchange. All floor tests reference the constant symbolically and pass unchanged.
- **`GET|POST /v1/rooms/{id}/messages`** — the room-shaped door, mirroring the spec door verbatim (same clamped paging, same FDE-bound-credential guard on POST, same response shapes); `SailOperations` delegates one-to-one, so Brick 6 retires the spec door with zero behavior change.
- Consumers re-keyed at exactly four sites (`SpecMessageView`, board decoration, run-inbox ack, sync pulled-message events); every lane call site is positional and identity-compatible.

## Release discipline

Cut this as `0.31.0` on its own, then `sail upgrade` the whole fleet before merging anything that builds on it. A `0.30.x` box syncing against `0.31.0` gets a clean, named refusal — never a partial exchange.

## Tests

- `SchemaManagerTest` +1 (the rename+FK-cascade prior-shape test) and the mid-chain staging tests updated to seed the pre-rename shape they stage at.
- `MessageStoreTest`/`MessageSyncTest`: all 19 pass re-keyed — including the full `mayPostAs` matrix (forged author, foreign room, run-principal scoping) now seeded through the rooms table; the byte-cap test now proves messages survive room-row mutation, deletion, and re-creation.
- `ApiRouterTest` +2 (room message routes through the port; unowned credential 403 like the spec door); server-lane delegation exercised through the real `SailOperations`.
