### PR TITLE
feat(rooms): every spec carries its room_id, readers key through it (decouple brick 3a)

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -419,7 +419,9 @@ public final class SchemaManager {
           "DROP TABLE run_delivered_messages",
           "ALTER TABLE run_delivered_messages_v2 RENAME TO run_delivered_messages",
           "DROP TABLE spec_messages",
-          "CREATE INDEX idx_room_messages_page ON room_messages(room_id, id DESC)");
+          "CREATE INDEX idx_room_messages_page ON room_messages(room_id, id DESC)",
+          "ALTER TABLE specs ADD COLUMN room_id TEXT",
+          "UPDATE specs SET room_id = id WHERE room_id IS NULL");
 
   /** The schema version this binary converges every database to. */
   static final int CURRENT_VERSION = V1_VERSION + MIGRATIONS.size();

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -57,7 +57,8 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
       List<String> dependsOn,
       List<String> repos,
       String wake,
-      String engagement) {
+      String engagement,
+      String roomId) {
 
     /** A row with no explicit wake mode — the default every spec has until an operator sets one. */
     public SpecRow(
@@ -94,6 +95,7 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
           updatedBy,
           dependsOn,
           repos,
+          null,
           null,
           null);
     }
@@ -135,6 +137,7 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
           dependsOn,
           repos,
           wake,
+          null,
           null);
     }
 
@@ -158,13 +161,42 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
           dependsOn,
           repos,
           wake,
-          engagement);
+          engagement,
+          roomId);
     }
 
     /**
      * This row with {@code engagement} replaced ({@code null} disengages) — the single-field edit
      * the engage and disengage surfaces use.
      */
+    public SpecRow withRoomId(String roomId) {
+      return new SpecRow(
+          id,
+          project,
+          title,
+          status,
+          assignee,
+          agent,
+          model,
+          reasoningEffort,
+          branch,
+          priority,
+          createdBy,
+          createdAt,
+          updatedAt,
+          updatedBy,
+          dependsOn,
+          repos,
+          wake,
+          engagement,
+          roomId);
+    }
+
+    /** The room this spec lives in — its own id for every spec born before rooms decoupled. */
+    public String roomIdOrIdentity() {
+      return roomId == null || roomId.isBlank() ? id : roomId;
+    }
+
     public SpecRow withEngagement(String engagement) {
       return new SpecRow(
           id,
@@ -184,7 +216,8 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
           dependsOn,
           repos,
           wake,
-          engagement);
+          engagement,
+          roomId);
     }
 
     /**
@@ -241,8 +274,8 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
               """
               INSERT INTO specs (id, project, title, status, assignee, agent, model,
                   reasoning_effort, branch, priority, created_by, created_at, updated_at,
-                  updated_by, wake, engagement)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                  updated_by, wake, engagement, room_id)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
               spec.id(),
               spec.project(),
               spec.title(),
@@ -258,7 +291,8 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
               now,
               spec.updatedBy(),
               spec.wake(),
-              spec.engagement());
+              spec.engagement(),
+              spec.roomIdOrIdentity());
           insertDependencies(spec.id(), spec.dependsOn());
           insertRepos(spec.id(), spec.repos());
           db.execute(
@@ -269,12 +303,24 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
         });
   }
 
+  /** Every spec attached to {@code roomId}, oldest first — the room's work-items. */
+  public List<SpecRow> listByRoom(String roomId) {
+    return db.query(
+        """
+        SELECT id, project, title, status, assignee, agent, model, reasoning_effort,
+            branch, priority, created_by, created_at, updated_at, updated_by, wake,
+            engagement, room_id
+        FROM specs WHERE room_id = ? ORDER BY created_at, id""",
+        this::mapSpec,
+        roomId);
+  }
+
   public Optional<SpecRow> findById(String id) {
     return db.queryOne(
             """
             SELECT id, project, title, status, assignee, agent, model, reasoning_effort,
                 branch, priority, created_by, created_at, updated_at, updated_by, wake,
-                engagement
+                engagement, room_id
             FROM specs WHERE id = ?""",
             this::mapSpec,
             id)
@@ -285,7 +331,7 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
     var sql = new StringBuilder("SELECT DISTINCT s.id, s.project, s.title, s.status, s.assignee,");
     sql.append(
         " s.agent, s.model, s.reasoning_effort, s.branch, s.priority, s.created_by, s.created_at,"
-            + " s.updated_at, s.updated_by, s.wake, s.engagement FROM specs s");
+            + " s.updated_at, s.updated_by, s.wake, s.engagement, s.room_id FROM specs s");
     var params = new ArrayList<>();
     var where = new ArrayList<String>();
 
