### PR TITLE
feat(rooms): spec-less rooms get their agents — the collaborator lane (decouple brick 4)

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -640,6 +640,44 @@ public final class RunStore implements ConflictResolver, SyncedStore {
       String logPath,
       String unit,
       Duration maxDuration) {
+    return reserveDispatch(
+        id,
+        project,
+        specId,
+        null,
+        node,
+        owner,
+        role,
+        repos,
+        agent,
+        branch,
+        task,
+        logPath,
+        unit,
+        maxDuration);
+  }
+
+  /**
+   * Reservation for a chat lane that may serve a room with no spec: {@code roomId} is stored on the
+   * run (a sync-local column, like the credential and delivery ledger — never journaled) and
+   * substitutes for the spec in the gate's serialization scope, so two wakes of the same spec-less
+   * room still conflict.
+   */
+  public Reservation reserveDispatch(
+      String id,
+      String project,
+      String specId,
+      String roomId,
+      String node,
+      String owner,
+      String role,
+      List<String> repos,
+      String agent,
+      String branch,
+      String task,
+      String logPath,
+      String unit,
+      Duration maxDuration) {
     var reserved = Objects.requireNonNullElse(repos, List.<String>of());
     return db.immediateTransaction(
         () -> {
@@ -649,35 +687,28 @@ public final class RunStore implements ConflictResolver, SyncedStore {
           }
           var running =
               db.query(
-                  "SELECT "
-                      + COLUMNS
-                      + " FROM runs WHERE project = ? AND status IN ('running', 'stopping')"
+                  "SELECT id, IFNULL(spec_id, room_id), role, repos FROM runs"
+                      + " WHERE project = ? AND status IN ('running', 'stopping')"
                       + " AND IFNULL(node, '') = ?",
-                  this::mapRow,
+                  row ->
+                      new DispatchGate.RunningRun(
+                          row.text(0), row.text(1), row.text(2), repoList(row.text(3))),
                   project,
                   ownerKey(node));
           var conflict =
-              DispatchGate.decide(
-                  specId,
-                  role,
-                  reserved,
-                  running.stream()
-                      .map(
-                          run ->
-                              new DispatchGate.RunningRun(
-                                  run.id(), run.specId(), run.role(), run.repos()))
-                      .toList());
+              DispatchGate.decide(specId != null ? specId : roomId, role, reserved, running);
           if (conflict.isPresent()) {
             return new Reservation.Conflicted(conflict.get());
           }
           db.execute(
               """
-              INSERT INTO runs (id, project, spec_id, node, role, agent, branch, task, status,
-                  started_at, log_path, unit, repos, principal, owner)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'running', ?, ?, ?, ?, ?, ?)""",
+              INSERT INTO runs (id, project, spec_id, room_id, node, role, agent, branch, task,
+                  status, started_at, log_path, unit, repos, principal, owner)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'running', ?, ?, ?, ?, ?, ?)""",
               id,
               project,
               specId,
+              roomId,
               node,
               role,
               agent,
@@ -694,6 +725,10 @@ public final class RunStore implements ConflictResolver, SyncedStore {
           recordRevision(id, "local", false);
           return new Reservation.Reserved(credential);
         });
+  }
+
+  private static List<String> repoList(String json) {
+    return json == null ? List.of() : YamlUtil.parseStringList(json);
   }
 
   public Optional<RunRow> findById(String id) {
@@ -1006,6 +1041,14 @@ public final class RunStore implements ConflictResolver, SyncedStore {
         "SELECT " + COLUMNS + " FROM runs WHERE project = ? ORDER BY started_at DESC",
         this::mapRow,
         project);
+  }
+
+  /** Chat runs of a room — spec-less rooms track their turns here; a sync-local read. */
+  public List<RunRow> listForRoom(String roomId) {
+    return db.query(
+        "SELECT " + COLUMNS + " FROM runs WHERE room_id = ? ORDER BY started_at DESC, id DESC",
+        this::mapRow,
+        roomId);
   }
 
   public List<RunRow> listForSpec(String specId) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -421,7 +421,8 @@ public final class SchemaManager {
           "DROP TABLE spec_messages",
           "CREATE INDEX idx_room_messages_page ON room_messages(room_id, id DESC)",
           "ALTER TABLE specs ADD COLUMN room_id TEXT",
-          "UPDATE specs SET room_id = id WHERE room_id IS NULL");
+          "UPDATE specs SET room_id = id WHERE room_id IS NULL",
+          "ALTER TABLE runs ADD COLUMN room_id TEXT");
 
   /** The schema version this binary converges every database to. */
   static final int CURRENT_VERSION = V1_VERSION + MIGRATIONS.size();

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -1948,4 +1948,57 @@ class RunStoreTest {
         store.consumeRoomGuardBaseline(id).isEmpty(),
         "consumed on first read — a replayed stop checks nothing twice");
   }
+
+  @Test
+  void aRoomKeyedReservationTracksAndSerializesByRoom(
+      @org.junit.jupiter.api.io.TempDir java.nio.file.Path dir) {
+    try (var roomDb = Sqlite.open(dir.resolve("room-runs.db"))) {
+      new SchemaManager(roomDb).migrate();
+      var runs = new RunStore(roomDb);
+
+      var first =
+          runs.reserveDispatch(
+              "run-1",
+              "acme",
+              null,
+              "chat-room",
+              "uday",
+              "uday",
+              "room",
+              java.util.List.of(),
+              "claude-code",
+              null,
+              "t",
+              "l",
+              "u",
+              null);
+      org.junit.jupiter.api.Assertions.assertInstanceOf(RunStore.Reservation.Reserved.class, first);
+      org.junit.jupiter.api.Assertions.assertNull(
+          runs.findById("run-1").orElseThrow().specId(), "no work-item on a chat turn");
+      org.junit.jupiter.api.Assertions.assertEquals(
+          1, runs.listForRoom("chat-room").size(), "the turn is tracked by its room");
+      org.junit.jupiter.api.Assertions.assertTrue(runs.listForRoom("other-room").isEmpty());
+
+      var second =
+          runs.reserveDispatch(
+              "run-2",
+              "acme",
+              null,
+              "chat-room",
+              "uday",
+              "uday",
+              "room",
+              java.util.List.of(),
+              "claude-code",
+              null,
+              "t",
+              "l",
+              "u",
+              null);
+      org.junit.jupiter.api.Assertions.assertInstanceOf(
+          RunStore.Reservation.Conflicted.class,
+          second,
+          "two live turns of one spec-less room must conflict — the room is the gate scope");
+    }
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -366,6 +366,9 @@ class SchemaManagerTest {
         "auth",
         db.queryOne("SELECT room_id FROM specs WHERE id = 'auth'", r -> r.text(0)).orElseThrow(),
         "a pre-decouple spec backfills its identity room id");
+    assertTrue(
+        db.query("PRAGMA table_info(runs)", r -> r.text(1)).contains("room_id"),
+        "chat runs can carry their room");
   }
 
   private void stageAtVersion(int version) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/LaunchAdmission.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/LaunchAdmission.java
@@ -35,6 +35,45 @@ public final class LaunchAdmission {
    * Refuses when the actor may not act on {@code spec} from the box identified by {@code
    * localHandle}.
    */
+  /**
+   * Refuses when the actor may not act on a spec-less room from this box: same four rules as the
+   * spec path — no agent lane, node handle set, this box owns the room (assignee, else creator),
+   * write credential, admin-or-owner — with room wording, since no work-item is involved.
+   */
+  public static void requireAllowedForRoom(
+      Actor actor, String roomId, String owner, String localHandle) {
+    if (actor.agentLane()) {
+      throw new ApiException(
+          ErrorCode.FORBIDDEN,
+          "Agent credentials cannot manage room membership.",
+          "Ask the engineer in the room to do it.");
+    }
+    if (Strings.isBlank(localHandle)) {
+      throw new ApiException(
+          ErrorCode.COMMAND_FAILED,
+          "This box has no FDE handle, so room ownership cannot be established.",
+          "Set it with: sail host config set sync-handle <handle>");
+    }
+    if (!localHandle.equals(owner)) {
+      throw new ApiException(
+          ErrorCode.NOT_YOUR_SPEC,
+          "Room '" + roomId + "' belongs to '" + owner + "', whose box serves its agents.",
+          "Manage the room from that box, or have an admin reassign it.");
+    }
+    if (!actor.canWrite()) {
+      throw new ApiException(
+          ErrorCode.READ_ONLY_CREDENTIAL,
+          "Your credential is read-only and cannot change room membership.",
+          "Ask an admin for a member or admin credential.");
+    }
+    if (!actor.isAdmin() && !owner.equals(actor.handle())) {
+      throw new ApiException(
+          ErrorCode.NOT_YOUR_SPEC,
+          "Room '" + roomId + "' belongs to '" + owner + "', not you.",
+          "Ask " + owner + " to manage it, or have an admin do it.");
+    }
+  }
+
   public static void requireAllowed(Actor actor, Spec spec, String localHandle) {
     if (DispatchPolicy.check(actor, spec, localHandle)
         instanceof DispatchDecision.Refused refused) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MembershipService.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MembershipService.java
@@ -133,13 +133,10 @@ public final class MembershipService {
       boolean takeSnapshot,
       Actor actor,
       String localHandle) {
-    var spec =
-        specStore
-            .findById(specId)
-            .orElseThrow(
-                () ->
-                    new ApiException(
-                        ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
+    var spec = specStore.findById(specId).orElse(null);
+    if (spec == null) {
+      return engageSpecless(specId, agentYamlName, mode, model, actor, localHandle);
+    }
     LaunchAdmission.requireAllowed(actor, spec.toSpec(), localHandle);
     admission.requireTrustedRoster(localHandle);
     requireRooms();
@@ -174,6 +171,56 @@ public final class MembershipService {
     return new EngageLaunch(member.agent(), member.mode(), label, completion);
   }
 
+  /**
+   * Seats a member in a room with no attached spec — the collaborator lane. Same guards, same
+   * roster write, same events (keyed by the room id); no spec column exists to mirror, and the
+   * engage-time snapshot is not offered — a spec-less room's full turns still pay per-turn
+   * reservations, and there is no work-item whose rollback point a snapshot would anchor.
+   */
+  private EngageLaunch engageSpecless(
+      String roomId,
+      String agentYamlName,
+      String mode,
+      String model,
+      Actor actor,
+      String localHandle) {
+    var store = requireRooms();
+    var room =
+        store
+            .findById(roomId)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.ROOM_NOT_FOUND, "Room '" + roomId + "' was not found."));
+    var owner =
+        room.assignee() == null || room.assignee().isBlank() ? room.createdBy() : room.assignee();
+    LaunchAdmission.requireAllowedForRoom(actor, roomId, owner, localHandle);
+    admission.requireTrustedRoster(localHandle);
+    var agentCli = LaunchAdmission.resolveAgent(agentYamlName);
+    Engagement member;
+    try {
+      member =
+          Engagement.of(
+              agentCli.yamlName(),
+              mode,
+              LaunchAdmission.validateModel(model),
+              DateTimeUtils.now().toString());
+    } catch (IllegalArgumentException e) {
+      throw new ApiException(ErrorCode.BAD_REQUEST, e.getMessage());
+    }
+    if (!member.full() && !agentCli.supportsRoomLane()) {
+      throw new ApiException(
+          ErrorCode.BAD_REQUEST,
+          agentCli.readOnlyInviteRefusal(),
+          "Engage " + agentCli.yamlName() + " with full access instead.");
+    }
+    projects.loadRunning(room.project());
+    admission.requireInstalled(agentCli, room.project());
+    store.updateRoster(roomId, Roster.solo(member).toJson(), actor.handle());
+    publishEngaged(room.project(), roomId, member, "");
+    return new EngageLaunch(member.agent(), member.mode(), "", null);
+  }
+
   private void completeEngage(
       String project, String specId, Engagement member, String label, Actor actor) {
     try {
@@ -200,13 +247,10 @@ public final class MembershipService {
 
   /** Dismisses the room's standing member. Idempotent: dismissing an empty room is a no-op. */
   public String disengage(String specId, Actor actor, String localHandle) {
-    var spec =
-        specStore
-            .findById(specId)
-            .orElseThrow(
-                () ->
-                    new ApiException(
-                        ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
+    var spec = specStore.findById(specId).orElse(null);
+    if (spec == null) {
+      return disengageSpecless(specId, actor, localHandle);
+    }
     LaunchAdmission.requireAllowed(actor, spec.toSpec(), localHandle);
     var standing = stateOf(rooms.get(), spec).standing();
     if (standing == null) {
@@ -216,6 +260,31 @@ public final class MembershipService {
     publish(
         spec.project(),
         specId,
+        Event.WellKnownTypes.SPEC_DISENGAGED,
+        Map.of("agent", standing.agent(), "mode", standing.mode()));
+    return standing.agent();
+  }
+
+  private String disengageSpecless(String roomId, Actor actor, String localHandle) {
+    var store = requireRooms();
+    var room =
+        store
+            .findById(roomId)
+            .orElseThrow(
+                () ->
+                    new ApiException(
+                        ErrorCode.ROOM_NOT_FOUND, "Room '" + roomId + "' was not found."));
+    var owner =
+        room.assignee() == null || room.assignee().isBlank() ? room.createdBy() : room.assignee();
+    LaunchAdmission.requireAllowedForRoom(actor, roomId, owner, localHandle);
+    var standing = Roster.fromJson(room.roster()).standing();
+    if (standing == null) {
+      return null;
+    }
+    store.updateRoster(roomId, null, actor.handle());
+    publish(
+        room.project(),
+        roomId,
         Event.WellKnownTypes.SPEC_DISENGAGED,
         Map.of("agent", standing.agent(), "mode", standing.mode()));
     return standing.agent();

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeLauncher.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeLauncher.java
@@ -76,13 +76,10 @@ public final class RoomWakeLauncher {
           ErrorCode.COMMAND_FAILED,
           "This box keeps no run aggregate, so a room wake cannot be reserved or tracked.");
     }
-    var spec =
-        specStore
-            .findById(specId)
-            .orElseThrow(
-                () ->
-                    new ApiException(
-                        ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
+    var spec = specStore.findById(specId).orElse(null);
+    if (spec == null) {
+      return wakeSpecless(project, specId, config, localHandle);
+    }
     var engagement = MembershipService.stateOf(roomStore.get(), spec).standing();
     var agentType =
         engagement != null
@@ -167,6 +164,102 @@ public final class RoomWakeLauncher {
                   resumeSessionId));
       runLauncher.finishLaunch(
           new RunLauncher.RunContext(project, unit, runId, specId, agentType, role, true), launch);
+      return runId;
+    } catch (RuntimeException e) {
+      runReservation.releaseIfAbsent(runId, project, unit);
+      throw e;
+    }
+  }
+
+  /**
+   * Wakes a room with no attached spec — the collaborator lane. Only a seated member wakes (the
+   * reactor guarantees it; this refuses defensively), the prompt carries no spec framing, the run
+   * reserves with a null spec and the room id as its serialization scope, and full mode claims the
+   * project's whole repo set — a conversation has no work-item to narrow it.
+   */
+  private String wakeSpecless(String project, String roomId, SailYaml config, String localHandle) {
+    var rooms = roomStore.get();
+    var room = rooms == null ? null : rooms.findById(roomId).orElse(null);
+    if (room == null) {
+      throw new ApiException(ErrorCode.ROOM_NOT_FOUND, "Room '" + roomId + "' was not found.");
+    }
+    var member = ai.singlr.sail.config.Roster.fromJson(room.roster()).standing();
+    if (member == null) {
+      throw new ApiException(
+          ErrorCode.COMMAND_FAILED,
+          "Room '" + roomId + "' has no seated member, so there is nobody to wake.");
+    }
+    var agentType = member.agent();
+    var full = member.full();
+    if (!full && !AgentCli.fromYamlName(agentType).supportsRoomLane()) {
+      throw new ApiException(
+          ErrorCode.AGENT_NOT_CONFIGURED,
+          "Room wake needs a harness-enforced read-only session, and "
+              + agentType
+              + " has none inside a sail container. Engage claude-code in this room, or engage "
+              + agentType
+              + " with full access.");
+    }
+    var messages = messageStore.get();
+    var conversation =
+        messages == null ? List.<MessageStore.MessageRow>of() : messages.list(roomId, null, 20);
+    var built = RoomWakePrompt.buildForRoom(roomId, room.title(), conversation, member);
+    var task = built.prompt();
+    var runId = DateTimeUtils.newId().toString();
+    var unit = AgentUnit.forRun(runId);
+    var role = full ? DispatchGate.ROOM_FULL_ROLE : DispatchGate.ROOM_ROLE;
+    var targetRepos = full ? config.repos() : List.<SailYaml.Repo>of();
+    var repoPaths = targetRepos.stream().map(SailYaml.Repo::path).toList();
+    var owner =
+        room.assignee() == null || room.assignee().isBlank()
+            ? Objects.toString(room.createdBy(), localHandle)
+            : room.assignee();
+    var credential =
+        runReservation.reserve(
+            runId,
+            project,
+            null,
+            roomId,
+            localHandle,
+            owner,
+            role,
+            repoPaths,
+            agentType,
+            null,
+            task,
+            unit,
+            config);
+    try {
+      seedRoomDelivery(runId, built.renderedMessages());
+      if (!full) {
+        roomCommitGuard.captureRoomBaseline(project, config, runId);
+      }
+      var workDir =
+          full
+              ? AgentSession.launchWorkDir(config.sshUser(), targetRepos)
+              : "/home/" + config.sshUser() + "/workspace";
+      var launch =
+          runLauncher.launchSession(
+              new RunLauncher.LaunchSpec(
+                  project,
+                  config,
+                  workDir,
+                  full,
+                  member.model(),
+                  null,
+                  roomId,
+                  agentType,
+                  task,
+                  "",
+                  repoPaths,
+                  true,
+                  unit,
+                  runId,
+                  credential,
+                  role,
+                  null));
+      runLauncher.finishLaunch(
+          new RunLauncher.RunContext(project, unit, runId, roomId, agentType, role, true), launch);
       return runId;
     } catch (RuntimeException e) {
       runReservation.releaseIfAbsent(runId, project, unit);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
@@ -13,6 +13,7 @@ import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SpecStore;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -180,20 +181,59 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
     }
   }
 
+  /**
+   * The conversation a message event targets: a spec (with its room state) when one exists — the
+   * work-item lane, unchanged — else the room row alone, the collaborator lane. Spec-less rooms
+   * wake only for a seated member (the wake vocabulary presumes dispatch history a conversation
+   * does not have), their waker box is the room's owner, and their turns are tracked by room id.
+   */
+  private record Target(
+      String id,
+      String project,
+      boolean owned,
+      MembershipService.RoomState state,
+      boolean dispatched,
+      List<RunStore.RunRow> runs) {}
+
+  private Target resolveTarget(String id) {
+    var spec = specStore.findById(id).orElse(null);
+    if (spec != null) {
+      return new Target(
+          id,
+          spec.project(),
+          spec.assignedTo(localHandle.get()),
+          MembershipService.stateOf(roomStore, spec),
+          dispatchedAtLeastOnce(id),
+          runStore.listForSpec(id));
+    }
+    var room = roomStore.findById(id).orElse(null);
+    if (room == null) {
+      return null;
+    }
+    var owner =
+        room.assignee() == null || room.assignee().isBlank() ? room.createdBy() : room.assignee();
+    var standing = ai.singlr.sail.config.Roster.fromJson(room.roster()).standing();
+    return new Target(
+        id,
+        room.project(),
+        owner != null && owner.equals(localHandle.get()),
+        new MembershipService.RoomState(null, standing),
+        false,
+        runStore.listForRoom(id));
+  }
+
   private void handleMessage(Event event) {
-    var specId = event.spec();
-    var spec = specStore.findById(specId).orElse(null);
-    if (spec == null || !spec.assignedTo(localHandle.get())) {
+    var target = resolveTarget(event.spec());
+    if (target == null || !target.owned()) {
       return;
     }
-    var state = MembershipService.stateOf(roomStore, spec);
-    var engaged = state.standing() != null;
+    var engaged = target.state().standing() != null;
     var message = messageOf(event);
     if (!RoomWakePolicy.shouldWake(
-        state.wake(), dispatchedAtLeastOnce(specId), engaged, message.author(), message.body())) {
+        target.state().wake(), target.dispatched(), engaged, message.author(), message.body())) {
       return;
     }
-    schedule(specId, message, engaged);
+    schedule(event.spec(), message, engaged);
   }
 
   private void schedule(String specId, Message message, boolean engaged) {
@@ -216,17 +256,16 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
 
   private void fire(String specId, Message message) {
     try {
-      var spec = specStore.findById(specId).orElse(null);
-      if (spec == null || !spec.assignedTo(localHandle.get())) {
+      var target = resolveTarget(specId);
+      if (target == null || !target.owned()) {
         return;
       }
-      var state = MembershipService.stateOf(roomStore, spec);
-      var engaged = state.standing() != null;
+      var engaged = target.state().standing() != null;
       if (!RoomWakePolicy.shouldWake(
-          state.wake(), dispatchedAtLeastOnce(specId), engaged, message.author(), message.body())) {
+          target.state().wake(), target.dispatched(), engaged, message.author(), message.body())) {
         return;
       }
-      var runs = runStore.listForSpec(specId);
+      var runs = target.runs();
       if (engaged) {
         if (runs.stream().anyMatch(run -> LIVE_STATUSES.contains(run.status()) && run.chatRole())) {
           return;
@@ -239,7 +278,7 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
           return;
         }
       }
-      waker.wake(spec.project(), specId);
+      waker.wake(target.project(), specId);
     } catch (Exception e) {
       System.err.println("room-wake: wake of spec " + specId + " failed: " + e.getMessage());
     }
@@ -274,13 +313,11 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
    * after the newest chat turn started, so no turn has read it.
    */
   private void refireOwedTurn(String specId) {
-    var spec = specStore.findById(specId).orElse(null);
-    if (spec == null
-        || !spec.assignedTo(localHandle.get())
-        || MembershipService.stateOf(roomStore, spec).standing() == null) {
+    var target = resolveTarget(specId);
+    if (target == null || !target.owned() || target.state().standing() == null) {
       return;
     }
-    var owed = owedMessage(spec);
+    var owed = owedMessage(specId, target);
     if (owed == null) {
       return;
     }
@@ -288,12 +325,13 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
   }
 
   /** The newest human message no chat turn has started after, or {@code null} when none is owed. */
-  private Message owedMessage(SpecStore.SpecRow spec) {
+  private Message owedMessage(String id, Target target) {
     if (messageStore == null) {
       return null;
     }
+    var roomId = specStore.findById(id).map(SpecStore.SpecRow::roomIdOrIdentity).orElse(id);
     var newestHuman =
-        messageStore.list(spec.roomIdOrIdentity(), null, 20).stream()
+        messageStore.list(roomId, null, 20).stream()
             .filter(row -> RoomWakePolicy.humanAuthor(row.author()))
             .reduce((first, second) -> second)
             .orElse(null);
@@ -305,7 +343,7 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
       return null;
     }
     var newestChatStart =
-        runStore.listForSpec(spec.id()).stream()
+        target.runs().stream()
             .filter(RunStore.RunRow::chatRole)
             .map(RunStore.RunRow::startedAt)
             .filter(Strings::isNotBlank)
@@ -329,10 +367,7 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
     specStore.listEngaged().forEach(spec -> engaged.add(spec.id()));
     for (var id : engaged) {
       try {
-        var spec = specStore.findById(id).orElse(null);
-        if (spec != null && spec.assignedTo(localHandle.get())) {
-          refireOwedTurn(spec.id());
-        }
+        refireOwedTurn(id);
       } catch (RuntimeException e) {
         System.err.println(
             "room-wake: engagement sweep of room " + id + " failed: " + e.getMessage());

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RunReservation.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RunReservation.java
@@ -60,6 +60,26 @@ public final class RunReservation {
       String task,
       AgentUnit unit,
       SailYaml config) {
+    return reserve(
+        runId, project, specId, null, node, owner, role, repos, agentType, branch, task, unit,
+        config);
+  }
+
+  /** Reservation variant for chat lanes that may serve a spec-less room. */
+  public String reserve(
+      String runId,
+      String project,
+      String specId,
+      String roomId,
+      String node,
+      String owner,
+      String role,
+      List<String> repos,
+      String agentType,
+      String branch,
+      String task,
+      AgentUnit unit,
+      SailYaml config) {
     RunStore.Reservation reservation;
     try {
       reservation =
@@ -67,6 +87,7 @@ public final class RunReservation {
               runId,
               project,
               specId,
+              roomId,
               node,
               owner,
               role,

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -552,36 +552,32 @@ public final class SailOperations implements Operations {
   }
 
   /**
-   * The room behind {@code roomId} — the room row when one exists, else a spec's identity room
-   * rendered as a room shape so pre-decouple data keeps answering on the room door.
+   * The conversation behind {@code roomId}, resolved spec-first: a spec's identity keeps its
+   * ownership fields authoritative for policy, and a genuinely spec-less room answers from its own
+   * row. {@code ROOM_NOT_FOUND} otherwise.
    */
   private RoomStore.RoomRow requireRoomOrSpec(String roomId) {
+    var spec = specStore == null ? null : specStore.findById(roomId).orElse(null);
+    if (spec != null) {
+      return new RoomStore.RoomRow(
+          spec.id(),
+          spec.project(),
+          spec.title(),
+          spec.assignee(),
+          spec.wake(),
+          null,
+          spec.createdBy(),
+          spec.createdAt(),
+          spec.updatedAt(),
+          spec.updatedBy());
+    }
     if (roomStore != null) {
       var room = roomStore.findById(roomId).orElse(null);
       if (room != null) {
         return room;
       }
     }
-    var spec =
-        specStore == null
-            ? java.util.Optional.<SpecStore.SpecRow>empty()
-            : specStore.findById(roomId);
-    return spec.map(
-            row ->
-                new RoomStore.RoomRow(
-                    row.id(),
-                    row.project(),
-                    row.title(),
-                    row.assignee(),
-                    row.wake(),
-                    null,
-                    row.createdBy(),
-                    row.createdAt(),
-                    row.updatedAt(),
-                    row.updatedBy()))
-        .orElseThrow(
-            () ->
-                new ApiException(ErrorCode.ROOM_NOT_FOUND, "Room '" + roomId + "' was not found."));
+    throw new ApiException(ErrorCode.ROOM_NOT_FOUND, "Room '" + roomId + "' was not found.");
   }
 
   @Override

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/RoomWakePrompt.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/RoomWakePrompt.java
@@ -67,6 +67,83 @@ public final class RoomWakePrompt {
     return new Built(prompt, conversation.fullyRendered());
   }
 
+  /**
+   * The collaborator prompt for a room with no attached spec: no spec framing at all — the agent is
+   * a standing participant in a conversation, not the custodian of a work-item. Same delivery
+   * contract as an engaged turn; the identity line is the only thing that changes, which is the
+   * point.
+   */
+  public static Built buildForRoom(
+      String roomId, String title, List<MessageStore.MessageRow> messages, Engagement engagement) {
+    var conversation =
+        PromptConversation.renderNewest(
+            messages,
+            message ->
+                message.author() + " (" + message.createdAt() + "):\n" + message.body() + "\n\n");
+    var conversationBlock =
+        conversation.text().isEmpty()
+            ? ""
+            : "## Conversation in this room\n\n" + conversation.text();
+    var prompt =
+        "You are a collaborator in the room \""
+            + title
+            + "\" (id: "
+            + roomId
+            + "). Humans and agents talk here; no spec is attached — this is a conversation,"
+            + " not a work-item. You are engaged as a standing participant: humans post, you"
+            + " answer, and the conversation continues across turns.\n\n"
+            + conversationBlock
+            + collaboratorDuty(roomId, engagement);
+    return new Built(prompt, conversation.fullyRendered());
+  }
+
+  private static String collaboratorDuty(String roomId, Engagement engagement) {
+    if (engagement != null && engagement.full()) {
+      return """
+          ## Collaborator Turn (full access)
+
+          Read the newest human messages above, then help however the conversation asks:
+          answer, critique, brainstorm, draft, or work in the workspace.
+
+          - Post to the room with `spec comment %s --body <text>` (or `--body -` for
+            stdin). For a question only a human can settle, add `--question` — the flag
+            pages the engineer on the board until a human replies.
+          - When the conversation shapes real work, capture it as a spec with
+            `spec create --id <id> --title "<title>" --body-file <file>`. New specs are
+            born draft; a human promotes them on the board — never set a status yourself.
+          - Work in the workspace freely when asked — diagrams, files, experiments: this
+            turn holds the repo reservation.
+
+          This is one turn of a continuing conversation. Replies posted while you work are
+          delivered into your context automatically after a tool call finishes, and unread
+          messages block your first attempt to stop. When you have done what was asked,
+          post your reply and end your turn — you remain in the room and will be resumed
+          for the next message. Never say goodbye; the room continues.
+          """
+          .formatted(roomId);
+    }
+    return """
+        ## Collaborator Turn (read only)
+
+        Read the newest human messages above, investigate in the workspace as needed, and
+        answer in the room with `spec comment %s --body <text>` (or `--body -` for stdin).
+
+        This engagement is read only, and the harness enforces it: file edits are denied,
+        and the only shell commands that run are the `spec` CLI and `cd` — use the Read
+        and Grep tools for files. Do not fight a denial; work within the lane. When the
+        conversation shapes real work, describe the spec it deserves — a human (or a
+        full-access turn) can create it. For a question only a human can settle, use
+        `spec comment %s --question --body <text>`.
+
+        This is one turn of a continuing conversation. Replies posted while you work are
+        delivered into your context automatically after a tool call finishes, and unread
+        messages block your first attempt to stop. When you have answered, post your reply
+        and end your turn — you remain in the room and will be resumed for the next
+        message. Never say goodbye; the room continues.
+        """
+        .formatted(roomId, roomId);
+  }
+
   private static String duty(String specId, Engagement engagement) {
     if (engagement == null) {
       return wakeDuty(specId);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
@@ -265,7 +265,7 @@ class EngagementLifecycleTest {
             () ->
                 ops.engage(
                     "ghost", "claude-code", null, null, false, Actor.cliOperator(HANDLE), HANDLE));
-    assertEquals(ErrorCode.SPEC_NOT_FOUND, ex.failure().errorCode());
+    assertEquals(ErrorCode.ROOM_NOT_FOUND, ex.failure().errorCode());
   }
 
   @Test
@@ -275,7 +275,7 @@ class EngagementLifecycleTest {
     var ex =
         assertThrows(
             ApiException.class, () -> ops.disengage("ghost", Actor.cliOperator(HANDLE), HANDLE));
-    assertEquals(ErrorCode.SPEC_NOT_FOUND, ex.failure().errorCode());
+    assertEquals(ErrorCode.ROOM_NOT_FOUND, ex.failure().errorCode());
   }
 
   @Test
@@ -482,6 +482,93 @@ class EngagementLifecycleTest {
 
     assertEquals(ErrorCode.COMMAND_FAILED, refusal.failure().errorCode());
     assertNull(stored("auth"), "nothing was seated");
+  }
+
+  @Test
+  void aSpeclessRoomSeatsAndDismissesItsCollaborator() throws Exception {
+    var ops = operations(shell());
+    roomStore.create(
+        new RoomStore.RoomRow(
+            "chat-room", "acme", "Chat", HANDLE, null, null, HANDLE, null, null, HANDLE));
+
+    var launch =
+        ops.engage(
+            "chat-room",
+            "claude-code",
+            "read-only",
+            null,
+            false,
+            Actor.cliOperator(HANDLE),
+            HANDLE);
+    assertEquals("read_only", launch.mode());
+    assertNull(launch.completion(), "no spec, no snapshot offer — nothing to anchor a rollback");
+    assertNotNull(roomMember("chat-room"), "the collaborator is seated on the room row");
+    assertEquals(1, ofType(Event.WellKnownTypes.SPEC_ENGAGED).size());
+
+    assertEquals("claude-code", ops.disengage("chat-room", Actor.cliOperator(HANDLE), HANDLE));
+    assertNull(roomMember("chat-room"));
+    assertNull(
+        ops.disengage("chat-room", Actor.cliOperator(HANDLE), HANDLE),
+        "dismissing an empty room is a no-op");
+  }
+
+  @Test
+  void aSpeclessRoomRefusesBogusModesAndUnsandboxedReadOnlyAgents() throws Exception {
+    var ops = operations(shell());
+    roomStore.create(
+        new RoomStore.RoomRow(
+            "picky-room", "acme", "Picky", HANDLE, null, null, HANDLE, null, null, HANDLE));
+
+    var badMode =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.engage(
+                    "picky-room",
+                    "claude-code",
+                    "yolo",
+                    null,
+                    false,
+                    Actor.cliOperator(HANDLE),
+                    HANDLE));
+    assertEquals(ErrorCode.BAD_REQUEST, badMode.failure().errorCode());
+
+    var codexReadOnly =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.engage(
+                    "picky-room",
+                    "codex",
+                    "read-only",
+                    null,
+                    false,
+                    Actor.cliOperator(HANDLE),
+                    HANDLE));
+    assertEquals(ErrorCode.BAD_REQUEST, codexReadOnly.failure().errorCode());
+    assertNull(roomMember("picky-room"), "no refused engage seats anyone");
+  }
+
+  @Test
+  void aSpeclessRoomRefusesMembershipFromANonOwner() throws Exception {
+    var ops = operations(shell());
+    roomStore.create(
+        new RoomStore.RoomRow(
+            "ada-room", "acme", "Ada's", "ada", null, null, "ada", null, null, "ada"));
+
+    var ex =
+        assertThrows(
+            ApiException.class,
+            () ->
+                ops.engage(
+                    "ada-room",
+                    "claude-code",
+                    null,
+                    null,
+                    false,
+                    Actor.cliOperator(HANDLE),
+                    HANDLE));
+    assertEquals(ErrorCode.NOT_YOUR_SPEC, ex.failure().errorCode());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/LaunchAdmissionTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/LaunchAdmissionTest.java
@@ -186,4 +186,53 @@ class LaunchAdmissionTest {
     var ex = assertThrows(ApiException.class, () -> LaunchAdmission.validateModel("bad model!"));
     assertEquals(ErrorCode.INVALID_REQUEST, ex.failure().errorCode());
   }
+
+  @org.junit.jupiter.api.Test
+  void roomAdmissionRefusesEachRuleWithItsOwnReason() {
+    var agent =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            ApiException.class,
+            () ->
+                LaunchAdmission.requireAllowedForRoom(
+                    Actor.agentPrincipal("claude/x", "uday"), "chat", "uday", "uday"));
+    org.junit.jupiter.api.Assertions.assertEquals(ErrorCode.FORBIDDEN, agent.failure().errorCode());
+
+    var noHandle =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            ApiException.class,
+            () ->
+                LaunchAdmission.requireAllowedForRoom(
+                    Actor.cliOperator("uday"), "chat", "uday", " "));
+    org.junit.jupiter.api.Assertions.assertEquals(
+        ErrorCode.COMMAND_FAILED, noHandle.failure().errorCode());
+
+    var foreign =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            ApiException.class,
+            () ->
+                LaunchAdmission.requireAllowedForRoom(
+                    Actor.cliOperator("uday"), "chat", "ada", "uday"));
+    org.junit.jupiter.api.Assertions.assertEquals(
+        ErrorCode.NOT_YOUR_SPEC, foreign.failure().errorCode());
+
+    var readOnly =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            ApiException.class,
+            () ->
+                LaunchAdmission.requireAllowedForRoom(
+                    new Actor("uday", Role.VIEWER, Actor.Lane.API, null), "chat", "uday", "uday"));
+    org.junit.jupiter.api.Assertions.assertEquals(
+        ErrorCode.READ_ONLY_CREDENTIAL, readOnly.failure().errorCode());
+
+    var notOwner =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            ApiException.class,
+            () ->
+                LaunchAdmission.requireAllowedForRoom(
+                    new Actor("sam", Role.MEMBER, Actor.Lane.API, null), "chat", "uday", "uday"));
+    org.junit.jupiter.api.Assertions.assertEquals(
+        ErrorCode.NOT_YOUR_SPEC, notOwner.failure().errorCode());
+
+    LaunchAdmission.requireAllowedForRoom(Actor.cliOperator("uday"), "chat", "uday", "uday");
+  }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
@@ -8,6 +8,7 @@ package ai.singlr.sail.api;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -19,6 +20,7 @@ import ai.singlr.sail.engine.WatcherSpawner;
 import ai.singlr.sail.store.FdeStore;
 import ai.singlr.sail.store.MessageStore;
 import ai.singlr.sail.store.ReviewStore;
+import ai.singlr.sail.store.RoomStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
@@ -162,6 +164,106 @@ class RoomWakeLaunchTest {
     ops.startRoomRun("acme", "auth", HANDLE);
 
     assertNotNull(launched.get(), "a box without a message store still wakes, room empty");
+  }
+
+  @Test
+  void aSpeclessRoomWakeLaunchesTheCollaboratorPrompt() throws Exception {
+    var ops = operations(liveAgentShell());
+    var rooms = new RoomStore(db);
+    rooms.create(
+        new RoomStore.RoomRow(
+            "chat-room", "acme", "Chat", HANDLE, null, null, HANDLE, null, null, HANDLE));
+    rooms.updateRoster(
+        "chat-room",
+        "[{\"agent\":\"claude-code\",\"mode\":\"read_only\",\"engaged_at\":\"t0\"}]",
+        HANDLE);
+    ops.useRooms(rooms);
+
+    var runId = ops.startRoomRun("acme", "chat-room", HANDLE);
+
+    assertNotNull(launched.get());
+    var run = runStore.findById(runId).orElseThrow();
+    assertNull(run.specId(), "a spec-less turn carries no work-item");
+    assertEquals(
+        "chat-room",
+        db.queryOne("SELECT room_id FROM runs WHERE id = ?", r -> r.text(0), runId).orElseThrow(),
+        "the run is tracked by its room");
+    var task = run.task();
+    assertTrue(task.contains("collaborator in the room"), task.substring(0, 80));
+    assertFalse(task.contains("standing agent of spec"));
+  }
+
+  @Test
+  void aSpeclessFullWakeClaimsTheRepoSetAndOwnerFallsToTheWaker() throws Exception {
+    var ops = operations(liveAgentShell());
+    var rooms = new RoomStore(db);
+    rooms.create(
+        new RoomStore.RoomRow(
+            "full-room", "acme", "Full", " ", null, null, null, null, null, null));
+    rooms.updateRoster(
+        "full-room",
+        "[{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}]",
+        HANDLE);
+    ops.useRooms(rooms);
+
+    var runId = ops.startRoomRun("acme", "full-room", HANDLE);
+
+    var run = runStore.findById(runId).orElseThrow();
+    assertEquals("room-full", run.role());
+    assertTrue(run.task().contains("Collaborator Turn (full access)"));
+    assertEquals(HANDLE, run.owner(), "a room with no owner falls to the waking box");
+  }
+
+  @Test
+  void aSpeclessCodexReadOnlyMemberRefusesTheWake() throws Exception {
+    var ops = operations(liveAgentShellFor("codex"));
+    var rooms = new RoomStore(db);
+    rooms.create(
+        new RoomStore.RoomRow(
+            "codex-room", "acme", "Codex", HANDLE, null, null, HANDLE, null, null, HANDLE));
+    rooms.updateRoster(
+        "codex-room",
+        "[{\"agent\":\"codex\",\"mode\":\"read_only\",\"engaged_at\":\"t0\"}]",
+        HANDLE);
+    ops.useRooms(rooms);
+
+    var ex = assertThrows(ApiException.class, () -> ops.startRoomRun("acme", "codex-room", HANDLE));
+    assertEquals(ErrorCode.AGENT_NOT_CONFIGURED, ex.failure().errorCode());
+  }
+
+  @Test
+  void aFailedSpeclessLaunchReleasesTheReservationAndRethrows() throws Exception {
+    var ops = operations(liveAgentShell(), YAML, true, command -> 1);
+    var rooms = new RoomStore(db);
+    rooms.create(
+        new RoomStore.RoomRow(
+            "crash-room", "acme", "Crash", HANDLE, null, null, HANDLE, null, null, HANDLE));
+    rooms.updateRoster(
+        "crash-room",
+        "[{\"agent\":\"claude-code\",\"mode\":\"read_only\",\"engaged_at\":\"t0\"}]",
+        HANDLE);
+    ops.useRooms(rooms);
+
+    var ex = assertThrows(ApiException.class, () -> ops.startRoomRun("acme", "crash-room", HANDLE));
+    assertEquals(ErrorCode.AGENT_LAUNCH_FAILED, ex.failure().errorCode());
+    assertEquals(
+        1,
+        runStore.listForRoom("crash-room").size(),
+        "the failed turn stays on the room's ledger — released now or by the missed-stop"
+            + " reconciler, per releaseIfAbsent's live-agent contract");
+  }
+
+  @Test
+  void aSpeclessRoomWithNoMemberRefusesTheWake() throws Exception {
+    var ops = operations(liveAgentShell());
+    var rooms = new RoomStore(db);
+    rooms.create(
+        new RoomStore.RoomRow(
+            "empty-room", "acme", "Empty", HANDLE, null, null, HANDLE, null, null, HANDLE));
+    ops.useRooms(rooms);
+
+    var ex = assertThrows(ApiException.class, () -> ops.startRoomRun("acme", "empty-room", HANDLE));
+    assertEquals(ErrorCode.COMMAND_FAILED, ex.failure().errorCode());
   }
 
   @Test
@@ -953,7 +1055,7 @@ class RoomWakeLaunchTest {
     var ops = operations(liveAgentShell());
 
     var missing = assertThrows(ApiException.class, () -> ops.startRoomRun("acme", "ghost", HANDLE));
-    assertEquals(ErrorCode.SPEC_NOT_FOUND, missing.failure().errorCode());
+    assertEquals(ErrorCode.ROOM_NOT_FOUND, missing.failure().errorCode());
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
@@ -977,6 +977,47 @@ class RoomWakeReactorTest {
   }
 
   @Test
+  void aSpeclessRoomWithASeatedMemberWakesOnItsOwnersBox() {
+    roomStore.create(
+        new RoomStore.RoomRow(
+            "chat-room", "acme", "Chat", "uday", null, null, "uday", null, null, "uday"));
+    roomStore.updateRoster(
+        "chat-room",
+        "[{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}]",
+        "uday");
+
+    reactor().onEvent(message("chat-room", "uday", "hello"));
+
+    assertEquals(1, launcher.woken.size(), "a conversation without a spec still gets its agent");
+  }
+
+  @Test
+  void aSpeclessRoomWithNoMemberStaysSilentRegardlessOfWakeMode() {
+    roomStore.create(
+        new RoomStore.RoomRow(
+            "quiet-room", "acme", "Quiet", "uday", "on", null, "uday", null, null, "uday"));
+
+    reactor().onEvent(message("quiet-room", "uday", "anyone?"));
+
+    assertTrue(launcher.woken.isEmpty(), "the wake vocabulary presumes a work-item; members wake");
+  }
+
+  @Test
+  void aSpeclessRoomIsSilentOnABoxThatDoesNotOwnIt() {
+    roomStore.create(
+        new RoomStore.RoomRow(
+            "foreign-room", "acme", "Foreign", "ada", null, null, "ada", null, null, "ada"));
+    roomStore.updateRoster(
+        "foreign-room",
+        "[{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}]",
+        "ada");
+
+    reactor().onEvent(message("foreign-room", "uday", "hello"));
+
+    assertTrue(launcher.woken.isEmpty(), "exactly one waker per room: its owner's box");
+  }
+
+  @Test
   void aMemberRecordedOnlyOnTheRoomRowWakesTheAgent() {
     seed("auth", "in_progress", "uday", "off");
     roomStore.ensureFor("auth", "acme", "auth", "uday", "off", "uday");

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/RoomWakePromptTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/RoomWakePromptTest.java
@@ -119,4 +119,40 @@ class RoomWakePromptTest {
     assertTrue(built.prompt().contains("git commands are denied too"));
     assertFalse(built.prompt().contains("read-only git (log, show, diff"));
   }
+
+  @Test
+  void aSpeclessRoomPromptCarriesNoSpecFraming() {
+    var member =
+        ai.singlr.sail.config.Engagement.of(
+            "claude-code", "read_only", null, "2026-08-24T00:00:00Z");
+
+    var built =
+        RoomWakePrompt.buildForRoom("design-room", "Design talk", java.util.List.of(), member);
+
+    org.junit.jupiter.api.Assertions.assertTrue(
+        built.prompt().contains("collaborator in the room \"Design talk\""));
+    org.junit.jupiter.api.Assertions.assertFalse(
+        built.prompt().contains("standing agent of spec"), "the spec leak dies here");
+    org.junit.jupiter.api.Assertions.assertFalse(built.prompt().contains("## Spec body"));
+    org.junit.jupiter.api.Assertions.assertTrue(
+        built.prompt().contains("Collaborator Turn (read only)"));
+    org.junit.jupiter.api.Assertions.assertTrue(
+        built.prompt().contains("spec comment design-room"), "posting still rides the CLI");
+  }
+
+  @Test
+  void aFullCollaboratorTurnOffersSpecCreationNeverStatusChanges() {
+    var member =
+        ai.singlr.sail.config.Engagement.of("claude-code", "full", null, "2026-08-24T00:00:00Z");
+
+    var built =
+        RoomWakePrompt.buildForRoom("design-room", "Design talk", java.util.List.of(), member);
+
+    org.junit.jupiter.api.Assertions.assertTrue(
+        built.prompt().contains("Collaborator Turn (full access)"));
+    org.junit.jupiter.api.Assertions.assertTrue(
+        built.prompt().contains("spec create"), "the promote flow is the collaborator's output");
+    org.junit.jupiter.api.Assertions.assertTrue(
+        built.prompt().contains("never set a status yourself"));
+  }
 }


### PR DESCRIPTION
Brick 4 of `room-spec-decouple`: spec-less rooms get their agents — the collaborator lane. The original felt-conflation complaint dies at its root: an agent in a plain conversation is prompted as a **collaborator in a room**, never as "the standing agent of spec …".

## What

- **`RoomWakePrompt.buildForRoom`** — no spec framing, no spec body, collaborator duties (read-only and full). The full turn's output channel is the promote flow: capture the conversation's work as a draft spec (`spec create`), never a status change. Posting rides the same `spec comment <roomId>` CLI, which the spec-first conversation resolver already serves for spec-less rooms.
- **Membership for spec-less rooms** — `MembershipService.engage/disengage` resolve spec-first (identity-room behavior byte-preserved), then fall to the room row: room-shaped admission (`LaunchAdmission.requireAllowedForRoom` — same four rules as dispatch, room wording; the room's owner is `assignee`, else creator), roster write, same events keyed by the room id. No engage-time snapshot on a spec-less room — there is no work-item to anchor a rollback point.
- **Wake for spec-less rooms** — the reactor resolves a `Target` (spec with room state, else room row): the waker box is the room's **owner**, spec-less rooms wake **only for a seated member** (the wake vocabulary presumes dispatch history a conversation doesn't have), and live-turn suppression, cooldown, and the owed-message check track by room. The sweep already unions both homes.
- **`runs.room_id`** — a **sync-local** column (never journaled — the `run_credentials`/delivery-ledger precedent), so run snapshots are wire-unchanged and **no floor bump is needed**. Chat turns for spec-less rooms reserve with a null spec and the room id as the gate's serialization scope — two live turns of one room conflict, proven by test. Existing signatures untouched: `reserveDispatch`/`reserve` gained delegating overloads; only the spec-less path uses them.
- **Launcher** — `wakeSpecless`: member's agent (defensively refused if nobody is seated), full mode claims the project's whole repo set (a conversation has no work-item to narrow it), collaborator prompt, room-keyed run.

## Scope lines

- Event vocabulary unchanged (`spec_engaged`/`spec_message_posted` keyed by room id — the established pattern Mast's Brick 5 consumes).
- Session resume for spec-less turns starts fresh each wake; resumable collaborator sessions ride the durable-session v2 wake engine (post-arc, on the PTY host substrate).

Ghost ids on the membership/wake doors now answer `ROOM_NOT_FOUND` — the honest post-decouple semantics (three expectations updated).

## Tests

- `RoomWakePromptTest` +2: the collaborator prompt carries no spec framing (the leak's regression test), read-only vs full duties, promote-flow language.
- `RoomWakeReactorTest` +3: spec-less room wakes on its owner's box; no member → silent regardless of wake mode (this test caught the first implementation passing the room's wake vocabulary through — the members-only rule is now enforced by construction: a spec-less target carries no wake mode); foreign owner → silent.
- `RoomWakeLaunchTest` +2: spec-less wake launches with the collaborator prompt, `spec_id` null + `room_id` set on the run; no member → loud refusal.
- `EngagementLifecycleTest` +2: seat/dismiss a collaborator on a chat-only room (no snapshot offer, events fire, idempotent dismiss); non-owner refused.
- `RunStoreTest` +1: room-keyed reservation tracks by room and **serializes by room** (second live turn conflicts).
