### PR TITLE
Rooms decouple brick 6: retire the spec doors and legacy columns

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
@@ -324,11 +324,12 @@ public final class MessageStore implements SyncedStore {
     var ownsAuthor =
         peer.equals(author)
             || db.queryOne(
-                    "SELECT 1 FROM runs r WHERE r.owner = ? AND r.spec_id = ?"
+                    "SELECT 1 FROM runs r WHERE r.owner = ? AND (r.spec_id = ? OR r.room_id = ?)"
                         + " AND (r.principal = ? OR EXISTS (SELECT 1 FROM run_principals rp"
                         + " WHERE rp.run_id = r.id AND rp.principal = ?)) LIMIT 1",
                     row -> true,
                     peer,
+                    roomId,
                     roomId,
                     author,
                     author)
@@ -336,11 +337,24 @@ public final class MessageStore implements SyncedStore {
     if (!ownsAuthor) {
       return false;
     }
+    return postAuthority(peer, "FROM rooms s", "s.id = ?", roomId)
+        || postAuthority(peer, "FROM specs s", "s.room_id = ?", roomId);
+  }
+
+  /**
+   * Whether {@code peer}'s box holds posting authority over the conversation: an admin FDE, the
+   * assignee, or the creator of an unassigned surface. Resolved against the room row and against
+   * any spec attached to the room — a spec's ownership fields stay authoritative for policy even
+   * when its room row has not been minted or has not arrived yet (a synced-in or imported spec).
+   */
+  private boolean postAuthority(String peer, String from, String where, String roomId) {
     return db.queryOne(
-            "SELECT 1 FROM rooms s LEFT JOIN fdes f ON f.handle = ? "
-                + "WHERE s.id = ? AND (lower(coalesce(f.role, '')) = 'admin' "
-                + "OR s.assignee = ? OR "
-                + "(trim(coalesce(s.assignee, '')) = '' AND s.created_by = ?)) LIMIT 1",
+            "SELECT 1 "
+                + from
+                + " LEFT JOIN fdes f ON f.handle = ? WHERE "
+                + where
+                + " AND (lower(coalesce(f.role, '')) = 'admin' OR s.assignee = ?"
+                + " OR (trim(coalesce(s.assignee, '')) = '' AND s.created_by = ?)) LIMIT 1",
             row -> true,
             peer,
             roomId,

--- a/sail-core/src/main/java/ai/singlr/sail/store/RoomsBackfillMigration.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RoomsBackfillMigration.java
@@ -36,6 +36,9 @@ public final class RoomsBackfillMigration implements DataMigration {
   @Override
   public Report apply(Sqlite db, ProjectRegistry projects, Prompter prompter) {
     var rooms = new RoomStore(db);
+    if (!hasLegacyColumns(db)) {
+      return new Report(0, 0, 0, List.of());
+    }
     var specs =
         db.query(
             """
@@ -86,6 +89,18 @@ public final class RoomsBackfillMigration implements DataMigration {
         spec.get(7),
         spec.get(9),
         spec.get(8));
+  }
+
+  /**
+   * Whether the specs table still carries the pre-decouple {@code wake}/{@code engagement} columns
+   * this backfill reads. A schema without them has nothing left to backfill — either the database
+   * was born after the columns retired, or the backfill already ran before the retiring migration
+   * dropped them — so the answer is a clean no-op, never a missing-column error.
+   */
+  private static boolean hasLegacyColumns(Sqlite db) {
+    return !db.query(
+            "SELECT name FROM pragma_table_info('specs') WHERE name = 'wake'", row -> row.text(0))
+        .isEmpty();
   }
 
   private static String text(Sqlite.Row row, int index) {

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -1313,8 +1313,9 @@ public final class RunStore implements ConflictResolver, SyncedStore {
         """
         INSERT INTO runs (id, project, spec_id, node, role, agent, branch, task, pid, watcher_pid,
             status, exit_code, log_path, unit, started_at, completed_at, repos, pid_ticks,
-            principal, owner, session_id, session_source, transcript_path, last_activity_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            principal, owner, session_id, session_source, transcript_path, last_activity_at,
+            room_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET project = excluded.project, spec_id = excluded.spec_id,
             node = excluded.node, role = excluded.role, agent = excluded.agent,
             branch = excluded.branch, task = excluded.task, pid = excluded.pid,
@@ -1325,7 +1326,7 @@ public final class RunStore implements ConflictResolver, SyncedStore {
             principal = excluded.principal, owner = excluded.owner,
             session_id = excluded.session_id, session_source = excluded.session_source,
             transcript_path = excluded.transcript_path,
-            last_activity_at = excluded.last_activity_at""",
+            last_activity_at = excluded.last_activity_at, room_id = excluded.room_id""",
         row.id(),
         row.project(),
         row.specId(),
@@ -1349,7 +1350,8 @@ public final class RunStore implements ConflictResolver, SyncedStore {
         row.sessionId(),
         row.sessionSource(),
         row.transcriptPath(),
-        row.lastActivityAt());
+        row.lastActivityAt(),
+        row.roomId());
   }
 
   private static Map<String, Object> snapshotMap(RunRow run) {
@@ -1378,6 +1380,7 @@ public final class RunStore implements ConflictResolver, SyncedStore {
     map.put("session_source", run.sessionSource());
     map.put("transcript_path", run.transcriptPath());
     map.put("last_activity_at", run.lastActivityAt());
+    map.put("room_id", run.roomId());
     return map;
   }
 
@@ -1427,7 +1430,7 @@ public final class RunStore implements ConflictResolver, SyncedStore {
         Snapshots.text(snapshot, "session_source"),
         Snapshots.text(snapshot, "transcript_path"),
         Snapshots.text(snapshot, "last_activity_at"),
-        null);
+        Snapshots.text(snapshot, "room_id"));
   }
 
   /** The run's store-specific half of the shared {@link RevisionJournal} sync protocol. */

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -102,7 +102,13 @@ public final class RunStore implements ConflictResolver, SyncedStore {
       String sessionId,
       String sessionSource,
       String transcriptPath,
-      String lastActivityAt) {
+      String lastActivityAt,
+      String roomId) {
+
+    /** The conversation this run serves — its spec's room, or the room itself when spec-less. */
+    public String conversationId() {
+      return specId != null ? specId : roomId;
+    }
 
     /** A row without activity — the shape every run has until its first progress stamp. */
     public RunRow(
@@ -153,6 +159,7 @@ public final class RunStore implements ConflictResolver, SyncedStore {
           sessionId,
           sessionSource,
           transcriptPath,
+          null,
           null);
     }
 
@@ -309,7 +316,8 @@ public final class RunStore implements ConflictResolver, SyncedStore {
   private static final String COLUMNS =
       "id, project, spec_id, node, role, agent, branch, task, pid, watcher_pid, status,"
           + " exit_code, log_path, unit, started_at, completed_at, repos, pid_ticks,"
-          + " principal, owner, session_id, session_source, transcript_path, last_activity_at";
+          + " principal, owner, session_id, session_source, transcript_path, last_activity_at,"
+          + " room_id";
 
   /**
    * Records a new run in the {@code running} state, journaling a baseline revision so it
@@ -1418,7 +1426,8 @@ public final class RunStore implements ConflictResolver, SyncedStore {
         Snapshots.text(snapshot, "session_id"),
         Snapshots.text(snapshot, "session_source"),
         Snapshots.text(snapshot, "transcript_path"),
-        Snapshots.text(snapshot, "last_activity_at"));
+        Snapshots.text(snapshot, "last_activity_at"),
+        null);
   }
 
   /** The run's store-specific half of the shared {@link RevisionJournal} sync protocol. */
@@ -1499,6 +1508,7 @@ public final class RunStore implements ConflictResolver, SyncedStore {
         row.text(20),
         row.text(21),
         row.text(22),
-        row.text(23));
+        row.text(23),
+        row.text(24));
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SchemaManager.java
@@ -422,7 +422,39 @@ public final class SchemaManager {
           "CREATE INDEX idx_room_messages_page ON room_messages(room_id, id DESC)",
           "ALTER TABLE specs ADD COLUMN room_id TEXT",
           "UPDATE specs SET room_id = id WHERE room_id IS NULL",
-          "ALTER TABLE runs ADD COLUMN room_id TEXT");
+          "ALTER TABLE runs ADD COLUMN room_id TEXT",
+          """
+          CREATE TABLE specs_v2 (
+              id TEXT PRIMARY KEY,
+              title TEXT NOT NULL,
+              status TEXT NOT NULL DEFAULT 'draft'
+                  CHECK (status IN ('draft', 'pending', 'in_progress', 'review', 'awaiting_merge',
+                      'done', 'cancelled', 'archived')),
+              assignee TEXT,
+              agent TEXT,
+              model TEXT,
+              reasoning_effort TEXT
+                  CHECK (reasoning_effort IS NULL OR reasoning_effort IN
+                      ('none', 'low', 'medium', 'high', 'xhigh')),
+              branch TEXT,
+              priority INTEGER NOT NULL DEFAULT 0,
+              created_by TEXT,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              project TEXT NOT NULL DEFAULT 'unassigned',
+              updated_by TEXT,
+              rev TEXT,
+              base_rev TEXT,
+              room_id TEXT
+          )""",
+          "INSERT INTO specs_v2 (id, title, status, assignee, agent, model, reasoning_effort,"
+              + " branch, priority, created_by, created_at, updated_at, project, updated_by, rev,"
+              + " base_rev, room_id) SELECT id, title, status, assignee, agent, model,"
+              + " reasoning_effort, branch, priority, created_by, created_at, updated_at, project,"
+              + " updated_by, rev, base_rev, room_id FROM specs",
+          "DROP TABLE specs",
+          "ALTER TABLE specs_v2 RENAME TO specs",
+          "CREATE INDEX idx_specs_project ON specs(project)");
 
   /** The schema version this binary converges every database to. */
   static final int CURRENT_VERSION = V1_VERSION + MIGRATIONS.size();

--- a/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/SpecStore.java
@@ -56,11 +56,9 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
       String updatedBy,
       List<String> dependsOn,
       List<String> repos,
-      String wake,
-      String engagement,
       String roomId) {
 
-    /** A row with no explicit wake mode — the default every spec has until an operator sets one. */
+    /** A row with no room attachment yet — the shape a spec has at creation time. */
     public SpecRow(
         String id,
         String project,
@@ -95,80 +93,10 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
           updatedBy,
           dependsOn,
           repos,
-          null,
-          null,
           null);
     }
 
-    /** A row with no engagement — the state every spec has until a human engages an agent. */
-    public SpecRow(
-        String id,
-        String project,
-        String title,
-        SpecStatus status,
-        String assignee,
-        String agent,
-        String model,
-        String reasoningEffort,
-        String branch,
-        int priority,
-        String createdBy,
-        String createdAt,
-        String updatedAt,
-        String updatedBy,
-        List<String> dependsOn,
-        List<String> repos,
-        String wake) {
-      this(
-          id,
-          project,
-          title,
-          status,
-          assignee,
-          agent,
-          model,
-          reasoningEffort,
-          branch,
-          priority,
-          createdBy,
-          createdAt,
-          updatedAt,
-          updatedBy,
-          dependsOn,
-          repos,
-          wake,
-          null,
-          null);
-    }
-
-    /** This row with {@code wake} replaced — the single-field edit the wake surfaces use. */
-    public SpecRow withWake(String wake) {
-      return new SpecRow(
-          id,
-          project,
-          title,
-          status,
-          assignee,
-          agent,
-          model,
-          reasoningEffort,
-          branch,
-          priority,
-          createdBy,
-          createdAt,
-          updatedAt,
-          updatedBy,
-          dependsOn,
-          repos,
-          wake,
-          engagement,
-          roomId);
-    }
-
-    /**
-     * This row with {@code engagement} replaced ({@code null} disengages) — the single-field edit
-     * the engage and disengage surfaces use.
-     */
+    /** This row with {@code roomId} replaced — the create-time attachment to its room. */
     public SpecRow withRoomId(String roomId) {
       return new SpecRow(
           id,
@@ -187,37 +115,12 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
           updatedBy,
           dependsOn,
           repos,
-          wake,
-          engagement,
           roomId);
     }
 
     /** The room this spec lives in — its own id for every spec born before rooms decoupled. */
     public String roomIdOrIdentity() {
       return roomId == null || roomId.isBlank() ? id : roomId;
-    }
-
-    public SpecRow withEngagement(String engagement) {
-      return new SpecRow(
-          id,
-          project,
-          title,
-          status,
-          assignee,
-          agent,
-          model,
-          reasoningEffort,
-          branch,
-          priority,
-          createdBy,
-          createdAt,
-          updatedAt,
-          updatedBy,
-          dependsOn,
-          repos,
-          wake,
-          engagement,
-          roomId);
     }
 
     /**
@@ -274,8 +177,8 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
               """
               INSERT INTO specs (id, project, title, status, assignee, agent, model,
                   reasoning_effort, branch, priority, created_by, created_at, updated_at,
-                  updated_by, wake, engagement, room_id)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                  updated_by, room_id)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
               spec.id(),
               spec.project(),
               spec.title(),
@@ -290,8 +193,6 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
               now,
               now,
               spec.updatedBy(),
-              spec.wake(),
-              spec.engagement(),
               spec.roomIdOrIdentity());
           insertDependencies(spec.id(), spec.dependsOn());
           insertRepos(spec.id(), spec.repos());
@@ -308,8 +209,7 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
     return db.query(
         """
         SELECT id, project, title, status, assignee, agent, model, reasoning_effort,
-            branch, priority, created_by, created_at, updated_at, updated_by, wake,
-            engagement, room_id
+            branch, priority, created_by, created_at, updated_at, updated_by, room_id
         FROM specs WHERE room_id = ? ORDER BY created_at, id""",
         this::mapSpec,
         roomId);
@@ -319,8 +219,7 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
     return db.queryOne(
             """
             SELECT id, project, title, status, assignee, agent, model, reasoning_effort,
-                branch, priority, created_by, created_at, updated_at, updated_by, wake,
-                engagement, room_id
+                branch, priority, created_by, created_at, updated_at, updated_by, room_id
             FROM specs WHERE id = ?""",
             this::mapSpec,
             id)
@@ -331,7 +230,7 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
     var sql = new StringBuilder("SELECT DISTINCT s.id, s.project, s.title, s.status, s.assignee,");
     sql.append(
         " s.agent, s.model, s.reasoning_effort, s.branch, s.priority, s.created_by, s.created_at,"
-            + " s.updated_at, s.updated_by, s.wake, s.engagement, s.room_id FROM specs s");
+            + " s.updated_at, s.updated_by, s.room_id FROM specs s");
     var params = new ArrayList<>();
     var where = new ArrayList<String>();
 
@@ -400,7 +299,7 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
               """
               UPDATE specs SET project = ?, title = ?, status = ?, assignee = ?, agent = ?,
                   model = ?, reasoning_effort = ?, branch = ?, priority = ?, updated_at = ?,
-                  updated_by = ?, wake = ?, engagement = ?
+                  updated_by = ?
               WHERE id = ?""",
               spec.project(),
               spec.title(),
@@ -413,8 +312,6 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
               spec.priority(),
               now,
               spec.updatedBy(),
-              spec.wake(),
-              spec.engagement(),
               spec.id());
           db.execute("DELETE FROM spec_dependencies WHERE spec_id = ?", spec.id());
           db.execute("DELETE FROM spec_repos WHERE spec_id = ?", spec.id());
@@ -432,23 +329,6 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
    */
   public <T> T atomically(java.util.function.Supplier<T> work) {
     return db.transaction(work);
-  }
-
-  /**
-   * Stores a new engagement mirror as a local edit — a single-column write, so it can never revert
-   * a concurrent status transition or reassignment the way a full-row rewrite from a stale read
-   * would.
-   */
-  public void updateEngagement(String id, String engagement) {
-    db.transaction(
-        () -> {
-          db.execute(
-              "UPDATE specs SET engagement = ?, updated_at = ? WHERE id = ?",
-              engagement,
-              DateTimeUtils.now().toString(),
-              id);
-          recordRevision(id, "local", false);
-        });
   }
 
   public void updateStatus(String id, SpecStatus status) {
@@ -588,8 +468,6 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
     map.put("updated_at", spec.updatedAt());
     map.put("depends_on", spec.dependsOn());
     map.put("repos", spec.repos());
-    map.put("wake", spec.wake());
-    map.put("engagement", spec.engagement());
     map.put("room_id", spec.roomIdOrIdentity());
     map.put("body", content.body());
     map.put("plan", content.plan());
@@ -604,7 +482,7 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
           """
           UPDATE specs SET project = ?, title = ?, status = ?, assignee = ?, agent = ?, model = ?,
               reasoning_effort = ?, branch = ?, priority = ?, updated_at = ?, updated_by = ?,
-              wake = ?, engagement = ?, room_id = ?
+              room_id = ?
           WHERE id = ?""",
           spec.project(),
           spec.title(),
@@ -617,8 +495,6 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
           spec.priority(),
           now,
           spec.updatedBy(),
-          spec.wake(),
-          spec.engagement(),
           spec.roomIdOrIdentity(),
           id);
       db.execute("DELETE FROM spec_dependencies WHERE spec_id = ?", id);
@@ -627,9 +503,8 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
       db.execute(
           """
           INSERT INTO specs (id, project, title, status, assignee, agent, model, reasoning_effort,
-              branch, priority, created_by, created_at, updated_at, updated_by, wake, engagement,
-              room_id)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+              branch, priority, created_by, created_at, updated_at, updated_by, room_id)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
           id,
           spec.project(),
           spec.title(),
@@ -644,8 +519,6 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
           spec.createdAt() == null || spec.createdAt().isBlank() ? now : spec.createdAt(),
           now,
           spec.updatedBy(),
-          spec.wake(),
-          spec.engagement(),
           spec.roomIdOrIdentity());
     }
     insertDependencies(id, spec.dependsOn());
@@ -688,8 +561,6 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
         Snapshots.text(s, "updated_by"),
         (List<String>) s.getOrDefault("depends_on", List.of()),
         (List<String>) s.getOrDefault("repos", List.of()),
-        Snapshots.text(s, "wake"),
-        Snapshots.text(s, "engagement"),
         roomIdOf(s));
   }
 
@@ -706,8 +577,6 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
           "priority",
           "depends_on",
           "repos",
-          "wake",
-          "engagement",
           "body",
           "plan",
           "room_id");
@@ -883,17 +752,6 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
         specId);
   }
 
-  /** Every spec with a standing engagement — the rooms the engagement sweeper walks. */
-  public List<SpecRow> listEngaged() {
-    return db.query(
-        """
-        SELECT id, project, title, status, assignee, agent, model, reasoning_effort,
-            branch, priority, created_by, created_at, updated_at, updated_by, wake,
-            engagement, room_id
-        FROM specs WHERE engagement IS NOT NULL""",
-        this::mapSpec);
-  }
-
   public List<SpecRow> readySpecs() {
     return readySpecs(null);
   }
@@ -904,7 +762,7 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
             """
             SELECT s.id, s.project, s.title, s.status, s.assignee, s.agent, s.model,
                 s.reasoning_effort, s.branch, s.priority, s.created_by, s.created_at, s.updated_at,
-                s.updated_by, s.wake, s.engagement, s.room_id
+                s.updated_by, s.room_id
             FROM specs s
             WHERE s.status = 'pending'
             AND (? IS NULL OR s.project = ?)
@@ -982,9 +840,7 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
         row.text(13),
         List.of(),
         List.of(),
-        row.text(14),
-        row.text(15),
-        row.text(16));
+        row.text(14));
   }
 
   private SpecRow hydrate(SpecRow spec) {
@@ -1012,8 +868,6 @@ public final class SpecStore implements ConflictResolver, SyncedStore {
         spec.updatedBy(),
         deps,
         repos,
-        spec.wake(),
-        spec.engagement(),
         spec.roomId());
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/sync/SyncWire.java
+++ b/sail-core/src/main/java/ai/singlr/sail/sync/SyncWire.java
@@ -51,7 +51,7 @@ public final class SyncWire {
    * up front — the refusal names 'sail upgrade' as the remedy. Bump again only when a change makes
    * older peers unsafe, never for a routine release.
    */
-  public static final String V1_UPGRADE_FLOOR = "0.32.0";
+  public static final String V1_UPGRADE_FLOOR = "0.34.0";
 
   /**
    * Hard ceiling on one framed message, bounding the memory a single read can claim. A sync message

--- a/sail-core/src/test/java/ai/singlr/sail/store/RoomsBackfillMigrationTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RoomsBackfillMigrationTest.java
@@ -36,6 +36,13 @@ class RoomsBackfillMigrationTest {
   }
 
   private static void seedSpec(Sqlite target, String id, String engagement) {
+    if (target
+        .query(
+            "SELECT name FROM pragma_table_info('specs') WHERE name = 'wake'", row -> row.text(0))
+        .isEmpty()) {
+      target.execute("ALTER TABLE specs ADD COLUMN wake TEXT");
+      target.execute("ALTER TABLE specs ADD COLUMN engagement TEXT");
+    }
     target.execute(
         """
         INSERT INTO specs (id, project, title, status, assignee, wake, engagement, created_by,
@@ -54,6 +61,19 @@ class RoomsBackfillMigrationTest {
 
   private ProjectRegistry noProjects() {
     return ProjectRegistry.loadFromDisk(tempDir.resolve("no-projects"));
+  }
+
+  @Test
+  void aSchemaWithoutTheRetiredColumnsBackfillsAsACleanNoOp() {
+    db.execute(
+        """
+        INSERT INTO specs (id, project, title, status, created_by, created_at, updated_at)
+        VALUES ('modern', 'acme', 'Modern', 'pending', 'uday', 't0', 't0')""");
+
+    var report = backfill(db);
+
+    assertEquals(0, report.applied(), "nothing to backfill once the columns are gone");
+    assertTrue(new RoomStore(db).findById("modern").isEmpty());
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/RunStoreTest.java
@@ -1950,6 +1950,43 @@ class RunStoreTest {
   }
 
   @Test
+  void aRoomKeyedRunSyncsItsRoomAcrossTheFleet(
+      @org.junit.jupiter.api.io.TempDir java.nio.file.Path dir) {
+    try (var ownerDb = Sqlite.open(dir.resolve("owner.db"));
+        var peerDb = Sqlite.open(dir.resolve("peer.db"))) {
+      new SchemaManager(ownerDb).migrate();
+      new SchemaManager(peerDb).migrate();
+      var owner = new RunStore(ownerDb);
+      var peer = new RunStore(peerDb);
+      owner.reserveDispatch(
+          "0195a2f0-0000-7000-8000-0000000000c1",
+          "acme",
+          null,
+          "chat-room",
+          "uday",
+          "uday",
+          "room",
+          java.util.List.of(),
+          "claude-code",
+          null,
+          "t",
+          "l",
+          "u",
+          null);
+      var snapshot = owner.comparableSnapshot("0195a2f0-0000-7000-8000-0000000000c1");
+      org.junit.jupiter.api.Assertions.assertEquals(
+          "chat-room", snapshot.get("room_id"), "the room key rides the run snapshot");
+
+      peer.applyRevision("0195a2f0-0000-7000-8000-0000000000c1", snapshot, "1-remote");
+
+      var replicated = peer.findById("0195a2f0-0000-7000-8000-0000000000c1").orElseThrow();
+      org.junit.jupiter.api.Assertions.assertEquals("chat-room", replicated.conversationId());
+      org.junit.jupiter.api.Assertions.assertEquals(
+          1, peer.listForRoom("chat-room").size(), "a peer box can key the turn by its room");
+    }
+  }
+
+  @Test
   void aRoomKeyedReservationTracksAndSerializesByRoom(
       @org.junit.jupiter.api.io.TempDir java.nio.file.Path dir) {
     try (var roomDb = Sqlite.open(dir.resolve("room-runs.db"))) {

--- a/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SchemaManagerTest.java
@@ -306,7 +306,7 @@ class SchemaManagerTest {
 
   @Test
   void theMessageRekeyCarriesRowsAndTheDeliveryLedgerAcrossTheRename() {
-    var staged = SchemaManager.CURRENT_VERSION - 10;
+    var staged = SchemaManager.CURRENT_VERSION - 15;
     stageAtBaseline();
     for (var v = SchemaManager.V1_VERSION + 1; v <= staged; v++) {
       db.execute(SchemaManager.MIGRATIONS.get(v - SchemaManager.V1_VERSION - 1));
@@ -350,7 +350,7 @@ class SchemaManagerTest {
 
   @Test
   void specsGainRoomIdBackfilledToTheirOwnIdOnUpgrade() {
-    var staged = SchemaManager.CURRENT_VERSION - 2;
+    var staged = SchemaManager.CURRENT_VERSION - 7;
     stageAtBaseline();
     for (var v = SchemaManager.V1_VERSION + 1; v <= staged; v++) {
       db.execute(SchemaManager.MIGRATIONS.get(v - SchemaManager.V1_VERSION - 1));
@@ -686,7 +686,7 @@ class SchemaManagerTest {
   }
 
   @Test
-  void aV0_27_0ShapedDatabaseGainsTheEngagementColumn() {
+  void aV0_27_0ShapedDatabaseConvergesAndShedsTheLegacyColumns() {
     stageAtBaseline();
     var tail = migrationIndex("ALTER TABLE specs ADD COLUMN engagement");
     db.execute("PRAGMA foreign_keys = OFF");
@@ -706,9 +706,13 @@ class SchemaManagerTest {
 
     assertEquals(SchemaManager.CURRENT_VERSION, new SchemaManager(db).currentVersion());
     assertTrue(
-        db.queryOne("SELECT engagement FROM specs WHERE id = 'pre'", r -> r.isNull(0))
-            .orElseThrow(),
-        "a pre-upgrade spec reads as not engaged");
+        db.query(
+                "SELECT name FROM pragma_table_info('specs') WHERE name IN ('wake', 'engagement')",
+                r -> r.text(0))
+            .isEmpty(),
+        "the conversation-side columns retire with the rebuild");
+    assertEquals(
+        "T", db.queryOne("SELECT title FROM specs WHERE id = 'pre'", r -> r.text(0)).orElseThrow());
     assertEquals(
         "keep",
         db.queryOne("SELECT agent FROM runs WHERE id = 'r-pre'", r -> r.text(0)).orElseThrow(),
@@ -722,24 +726,68 @@ class SchemaManagerTest {
             db.execute(
                 "INSERT INTO runs (id, project, agent, status, started_at, role) VALUES"
                     + " ('r-bad', 'p', 'claude-code', 'running', 't0', 'shout')"));
-    db.execute("UPDATE specs SET engagement = '{\"agent\":\"claude-code\"}' WHERE id = 'pre'");
-    assertEquals(
-        "{\"agent\":\"claude-code\"}",
-        db.queryOne("SELECT engagement FROM specs WHERE id = 'pre'", r -> r.text(0)).orElseThrow());
   }
 
   @Test
-  void theWakeColumnAdmitsItsThreeModesAndRejectsGarbage() {
-    new SchemaManager(db).migrate();
+  void theSpecsRebuildShedsConversationColumnsAndKeepsRowsChildrenAndConstraints() {
+    var staged = SchemaManager.CURRENT_VERSION - 5;
+    stageAtBaseline();
+    db.execute("PRAGMA foreign_keys = OFF");
+    for (var v = SchemaManager.V1_VERSION + 1; v <= staged; v++) {
+      db.execute(SchemaManager.MIGRATIONS.get(v - SchemaManager.V1_VERSION - 1));
+      db.execute("INSERT INTO schema_version (version, applied_at) VALUES (?, 'staged')", v);
+    }
+    db.execute("PRAGMA foreign_keys = ON");
     db.execute(
-        "INSERT INTO specs (id, title, status, created_at, updated_at, wake)"
-            + " VALUES ('auth', 'T', 'pending', 't0', 't0', 'mention')");
+        "INSERT INTO specs (id, title, status, created_at, updated_at, project, wake, engagement,"
+            + " room_id) VALUES ('auth', 'OAuth', 'pending', 't0', 't1', 'acme', 'on',"
+            + " '{\"agent\":\"claude-code\"}', 'auth')");
+    db.execute(
+        "INSERT INTO specs (id, title, status, created_at, updated_at) VALUES"
+            + " ('base', 'Base', 'done', 't0', 't0')");
+    db.execute("INSERT INTO spec_dependencies (spec_id, depends_on) VALUES ('auth', 'base')");
+    db.execute("INSERT INTO spec_repos (spec_id, repo) VALUES ('auth', 'api')");
+    db.execute(
+        "INSERT INTO spec_content (spec_id, body, plan, updated_at) VALUES ('auth', 'B', 'P', 't0')");
+
+    new SchemaManager(db).migrate();
+
+    assertEquals(SchemaManager.CURRENT_VERSION, new SchemaManager(db).currentVersion());
+    assertTrue(
+        db.query(
+                "SELECT name FROM pragma_table_info('specs') WHERE name IN ('wake', 'engagement')",
+                r -> r.text(0))
+            .isEmpty());
     assertEquals(
-        "mention",
-        db.queryOne("SELECT wake FROM specs WHERE id = 'auth'", r -> r.text(0)).orElseThrow());
+        "OAuth",
+        db.queryOne("SELECT title FROM specs WHERE id = 'auth'", r -> r.text(0)).orElseThrow());
+    assertEquals(
+        "auth",
+        db.queryOne("SELECT room_id FROM specs WHERE id = 'auth'", r -> r.text(0)).orElseThrow());
+    assertEquals(
+        "base",
+        db.queryOne(
+                "SELECT depends_on FROM spec_dependencies WHERE spec_id = 'auth'", r -> r.text(0))
+            .orElseThrow());
+    assertEquals(
+        "B",
+        db.queryOne("SELECT body FROM spec_content WHERE spec_id = 'auth'", r -> r.text(0))
+            .orElseThrow());
+    assertTrue(
+        db.query("SELECT * FROM pragma_foreign_key_check", r -> r.text(0)).isEmpty(),
+        "the rebuild leaves no dangling child references");
+    assertTrue(
+        db.query(
+                    "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_specs_project'",
+                    r -> r.text(0))
+                .size()
+            == 1);
     assertThrows(
         SqliteException.class,
-        () -> db.execute("UPDATE specs SET wake = 'loud' WHERE id = 'auth'"));
+        () ->
+            db.execute(
+                "INSERT INTO specs (id, title, status, created_at, updated_at) VALUES"
+                    + " ('bad', 'T', 'shouting', 't0', 't0')"));
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/store/SpecStoreTest.java
@@ -8,8 +8,6 @@ package ai.singlr.sail.store;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -102,33 +100,22 @@ class SpecStoreTest {
   }
 
   @Test
+  void aLegacySnapshotCarryingRetiredKeysAppliesCleanly() {
+    store.create(spec("auth", "OAuth", "pending"));
+    var snapshot = store.comparableSnapshot("auth");
+    var legacy = new java.util.LinkedHashMap<String, Object>(snapshot);
+    legacy.put("wake", "on");
+    legacy.put("engagement", "{\"agent\":\"claude-code\",\"engaged_at\":\"t0\"}");
+
+    store.applyRevision("auth", legacy, "2-legacy");
+
+    var applied = store.findById("auth").orElseThrow();
+    assertEquals("OAuth", applied.title(), "retired keys are ignored, never fatal");
+  }
+
+  @Test
   void findByIdReturnsEmptyForMissing() {
     assertTrue(store.findById("nonexistent").isEmpty());
-  }
-
-  @Test
-  void wakeModePersistsThroughCreateUpdateAndList() {
-    store.create(spec("auth", "OAuth", "pending").withWake("mention"));
-
-    assertEquals("mention", store.findById("auth").orElseThrow().wake());
-    assertEquals("mention", store.list(SpecStore.SpecFilter.all()).getFirst().wake());
-
-    store.update(store.findById("auth").orElseThrow().withWake("off"));
-    assertEquals("off", store.findById("auth").orElseThrow().wake());
-
-    store.update(store.findById("auth").orElseThrow().withWake(null));
-    assertTrue(store.findById("auth").orElseThrow().wake() == null);
-  }
-
-  @Test
-  void wakeModeRidesTheSnapshotAndSurvivesApplyRevision() {
-    store.create(spec("auth", "OAuth", "pending").withWake("on"));
-
-    var snapshot = store.comparableSnapshot("auth");
-    assertEquals("on", snapshot.get("wake"));
-
-    store.applyRevision("auth", snapshot, "2-abc");
-    assertEquals("on", store.findById("auth").orElseThrow().wake());
   }
 
   @Test
@@ -645,51 +632,5 @@ class SpecStoreTest {
         "auth",
         store.findById("auth").orElseThrow().roomIdOrIdentity(),
         "a pre-decouple snapshot falls back to the identity room");
-  }
-
-  @Test
-  void updateEngagementTouchesOnlyTheMirrorColumnAndJournals() {
-    store.create(spec("auth", "OAuth", "draft"));
-    store.updateStatus("auth", SpecStatus.IN_PROGRESS);
-    var before = store.findById("auth").orElseThrow();
-    var rev = store.revOf("auth");
-
-    store.updateEngagement("auth", "{\"agent\":\"claude-code\",\"engaged_at\":\"t0\"}");
-
-    var after = store.findById("auth").orElseThrow();
-    assertEquals(SpecStatus.IN_PROGRESS, after.status(), "a mirror write never touches status");
-    assertEquals(before.assignee(), after.assignee());
-    assertEquals(before.title(), after.title());
-    assertNotNull(after.engagement());
-    assertNotEquals(rev, store.revOf("auth"), "the mirror write journals a revision");
-
-    store.updateEngagement("auth", null);
-    assertNull(store.findById("auth").orElseThrow().engagement());
-  }
-
-  @Test
-  void engagementRoundTripsThroughCreateUpdateSnapshotAndList() {
-    var engagement = "{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}";
-    store.create(spec("auth", "OAuth", "draft").withEngagement(engagement));
-    store.create(spec("plain", "Other", "draft"));
-
-    assertEquals(engagement, store.findById("auth").orElseThrow().engagement());
-    assertEquals(
-        List.of("auth"),
-        store.listEngaged().stream().map(SpecStore.SpecRow::id).toList(),
-        "only engaged rooms join the sweep");
-
-    var journaled =
-        db.queryOne(
-                "SELECT snapshot FROM change_log WHERE entity_id = 'auth'"
-                    + " ORDER BY seq DESC LIMIT 1",
-                r -> r.text(0))
-            .orElseThrow();
-    assertTrue(journaled.contains("engagement"), "the engagement syncs as one atomic field");
-
-    store.update(store.findById("auth").orElseThrow().withEngagement(null));
-    assertTrue(store.listEngaged().isEmpty(), "disengaging clears the room");
-    assertEquals(
-        null, store.findById("auth").orElseThrow().engagement(), "the column reads back null");
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
@@ -151,6 +151,25 @@ class MessageSyncTest {
   }
 
   @Test
+  void aSpecRowGrantsPostingAuthorityBeforeItsRoomRowArrives() {
+    main.db.execute(
+        """
+        INSERT INTO specs (id, project, title, status, created_at, updated_at, assignee, room_id)
+        VALUES ('orphan', 'acme', 'Orphan', 'pending', 'now', 'now', 'node', 'orphan')""");
+
+    var accepted =
+        SyncPeer.with(
+            "node",
+            () ->
+                main.messages.commitRevision(
+                    "019fee00-0000-7000-8000-0000000000ac", snapshot("node", "orphan"), null));
+
+    assertTrue(
+        accepted instanceof ai.singlr.sail.store.PushOutcome.Accepted,
+        "a spec's ownership fields are authoritative for policy before its room row exists");
+  }
+
+  @Test
   void authenticatedPeerCannotForgeAnotherFdeAuthor() {
     var messageId = "00000000-0000-7000-8000-000000000001";
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiModels.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.api;
 
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.config.Roster;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.Spec;
 import ai.singlr.sail.config.SpecCatalog;
@@ -769,7 +770,7 @@ record EngageRequest(String agent, String mode, String model, boolean snapshot) 
   }
 }
 
-/** Response of {@code POST /v1/specs/{id}/engage}: the recorded (or pending) engagement. */
+/** Response of {@code POST /v1/rooms/{id}/members}: the recorded (or pending) membership. */
 record EngageResponse(String agent, String mode, String snapshot) implements Mappable {
   @Override
   public Map<String, Object> toMap() {
@@ -1076,6 +1077,16 @@ record GlobalSpecView(
     String roomId)
     implements Mappable {
   static GlobalSpecView from(SpecStore.SpecRow row) {
+    return from(row, null);
+  }
+
+  /**
+   * The view with its conversation-side fields — {@code wake} and {@code engagement} — decorated
+   * from the spec's room row, their only home since the legacy spec columns retired. A null room (a
+   * box without the aggregate, or a synced spec whose room has not arrived) reads as default wake
+   * with nobody seated.
+   */
+  static GlobalSpecView from(SpecStore.SpecRow row, RoomStore.RoomRow room) {
     return new GlobalSpecView(
         row.id(),
         row.project(),
@@ -1089,8 +1100,8 @@ record GlobalSpecView(
         row.priority(),
         row.dependsOn(),
         row.repos(),
-        row.wake(),
-        engagementMap(row.engagement()),
+        room == null ? null : room.wake(),
+        engagementMap(room == null ? null : Roster.fromJson(room.roster()).standing()),
         row.createdBy(),
         row.createdAt(),
         row.updatedAt(),
@@ -1098,8 +1109,7 @@ record GlobalSpecView(
         row.roomIdOrIdentity());
   }
 
-  private static Map<String, Object> engagementMap(String stored) {
-    var engagement = ai.singlr.sail.config.Engagement.fromJson(stored);
+  private static Map<String, Object> engagementMap(ai.singlr.sail.config.Engagement engagement) {
     if (engagement == null) {
       return null;
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ApiRouter.java
@@ -59,10 +59,8 @@ public final class ApiRouter implements HttpHandler {
   private static final String FOLLOWUP = "followup";
   private static final String MESSAGES = "messages";
   private static final String INVITE = "invite";
-  private static final String ENGAGE = "engage";
   private static final String ROOMS = "rooms";
   private static final String MEMBERS = "members";
-  private static final String DISENGAGE = "disengage";
   private static final String AGENTS = "agents";
   private static final String SNAPSHOTS = "snapshots";
   private static final int DEFAULT_MESSAGES = 50;
@@ -310,9 +308,10 @@ public final class ApiRouter implements HttpHandler {
   }
 
   /**
-   * Routes the rooms membership surface — {@code GET|POST|DELETE /v1/rooms/{id}/members}. A room id
-   * is a spec id while rooms and specs share identity; the write forms reuse the engage shapes and
-   * semantics, so the spec-shaped doors can retire without a behavior change.
+   * Routes the rooms surface: the room resource itself, its membership ({@code GET|POST|DELETE
+   * /v1/rooms/{id}/members}), its conversation ({@code /v1/rooms/{id}/messages}), and one-shot
+   * invites ({@code POST /v1/rooms/{id}/invite}). The spec-shaped conversation doors are retired;
+   * every id resolves spec-first, so a spec's room answers under the spec's id unchanged.
    */
   private ApiResponse routeRooms(HttpExchange exchange, RouteRequest request) throws IOException {
     if (request.size() == 2) {
@@ -360,6 +359,15 @@ public final class ApiRouter implements HttpHandler {
                 operations.removeRoomMember(roomId, actorOf(exchange), nodeHandle.get()));
         default -> throw methodNotAllowed();
       };
+    }
+    if (INVITE.equals(sub)) {
+      requireMethod(request, POST);
+      return ApiResponse.from(
+          operations.inviteToRoom(
+              roomId,
+              InviteRequest.fromMap(JsonBody.readMap(exchange)),
+              actorOf(exchange),
+              nodeHandle.get()));
     }
     if (MESSAGES.equals(sub)) {
       return switch (request.method()) {
@@ -482,58 +490,6 @@ public final class ApiRouter implements HttpHandler {
                 specId,
                 FollowupCreateRequest.fromMap(JsonBody.readMap(exchange))
                     .withCreatedBy(actor(exchange))));
-      }
-      if (INVITE.equals(sub)) {
-        requireMethod(request, POST);
-        return ApiResponse.from(
-            operations.inviteToSpec(
-                specId,
-                InviteRequest.fromMap(JsonBody.readMap(exchange)),
-                actorOf(exchange),
-                nodeHandle.get()));
-      }
-      if (ENGAGE.equals(sub)) {
-        requireMethod(request, POST);
-        return ApiResponse.from(
-            operations.engageToSpec(
-                specId,
-                EngageRequest.fromMap(JsonBody.readMap(exchange)),
-                actorOf(exchange),
-                nodeHandle.get()));
-      }
-      if (DISENGAGE.equals(sub)) {
-        requireMethod(request, POST);
-        return ApiResponse.from(
-            operations.disengageSpec(specId, actorOf(exchange), nodeHandle.get()));
-      }
-      if (MESSAGES.equals(sub)) {
-        return switch (request.method()) {
-          case GET -> {
-            var params = QueryParameters.from(request.uri()).values();
-            yield ApiResponse.from(
-                operations.specMessages(
-                    specId,
-                    params.get("before"),
-                    params.get("after"),
-                    clampedLimit(params.get(LIMIT), DEFAULT_MESSAGES, MAX_MESSAGES)));
-          }
-          case POST -> {
-            var principal = actorOf(exchange);
-            if (principal.handle() == null) {
-              throw new ApiException(
-                  ErrorCode.FORBIDDEN,
-                  "Spec messages require an FDE-bound credential so authorship can be"
-                      + " synchronized.");
-            }
-            yield ApiResponse.fromCreated(
-                operations.postSpecMessage(
-                    specId,
-                    SpecMessageRequest.fromMap(JsonBody.readMessageMap(exchange)),
-                    principal,
-                    principal.handle()));
-          }
-          default -> throw methodNotAllowed();
-        };
       }
     }
     throw notFound();

--- a/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/GlobalSpecOperations.java
@@ -67,7 +67,7 @@ final class GlobalSpecOperations {
   GlobalSpecsListResponse list(SpecStore.SpecFilter filter) {
     requireStore();
     try {
-      var specs = specStore.list(filter).stream().map(GlobalSpecView::from).toList();
+      var specs = specStore.list(filter).stream().map(this::viewOf).toList();
       return new GlobalSpecsListResponse(specs, specs.size());
     } catch (IllegalArgumentException e) {
       throw new ApiException(ErrorCode.INVALID_REQUEST, e.getMessage());
@@ -79,7 +79,7 @@ final class GlobalSpecOperations {
     var row = findOrThrow(specId);
     var content = specStore.getContent(specId).orElse(null);
     return new GlobalSpecDetailResponse(
-        GlobalSpecView.from(row),
+        viewOf(row),
         content != null ? content.body() : null,
         content != null ? content.plan() : null,
         openFindingCount(specId),
@@ -144,7 +144,7 @@ final class GlobalSpecOperations {
     var created = specStore.findById(request.id()).orElseThrow();
     mintIdentityRoom(created);
     publishBoardUpdated(created.project(), created.id(), principal(request.createdBy()));
-    return new GlobalSpecCreatedResponse(GlobalSpecView.from(created));
+    return new GlobalSpecCreatedResponse(viewOf(created));
   }
 
   GlobalSpecUpdatedResponse update(String specId, SpecUpdateRequest request, Actor actor) {
@@ -172,11 +172,9 @@ final class GlobalSpecOperations {
             request.updatedBy(),
             request.dependsOn() != null ? request.dependsOn() : existing.dependsOn(),
             request.repos() != null ? request.repos() : existing.repos(),
-            request.wake() != null ? validWake(request.wake()) : existing.wake(),
-            existing.engagement(),
             existing.roomIdOrIdentity());
     specStore.update(updated);
-    dualWriteWake(updated, request);
+    writeWake(updated, request);
     if (updated.status() == SpecStatus.DONE
         && existing.status() != SpecStatus.DONE
         && reviewStore != null) {
@@ -194,7 +192,7 @@ final class GlobalSpecOperations {
     } else {
       publishBoardUpdated(result.project(), specId, principal(request.updatedBy()));
     }
-    return new GlobalSpecUpdatedResponse(GlobalSpecView.from(result));
+    return new GlobalSpecUpdatedResponse(viewOf(result));
   }
 
   /**
@@ -208,6 +206,13 @@ final class GlobalSpecOperations {
    * box keeps a room aggregate. Membership writes {@code ensureFor} the room defensively, so a box
    * without the aggregate here loses nothing; this keeps the room's birth beside the spec's.
    */
+  /** The row as a wire view, wake and roster decorated from its room — the fields' only home. */
+  private GlobalSpecView viewOf(SpecStore.SpecRow row) {
+    var store = rooms.get();
+    return GlobalSpecView.from(
+        row, store == null ? null : store.findById(row.roomIdOrIdentity()).orElse(null));
+  }
+
   private void mintIdentityRoom(SpecStore.SpecRow spec) {
     var store = rooms.get();
     if (store == null) {
@@ -218,29 +223,31 @@ final class GlobalSpecOperations {
         spec.project(),
         spec.title(),
         spec.assignee(),
-        spec.wake(),
+        null,
         spec.createdBy());
   }
 
   /**
-   * Dual-writes an explicit wake edit onto the room row — the authoritative conversation-side home
-   * — beside the spec column the readers that have not moved yet still consult.
+   * Writes an explicit wake edit onto the room row — the one home the wake mode has. The spec
+   * update door keeps accepting {@code wake} so the CLI's {@code spec update --wake} still works;
+   * the value lands only on the room.
    */
-  private void dualWriteWake(SpecStore.SpecRow updated, SpecUpdateRequest request) {
+  private void writeWake(SpecStore.SpecRow updated, SpecUpdateRequest request) {
     var store = rooms.get();
     if (store == null || request.wake() == null) {
       return;
     }
+    var wake = validWake(request.wake());
     var room =
         store.ensureFor(
             updated.id(),
             updated.project(),
             updated.title(),
             updated.assignee(),
-            updated.wake(),
+            null,
             request.updatedBy());
-    if (!Objects.equals(room.wake(), updated.wake())) {
-      store.updateWake(updated.id(), updated.wake(), request.updatedBy());
+    if (!Objects.equals(room.wake(), wake)) {
+      store.updateWake(updated.id(), wake, request.updatedBy());
     }
   }
 
@@ -361,7 +368,7 @@ final class GlobalSpecOperations {
     specStore.restore(specId, request.rev());
     var row = specStore.findById(specId).orElseThrow();
     publishBoardUpdated(row.project(), specId, Event.SAIL_AGENT);
-    return new GlobalSpecRestoredResponse(GlobalSpecView.from(row), request.rev());
+    return new GlobalSpecRestoredResponse(viewOf(row), request.rev());
   }
 
   private String revisionAssignee(String specId, String rev) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/LocalApiRouter.java
@@ -287,19 +287,19 @@ final class LocalApiRouter implements LocalApiHandler {
         var before = request.query().get("before");
         var after = request.query().get("after");
         var result =
-            operations.specMessages(id, before, after, clampedLimit(request.query().get("limit")));
+            operations.roomMessages(id, before, after, clampedLimit(request.query().get("limit")));
         markDeliveredOnSelfRead(caller, id, result);
         yield ApiResponse.from(result);
       }
       case "POST" -> {
         if (caller instanceof Caller.Run(var run)
             && run.readOnlyLane()
-            && !id.equals(run.specId())) {
-          yield problem(403, "A room session posts only to its own spec's room.");
+            && !id.equals(run.conversationId())) {
+          yield problem(403, "A room session posts only to its own room.");
         }
         var form = request.form();
         yield ApiResponse.fromCreated(
-            operations.postSpecMessage(
+            operations.postRoomMessage(
                 id,
                 new SpecMessageRequest(
                     form.get("body"),

--- a/sail-infra/src/main/java/ai/singlr/sail/api/LocalLaneOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/LocalLaneOperations.java
@@ -56,14 +56,15 @@ public interface LocalLaneOperations {
 
   Result<GlobalBoardResponse> globalBoard(String project);
 
-  Result<SpecMessageResponse> postSpecMessage(
-      String specId, SpecMessageRequest request, Actor actor, String author);
+  Result<SpecMessageResponse> postRoomMessage(
+      String roomId, SpecMessageRequest request, Actor actor, String author);
 
   /**
-   * A page of a spec room: {@code before} pages backward from the newest (the default), {@code
-   * after} reads forward past a known message id. The two are exclusive.
+   * A page of a room's conversation: {@code before} pages backward from the newest (the default),
+   * {@code after} reads forward past a known message id. The two are exclusive. The id resolves
+   * spec-first, so a spec id reads its room.
    */
-  Result<SpecMessagesResponse> specMessages(String specId, String before, String after, int limit);
+  Result<SpecMessagesResponse> roomMessages(String roomId, String before, String after, int limit);
 
   /**
    * The run's undelivered room messages: everything on the run's spec absent from the run's

--- a/sail-infra/src/main/java/ai/singlr/sail/api/MembershipService.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/MembershipService.java
@@ -64,48 +64,26 @@ public final class MembershipService {
   public record RoomState(String wake, Engagement standing) {}
 
   /**
-   * The conversation-side state a spec's room runs under — the room row when one exists (the
-   * authoritative home), the spec's legacy columns otherwise. A present room is authoritative for
-   * the standing member even when its roster is empty; only a missing row falls back, so a
-   * dismissal recorded on the room can never be resurrected by a stale spec column.
+   * The conversation-side state a spec's room runs under — the room row, the one home this state
+   * has. A missing row (a box without the room aggregate, or a synced spec whose room has not
+   * arrived yet) reads as default wake with nobody seated; the legacy spec columns are gone.
    */
   public static RoomState stateOf(RoomStore rooms, SpecStore.SpecRow spec) {
     var room = rooms == null ? null : rooms.findById(spec.roomIdOrIdentity()).orElse(null);
     if (room == null) {
-      return new RoomState(spec.wake(), legacyRosterOf(spec).standing());
+      return new RoomState(null, null);
     }
-    var wake = room.wake() != null ? room.wake() : spec.wake();
-    return new RoomState(wake, Roster.fromJson(room.roster()).standing());
+    return new RoomState(room.wake(), Roster.fromJson(room.roster()).standing());
   }
 
-  /**
-   * The spec's legacy engagement column read as a one-member roster — the fallback every room-first
-   * reader uses when no room row exists for pre-decouple data.
-   */
-  public static Roster legacyRosterOf(SpecStore.SpecRow spec) {
-    var legacy = Engagement.fromJson(spec.engagement());
-    return legacy == null ? Roster.EMPTY : Roster.solo(legacy);
-  }
-
-  /**
-   * The members of {@code roomId}'s roster. A present room row is the authoritative home — a
-   * chat-only room needs no spec; a missing row falls back to a spec's legacy column so a
-   * pre-decouple box's data still reads.
-   */
+  /** The members of {@code roomId}'s roster — the room row is the only home a roster has. */
   public java.util.List<Engagement> members(String roomId) {
     var store = rooms.get();
     var room = store == null ? null : store.findById(roomId).orElse(null);
-    if (room != null) {
-      return Roster.fromJson(room.roster()).members();
+    if (room == null) {
+      throw new ApiException(ErrorCode.ROOM_NOT_FOUND, "Room '" + roomId + "' was not found.");
     }
-    var spec =
-        specStore
-            .findById(roomId)
-            .orElseThrow(
-                () ->
-                    new ApiException(
-                        ErrorCode.ROOM_NOT_FOUND, "Room '" + roomId + "' was not found."));
-    return legacyRosterOf(spec).members();
+    return Roster.fromJson(room.roster()).members();
   }
 
   /** A prepared membership: the snapshot label a full mode will pay, and the deferred half. */
@@ -113,17 +91,17 @@ public final class MembershipService {
 
   /**
    * Seats an agent in {@code specId}'s room: records the member on the room row's roster (synced,
-   * atomic — one JSON array) and dual-writes the spec's legacy engagement column, so the wake
-   * reactor answers every human message with a chat turn until a human dismisses the member. Mode
-   * {@code full} is the default; {@code read-only} is the explicit narrow choice, offered only
-   * where the harness enforces it. A full membership may take one engage-time rollback snapshot
-   * (never per turn), but the default is none — on the {@code dir} backend a snapshot is a slow
-   * full filesystem copy, so the rollback point is opt-in ({@code takeSnapshot}) and the per-turn
-   * repo reservation remains the standing guard. A requested snapshot runs off the request thread
-   * ({@code completion}) because a {@code dir}-backend snapshot would blow the HTTP timeout; the
-   * membership is then persisted only after the snapshot succeeds — the payment precedes the access
-   * — and a failure publishes {@code spec_engage_failed} into the room instead of seating anyone.
-   * Requires the dispatch tier on the spec, exactly like an invite.
+   * atomic — one JSON array), so the wake reactor answers every human message with a chat turn
+   * until a human dismisses the member. Mode {@code full} is the default; {@code read-only} is the
+   * explicit narrow choice, offered only where the harness enforces it. A full membership may take
+   * one engage-time rollback snapshot (never per turn), but the default is none — on the {@code
+   * dir} backend a snapshot is a slow full filesystem copy, so the rollback point is opt-in ({@code
+   * takeSnapshot}) and the per-turn repo reservation remains the standing guard. A requested
+   * snapshot runs off the request thread ({@code completion}) because a {@code dir}-backend
+   * snapshot would blow the HTTP timeout; the membership is then persisted only after the snapshot
+   * succeeds — the payment precedes the access — and a failure publishes {@code spec_engage_failed}
+   * into the room instead of seating anyone. Requires the dispatch tier on the spec, exactly like
+   * an invite.
    */
   public EngageLaunch engage(
       String specId,
@@ -305,18 +283,11 @@ public final class MembershipService {
   private void writeRoster(SpecStore.SpecRow spec, Roster roster, Actor actor) {
     var store = requireRooms();
     var handle = actor == null ? spec.updatedBy() : actor.handle();
-    var standing = roster.standing();
     specStore.atomically(
         () -> {
           store.ensureFor(
-              spec.roomIdOrIdentity(),
-              spec.project(),
-              spec.title(),
-              spec.assignee(),
-              spec.wake(),
-              handle);
+              spec.roomIdOrIdentity(), spec.project(), spec.title(), spec.assignee(), null, handle);
           store.updateRoster(spec.roomIdOrIdentity(), roster.toJson(), handle);
-          specStore.updateEngagement(spec.id(), standing == null ? null : standing.toJson());
           return null;
         });
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Operations.java
@@ -113,13 +113,8 @@ public interface Operations extends LocalLaneOperations {
   Result<GlobalSpecRestoredResponse> restoreGlobalSpec(
       String specId, SpecRestoreRequest request, Actor actor);
 
-  Result<InviteResponse> inviteToSpec(
+  Result<InviteResponse> inviteToRoom(
       String specId, InviteRequest request, Actor actor, String localHandle);
-
-  Result<EngageResponse> engageToSpec(
-      String specId, EngageRequest request, Actor actor, String localHandle);
-
-  Result<DisengageResponse> disengageSpec(String specId, Actor actor, String localHandle);
 
   Result<RoomMembersResponse> roomMembers(String roomId);
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RoomWakeReactor.java
@@ -364,7 +364,6 @@ public final class RoomWakeReactor implements EventSubscriber, AutoCloseable {
   public void sweepEngagedRooms() {
     var engaged = new java.util.LinkedHashSet<String>();
     roomStore.listEngaged().forEach(room -> engaged.add(room.id()));
-    specStore.listEngaged().forEach(spec -> engaged.add(spec.id()));
     for (var id : engaged) {
       try {
         refireOwedTurn(id);

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -450,7 +450,7 @@ public final class SailOperations implements Operations {
   }
 
   @Override
-  public Result<InviteResponse> inviteToSpec(
+  public Result<InviteResponse> inviteToRoom(
       String specId, InviteRequest request, Actor actor, String localHandle) {
     freshenForRead();
     var result = safe(() -> inviteValue(specId, request, actor, localHandle));
@@ -461,7 +461,7 @@ public final class SailOperations implements Operations {
   }
 
   @Override
-  public Result<EngageResponse> engageToSpec(
+  public Result<EngageResponse> addRoomMember(
       String specId, EngageRequest request, Actor actor, String localHandle) {
     freshenForRead();
     var result =
@@ -559,12 +559,17 @@ public final class SailOperations implements Operations {
   private RoomStore.RoomRow requireRoomOrSpec(String roomId) {
     var spec = specStore == null ? null : specStore.findById(roomId).orElse(null);
     if (spec != null) {
+      var room =
+          roomStore == null ? null : roomStore.findById(spec.roomIdOrIdentity()).orElse(null);
+      if (room != null) {
+        return room;
+      }
       return new RoomStore.RoomRow(
           spec.id(),
           spec.project(),
           spec.title(),
           spec.assignee(),
-          spec.wake(),
+          null,
           null,
           spec.createdBy(),
           spec.createdAt(),
@@ -732,19 +737,8 @@ public final class SailOperations implements Operations {
   }
 
   @Override
-  public Result<EngageResponse> addRoomMember(
-      String roomId, EngageRequest request, Actor actor, String localHandle) {
-    return engageToSpec(roomId, request, actor, localHandle);
-  }
-
-  @Override
   public Result<DisengageResponse> removeRoomMember(
-      String roomId, Actor actor, String localHandle) {
-    return disengageSpec(roomId, actor, localHandle);
-  }
-
-  @Override
-  public Result<DisengageResponse> disengageSpec(String specId, Actor actor, String localHandle) {
+      String specId, Actor actor, String localHandle) {
     freshenForRead();
     var result =
         safe(() -> new DisengageResponse(dispatchOps.disengage(specId, actor, localHandle)));
@@ -756,6 +750,16 @@ public final class SailOperations implements Operations {
 
   private InviteResponse inviteValue(
       String specId, InviteRequest request, Actor actor, String localHandle) {
+    if (specStore != null && specStore.findById(specId).isEmpty()) {
+      requireRoomOrSpec(specId);
+      throw new ApiException(
+          ErrorCode.COMMAND_FAILED,
+          "Room '"
+              + specId
+              + "' has no attached spec, and an invite is a one-shot turn on a"
+              + " spec's checkout.",
+          "Seat a standing member instead (POST /v1/rooms/{id}/members), or attach a spec first.");
+    }
     var launch =
         dispatchOps.startInvite(
             specId,
@@ -1457,56 +1461,6 @@ public final class SailOperations implements Operations {
   public Result<GlobalSpecContentResponse> setGlobalSpecContent(
       String specId, SpecContentRequest request, Actor actor) {
     return safeWrite(() -> globalSpecOps.setContent(specId, request, actor));
-  }
-
-  @Override
-  public Result<SpecMessageResponse> postSpecMessage(
-      String specId, SpecMessageRequest request, Actor actor, String author) {
-    return safeWrite(
-        () -> {
-          var store = requireMessageStore();
-          var spec =
-              specStore
-                  .findById(specId)
-                  .orElseThrow(
-                      () ->
-                          new ApiException(
-                              ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
-          SpecPolicy.post(actor, spec.id(), spec.assignee(), spec.createdBy()).enforce();
-          return appendMessage(spec.project(), spec.roomIdOrIdentity(), request, author);
-        });
-  }
-
-  @Override
-  public Result<SpecMessagesResponse> specMessages(
-      String specId, String before, String after, int limit) {
-    return safeRead(
-        () -> {
-          if (before != null && after != null) {
-            throw new ApiException(
-                ErrorCode.BAD_REQUEST, "before and after are exclusive; pass at most one.");
-          }
-          var spec =
-              specStore
-                  .findById(specId)
-                  .orElseThrow(
-                      () ->
-                          new ApiException(
-                              ErrorCode.SPEC_NOT_FOUND, "Spec '" + specId + "' was not found."));
-          var roomId = spec.roomIdOrIdentity();
-          List<SpecMessageView> messages;
-          try {
-            var store = requireMessageStore();
-            var rows =
-                after != null
-                    ? store.listAfter(roomId, after, limit)
-                    : store.list(roomId, before, limit);
-            messages = rows.stream().map(SpecMessageView::from).toList();
-          } catch (IllegalArgumentException invalid) {
-            throw new ApiException(ErrorCode.BAD_REQUEST, invalid.getMessage());
-          }
-          return new SpecMessagesResponse(specId, messages);
-        });
   }
 
   @Override

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCommentCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCommentCommand.java
@@ -59,7 +59,7 @@ public final class ApiSpecCommentCommand implements Runnable {
     }
     var config = connection.resolve();
     try (var client = new SailApiClient(config.serverUrl(), config.token(), syncOptions.noSync())) {
-      Map<String, Object> result = client.post("/v1/specs/" + specId + "/messages", request);
+      Map<String, Object> result = client.post("/v1/rooms/" + specId + "/messages", request);
       System.out.println(YamlUtil.dumpJson(new LinkedHashMap<>(result)));
     }
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCommentsCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecCommentsCommand.java
@@ -45,7 +45,7 @@ public final class ApiSpecCommentsCommand implements Runnable {
   private void execute() throws Exception {
     NameValidator.requireValidSpecId(specId);
     var path =
-        new StringBuilder("/v1/specs/").append(specId).append("/messages?limit=").append(limit);
+        new StringBuilder("/v1/rooms/").append(specId).append("/messages?limit=").append(limit);
     if (before != null) {
       path.append("&before=").append(URLEncoder.encode(before, StandardCharsets.UTF_8));
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecDisengageCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecDisengageCommand.java
@@ -9,7 +9,6 @@ import ai.singlr.sail.api.SailApiClient;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.NameValidator;
 import java.util.LinkedHashMap;
-import java.util.Map;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Mixin;
@@ -20,7 +19,7 @@ import picocli.CommandLine.Spec;
 
 /**
  * Dismisses a spec room's engaged agent. Idempotent — dismissing an empty room reports that nobody
- * was there rather than erroring. A thin client of {@code POST /v1/specs/{id}/disengage}.
+ * was there rather than erroring. A thin client of {@code DELETE /v1/rooms/{id}/members}.
  */
 @Command(
     name = "disengage",
@@ -49,7 +48,7 @@ public final class ApiSpecDisengageCommand implements Runnable {
     NameValidator.requireValidSpecId(specId);
     var config = connection.resolve();
     try (var client = new SailApiClient(config.serverUrl(), config.token(), syncOptions.noSync())) {
-      var result = client.post("/v1/specs/" + specId + "/disengage", Map.of());
+      var result = client.delete("/v1/rooms/" + specId + "/members");
 
       if (json) {
         System.out.println(YamlUtil.dumpJson(new LinkedHashMap<>(result)));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecEngageCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecEngageCommand.java
@@ -25,7 +25,7 @@ import picocli.CommandLine.Spec;
  * until dismissed. Full access is the default — conversations produce artifacts. {@code --snapshot}
  * opts into a rollback point first (off by default: a dir-backend snapshot is a slow full copy);
  * {@code --read-only} is the explicit narrow choice, offered only where the harness enforces it. A
- * thin client of {@code POST /v1/specs/{id}/engage}; the server's refusals render verbatim.
+ * thin client of {@code POST /v1/rooms/{id}/members}; the server's refusals render verbatim.
  */
 @Command(
     name = "engage",
@@ -84,7 +84,7 @@ public final class ApiSpecEngageCommand implements Runnable {
       body.put("model", model);
     }
     try (var client = new SailApiClient(config.serverUrl(), config.token(), syncOptions.noSync())) {
-      var result = client.post("/v1/specs/" + specId + "/engage", Map.copyOf(body));
+      var result = client.post("/v1/rooms/" + specId + "/members", Map.copyOf(body));
 
       if (json) {
         System.out.println(YamlUtil.dumpJson(new LinkedHashMap<>(result)));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecInviteCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ApiSpecInviteCommand.java
@@ -23,7 +23,7 @@ import picocli.CommandLine.Spec;
  * Runs a task-shaped invite: one full-access agent turn in the spec's room, paid with a pre-launch
  * snapshot and the repo reservation. Joining a room conversationally is {@code sail spec engage} —
  * this lane is for "do this now" work. The server owns the whole launch, so this command is a thin
- * client of {@code POST /v1/specs/{id}/invite} and renders the server's refusals verbatim.
+ * client of {@code POST /v1/rooms/{id}/invite} and renders the server's refusals verbatim.
  */
 @Command(
     name = "invite",
@@ -66,7 +66,7 @@ public final class ApiSpecInviteCommand implements Runnable {
     }
     body.put("full", true);
     try (var client = new SailApiClient(config.serverUrl(), config.token(), syncOptions.noSync())) {
-      var result = client.post("/v1/specs/" + specId + "/invite", Map.copyOf(body));
+      var result = client.post("/v1/rooms/" + specId + "/invite", Map.copyOf(body));
 
       if (json) {
         System.out.println(YamlUtil.dumpJson(new LinkedHashMap<>(result)));

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ApiRouterTest.java
@@ -907,40 +907,20 @@ class ApiRouterTest {
   }
 
   @Test
-  void specMessagesPostAndGetReturnJsonAndClampLimit() throws Exception {
-    var ops = new MessageActorProbe();
+  void retiredSpecConversationDoorsAnswer404() throws Exception {
+    var ops = new FakeOperations();
     try (var server = serverWithOwnedToken(ops, true)) {
-      var posted =
-          post(
-              server,
-              "/v1/specs/auth-flow/messages",
-              "token",
-              "{\"body\":\"progress\",\"reply_to\":\"01900000-0000-7000-8000-000000000001\"}");
-      assertEquals(201, posted.statusCode());
-      assertTrue(posted.body().contains("\"body\": \"progress\""));
-      assertEquals("ada", ops.actor.handle());
-      assertEquals(Role.ADMIN, ops.actor.role());
-      assertEquals(Actor.Lane.API, ops.actor.lane());
-      assertEquals("ada", ops.author);
-      assertFalse(ops.question);
-
-      var asked =
-          post(
-              server,
-              "/v1/specs/auth-flow/messages",
-              "token",
-              "{\"body\":\"which flow?\",\"question\":true}");
-      assertEquals(201, asked.statusCode());
-      assertTrue(ops.question, "the JSON flag reaches the request");
-
-      var listed = get(server, "/v1/specs/auth-flow/messages?limit=999", "token");
-      assertEquals(200, listed.statusCode());
-      assertTrue(listed.body().contains("\"messages\""));
-      assertEquals(200, get(server, "/v1/specs/auth-flow/messages?limit=0", "token").statusCode());
-      assertEquals(200, get(server, "/v1/specs/auth-flow/messages", "token").statusCode());
+      assertEquals(404, get(server, "/v1/specs/auth-flow/messages", "token").statusCode());
       assertEquals(
-          400, get(server, "/v1/specs/auth-flow/messages?limit=bad", "token").statusCode());
-      assertEquals(405, put(server, "/v1/specs/auth-flow/messages", "token", "{}").statusCode());
+          404,
+          post(server, "/v1/specs/auth-flow/messages", "token", "{\"body\":\"x\"}").statusCode());
+      assertEquals(
+          404,
+          post(server, "/v1/specs/auth-flow/engage", "token", "{\"agent\":\"c\"}").statusCode());
+      assertEquals(404, post(server, "/v1/specs/auth-flow/disengage", "token", "{}").statusCode());
+      assertEquals(
+          404,
+          post(server, "/v1/specs/auth-flow/invite", "token", "{\"agent\":\"c\"}").statusCode());
     }
   }
 
@@ -950,23 +930,10 @@ class ApiRouterTest {
     var body = "\"".repeat(34_000);
     var json = "{\"body\":\"" + "\\\"".repeat(34_000) + "\"}";
     try (var server = serverWithOwnedToken(ops, true)) {
-      var response = post(server, "/v1/specs/auth-flow/messages", "token", json);
+      var response = post(server, "/v1/rooms/auth-flow/messages", "token", json);
 
       assertEquals(201, response.statusCode());
       assertEquals(body, ops.body);
-    }
-  }
-
-  @Test
-  void specMessagesRejectUnownedCredentialsBeforePosting() throws Exception {
-    var ops = new MessageActorProbe();
-    try (var server = serverWith(ops, true)) {
-      var response =
-          post(server, "/v1/specs/auth-flow/messages", "token", "{\"body\":\"progress\"}");
-
-      assertEquals(403, response.statusCode());
-      assertTrue(response.body().contains("FDE-bound credential"));
-      assertNull(ops.actor);
     }
   }
 
@@ -1039,28 +1006,6 @@ class ApiRouterTest {
       var response = get(server, "/v1/agents", null);
 
       assertEquals(401, response.statusCode());
-    }
-  }
-
-  @Test
-  void engagePostRoutesTheBodyToTheOperation() throws Exception {
-    var ops = new FakeOperations();
-    try (var server = serverWith(ops, true)) {
-      var response =
-          post(
-              server,
-              "/v1/specs/auth-flow/engage",
-              "token",
-              "{\"agent\": \"claude-code\", \"model\": \"opus-x\", \"snapshot\": true}");
-
-      assertEquals(200, response.statusCode());
-      assertTrue(response.body().contains("\"agent\": \"claude-code\""));
-      assertTrue(response.body().contains("\"mode\": \"full\""));
-      assertTrue(response.body().contains("\"snapshot\": \"engage-1\""));
-      assertEquals("auth-flow", ops.lastEngage.specId());
-      assertEquals("claude-code", ops.lastEngage.request().agent());
-      assertEquals("opus-x", ops.lastEngage.request().model());
-      assertTrue(ops.lastEngage.request().snapshot());
     }
   }
 
@@ -1174,27 +1119,13 @@ class ApiRouterTest {
   }
 
   @Test
-  void engageRequiresPostAndDisengageRoutesTheSpec() throws Exception {
-    var ops = new FakeOperations();
-    try (var server = serverWith(ops, true)) {
-      assertEquals(405, get(server, "/v1/specs/auth-flow/engage", "token").statusCode());
-
-      var response = post(server, "/v1/specs/auth-flow/disengage", "token", "{}");
-
-      assertEquals(200, response.statusCode());
-      assertTrue(response.body().contains("\"disengaged\": true"));
-      assertEquals("auth-flow", ops.lastDisengage);
-    }
-  }
-
-  @Test
   void invitePostRoutesTheBodyToTheOperation() throws Exception {
     var ops = new FakeOperations();
     try (var server = serverWith(ops, true)) {
       var response =
           post(
               server,
-              "/v1/specs/auth-flow/invite",
+              "/v1/rooms/auth-flow/invite",
               "token",
               "{\"agent\": \"codex\", \"model\": \"gpt-6\", \"full\": true}");
 
@@ -1215,7 +1146,7 @@ class ApiRouterTest {
     var ops = new FakeOperations();
     try (var server = serverWith(ops, true)) {
       var response =
-          post(server, "/v1/specs/auth-flow/invite", "token", "{\"agent\": \"claude-code\"}");
+          post(server, "/v1/rooms/auth-flow/invite", "token", "{\"agent\": \"claude-code\"}");
 
       assertEquals(200, response.statusCode());
       assertTrue(response.body().contains("\"mode\": \"read_only\""));
@@ -1226,7 +1157,7 @@ class ApiRouterTest {
   @Test
   void inviteRejectsNonPost() throws Exception {
     try (var server = server()) {
-      var response = get(server, "/v1/specs/auth-flow/invite", "token");
+      var response = get(server, "/v1/rooms/auth-flow/invite", "token");
       assertEquals(405, response.statusCode());
     }
   }
@@ -1481,13 +1412,13 @@ class ApiRouterTest {
     private boolean question;
 
     @Override
-    public Result<SpecMessageResponse> postSpecMessage(
+    public Result<SpecMessageResponse> postRoomMessage(
         String specId, SpecMessageRequest request, Actor actor, String author) {
       this.actor = actor;
       this.author = author;
       this.body = request.body();
       this.question = request.question();
-      return super.postSpecMessage(specId, request, actor, author);
+      return super.postRoomMessage(specId, request, actor, author);
     }
   }
 
@@ -1618,24 +1549,11 @@ class ApiRouterTest {
                           new AgentModeView("full", true, null))))));
     }
 
-    Engage lastEngage;
-    String lastDisengage;
     String lastMembersRoom;
     Engage lastAddMember;
     String lastRemoveMember;
 
     record Engage(String specId, EngageRequest request, String localHandle) {}
-
-    @Override
-    public Result<EngageResponse> engageToSpec(
-        String specId, EngageRequest request, Actor actor, String localHandle) {
-      lastEngage = new Engage(specId, request, localHandle);
-      return Result.success(
-          new EngageResponse(
-              request.agent(),
-              request.mode() == null ? "full" : request.mode(),
-              request.snapshot() ? "engage-1" : ""));
-    }
 
     @Override
     public Result<RoomMembersResponse> roomMembers(String roomId) {
@@ -1764,13 +1682,7 @@ class ApiRouterTest {
     }
 
     @Override
-    public Result<DisengageResponse> disengageSpec(String specId, Actor actor, String localHandle) {
-      lastDisengage = specId;
-      return Result.success(new DisengageResponse("claude-code"));
-    }
-
-    @Override
-    public Result<InviteResponse> inviteToSpec(
+    public Result<InviteResponse> inviteToRoom(
         String specId, InviteRequest request, Actor actor, String localHandle) {
       lastInvite = new Invite(specId, request, localHandle);
       return Result.success(
@@ -2084,18 +1996,6 @@ class ApiRouterTest {
     public Result<GlobalSpecContentResponse> setGlobalSpecContent(
         String specId, SpecContentRequest request, Actor actor) {
       return Result.success(new GlobalSpecContentResponse(specId, request.body(), request.plan()));
-    }
-
-    @Override
-    public Result<SpecMessageResponse> postSpecMessage(
-        String specId, SpecMessageRequest request, Actor actor, String author) {
-      return new TestOperations().postSpecMessage(specId, request, actor, author);
-    }
-
-    @Override
-    public Result<SpecMessagesResponse> specMessages(
-        String specId, String before, String after, int limit) {
-      return new TestOperations().specMessages(specId, before, after, limit);
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
@@ -129,10 +129,13 @@ class EngagementLifecycleTest {
   }
 
   private Engagement stored(String specId) {
-    return Engagement.fromJson(specStore.findById(specId).orElseThrow().engagement());
+    return roomMember(specId);
   }
 
   private Engagement roomMember(String specId) {
+    if (roomStore == null) {
+      return null;
+    }
     return roomStore
         .findById(specId)
         .map(room -> Roster.fromJson(room.roster()).standing())
@@ -368,7 +371,7 @@ class EngagementLifecycleTest {
               .useInviteExecutor(Runnable::run);
 
       var engaged =
-          sailOps.engageToSpec(
+          sailOps.addRoomMember(
               "auth",
               new EngageRequest("claude-code", null, null, true),
               Actor.cliOperator(HANDLE),
@@ -380,7 +383,7 @@ class EngagementLifecycleTest {
       assertNotNull(stored("auth"), "the deferred snapshot ran inline and engaged the room");
 
       var refused =
-          sailOps.engageToSpec(
+          sailOps.addRoomMember(
               "auth",
               new EngageRequest("codex", "read-only", null, false),
               Actor.cliOperator(HANDLE),
@@ -411,18 +414,18 @@ class EngagementLifecycleTest {
       var removed = sailOps.removeRoomMember("auth", Actor.cliOperator(HANDLE), HANDLE);
       assertTrue(removed instanceof Result.Success<DisengageResponse>);
       assertEquals("claude-code", ((Result.Success<DisengageResponse>) removed).value().agent());
-      sailOps.engageToSpec(
+      sailOps.addRoomMember(
           "auth",
           new EngageRequest("claude-code", null, null, true),
           Actor.cliOperator(HANDLE),
           HANDLE);
 
-      var dismissed = sailOps.disengageSpec("auth", Actor.cliOperator(HANDLE), HANDLE);
+      var dismissed = sailOps.removeRoomMember("auth", Actor.cliOperator(HANDLE), HANDLE);
       assertTrue(dismissed instanceof Result.Success<DisengageResponse>);
       assertEquals("claude-code", ((Result.Success<DisengageResponse>) dismissed).value().agent());
       assertNull(stored("auth"));
 
-      var empty = sailOps.disengageSpec("auth", Actor.cliOperator(HANDLE), HANDLE);
+      var empty = sailOps.removeRoomMember("auth", Actor.cliOperator(HANDLE), HANDLE);
       assertTrue(empty instanceof Result.Success<DisengageResponse>);
       assertNull(((Result.Success<DisengageResponse>) empty).value().agent());
     }
@@ -601,7 +604,7 @@ class EngagementLifecycleTest {
     ops.disengage("auth", Actor.cliOperator(HANDLE), HANDLE);
 
     assertNull(roomMember("auth"), "the roster empties");
-    assertNull(stored("auth"), "the legacy column clears with it");
+    assertNull(stored("auth"), "the roster clears with it");
     assertNull(
         roomStore.findById("auth").orElseThrow().roster(),
         "an empty roster stores as null, matching the engagement convention");
@@ -624,14 +627,16 @@ class EngagementLifecycleTest {
     assertEquals(
         ai.singlr.sail.config.SpecStatus.IN_PROGRESS,
         after.status(),
-        "the engagement mirror is a single-column write — it cannot clobber a status race");
-    assertNotNull(Engagement.fromJson(after.engagement()));
+        "a membership write never touches the spec row — it cannot clobber a status race");
+    assertNotNull(roomMember("auth"));
   }
 
   @Test
   void membersReadsTheRosterRoomFirstThroughTheLifecycle() throws Exception {
     var ops = operations(shell());
     seedSpec("auth");
+    var seeded = specStore.findById("auth").orElseThrow();
+    roomStore.ensureFor("auth", seeded.project(), seeded.title(), seeded.assignee(), null, HANDLE);
     assertTrue(ops.roomMembers("auth").isEmpty(), "a fresh room seats nobody");
 
     ops.engage("auth", "claude-code", "read-only", null, false, Actor.cliOperator(HANDLE), HANDLE);
@@ -648,7 +653,7 @@ class EngagementLifecycleTest {
   }
 
   @Test
-  void stateAndRosterFallBackToSpecColumnsWithoutARoomStore() {
+  void stateReadsAsNobodySeatedWithoutARoomRow() {
     var spec =
         new SpecStore.SpecRow(
             "solo",
@@ -666,39 +671,31 @@ class EngagementLifecycleTest {
             "",
             HANDLE,
             List.of(),
-            List.of(),
-            "on",
-            "{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}",
-            null);
+            List.of());
 
-    assertEquals("on", MembershipService.stateOf(null, spec).wake());
-    assertEquals("claude-code", MembershipService.stateOf(null, spec).standing().agent());
-    assertEquals(1, MembershipService.legacyRosterOf(spec).members().size());
+    var state = MembershipService.stateOf(null, spec);
+
+    assertNull(state.wake(), "no room row means default wake — the legacy columns are gone");
+    assertNull(state.standing(), "no room row seats nobody");
   }
 
   @Test
-  void membersFallBackToTheLegacyColumnWhenNoRoomRowExists() throws Exception {
+  void membersRequireTheRoomRow() throws Exception {
     var ops = operations(shell());
     seedSpec("orphan");
-    var spec = specStore.findById("orphan").orElseThrow();
-    specStore.update(
-        spec.withEngagement("{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}"));
 
-    var members = ops.roomMembers("orphan");
+    var missing = assertThrows(ApiException.class, () -> ops.roomMembers("orphan"));
 
-    assertEquals(1, members.size(), "a pre-decouple engagement still reads without a room row");
-    assertEquals("claude-code", members.getFirst().agent());
+    assertEquals(ErrorCode.ROOM_NOT_FOUND, missing.failure().errorCode());
   }
 
   @Test
-  void aDismissalOnTheRoomWinsEvenIfTheLegacyColumnIsStale() throws Exception {
+  void anEmptiedRosterMeansNobodyIsSeated() throws Exception {
     var ops = operations(shell());
     seedSpec("auth");
     ops.engage("auth", "claude-code", "read-only", null, false, Actor.cliOperator(HANDLE), HANDLE);
-    var spec = specStore.findById("auth").orElseThrow();
     roomStore.updateRoster("auth", null, HANDLE);
 
-    assertNotNull(Engagement.fromJson(spec.engagement()), "the legacy column is now stale");
     assertNull(
         ops.disengage("auth", Actor.cliOperator(HANDLE), HANDLE),
         "the room row is authoritative: an empty roster means nobody is seated");

--- a/sail-infra/src/test/java/ai/singlr/sail/api/Fleet.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/Fleet.java
@@ -418,14 +418,14 @@ public final class Fleet implements AutoCloseable {
 
     public SpecMessageView postMessage(String specId, String body) {
       return operations
-          .postSpecMessage(
+          .postRoomMessage(
               specId, new SpecMessageRequest(body, null, false), Actor.cliOperator(handle), handle)
           .orThrow()
           .message();
     }
 
     public List<SpecMessageView> listMessages(String specId) {
-      return operations.specMessages(specId, null, null, 50).orThrow().messages();
+      return operations.roomMessages(specId, null, null, 50).orThrow().messages();
     }
 
     public void assertSpecStatus(String id, SpecStatus status) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecOperationsTest.java
@@ -190,24 +190,29 @@ class GlobalSpecOperationsTest {
   }
 
   @Test
-  void updateSetsClearsAndRejectsTheWakeMode() {
-    ops.create(createReq(Map.of()));
+  void updateSetsClearsAndRejectsTheWakeModeOnTheRoom() {
+    var rooms = new RoomStore(db);
+    var withRooms = new GlobalSpecOperations(specStore, reviewStore, null, null, () -> rooms);
+    withRooms.create(createReq(Map.of()));
 
-    var set = ops.update("auth", SpecUpdateRequest.fromMap(Map.of("wake", "mention")), ADMIN);
+    var set = withRooms.update("auth", SpecUpdateRequest.fromMap(Map.of("wake", "mention")), ADMIN);
     assertEquals("mention", set.spec().wake());
     assertEquals("mention", set.spec().toMap().get("wake"));
+    assertEquals("mention", rooms.findById("auth").orElseThrow().wake(), "the room is the home");
 
-    var untouched = ops.update("auth", SpecUpdateRequest.fromMap(Map.of("title", "T2")), ADMIN);
+    var untouched =
+        withRooms.update("auth", SpecUpdateRequest.fromMap(Map.of("title", "T2")), ADMIN);
     assertEquals("mention", untouched.spec().wake(), "an unrelated edit never wipes the mode");
 
-    var cleared = ops.update("auth", SpecUpdateRequest.fromMap(Map.of("wake", "")), ADMIN);
+    var cleared = withRooms.update("auth", SpecUpdateRequest.fromMap(Map.of("wake", "")), ADMIN);
     assertNull(cleared.spec().wake(), "an empty wake clears the mode back to the default");
     assertFalse(cleared.spec().toMap().containsKey("wake"));
 
     var refusal =
         assertThrows(
             ApiException.class,
-            () -> ops.update("auth", SpecUpdateRequest.fromMap(Map.of("wake", "loud")), ADMIN));
+            () ->
+                withRooms.update("auth", SpecUpdateRequest.fromMap(Map.of("wake", "loud")), ADMIN));
     assertTrue(refusal.getMessage().contains("on, mention, or off"));
   }
 
@@ -773,10 +778,8 @@ class GlobalSpecOperationsTest {
         SpecCreateRequest.fromMap(
                 java.util.Map.of("id", "kept", "title", "Kept", "project", "acme"))
             .withCreatedBy("uday"));
-    var seeded = specStore.findById("kept").orElseThrow();
-    specStore.update(
-        seeded.withEngagement(
-            "{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}"));
+    rooms.updateRoster(
+        "kept", "[{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}]", "uday");
 
     withRooms.update(
         "kept",
@@ -785,7 +788,9 @@ class GlobalSpecOperationsTest {
 
     var after = specStore.findById("kept").orElseThrow();
     assertEquals("Kept v2", after.title());
-    assertNotNull(after.engagement(), "an ordinary edit must never wipe the engagement mirror");
+    assertNotNull(
+        rooms.findById("kept").orElseThrow().roster(),
+        "an ordinary edit must never unseat the room's member");
     assertEquals("kept", after.roomIdOrIdentity(), "the room link survives every edit");
   }
 
@@ -820,7 +825,7 @@ class GlobalSpecOperationsTest {
   }
 
   @Test
-  void anExplicitWakeEditDualWritesTheRoomRow() {
+  void anExplicitWakeEditWritesTheRoomRow() {
     var rooms = new RoomStore(db);
     var withRooms = new GlobalSpecOperations(specStore, reviewStore, null, null, () -> rooms);
     withRooms.create(
@@ -833,11 +838,10 @@ class GlobalSpecOperationsTest {
         SpecUpdateRequest.fromMap(java.util.Map.of("wake", "mention", "updated_by", "uday")),
         ADMIN);
 
-    assertEquals("mention", specStore.findById("wakey").orElseThrow().wake());
     assertEquals(
         "mention",
         rooms.findById("wakey").orElseThrow().wake(),
-        "the room row carries the authoritative conversation-side wake");
+        "the room row is the one home the wake mode has");
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecViewTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/GlobalSpecViewTest.java
@@ -10,7 +10,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import ai.singlr.sail.config.Engagement;
+import ai.singlr.sail.config.Roster;
 import ai.singlr.sail.config.SpecStatus;
+import ai.singlr.sail.store.RoomStore;
 import ai.singlr.sail.store.SpecStore;
 import java.util.List;
 import java.util.Map;
@@ -18,7 +20,7 @@ import org.junit.jupiter.api.Test;
 
 class GlobalSpecViewTest {
 
-  private static SpecStore.SpecRow row(String engagement) {
+  private static SpecStore.SpecRow row() {
     return new SpecStore.SpecRow(
         "auth",
         "acme",
@@ -35,18 +37,21 @@ class GlobalSpecViewTest {
         "t1",
         "uday",
         List.of(),
-        List.of(),
-        null,
-        engagement,
-        null);
+        List.of());
+  }
+
+  private static RoomStore.RoomRow room(String wake, String roster) {
+    return new RoomStore.RoomRow(
+        "auth", "acme", "OAuth", "uday", wake, roster, "uday", "t0", "t1", "uday");
   }
 
   @Test
-  void anEngagedRowCarriesTheEngagementIntoTheViewAndItsMap() {
-    var engagement = Engagement.of("claude-code", "full", "opus-x", "t0");
+  void theRoomRowDecoratesWakeAndEngagementIntoTheViewAndItsMap() {
+    var member = Engagement.of("claude-code", "full", "opus-x", "t0");
 
-    var view = GlobalSpecView.from(row(engagement.toJson()));
+    var view = GlobalSpecView.from(row(), room("mention", Roster.solo(member).toJson()));
 
+    assertEquals("mention", view.wake());
     assertEquals("claude-code", view.engagement().get("agent"));
     assertEquals("full", view.engagement().get("mode"));
     assertEquals("opus-x", view.engagement().get("model"));
@@ -57,18 +62,20 @@ class GlobalSpecViewTest {
   }
 
   @Test
-  void aModelLessEngagementOmitsTheModelKey() {
-    var engagement = Engagement.of("codex", "full", null, "t0");
+  void aModelLessMemberOmitsTheModelKey() {
+    var member = Engagement.of("codex", "full", null, "t0");
 
-    var view = GlobalSpecView.from(row(engagement.toJson()));
+    var view = GlobalSpecView.from(row(), room(null, Roster.solo(member).toJson()));
 
     assertFalse(view.engagement().containsKey("model"));
   }
 
   @Test
-  void anUnengagedOrCorruptRowRendersNoEngagement() {
-    assertNull(GlobalSpecView.from(row(null)).engagement());
-    assertNull(GlobalSpecView.from(row("garbage {{{")).engagement());
-    assertFalse(GlobalSpecView.from(row(null)).toMap().containsKey("engagement"));
+  void aMissingRoomOrEmptyOrCorruptRosterRendersNoEngagement() {
+    assertNull(GlobalSpecView.from(row()).engagement());
+    assertNull(GlobalSpecView.from(row()).wake());
+    assertNull(GlobalSpecView.from(row(), room("on", null)).engagement());
+    assertNull(GlobalSpecView.from(row(), room("on", "garbage {{{")).engagement());
+    assertFalse(GlobalSpecView.from(row()).toMap().containsKey("engagement"));
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
@@ -526,7 +526,7 @@ class InviteLaunchTest {
               .useInviteExecutor(Runnable::run);
 
       var launched =
-          sailOps.inviteToSpec(
+          sailOps.inviteToRoom(
               "auth",
               new InviteRequest("claude-code", null, true, true),
               Actor.cliOperator(HANDLE),
@@ -537,7 +537,7 @@ class InviteLaunchTest {
       assertEquals("invite-full", runStore.findById(response.runId()).orElseThrow().role());
 
       var refused =
-          sailOps.inviteToSpec(
+          sailOps.inviteToRoom(
               "auth",
               new InviteRequest("codex", null, false, true),
               Actor.cliOperator(HANDLE),

--- a/sail-infra/src/test/java/ai/singlr/sail/api/LocalApiRouterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/LocalApiRouterTest.java
@@ -35,6 +35,10 @@ class LocalApiRouterTest {
     return Map.of("authorization", "Bearer " + TestOperations.BOX_CREDENTIAL);
   }
 
+  private static Map<String, String> roomAuth() {
+    return Map.of("authorization", "Bearer " + TestOperations.ROOM_RUN_CREDENTIAL);
+  }
+
   private static LocalApiRequest get(String path, Map<String, String> query) {
     return new LocalApiRequest("GET", path, query, auth(), new byte[0]);
   }
@@ -335,6 +339,29 @@ class LocalApiRouterTest {
   }
 
   @Test
+  void aSpeclessRoomSessionPostsOnlyToItsOwnRoom() {
+    var own =
+        router.handle(
+            new LocalApiRequest(
+                "POST",
+                "/v1/specs/lounge/messages",
+                Map.of(),
+                roomAuth(),
+                "body=hi".getBytes(StandardCharsets.UTF_8)));
+    assertEquals(201, own.status(), "a room-keyed run owns its own conversation");
+
+    var foreign =
+        router.handle(
+            new LocalApiRequest(
+                "POST",
+                "/v1/specs/auth/messages",
+                Map.of(),
+                roomAuth(),
+                "body=hi".getBytes(StandardCharsets.UTF_8)));
+    assertEquals(403, foreign.status(), "another room is never this session's to post into");
+  }
+
+  @Test
   void aRunReadingItsOwnRoomAcknowledgesExactlyTheMessagesShown() {
     var response = router.handle(get("/v1/specs/auth/messages", Map.of()));
 
@@ -627,16 +654,16 @@ class LocalApiRouterTest {
     }
 
     @Override
-    public Result<SpecMessageResponse> postSpecMessage(
+    public Result<SpecMessageResponse> postRoomMessage(
         String specId, SpecMessageRequest request, Actor actor, String author) {
       lastMessage = request;
       lastMessageAuthor = author;
       lastActor = actor;
-      return super.postSpecMessage(specId, request, actor, author);
+      return super.postRoomMessage(specId, request, actor, author);
     }
 
     @Override
-    public Result<SpecMessagesResponse> specMessages(
+    public Result<SpecMessagesResponse> roomMessages(
         String specId, String before, String after, int limit) {
       lastBefore = before;
       lastAfter = after;
@@ -647,7 +674,7 @@ class LocalApiRouterTest {
       if (emptyMessages) {
         return Result.success(new SpecMessagesResponse(specId, List.of()));
       }
-      return super.specMessages(specId, before, after, limit);
+      return super.roomMessages(specId, before, after, limit);
     }
 
     @Override

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
@@ -131,7 +131,8 @@ class RoomWakeLaunchTest {
             (project, config) -> "",
             launcher,
             DispatchOperations.Listener.NONE)
-        .useMessages(messageStore);
+        .useMessages(messageStore)
+        .useRooms(new RoomStore(db));
   }
 
   @Test
@@ -588,10 +589,14 @@ class RoomWakeLaunchTest {
 
   private void engage(String specId, String agent, String mode) {
     var spec = specStore.findById(specId).orElseThrow();
-    specStore.update(
-        spec.withEngagement(
-            ai.singlr.sail.config.Engagement.of(agent, mode, null, "2026-08-18T00:00:00Z")
-                .toJson()));
+    var rooms = new RoomStore(db);
+    rooms.ensureFor(specId, spec.project(), spec.title(), spec.assignee(), null, HANDLE);
+    rooms.updateRoster(
+        specId,
+        ai.singlr.sail.config.Roster.solo(
+                ai.singlr.sail.config.Engagement.of(agent, mode, null, "2026-08-18T00:00:00Z"))
+            .toJson(),
+        HANDLE);
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeReactorTest.java
@@ -173,15 +173,14 @@ class RoomWakeReactorTest {
             "",
             null,
             List.of(),
-            List.of(),
-            wake));
+            List.of()));
+    roomStore.ensureFor(id, "acme", id, assignee, wake, "uday");
   }
 
   private void engage(String id, String agent, String mode) {
     var spec = specStore.findById(id).orElseThrow();
     var member = ai.singlr.sail.config.Engagement.of(agent, mode, null, now.get().toString());
-    specStore.update(spec.withEngagement(member.toJson()));
-    roomStore.ensureFor(id, spec.project(), spec.title(), spec.assignee(), spec.wake(), "uday");
+    roomStore.ensureFor(id, spec.project(), spec.title(), spec.assignee(), null, "uday");
     roomStore.updateRoster(id, ai.singlr.sail.config.Roster.solo(member).toJson(), "uday");
   }
 
@@ -427,11 +426,11 @@ class RoomWakeReactorTest {
     var reactor = reactor(executor);
 
     reactor.onEvent(message("auth", "uday", "hello"));
-    specStore.update(specStore.findById("auth").orElseThrow().withWake("off"));
+    roomStore.updateWake("auth", "off", "uday");
     executor.drain();
     assertTrue(launcher.woken.isEmpty(), "a mode flipped off mid-debounce wins");
 
-    specStore.update(specStore.findById("auth").orElseThrow().withWake("on"));
+    roomStore.updateWake("auth", "on", "uday");
     reactor.onEvent(message("auth", "uday", "hello again"));
     buildRun("auth", "running");
     executor.drain();
@@ -962,21 +961,6 @@ class RoomWakeReactorTest {
   }
 
   @Test
-  void theSweepStillRescuesALegacyColumnEngagementWithNoRoomRow() {
-    seed("legacy", "in_progress", "uday", "on");
-    var spec = specStore.findById("legacy").orElseThrow();
-    specStore.update(
-        spec.withEngagement(
-            ai.singlr.sail.config.Engagement.of("claude-code", "full", null, now.get().toString())
-                .toJson()));
-    messageStore.append("legacy", "uday", "anyone there?", null);
-
-    reactor().sweepEngagedRooms();
-
-    assertEquals(1, launcher.woken.size(), "the sweep unions the legacy column until it retires");
-  }
-
-  @Test
   void aSpeclessRoomWithASeatedMemberWakesOnItsOwnersBox() {
     roomStore.create(
         new RoomStore.RoomRow(
@@ -1031,7 +1015,58 @@ class RoomWakeReactorTest {
   }
 
   @Test
-  void aDismissalRecordedOnTheRoomWinsOverAStaleSpecColumn() {
+  void aChatRoomMessageFiresAWakeOnItsOwnersBox() {
+    roomStore.create(
+        new RoomStore.RoomRow(
+            "lounge",
+            "acme",
+            "Lounge",
+            "uday",
+            "on",
+            "[{\"agent\":\"claude-code\",\"mode\":\"full\",\"engaged_at\":\"t0\"}]",
+            "uday",
+            "t0",
+            "t0",
+            "uday"));
+    messageStore.append("lounge", "uday", "anyone around?", null);
+    var executor = new ManualExecutorService();
+    var reactor = reactor(executor);
+
+    reactor.onEvent(message("lounge", "uday", "anyone around?"));
+    executor.drain();
+
+    assertEquals(1, launcher.woken.size(), "a seated chat room wakes through the fire path");
+  }
+
+  @Test
+  void aConversationDeletedMidDebounceFiresNothing() {
+    seed("auth", "in_progress", "uday", "on");
+    engage("auth", "claude-code", "full");
+    var executor = new ManualExecutorService();
+    var reactor = reactor(executor);
+
+    reactor.onEvent(message("auth", "uday", "hello"));
+    specStore.delete("auth");
+    roomStore.delete("auth");
+    executor.drain();
+
+    assertTrue(
+        launcher.woken.isEmpty(), "a conversation deleted mid-debounce resolves to no target");
+  }
+
+  @Test
+  void aGhostConversationFiresNothing() {
+    var executor = new ManualExecutorService();
+    var reactor = reactor(executor);
+
+    reactor.onEvent(message("ghost", "uday", "hello?"));
+    executor.drain();
+
+    assertTrue(launcher.woken.isEmpty(), "no spec and no room resolves to no target");
+  }
+
+  @Test
+  void aDismissalRecordedOnTheRoomLeavesNobodyToWake() {
     seed("auth", "in_progress", "uday", "off");
     engage("auth", "claude-code", "full");
     roomStore.updateRoster("auth", null, "uday");
@@ -1039,19 +1074,17 @@ class RoomWakeReactorTest {
     var reactor = reactor();
     reactor.onEvent(message("auth", "uday", "hello"));
 
-    assertTrue(
-        launcher.woken.isEmpty(),
-        "a present room with an empty roster is authoritative — no stale-column resurrection");
+    assertTrue(launcher.woken.isEmpty(), "a present room with an empty roster seats nobody");
   }
 
   @Test
   void theWakeModeStoredOnTheRoomRowGovernsTheDecision() {
     seed("auth", "in_progress", "uday", "off");
-    roomStore.ensureFor("auth", "acme", "auth", "uday", "on", "uday");
+    roomStore.updateWake("auth", "on", "uday");
 
     var reactor = reactor();
     reactor.onEvent(message("auth", "uday", "hello"));
 
-    assertEquals(1, launcher.woken.size(), "the room's wake mode overrides the spec column");
+    assertEquals(1, launcher.woken.size(), "the room's wake mode is the decision");
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RunDeliveryOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RunDeliveryOperationsTest.java
@@ -299,15 +299,15 @@ class RunDeliveryOperationsTest {
     var first = messages.append("room", "ada", "one", null);
     var second = messages.append("room", "ada", "two", null);
 
-    var page = operations.specMessages("room", null, first.id(), 50).orThrow();
+    var page = operations.roomMessages("room", null, first.id(), 50).orThrow();
     assertEquals(List.of(second.id()), page.messages().stream().map(m -> m.id()).toList());
 
     assertEquals(
         ErrorCode.BAD_REQUEST,
-        operations.specMessages("room", first.id(), second.id(), 50).asFailure().errorCode(),
+        operations.roomMessages("room", first.id(), second.id(), 50).asFailure().errorCode(),
         "before and after are exclusive");
     assertEquals(
         ErrorCode.BAD_REQUEST,
-        operations.specMessages("room", null, "not-a-uuid", 50).asFailure().errorCode());
+        operations.roomMessages("room", null, "not-a-uuid", 50).asFailure().errorCode());
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -1618,7 +1618,7 @@ class SailOperationsTest {
             .useMessages(new MessageStore(db));
 
     var result =
-        operations.postSpecMessage(
+        operations.postRoomMessage(
             "auth",
             new SpecMessageRequest("Ready", null, false),
             new Actor("sail", Role.ADMIN, Actor.Lane.API),

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SpecMessageOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SpecMessageOperationsTest.java
@@ -86,7 +86,7 @@ class SpecMessageOperationsTest {
 
     var posted =
         operations
-            .postSpecMessage(
+            .postRoomMessage(
                 "room",
                 new SpecMessageRequest("Progress\n  update", null, false),
                 member("ada"),
@@ -101,7 +101,7 @@ class SpecMessageOperationsTest {
     assertEquals(posted.message().id(), event.get().data().get("message_id"));
     assertEquals("Progress update", event.get().data().get("preview"));
 
-    var listed = operations.specMessages("room", null, null, 50).orThrow();
+    var listed = operations.roomMessages("room", null, null, 50).orThrow();
     assertEquals(1, listed.messages().size());
     assertEquals(posted.message().id(), listed.messages().getFirst().id());
   }
@@ -109,38 +109,38 @@ class SpecMessageOperationsTest {
   @Test
   void validatesUnknownSpecsBodiesCursorsAndLongPreviews() {
     assertEquals(
-        ErrorCode.SPEC_NOT_FOUND,
+        ErrorCode.ROOM_NOT_FOUND,
         operations
-            .postSpecMessage(
+            .postRoomMessage(
                 "missing", new SpecMessageRequest("body", null, false), member("ada"), "ada")
             .asFailure()
             .errorCode());
     assertEquals(
         ErrorCode.BAD_REQUEST,
         operations
-            .postSpecMessage("room", new SpecMessageRequest(" ", null, false), member("ada"), "ada")
+            .postRoomMessage("room", new SpecMessageRequest(" ", null, false), member("ada"), "ada")
             .asFailure()
             .errorCode());
     assertEquals(
         ErrorCode.BAD_REQUEST,
-        operations.specMessages("room", "not-a-uuid", null, 50).asFailure().errorCode());
+        operations.roomMessages("room", "not-a-uuid", null, 50).asFailure().errorCode());
     assertEquals(
-        ErrorCode.SPEC_NOT_FOUND,
-        operations.specMessages("missing", null, null, 50).asFailure().errorCode());
+        ErrorCode.ROOM_NOT_FOUND,
+        operations.roomMessages("missing", null, null, 50).asFailure().errorCode());
 
     var longMessage = "x".repeat(200);
     operations
-        .postSpecMessage(
+        .postRoomMessage(
             "room", new SpecMessageRequest(longMessage, null, false), member("ada"), "ada")
         .orThrow();
-    assertEquals(1, operations.specMessages("room", null, null, 50).orThrow().messages().size());
+    assertEquals(1, operations.roomMessages("room", null, null, 50).orThrow().messages().size());
   }
 
   @Test
   void onlyTheSpecOwnerOrAnAdminCanPost() {
     var refused =
         operations
-            .postSpecMessage(
+            .postRoomMessage(
                 "room",
                 new SpecMessageRequest("foreign instruction", null, false),
                 member("mallory"),
@@ -148,12 +148,12 @@ class SpecMessageOperationsTest {
             .asFailure();
 
     assertEquals(ErrorCode.FORBIDDEN_NOT_ASSIGNEE, refused.errorCode());
-    assertTrue(operations.specMessages("room", null, null, 50).orThrow().messages().isEmpty());
+    assertTrue(operations.roomMessages("room", null, null, 50).orThrow().messages().isEmpty());
 
     var agent = Actor.agentPrincipal("codex/run-1", "ada");
     var posted =
         operations
-            .postSpecMessage(
+            .postRoomMessage(
                 "room", new SpecMessageRequest("owner update", null, false), agent, agent.handle())
             .orThrow();
     assertEquals(agent.handle(), posted.message().author());
@@ -169,7 +169,7 @@ class SpecMessageOperationsTest {
     db.execute("UPDATE specs SET updated_at = '2026-07-01T00:00:00Z' WHERE id = 'room'");
     var posted =
         operations
-            .postSpecMessage(
+            .postRoomMessage(
                 "room", new SpecMessageRequest("activity", null, false), member("ada"), "ada")
             .orThrow();
 
@@ -238,7 +238,7 @@ class SpecMessageOperationsTest {
     var agent = Actor.agentPrincipal("claude/run-1", "ada");
     var posted =
         operations
-            .postSpecMessage(
+            .postRoomMessage(
                 "room", new SpecMessageRequest("Which flow?", null, true), agent, agent.handle())
             .orThrow();
 
@@ -259,7 +259,7 @@ class SpecMessageOperationsTest {
     assertEquals(1, operations.globalBoard("acme").orThrow().toMap().get("needs_reply"));
 
     operations
-        .postSpecMessage(
+        .postRoomMessage(
             "room", new SpecMessageRequest("use PKCE", null, false), member("ada"), "ada")
         .orThrow();
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/TestOperations.java
@@ -17,6 +17,7 @@ class TestOperations implements Operations {
   static final String PRINCIPAL = "claude/abc123";
   static final String OWNER = "uday";
   static final String BOX_CREDENTIAL = "sailbox_test";
+  static final String ROOM_RUN_CREDENTIAL = "sailroom_test";
   static final String BOX_HANDLE = "uday";
 
   @Override
@@ -29,6 +30,35 @@ class TestOperations implements Operations {
 
   @Override
   public Optional<RunStore.RunRow> runForCredential(String credential) {
+    if (ROOM_RUN_CREDENTIAL.equals(credential)) {
+      return Optional.of(
+          new RunStore.RunRow(
+              "run-2",
+              "acme",
+              null,
+              "node-a",
+              "room",
+              "claude-code",
+              null,
+              "chat",
+              null,
+              null,
+              "running",
+              null,
+              null,
+              null,
+              "t0",
+              null,
+              List.of(),
+              null,
+              PRINCIPAL,
+              OWNER,
+              null,
+              null,
+              null,
+              null,
+              "lounge"));
+    }
     if (!RUN_CREDENTIAL.equals(credential)) {
       return Optional.empty();
     }
@@ -78,24 +108,6 @@ class TestOperations implements Operations {
   }
 
   @Override
-  public Result<InviteResponse> inviteToSpec(
-      String specId, InviteRequest request, Actor actor, String localHandle) {
-    return Result.success(new InviteResponse("run-1", "claude/invite-run-1", "read_only", ""));
-  }
-
-  @Override
-  public Result<EngageResponse> engageToSpec(
-      String specId, EngageRequest request, Actor actor, String localHandle) {
-    return Result.success(
-        new EngageResponse(request.agent(), request.mode() == null ? "full" : request.mode(), ""));
-  }
-
-  @Override
-  public Result<DisengageResponse> disengageSpec(String specId, Actor actor, String localHandle) {
-    return Result.success(new DisengageResponse(null));
-  }
-
-  @Override
   public Result<RoomMembersResponse> roomMembers(String roomId) {
     return Result.success(new RoomMembersResponse(java.util.List.of()));
   }
@@ -123,13 +135,45 @@ class TestOperations implements Operations {
   @Override
   public Result<SpecMessagesResponse> roomMessages(
       String roomId, String before, String after, int limit) {
-    return Result.success(new SpecMessagesResponse(roomId, java.util.List.of()));
+    return Result.success(
+        new SpecMessagesResponse(
+            roomId,
+            List.of(
+                SpecMessageView.from(
+                    new MessageStore.MessageRow(
+                        "01900000-0000-7000-8000-000000000001",
+                        roomId,
+                        PRINCIPAL,
+                        "hello",
+                        null,
+                        "2026-07-28T00:00:00Z",
+                        "1-a",
+                        null,
+                        false)))));
   }
 
   @Override
   public Result<SpecMessageResponse> postRoomMessage(
       String roomId, SpecMessageRequest request, Actor principal, String authorHandle) {
-    return Result.failure(ErrorCode.COMMAND_FAILED, "not supported in this fake");
+    return Result.success(
+        new SpecMessageResponse(
+            SpecMessageView.from(
+                new MessageStore.MessageRow(
+                    "01900000-0000-7000-8000-000000000001",
+                    roomId,
+                    authorHandle,
+                    request.body(),
+                    request.replyTo(),
+                    "2026-07-28T00:00:00Z",
+                    "1-a",
+                    null,
+                    request.question()))));
+  }
+
+  @Override
+  public Result<InviteResponse> inviteToRoom(
+      String roomId, InviteRequest request, Actor actor, String localHandle) {
+    return Result.success(new InviteResponse("run-1", "claude/invite-run-1", "read_only", ""));
   }
 
   @Override
@@ -430,41 +474,6 @@ class TestOperations implements Operations {
   public Result<GlobalSpecContentResponse> setGlobalSpecContent(
       String specId, SpecContentRequest request, Actor actor) {
     return Result.success(new GlobalSpecContentResponse(specId, request.body(), request.plan()));
-  }
-
-  @Override
-  public Result<SpecMessageResponse> postSpecMessage(
-      String specId, SpecMessageRequest request, Actor actor, String author) {
-    return Result.success(
-        new SpecMessageResponse(
-            SpecMessageView.from(
-                new MessageStore.MessageRow(
-                    "01900000-0000-7000-8000-000000000001",
-                    specId,
-                    author,
-                    request.body(),
-                    request.replyTo(),
-                    "2026-07-28T00:00:00Z",
-                    "1-a",
-                    null,
-                    request.question()))));
-  }
-
-  @Override
-  public Result<SpecMessagesResponse> specMessages(
-      String specId, String before, String after, int limit) {
-    return Result.success(
-        new SpecMessagesResponse(
-            specId,
-            List.of(
-                new SpecMessageView(
-                    "01900000-0000-7000-8000-000000000001",
-                    specId,
-                    PRINCIPAL,
-                    "hello",
-                    null,
-                    "2026-07-28T00:00:00Z",
-                    false))));
   }
 
   @Override


### PR DESCRIPTION
Brick 6 of `room-spec-decouple` — the arc's close: the old spec-shaped conversation path is retired end-to-end. No "spec-is-room" code is left.

## What

- **Spec doors removed.** `/v1/specs/{id}/messages|engage|disengage|invite` answer 404. The room surface is the only conversation door: membership (`/v1/rooms/{id}/members`), messages (`/v1/rooms/{id}/messages`), and a new **`POST /v1/rooms/{id}/invite`** (spec-first resolution like every room door; a chat-only room refuses with an actionable message — an invite is a one-shot turn on a spec's checkout).
- **Operations inverted.** `engageToSpec`/`disengageSpec`/`inviteToSpec`/`specMessages`/`postSpecMessage` are gone from the ports; `addRoomMember`/`removeRoomMember`/`inviteToRoom`/`roomMessages`/`postRoomMessage` are the real implementations, not delegates. The local (in-container) lane rides the same methods.
- **`spec` CLI repointed.** `spec comment|comments|engage|disengage|invite` call the room doors — pure path swaps, since room doors resolve spec-first. User-facing vocabulary unchanged.
- **Legacy columns dropped.** `specs.wake` and `specs.engagement` are out of the row, the SQL, the snapshot, and the sync wire (`SYNC_FIELDS`). The migration rebuilds the specs table portably (create-final-shape → insert → drop → rename — the macOS system-SQLite lesson), preserving rows, child FKs, the project index, and the status CHECK. Incoming legacy snapshots that still carry the keys apply cleanly (ignored, never fatal).
- **`V1_UPGRADE_FLOOR` → 0.34.0.** Removing synced fields is a wire-shape change — lockstep fleet upgrade, same class as Brick 3a.
- **Readers re-sourced.** `stateOf` reads the room row only (no room = default wake, nobody seated); `legacyRosterOf` deleted; `members()` requires the room row (`ROOM_NOT_FOUND`); `GlobalSpecView` decorates `wake`/`engagement` from the room via `from(row, room)` — API shape unchanged for clients; `spec update --wake` still works, landing only on the room; the sweep walks rooms only.
- **Backfill guarded.** `RoomsBackfillMigration` no-ops cleanly on a schema without the legacy columns (fresh 0.34+ installs would otherwise fail on the raw SELECT).
- **Field bug fixed (found during the survey, proven by test):** the local lane's read-only messages guard compared against `run.specId()`, which is null for Brick 4's spec-less collaborator runs — a read-only member was 403'd off its own room, and the room id was unenforceable. `RunRow` now carries `roomId` (sync-local, never journaled) with a `conversationId()` accessor; the guard keys on it. A spec-less session posts to its own room and only its own room.

## Tests

Ghost ids answer `ROOM_NOT_FOUND` everywhere (honest post-decouple semantics). New: retired doors 404; room invite routing (full/read-only/405); specs-rebuild migration seed-prior-shape test (columns gone, rows/children/FK-check/index/CHECK intact); legacy-snapshot-keys-ignored skew test; backfill no-op guard; spec-less session posts only to its own room; chat-room fire-path wake; mid-debounce deletion resolves to no target; state-without-room reads as nobody seated. Coverage gate held at 100% `api.*` lines by behavioral tests — no excludes added.

Companion: mast#57 repoints Mast's `invite` to the room door. Release order: sail 0.34.0 (lockstep floor) before the mast tag.