@@ -544,6 +590,7 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
     map.put("repos", spec.repos());
     map.put("wake", spec.wake());
     map.put("engagement", spec.engagement());
+    map.put("room_id", spec.roomIdOrIdentity());
     map.put("body", content.body());
     map.put("plan", content.plan());
     return map;
@@ -557,7 +604,7 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
           """
           UPDATE specs SET project = ?, title = ?, status = ?, assignee = ?, agent = ?, model = ?,
               reasoning_effort = ?, branch = ?, priority = ?, updated_at = ?, updated_by = ?,
-              wake = ?, engagement = ?
+              wake = ?, engagement = ?, room_id = ?
           WHERE id = ?""",
           spec.project(),
           spec.title(),
@@ -572,6 +619,7 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
           spec.updatedBy(),
           spec.wake(),
           spec.engagement(),
+          spec.roomIdOrIdentity(),
           id);
       db.execute("DELETE FROM spec_dependencies WHERE spec_id = ?", id);
       db.execute("DELETE FROM spec_repos WHERE spec_id = ?", id);
@@ -579,8 +627,9 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
       db.execute(
           """
           INSERT INTO specs (id, project, title, status, assignee, agent, model, reasoning_effort,
-              branch, priority, created_by, created_at, updated_at, updated_by, wake, engagement)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+              branch, priority, created_by, created_at, updated_at, updated_by, wake, engagement,
+              room_id)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
           id,
           spec.project(),
           spec.title(),
@@ -596,7 +645,8 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
           now,
           spec.updatedBy(),
           spec.wake(),
-          spec.engagement());
+          spec.engagement(),
+          spec.roomIdOrIdentity());
     }
     insertDependencies(id, spec.dependsOn());
     insertRepos(id, spec.repos());
@@ -611,6 +661,11 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
         Snapshots.text(snapshot, "body"),
         Snapshots.text(snapshot, "plan"),
         now);
+  }
+
+  private static String roomIdOf(Map<String, Object> s) {
+    var roomId = Snapshots.text(s, "room_id");
+    return roomId != null ? roomId : Snapshots.text(s, "id");
   }
 
   @SuppressWarnings("unchecked")
@@ -634,7 +689,8 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
         (List<String>) s.getOrDefault("depends_on", List.of()),
         (List<String>) s.getOrDefault("repos", List.of()),
         Snapshots.text(s, "wake"),
-        Snapshots.text(s, "engagement"));
+        Snapshots.text(s, "engagement"),
+        roomIdOf(s));
   }
 
   private static final Set<String> SYNC_FIELDS =
@@ -653,7 +709,8 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
           "wake",
           "engagement",
           "body",
-          "plan");
+          "plan",
+          "room_id");
 
   /**
    * The subset of a snapshot that carries an FDE's actual work — everything except the surrogate
@@ -832,7 +889,7 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
         """
         SELECT id, project, title, status, assignee, agent, model, reasoning_effort,
             branch, priority, created_by, created_at, updated_at, updated_by, wake,
-            engagement
+            engagement, room_id
         FROM specs WHERE engagement IS NOT NULL""",
         this::mapSpec);
   }
@@ -847,7 +904,7 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
             """
             SELECT s.id, s.project, s.title, s.status, s.assignee, s.agent, s.model,
                 s.reasoning_effort, s.branch, s.priority, s.created_by, s.created_at, s.updated_at,
-                s.updated_by, s.wake, s.engagement
+                s.updated_by, s.wake, s.engagement, s.room_id
             FROM specs s
             WHERE s.status = 'pending'
             AND (? IS NULL OR s.project = ?)
@@ -926,7 +983,8 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
         List.of(),
         List.of(),
         row.text(14),
-        row.text(15));
+        row.text(15),
+        row.text(16));
   }
 
   private SpecRow hydrate(SpecRow spec) {
@@ -955,7 +1013,8 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
         deps,
         repos,
         spec.wake(),
-        spec.engagement());
+        spec.engagement(),
+        spec.roomId());
   }
 
   /**

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncWire.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncWire.java
@@ -51,7 +51,7 @@ public final class SyncWire {
    * up front — the refusal names 'sail upgrade' as the remedy. Bump again only when a change makes
    * older peers unsafe, never for a routine release.
    */
-  public static final String V1_UPGRADE_FLOOR = "0.31.0";
+  public static final String V1_UPGRADE_FLOOR = "0.32.0";
 
   /**
    * Hard ceiling on one framed message, bounding the memory a single read can claim. A sync message

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -306,7 +306,7 @@ class SchemaManagerTest {
 
   @Test
   void theMessageRekeyCarriesRowsAndTheDeliveryLedgerAcrossTheRename() {
-    var staged = SchemaManager.CURRENT_VERSION - 8;
+    var staged = SchemaManager.CURRENT_VERSION - 10;
     stageAtBaseline();
     for (var v = SchemaManager.V1_VERSION + 1; v <= staged; v++) {
       db.execute(SchemaManager.MIGRATIONS.get(v - SchemaManager.V1_VERSION - 1));
@@ -346,6 +346,26 @@ class SchemaManagerTest {
         0,
         db.query("SELECT run_id FROM run_delivered_messages", r -> r.text(0)).size(),
         "the delivery ledger's FK followed the rename and still cascades");
+  }
+
+  @Test
+  void specsGainRoomIdBackfilledToTheirOwnIdOnUpgrade() {
+    var staged = SchemaManager.CURRENT_VERSION - 2;
+    stageAtBaseline();
+    for (var v = SchemaManager.V1_VERSION + 1; v <= staged; v++) {
+      db.execute(SchemaManager.MIGRATIONS.get(v - SchemaManager.V1_VERSION - 1));
+      db.execute("INSERT INTO schema_version (version, applied_at) VALUES (?, 'staged')", v);
+    }
+    db.execute(
+        "INSERT INTO specs (id, title, status, priority, created_at, updated_at, project,"
+            + " updated_by) VALUES ('auth', 'OAuth', 'done', 0, 'c', 'u', 'acme', 'uday')");
+
+    new SchemaManager(db).migrate();
+
+    assertEquals(
+        "auth",
+        db.queryOne("SELECT room_id FROM specs WHERE id = 'auth'", r -> r.text(0)).orElseThrow(),
+        "a pre-decouple spec backfills its identity room id");
   }
 
   private void stageAtVersion(int version) {

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
@@ -632,6 +632,22 @@ class SpecStoreTest {
   }
 
   @Test
+  void roomIdRidesTheSnapshotAndLegacySnapshotsFallBackToIdentity() {
+    store.create(spec("auth", "OAuth", "draft").withRoomId("design-room"));
+    assertEquals("design-room", store.findById("auth").orElseThrow().roomIdOrIdentity());
+    var snapshot = store.comparableSnapshot("auth");
+    assertEquals("design-room", snapshot.get("room_id"), "the room link syncs");
+
+    var legacy = new java.util.LinkedHashMap<String, Object>(snapshot);
+    legacy.remove("room_id");
+    store.applyRevision("auth", legacy, "9-legacy");
+    assertEquals(
+        "auth",
+        store.findById("auth").orElseThrow().roomIdOrIdentity(),
+        "a pre-decouple snapshot falls back to the identity room");
+  }
+
+  @Test
   void updateEngagementTouchesOnlyTheMirrorColumnAndJournals() {
     store.create(spec("auth", "OAuth", "draft"));
     store.updateStatus("auth", SpecStatus.IN_PROGRESS);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -610,7 +610,8 @@ record SpecCreateRequest(
     List<String> repos,
     String body,
     String plan,
-    String createdBy) {
+    String createdBy,
+    String roomId) {
 
   @SuppressWarnings("unchecked")
   static SpecCreateRequest fromMap(Map<String, Object> map) {
@@ -629,7 +630,8 @@ record SpecCreateRequest(
         map.containsKey("repos") ? (List<String>) map.get("repos") : List.of(),
         (String) map.get("body"),
         (String) map.get("plan"),
-        null);
+        null,
+        (String) map.get("room_id"));
   }
 
   /**
@@ -652,7 +654,8 @@ record SpecCreateRequest(
         repos,
         body,
         plan,
-        actor);
+        actor,
+        roomId);
   }
 }
 
@@ -938,7 +941,8 @@ record GlobalSpecView(
     String createdBy,
     String createdAt,
     String updatedAt,
-    String updatedBy)
+    String updatedBy,
+    String roomId)
     implements Mappable {
   static GlobalSpecView from(SpecStore.SpecRow row) {
     return new GlobalSpecView(
@@ -959,7 +963,8 @@ record GlobalSpecView(
         row.createdBy(),
         row.createdAt(),
         row.updatedAt(),
-        row.updatedBy());
+        row.updatedBy(),
+        row.roomIdOrIdentity());
   }
 
   private static Map<String, Object> engagementMap(String stored) {
@@ -996,6 +1001,7 @@ record GlobalSpecView(
     m.put("created_at", createdAt);
     m.put("updated_at", updatedAt);
     if (updatedBy != null) m.put("updated_by", updatedBy);
+    m.put("room_id", roomId);
     return m;
   }
 }
@@ -1039,7 +1045,7 @@ record GlobalSpecsListResponse(
                     spec.put(
                         "last_activity_at",
                         message != null && message.compareTo(updated) > 0 ? message : updated);
-                    var question = openQuestions.get(view.id());
+                    var question = openQuestions.get(view.roomId());
                     if (question != null) {
                       spec.put("needs_reply", true);
                       spec.put("question_message_id", question);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
@@ -114,6 +114,8 @@ final class GlobalSpecOperations {
           "Pass --project <name> or run from a directory containing sail.yaml.");
     }
     var assignee = Strings.isBlank(request.assignee()) ? request.createdBy() : request.assignee();
+    var roomId = Strings.isBlank(request.roomId()) ? request.id() : request.roomId();
+    NameValidator.requireValidSpecId(roomId);
     var row =
         new SpecStore.SpecRow(
             request.id(),
@@ -132,7 +134,7 @@ final class GlobalSpecOperations {
             request.createdBy(),
             request.dependsOn(),
             request.repos());
-    specStore.create(row);
+    specStore.create(row.withRoomId(roomId));
     if (request.body() != null || request.plan() != null) {
       specStore.setContent(
           request.id(),
@@ -170,7 +172,9 @@ final class GlobalSpecOperations {
             request.updatedBy(),
             request.dependsOn() != null ? request.dependsOn() : existing.dependsOn(),
             request.repos() != null ? request.repos() : existing.repos(),
-            request.wake() != null ? validWake(request.wake()) : existing.wake());
+            request.wake() != null ? validWake(request.wake()) : existing.wake(),
+            existing.engagement(),
+            existing.roomIdOrIdentity());
     specStore.update(updated);
     dualWriteWake(updated, request);
     if (updated.status() == SpecStatus.DONE
@@ -210,7 +214,12 @@ final class GlobalSpecOperations {
       return;
     }
     store.ensureFor(
-        spec.id(), spec.project(), spec.title(), spec.assignee(), spec.wake(), spec.createdBy());
+        spec.roomIdOrIdentity(),
+        spec.project(),
+        spec.title(),
+        spec.assignee(),
+        spec.wake(),
+        spec.createdBy());
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/InviteLauncher.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/InviteLauncher.java
@@ -121,7 +121,9 @@ public final class InviteLauncher {
     var body = specStore.getContent(specId).map(SpecStore.SpecContent::body).orElse("");
     var messages = messageStore.get();
     var room =
-        messages == null ? List.<MessageStore.MessageRow>of() : messages.list(specId, null, 20);
+        messages == null
+            ? List.<MessageStore.MessageRow>of()
+            : messages.list(spec.roomIdOrIdentity(), null, 20);
     var built = InvitePrompt.build(spec, body.isBlank() ? spec.title() : body, room);
     var task = built.prompt();
     var runId = DateTimeUtils.newId().toString();

--- a/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
@@ -431,6 +431,7 @@ final class LocalApiRouter implements LocalApiHandler {
             csv(form.get("repos")),
             form.get("body"),
             form.get("plan"),
+            null,
             null)
         .withCreatedBy(principal);
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MembershipService.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MembershipService.java
@@ -70,7 +70,7 @@ public final class MembershipService {
    * dismissal recorded on the room can never be resurrected by a stale spec column.
    */
   public static RoomState stateOf(RoomStore rooms, SpecStore.SpecRow spec) {
-    var room = rooms == null ? null : rooms.findById(spec.id()).orElse(null);
+    var room = rooms == null ? null : rooms.findById(spec.roomIdOrIdentity()).orElse(null);
     if (room == null) {
       return new RoomState(spec.wake(), rosterOf(null, spec).standing());
     }
@@ -83,7 +83,7 @@ public final class MembershipService {
    * even when empty), else the spec's legacy engagement column as a one-member roster.
    */
   public static Roster rosterOf(RoomStore rooms, SpecStore.SpecRow spec) {
-    var room = rooms == null ? null : rooms.findById(spec.id()).orElse(null);
+    var room = rooms == null ? null : rooms.findById(spec.roomIdOrIdentity()).orElse(null);
     if (room != null) {
       return Roster.fromJson(room.roster());
     }
@@ -235,8 +235,13 @@ public final class MembershipService {
     specStore.atomically(
         () -> {
           store.ensureFor(
-              spec.id(), spec.project(), spec.title(), spec.assignee(), spec.wake(), handle);
-          store.updateRoster(spec.id(), roster.toJson(), handle);
+              spec.roomIdOrIdentity(),
+              spec.project(),
+              spec.title(),
+              spec.assignee(),
+              spec.wake(),
+              handle);
+          store.updateRoster(spec.roomIdOrIdentity(), roster.toJson(), handle);
           specStore.updateEngagement(spec.id(), standing == null ? null : standing.toJson());
           return null;
         });

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -721,12 +721,16 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
    * conversation enriches the prompt, it is not a precondition — a dead message store must degrade
    * the review, never error it.
    */
+  private String roomOf(String specId) {
+    return specStore.findById(specId).map(SpecStore.SpecRow::roomIdOrIdentity).orElse(specId);
+  }
+
   private List<MessageStore.MessageRow> roomMessages(String specId) {
     if (messageStore == null) {
       return List.of();
     }
     try {
-      return messageStore.list(specId, null, 20);
+      return messageStore.list(roomOf(specId), null, 20);
     } catch (RuntimeException e) {
       System.err.println(
           "review-pipeline: could not read the room of spec " + specId + ": " + e.getMessage());
@@ -751,7 +755,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
   private void postRoom(String specId, String body) {
     if (messageStore == null) return;
     try {
-      messageStore.append(specId, Event.SAIL_AGENT, body, null);
+      messageStore.append(roomOf(specId), Event.SAIL_AGENT, body, null);
       syncTrigger.run();
     } catch (RuntimeException e) {
       System.err.println(

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeLauncher.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeLauncher.java
@@ -102,7 +102,9 @@ public final class RoomWakeLauncher {
     var body = specStore.getContent(specId).map(SpecStore.SpecContent::body).orElse("");
     var messages = messageStore.get();
     var room =
-        messages == null ? List.<MessageStore.MessageRow>of() : messages.list(specId, null, 20);
+        messages == null
+            ? List.<MessageStore.MessageRow>of()
+            : messages.list(spec.roomIdOrIdentity(), null, 20);
     var resumeSessionId =
         engagement != null
             ? engagedSessionId(specId, agentType, localHandle)

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
@@ -280,7 +280,7 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
         || MembershipService.stateOf(roomStore, spec).standing() == null) {
       return;
     }
-    var owed = owedMessage(specId);
+    var owed = owedMessage(spec);
     if (owed == null) {
       return;
     }
@@ -288,12 +288,12 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
   }
 
   /** The newest human message no chat turn has started after, or {@code null} when none is owed. */
-  private Message owedMessage(String specId) {
+  private Message owedMessage(SpecStore.SpecRow spec) {
     if (messageStore == null) {
       return null;
     }
     var newestHuman =
-        messageStore.list(specId, null, 20).stream()
+        messageStore.list(spec.roomIdOrIdentity(), null, 20).stream()
             .filter(row -> RoomWakePolicy.humanAuthor(row.author()))
             .reduce((first, second) -> second)
             .orElse(null);
@@ -305,7 +305,7 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
       return null;
     }
     var newestChatStart =
-        runStore.listForSpec(specId).stream()
+        runStore.listForSpec(spec.id()).stream()
             .filter(RunStore.RunRow::chatRole)
             .map(RunStore.RunRow::startedAt)
             .filter(Strings::isNotBlank)

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -1195,7 +1195,7 @@ public final class SailOperations implements Operations {
               detail.plan(),
               detail.openFindings(),
               detail.latestRun(),
-              messageStore.openQuestions().get(specId));
+              messageStore.openQuestions().get(detail.spec().roomId()));
         });
   }
 
@@ -1249,7 +1249,12 @@ public final class SailOperations implements Operations {
           MessageStore.MessageRow row;
           try {
             row =
-                store.append(specId, author, request.body(), request.replyTo(), request.question());
+                store.append(
+                    spec.roomIdOrIdentity(),
+                    author,
+                    request.body(),
+                    request.replyTo(),
+                    request.question());
           } catch (IllegalArgumentException invalid) {
             throw new ApiException(ErrorCode.BAD_REQUEST, invalid.getMessage());
           }
@@ -1280,17 +1285,21 @@ public final class SailOperations implements Operations {
             throw new ApiException(
                 ErrorCode.BAD_REQUEST, "before and after are exclusive; pass at most one.");
           }
-          if (specStore.findById(specId).isEmpty()) {
-            throw new ApiException(
-                ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found.");
-          }
+          var spec =
+              specStore
+                  .findById(specId)
+                  .orElseThrow(
+                      () ->
+                          new ApiException(
+                              ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
+          var roomId = spec.roomIdOrIdentity();
           List<SpecMessageView> messages;
           try {
             var store = requireMessageStore();
             var rows =
                 after != null
-                    ? store.listAfter(specId, after, limit)
-                    : store.list(specId, before, limit);
+                    ? store.listAfter(roomId, after, limit)
+                    : store.list(roomId, before, limit);
             messages = rows.stream().map(SpecMessageView::from).toList();
           } catch (IllegalArgumentException invalid) {
             throw new ApiException(ErrorCode.BAD_REQUEST, invalid.getMessage());
@@ -1310,11 +1319,22 @@ public final class SailOperations implements Operations {
           var store = requireMessageStore();
           var fetched =
               store.listUndelivered(
-                  run.specId(), runId, Objects.toString(run.principal(), ""), INBOX_LIMIT + 1);
+                  runRoomId(run), runId, Objects.toString(run.principal(), ""), INBOX_LIMIT + 1);
           var hasMore = fetched.size() > INBOX_LIMIT;
           var fresh = fetched.stream().limit(INBOX_LIMIT).map(SpecMessageView::from).toList();
           return new RunInboxResponse(runId, run.specId(), fresh, hasMore);
         });
+  }
+
+  /** The room a run's messages live in: its spec's room, or the raw id for a spec-less run. */
+  private String runRoomId(RunStore.RunRow run) {
+    if (Strings.isBlank(run.specId()) || specStore == null) {
+      return run.specId();
+    }
+    return specStore
+        .findById(run.specId())
+        .map(SpecStore.SpecRow::roomIdOrIdentity)
+        .orElse(run.specId());
   }
 
   @Override
@@ -1332,7 +1352,7 @@ public final class SailOperations implements Operations {
                 !Strings.isBlank(messageId)
                     && store
                         .findById(messageId)
-                        .filter(message -> message.roomId().equals(run.specId()))
+                        .filter(message -> message.roomId().equals(runRoomId(run)))
                         .isPresent();
             if (!onSpec) {
               throw new ApiException(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SyncCommand.java
@@ -294,8 +294,8 @@ public final class SyncCommand implements Callable<Integer> {
         .flatMap(Optional::stream)
         .map(
             row ->
-                specs
-                    .findById(row.roomId())
+                specs.listByRoom(row.roomId()).stream()
+                    .findFirst()
                     .map(
                         spec ->
                             SyncTransitionEvents.messagePosted(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -1865,6 +1865,7 @@ class ApiRouterTest {
                   null,
                   "",
                   "",
+                  null,
                   null),
               null,
               null,
@@ -1896,7 +1897,8 @@ class ApiRouterTest {
                   request.createdBy(),
                   "",
                   "",
-                  request.createdBy()),
+                  request.createdBy(),
+                  null),
               specId,
               "r1",
               2));
@@ -1924,6 +1926,7 @@ class ApiRouterTest {
                   null,
                   "",
                   "",
+                  null,
                   null)));
     }
 
@@ -1950,6 +1953,7 @@ class ApiRouterTest {
                   null,
                   "",
                   "",
+                  null,
                   null)));
     }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
@@ -766,6 +766,60 @@ class GlobalSpecOperationsTest {
   }
 
   @Test
+  void anEditPreservesTheEngagementMirrorAndTheRoomLink() {
+    var rooms = new RoomStore(db);
+    var withRooms = new GlobalSpecOperations(specStore, reviewStore, null, null, () -> rooms);
+    withRooms.create(
+        SpecCreateRequest.fromMap(
+                java.util.Map.of("id", "kept", "title", "Kept", "project", "acme"))
+            .withCreatedBy("uday"));
+    var seeded = specStore.findById("kept").orElseThrow();
+    specStore.update(
+        seeded.withEngagement(
+            "{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}"));
+
+    withRooms.update(
+        "kept",
+        SpecUpdateRequest.fromMap(java.util.Map.of("title", "Kept v2", "updated_by", "uday")),
+        ADMIN);
+
+    var after = specStore.findById("kept").orElseThrow();
+    assertEquals("Kept v2", after.title());
+    assertNotNull(after.engagement(), "an ordinary edit must never wipe the engagement mirror");
+    assertEquals("kept", after.roomIdOrIdentity(), "the room link survives every edit");
+  }
+
+  @Test
+  void createIntoAnExistingRoomAttachesInsteadOfMinting() {
+    var rooms = new RoomStore(db);
+    var withRooms = new GlobalSpecOperations(specStore, reviewStore, null, null, () -> rooms);
+    rooms.create(
+        new RoomStore.RoomRow(
+            "design-room", "acme", "Design talk", "uday", "on", null, "uday", null, null, "uday"));
+
+    withRooms.create(
+        SpecCreateRequest.fromMap(
+                java.util.Map.of(
+                    "id",
+                    "attached",
+                    "title",
+                    "Attached spec",
+                    "project",
+                    "acme",
+                    "room_id",
+                    "design-room"))
+            .withCreatedBy("uday"));
+
+    var spec = specStore.findById("attached").orElseThrow();
+    assertEquals("design-room", spec.roomIdOrIdentity(), "the spec lives in the given room");
+    assertEquals(
+        "Design talk",
+        rooms.findById("design-room").orElseThrow().title(),
+        "attaching never rewrites the existing room");
+    assertTrue(rooms.findById("attached").isEmpty(), "no identity room is minted beside it");
+  }
+
+  @Test
   void anExplicitWakeEditDualWritesTheRoomRow() {
     var rooms = new RoomStore(db);
     var withRooms = new GlobalSpecOperations(specStore, reviewStore, null, null, () -> rooms);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecViewTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecViewTest.java
@@ -37,7 +37,8 @@ class GlobalSpecViewTest {
         List.of(),
         List.of(),
         null,
-        engagement);
+        engagement,
+        null);
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
@@ -133,6 +133,38 @@ class RoomWakeLaunchTest {
   }
 
   @Test
+  void aWakeWithoutAMessageStoreLaunchesWithAnEmptyRoom() throws Exception {
+    var yaml = tempDir.resolve("sail-" + System.nanoTime() + ".yaml");
+    Files.writeString(yaml, YAML);
+    db = Sqlite.open(tempDir.resolve("wake-" + System.nanoTime() + ".db"));
+    new SchemaManager(db).migrate();
+    specStore = new SpecStore(db);
+    runStore = new RunStore(db);
+    new FdeStore(db).add(HANDLE, null, null, "admin");
+    var ops =
+        new DispatchOperations(
+            liveAgentShell(),
+            yaml.toString(),
+            specStore,
+            new ReviewStore(db),
+            runStore,
+            new FdeStore(db),
+            events::add,
+            new WatcherSpawner(liveAgentShell(), (command, logPath) -> 4242L),
+            (project, config) -> "",
+            command -> {
+              launched.set(command);
+              return 0;
+            },
+            DispatchOperations.Listener.NONE);
+    seedSpec("auth");
+
+    ops.startRoomRun("acme", "auth", HANDLE);
+
+    assertNotNull(launched.get(), "a box without a message store still wakes, room empty");
+  }
+
+  @Test
   void aWakeWithoutAnAgentBlockIsRefused() throws Exception {
     var ops = operations(liveAgentShell(), YAML_NO_AGENT, true, command -> 0);
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsSyncTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsSyncTest.java
@@ -255,7 +255,8 @@ class SailOperationsSyncTest {
         List.of(),
         null,
         null,
-        "uday");
+        "uday",
+        null);
   }
 
   private static SpecUpdateRequest update(String status) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -305,6 +305,7 @@ class TestOperations implements Operations {
                 null,
                 "",
                 "",
+                null,
                 null),
             null,
             null,
@@ -335,7 +336,8 @@ class TestOperations implements Operations {
                 request.createdBy(),
                 "",
                 "",
-                request.createdBy()),
+                request.createdBy(),
+                null),
             specId,
             "r1",
             2));
@@ -363,6 +365,7 @@ class TestOperations implements Operations {
                 null,
                 "",
                 "",
+                null,
                 null)));
   }
 
@@ -389,6 +392,7 @@ class TestOperations implements Operations {
                 null,
                 "",
                 "",
+                null,
                 null)));
   }
 


### PR DESCRIPTION
Brick 3a of `room-spec-decouple`: every spec carries its room — `specs.room_id` lands end-to-end (column, row, snapshot, sync, backfill), every conversation-side reader keys through it, and the identity assumption (`room id ≡ spec id`) retires from the code. **This is the second and final floor-bump brick** (`V1_UPGRADE_FLOOR` → `0.32.0`): spec snapshots now carry `room_id`, and a pre-0.32 peer's apply would drop the unknown key and push the row back without it — silently nulling the room link fleet-wide — so it must be refused up front.

## What

- **`specs.room_id`** (append-only migrations: `ADD COLUMN` + `UPDATE … SET room_id = id` backfill, prior-shape upgrade test included): threaded through `SpecRow` (new component + `withRoomId` + `roomIdOrIdentity()`), every SELECT, create/update/applySnapshot SQL, `snapshotMap`, `SYNC_FIELDS`, and `specFromSnapshot` — with a **legacy-snapshot fallback** (a pre-decouple snapshot or journal entry resolves to the identity room, tested).
- **`room_id` is immutable on the local write path** (not in the local `UPDATE … SET` list) and sync-written in `applySnapshot` — a stale row can never re-home a spec.
- **Create attaches, or mints**: `SpecCreateRequest` gains `room_id`; creating into an existing room attaches the spec without touching the room (tested — no identity room minted beside it); absent, the spec gets its identity room as before.
- **Every reader keys through `roomIdOrIdentity()`**: membership state/roster/writes, wake launcher + invite prompts' room reads, the reactor's owed-message check, the review pipeline's room posts (new `roomOf` resolution), spec-door message list/post, the run inbox/ack lane (new `runRoomId` resolution), board decoration (`GlobalSpecView` gains `room_id`; activity/needs-reply looked up by room), and sync's pulled-message events (new `SpecStore.listByRoom`).

## A real pre-existing bug found and fixed (TDD)

`GlobalSpecOperations.update` built its row with the overload that defaults `engagement` to null — **every ordinary spec edit (a title change, a board drag) silently wiped the engagement mirror** since the column was introduced. Room-authoritative reads (Brick 1a) masked the behavior, but every spec view lied after any edit. Fixed by carrying `existing.engagement()` (and now `room_id`) through the edit; regression test proves an edit preserves both.

## Release discipline

Same as Brick 2: this brick's floor bump cuts as `0.32.0` solo (with 3b riding along if merged first), then lockstep fleet upgrade.
