### PR TITLE
PTY session host brick 0: the host owns the terminals, clients come and go

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/SailPaths.java
@@ -212,6 +212,16 @@ public final class SailPaths {
     return dataDir().resolve("run").resolve("api.sock");
   }
 
+  /** The pty session host's unix socket — in-container, owned by the dev user. */
+  public static Path ptySocketPath() {
+    return sailDir().resolve("pty.sock");
+  }
+
+  /** Where session ring journals live: {@code ~/.sail/sessions/<name>.ring}. */
+  public static Path sessionsDir() {
+    return sailDir().resolve("sessions");
+  }
+
   /** Returns true when the current process runs as root — the single privilege check. */
   public static boolean isRoot() {
     return "root".equals(ProcessHandle.current().info().user().orElse(""));

--- a/sail-core/src/main/java/ai/singlr/sail/pty/Pty.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/Pty.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A pseudo-terminal pair owned by this process, with the child spawned as a session leader whose
+ * controlling terminal is the slave side. The JVM cannot {@code fork()}, so the classic {@code
+ * forkpty} is replaced by first principles: the master is allocated here via {@code posix_openpt}/
+ * {@code grantpt}/{@code unlockpt} (libc through the same Panama discipline as the SQLite layer),
+ * and the child is spawned with {@link ProcessBuilder} wrapped in util-linux {@code setsid --ctty},
+ * its stdio redirected to the slave device — {@code setsid} makes it a session leader and issues
+ * {@code TIOCSCTTY} on stdin, which is exactly what {@code forkpty} would have done.
+ *
+ * <p>Reads block the calling thread (the session host dedicates a platform gather thread per
+ * session — the ghostty drain discipline); a read against a dead child reports end of stream
+ * ({@code EIO} on Linux) as {@code -1}, never an exception, so the reaper owns the child's ending.
+ */
+public final class Pty implements AutoCloseable {
+
+  private static final int O_RDWR = 2;
+  private static final int O_NOCTTY = 0x100;
+  private static final long TIOCSWINSZ = 0x5414;
+  private static final int EINTR = 4;
+  private static final int EIO = 5;
+
+  private static final StructLayout WINSIZE =
+      java.lang.foreign.MemoryLayout.structLayout(
+          ValueLayout.JAVA_SHORT.withName("ws_row"),
+          ValueLayout.JAVA_SHORT.withName("ws_col"),
+          ValueLayout.JAVA_SHORT.withName("ws_xpixel"),
+          ValueLayout.JAVA_SHORT.withName("ws_ypixel"));
+  private static final VarHandle WS_ROW =
+      WINSIZE.varHandle(java.lang.foreign.MemoryLayout.PathElement.groupElement("ws_row"));
+  private static final VarHandle WS_COL =
+      WINSIZE.varHandle(java.lang.foreign.MemoryLayout.PathElement.groupElement("ws_col"));
+
+  private record Libc(
+      MethodHandle posixOpenpt,
+      MethodHandle grantpt,
+      MethodHandle unlockpt,
+      MethodHandle ptsname,
+      MethodHandle ioctl,
+      MethodHandle read,
+      MethodHandle write,
+      MethodHandle close,
+      StructLayout capturedState,
+      VarHandle errno) {}
+
+  private static final Libc LIBC = loadLibc();
+
+  private static Libc loadLibc() {
+    var linker = Linker.nativeLinker();
+    var lookup = linker.defaultLookup();
+    var captured = Linker.Option.captureCallState("errno");
+    var capturedLayout = Linker.Option.captureStateLayout();
+    var errnoHandle =
+        capturedLayout.varHandle(java.lang.foreign.MemoryLayout.PathElement.groupElement("errno"));
+    return new Libc(
+        linker.downcallHandle(
+            lookup.find("posix_openpt").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT)),
+        linker.downcallHandle(
+            lookup.find("grantpt").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT)),
+        linker.downcallHandle(
+            lookup.find("unlockpt").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT)),
+        linker.downcallHandle(
+            lookup.find("ptsname").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.JAVA_INT)),
+        linker.downcallHandle(
+            lookup.find("ioctl").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_INT,
+                ValueLayout.JAVA_INT,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.ADDRESS)),
+        linker.downcallHandle(
+            lookup.find("read").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_INT,
+                ValueLayout.ADDRESS,
+                ValueLayout.JAVA_LONG),
+            captured),
+        linker.downcallHandle(
+            lookup.find("write").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_INT,
+                ValueLayout.ADDRESS,
+                ValueLayout.JAVA_LONG),
+            captured),
+        linker.downcallHandle(
+            lookup.find("close").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT)),
+        capturedLayout,
+        errnoHandle);
+  }
+
+  private final int masterFd;
+  private final String slavePath;
+  private final Arena arena;
+  private final MemorySegment ioBuffer;
+  private final MemorySegment errnoState;
+  private volatile boolean closed;
+
+  private Pty(int masterFd, String slavePath) {
+    this.masterFd = masterFd;
+    this.slavePath = slavePath;
+    this.arena = Arena.ofShared();
+    this.ioBuffer = arena.allocate(64 * 1024);
+    this.errnoState = arena.allocate(LIBC.capturedState());
+  }
+
+  /** Allocates a master/slave pair and stamps the initial window size on it. */
+  public static Pty open(int cols, int rows) throws IOException {
+    try {
+      var fd = (int) LIBC.posixOpenpt().invokeExact(O_RDWR | O_NOCTTY);
+      if (fd < 0) {
+        throw new IOException("posix_openpt failed; no pseudo-terminals available.");
+      }
+      if ((int) LIBC.grantpt().invokeExact(fd) != 0 || (int) LIBC.unlockpt().invokeExact(fd) != 0) {
+        LIBC.close().invokeExact(fd);
+        throw new IOException("grantpt/unlockpt failed for the new pseudo-terminal.");
+      }
+      var name = (MemorySegment) LIBC.ptsname().invokeExact(fd);
+      if (name.equals(MemorySegment.NULL)) {
+        LIBC.close().invokeExact(fd);
+        throw new IOException("ptsname returned no slave path for fd " + fd + ".");
+      }
+      var slave = name.reinterpret(256).getString(0);
+      var pty = new Pty(fd, slave);
+      pty.resize(cols, rows);
+      return pty;
+    } catch (IOException e) {
+      throw e;
+    } catch (Throwable t) {
+      throw new IOException("pty allocation failed", t);
+    }
+  }
+
+  /**
+   * Spawns {@code command} as a session leader with this pty as its controlling terminal. The
+   * caller owns the returned process's ending: waiting, exit codes, and reaping happen there.
+   */
+  public Process spawn(List<String> command, Map<String, String> env, Path cwd) throws IOException {
+    requireOpen();
+    var full = new ArrayList<String>(command.size() + 2);
+    full.add("setsid");
+    full.add("--ctty");
+    full.addAll(command);
+    var builder = new ProcessBuilder(full);
+    builder.environment().putAll(env);
+    builder.directory(cwd.toFile());
+    var slave = new File(slavePath);
+    builder.redirectInput(slave);
+    builder.redirectOutput(slave);
+    builder.redirectError(slave);
+    return builder.start();
+  }
+
+  /**
+   * Reads from the master into {@code buf}, blocking until output arrives. Returns the byte count,
+   * or {@code -1} once the child side is gone ({@code EIO}) or this pty is closed.
+   */
+  public int read(byte[] buf) throws IOException {
+    while (true) {
+      if (closed) {
+        return -1;
+      }
+      long n;
+      int err;
+      try {
+        n =
+            (long)
+                LIBC.read()
+                    .invokeExact(
+                        errnoState, masterFd, ioBuffer, (long) Math.min(buf.length, 64 * 1024));
+        err = (int) LIBC.errno().get(errnoState, 0L);
+      } catch (Throwable t) {
+        throw new IOException("pty read failed", t);
+      }
+      if (n > 0) {
+        MemorySegment.ofArray(buf).copyFrom(ioBuffer.asSlice(0, n));
+        return (int) n;
+      }
+      if (n == 0) {
+        return -1;
+      }
+      if (err == EINTR) {
+        continue;
+      }
+      if (err == EIO || closed) {
+        return -1;
+      }
+      throw new IOException("pty read failed with errno " + err + ".");
+    }
+  }
+
+  /** Writes {@code data} to the master — keystrokes bound for the child. */
+  public void write(byte[] data) throws IOException {
+    requireOpen();
+    var offset = 0;
+    while (offset < data.length) {
+      var chunk = Math.min(data.length - offset, 64 * 1024);
+      ioBuffer.asSlice(0, chunk).copyFrom(MemorySegment.ofArray(data).asSlice(offset, chunk));
+      long n;
+      int err;
+      try {
+        n = (long) LIBC.write().invokeExact(errnoState, masterFd, ioBuffer, (long) chunk);
+        err = (int) LIBC.errno().get(errnoState, 0L);
+      } catch (Throwable t) {
+        throw new IOException("pty write failed", t);
+      }
+      if (n < 0) {
+        if (err == EINTR) {
+          continue;
+        }
+        throw new IOException("pty write failed with errno " + err + ".");
+      }
+      offset += (int) n;
+    }
+  }
+
+  /** Sets the window size; the kernel delivers {@code SIGWINCH} to the foreground group. */
+  public void resize(int cols, int rows) throws IOException {
+    requireOpen();
+    try (var local = Arena.ofConfined()) {
+      var ws = local.allocate(WINSIZE);
+      WS_ROW.set(ws, 0L, (short) rows);
+      WS_COL.set(ws, 0L, (short) cols);
+      var rc = (int) LIBC.ioctl().invokeExact(masterFd, TIOCSWINSZ, ws);
+      if (rc != 0) {
+        throw new IOException("TIOCSWINSZ failed on the pty master.");
+      }
+    } catch (IOException e) {
+      throw e;
+    } catch (Throwable t) {
+      throw new IOException("pty resize failed", t);
+    }
+  }
+
+  public String slavePath() {
+    return slavePath;
+  }
+
+  private void requireOpen() throws IOException {
+    if (closed) {
+      throw new IOException("This pty is closed.");
+    }
+  }
+
+  @Override
+  public void close() {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    try {
+      var ignored = (int) LIBC.close().invokeExact(masterFd);
+    } catch (Throwable t) {
+      throw new IllegalStateException("pty close failed", t);
+    }
+    arena.close();
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyMessage.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyMessage.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import java.util.List;
+
+/**
+ * The session-host wire vocabulary — one sealed hierarchy for both directions. Client to host:
+ * create, attach, input, resize, write-token, detach, list, kill. Host to client: output (carrying
+ * the last applied input sequence — the one enabler client-side predictive echo needs), replay
+ * bracketing, writer and size changes, flow control, endings, listings, and errors.
+ */
+public sealed interface PtyMessage {
+
+  record Create(String session, List<String> command, String cwd, int cols, int rows)
+      implements PtyMessage {}
+
+  record Attach(String session, boolean write) implements PtyMessage {}
+
+  record Input(long seq, byte[] bytes) implements PtyMessage {}
+
+  record Resize(int cols, int rows) implements PtyMessage {}
+
+  record TakeWrite() implements PtyMessage {}
+
+  record Detach() implements PtyMessage {}
+
+  record ListSessions() implements PtyMessage {}
+
+  record Kill(String session) implements PtyMessage {}
+
+  record Output(long lastInputSeq, byte[] bytes) implements PtyMessage {}
+
+  record ReplayBegin(boolean safe) implements PtyMessage {}
+
+  record ReplayEnd() implements PtyMessage {}
+
+  record WriterChanged(String fde) implements PtyMessage {}
+
+  record Resized(int cols, int rows) implements PtyMessage {}
+
+  record Paused() implements PtyMessage {}
+
+  record Continued() implements PtyMessage {}
+
+  record SessionEnded(String reason) implements PtyMessage {}
+
+  record SessionInfo(String name, boolean live, int attached, String writerFde)
+      implements PtyMessage {}
+
+  record Sessions(List<SessionInfo> sessions) implements PtyMessage {}
+
+  record Ok() implements PtyMessage {}
+
+  record Err(String message) implements PtyMessage {}
+}

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * One live conversation: a {@link Pty} and its child, a gather thread that drains the pty
+ * unconditionally into the {@link RingJournal} (the child is never backpressured — the ghostty
+ * discipline), and any number of subscribers, each served by its own sender thread over a bounded
+ * queue. A subscriber that cannot keep up is paused — its backlog dropped, marked by {@code
+ * Paused}/{@code Continued} frames — while the writer and everyone else stay live.
+ *
+ * <p>Exactly one subscriber holds the write token; input from anyone else is refused. Attach
+ * replays the journal tail bracketed by {@code ReplayBegin}/{@code ReplayEnd}, then streams. When
+ * the child exits, every subscriber hears {@code SessionEnded} and the corpse (ring included) stays
+ * readable until the host reaps it.
+ */
+public final class PtySession implements AutoCloseable {
+
+  /** A connected client; {@code deliver} is called from this subscriber's own sender thread. */
+  public interface Client {
+    void deliver(PtyMessage message);
+  }
+
+  private record Subscriber(long id, Client client, SubscriberQueue queue) {}
+
+  private final String name;
+  private final Pty pty;
+  private final Process child;
+  private final RingJournal journal;
+  private final TermBoundary boundary = new TermBoundary();
+  private final int queueCapacity;
+  private final int replayMax;
+  private final Map<Long, Subscriber> subscribers = new ConcurrentHashMap<>();
+  private final AtomicLong subscriberIds = new AtomicLong();
+  private final AtomicLong lastInputSeq = new AtomicLong(-1);
+  private final CountDownLatch gatherDone = new CountDownLatch(1);
+  private final long createdAt = System.nanoTime();
+  private volatile long writerId = -1;
+  private volatile String endedReason;
+  private volatile long endedAtNanos;
+  private volatile boolean everAttached;
+
+  private PtySession(
+      String name, Pty pty, Process child, RingJournal journal, int queueCapacity, int replayMax) {
+    this.name = name;
+    this.pty = pty;
+    this.child = child;
+    this.journal = journal;
+    this.queueCapacity = queueCapacity;
+    this.replayMax = replayMax;
+  }
+
+  public static PtySession start(
+      String name,
+      List<String> command,
+      Map<String, String> env,
+      Path cwd,
+      Path journalPath,
+      long journalCapacity,
+      int cols,
+      int rows)
+      throws IOException {
+    return start(name, command, env, cwd, journalPath, journalCapacity, cols, rows, 4096, 262_144);
+  }
+
+  static PtySession start(
+      String name,
+      List<String> command,
+      Map<String, String> env,
+      Path cwd,
+      Path journalPath,
+      long journalCapacity,
+      int cols,
+      int rows,
+      int queueCapacity,
+      int replayMax)
+      throws IOException {
+    var journal = RingJournal.open(journalPath, journalCapacity);
+    var pty = Pty.open(cols, rows);
+    Process child;
+    try {
+      child = pty.spawn(command, env, cwd);
+    } catch (IOException e) {
+      pty.close();
+      journal.close();
+      throw e;
+    }
+    var session = new PtySession(name, pty, child, journal, queueCapacity, replayMax);
+    Thread.ofPlatform().name("pty-gather-" + name).start(session::gather);
+    return session;
+  }
+
+  private void gather() {
+    var buf = new byte[65536];
+    try {
+      while (true) {
+        var n = pty.read(buf);
+        if (n < 0) {
+          break;
+        }
+        journal.append(buf, n);
+        boundary.feed(buf, n);
+        if (boundary.atSafeLineStart()) {
+          journal.markSafe(Math.max(0, journal.totalWritten() - replayMax));
+        }
+        var chunk = new byte[n];
+        System.arraycopy(buf, 0, chunk, 0, n);
+        var output = new PtyMessage.Output(lastInputSeq.get(), chunk);
+        subscribers.values().forEach(subscriber -> subscriber.queue().enqueue(output));
+      }
+    } catch (IOException e) {
+      endedReason = "pty failed: " + e.getMessage();
+    } finally {
+      var exit = child.onExit().join().exitValue();
+      if (endedReason == null) {
+        endedReason = "exited(" + exit + ")";
+      }
+      endedAtNanos = System.nanoTime();
+      pty.close();
+      var ended = new PtyMessage.SessionEnded(endedReason);
+      subscribers.values().forEach(subscriber -> subscriber.queue().force(ended));
+      gatherDone.countDown();
+    }
+  }
+
+  /** Attaches a client: replay first, live stream after, write token if free and requested. */
+  public long attach(Client client, boolean wantsWrite) throws IOException {
+    if (endedReason != null) {
+      throw new IOException("Session '" + name + "' has ended: " + endedReason + ".");
+    }
+    everAttached = true;
+    var subscriber =
+        new Subscriber(subscriberIds.incrementAndGet(), client, new SubscriberQueue(queueCapacity));
+    var tail = journal.tail(replayMax);
+    subscriber.queue().force(new PtyMessage.ReplayBegin(tail.safe()));
+    if (tail.bytes().length > 0) {
+      subscriber.queue().force(new PtyMessage.Output(lastInputSeq.get(), tail.bytes()));
+    }
+    subscriber.queue().force(new PtyMessage.ReplayEnd());
+    subscribers.put(subscriber.id, subscriber);
+    synchronized (this) {
+      if (wantsWrite && writerId < 0) {
+        writerId = subscriber.id;
+      }
+    }
+    Thread.ofVirtual()
+        .name("pty-send-" + name + "-" + subscriber.id())
+        .start(() -> send(subscriber));
+    return subscriber.id();
+  }
+
+  private void send(Subscriber subscriber) {
+    try {
+      while (true) {
+        var message = subscriber.queue().next();
+        if (message instanceof PtyMessage.Ok) {
+          return;
+        }
+        subscriber.client().deliver(message);
+        if (message instanceof PtyMessage.SessionEnded) {
+          return;
+        }
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /** Writes input; only the write-token holder may, and the sequence rides future output. */
+  public void input(long subscriberId, long seq, byte[] bytes) throws IOException {
+    if (subscriberId != writerId) {
+      throw new IOException("Subscriber " + subscriberId + " does not hold the write token.");
+    }
+    lastInputSeq.set(seq);
+    pty.write(bytes);
+  }
+
+  /** Transfers the write token to {@code subscriberId}; everyone hears about it. */
+  public synchronized void takeWrite(long subscriberId, String fde) {
+    if (!subscribers.containsKey(subscriberId)) {
+      throw new IllegalArgumentException("No attached subscriber " + subscriberId + ".");
+    }
+    writerId = subscriberId;
+    var changed = new PtyMessage.WriterChanged(fde);
+    subscribers.values().forEach(subscriber -> subscriber.queue().force(changed));
+  }
+
+  /** Resizes; only the write-token holder may, and observers hear the new geometry. */
+  public void resize(long subscriberId, int cols, int rows) throws IOException {
+    if (subscriberId != writerId) {
+      throw new IOException("Only the writer resizes; the writer's window wins.");
+    }
+    pty.resize(cols, rows);
+    var resized = new PtyMessage.Resized(cols, rows);
+    subscribers.values().stream()
+        .filter(subscriber -> subscriber.id() != subscriberId)
+        .forEach(subscriber -> subscriber.queue().force(resized));
+  }
+
+  public synchronized void detach(long subscriberId) {
+    var subscriber = subscribers.remove(subscriberId);
+    if (subscriber != null) {
+      subscriber.queue().clearAnd(new PtyMessage.Ok());
+    }
+    if (writerId == subscriberId) {
+      writerId = -1;
+    }
+  }
+
+  /** Bytes gathered from the pty so far — the child's progress, independent of any subscriber. */
+  public long journaledBytes() {
+    return journal.totalWritten();
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public boolean live() {
+    return endedReason == null;
+  }
+
+  public String endedReason() {
+    return endedReason;
+  }
+
+  public int attachedCount() {
+    return subscribers.size();
+  }
+
+  public long writerId() {
+    return writerId;
+  }
+
+  public boolean everAttached() {
+    return everAttached;
+  }
+
+  public long endedAtNanos() {
+    return endedAtNanos;
+  }
+
+  public long createdAtNanos() {
+    return createdAt;
+  }
+
+  /** Ends the child (if alive), waits for the gather thread, and releases the journal. */
+  @Override
+  public void close() {
+    child.destroy();
+    try {
+      if (!gatherDone.await(5, java.util.concurrent.TimeUnit.SECONDS)) {
+        child.destroyForcibly();
+        gatherDone.await();
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    subscribers.keySet().forEach(this::detach);
+    try {
+      journal.close();
+    } catch (IOException e) {
+      throw new IllegalStateException("journal close failed for session '" + name + "'", e);
+    }
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -17,8 +17,11 @@ import java.util.concurrent.atomic.AtomicLong;
  * One live conversation: a {@link Pty} and its child, a gather thread that drains the pty
  * unconditionally into the {@link RingJournal} (the child is never backpressured — the ghostty
  * discipline), and any number of subscribers, each served by its own sender thread over a bounded
- * queue. A subscriber that cannot keep up is paused — its backlog dropped, marked by {@code
- * Paused}/{@code Continued} frames — while the writer and everyone else stay live.
+ * queue. Attach (journal snapshot + subscription) and the gather fanout (append + delivery)
+ * serialize on one lock so no byte falls between a subscriber's replay and its live stream; the
+ * blocking pty read stays outside the lock. A subscriber that cannot keep up is paused — its
+ * backlog dropped, marked by {@code Paused}/{@code Continued} frames — while the writer and
+ * everyone else stay live.
  *
  * <p>Exactly one subscriber holds the write token; input from anyone else is refused. Attach
  * replays the journal tail bracketed by {@code ReplayBegin}/{@code ReplayEnd}, then streams. When
@@ -42,6 +45,7 @@ public final class PtySession implements AutoCloseable {
   private final int queueCapacity;
   private final int replayMax;
   private final Map<Long, Subscriber> subscribers = new ConcurrentHashMap<>();
+  private final Object fanout = new Object();
   private final AtomicLong subscriberIds = new AtomicLong();
   private final AtomicLong lastInputSeq = new AtomicLong(-1);
   private final CountDownLatch gatherDone = new CountDownLatch(1);
@@ -109,15 +113,17 @@ public final class PtySession implements AutoCloseable {
         if (n < 0) {
           break;
         }
-        journal.append(buf, n);
-        boundary.feed(buf, n);
-        if (boundary.atSafeLineStart()) {
-          journal.markSafe(Math.max(0, journal.totalWritten() - replayMax));
+        synchronized (fanout) {
+          journal.append(buf, n);
+          boundary.feed(buf, n);
+          if (boundary.atSafeLineStart()) {
+            journal.markSafe(Math.max(0, journal.totalWritten() - replayMax));
+          }
+          var chunk = new byte[n];
+          System.arraycopy(buf, 0, chunk, 0, n);
+          var output = new PtyMessage.Output(lastInputSeq.get(), chunk);
+          subscribers.values().forEach(subscriber -> subscriber.queue().enqueue(output));
         }
-        var chunk = new byte[n];
-        System.arraycopy(buf, 0, chunk, 0, n);
-        var output = new PtyMessage.Output(lastInputSeq.get(), chunk);
-        subscribers.values().forEach(subscriber -> subscriber.queue().enqueue(output));
       }
     } catch (IOException e) {
       endedReason = "pty failed: " + e.getMessage();
@@ -142,13 +148,15 @@ public final class PtySession implements AutoCloseable {
     everAttached = true;
     var subscriber =
         new Subscriber(subscriberIds.incrementAndGet(), client, new SubscriberQueue(queueCapacity));
-    var tail = journal.tail(replayMax);
-    subscriber.queue().force(new PtyMessage.ReplayBegin(tail.safe()));
-    if (tail.bytes().length > 0) {
-      subscriber.queue().force(new PtyMessage.Output(lastInputSeq.get(), tail.bytes()));
+    synchronized (fanout) {
+      var tail = journal.tail(replayMax);
+      subscriber.queue().force(new PtyMessage.ReplayBegin(tail.safe()));
+      if (tail.bytes().length > 0) {
+        subscriber.queue().force(new PtyMessage.Output(lastInputSeq.get(), tail.bytes()));
+      }
+      subscriber.queue().force(new PtyMessage.ReplayEnd());
+      subscribers.put(subscriber.id, subscriber);
     }
-    subscriber.queue().force(new PtyMessage.ReplayEnd());
-    subscribers.put(subscriber.id, subscriber);
     synchronized (this) {
       if (wantsWrite && writerId < 0) {
         writerId = subscriber.id;

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyWire.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyWire.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The framing for {@link PtyMessage} over a byte channel: an 8-byte magic handshake carrying the
+ * protocol version, then length-prefixed frames ({@code int length, byte type, payload}). Frames
+ * are capped at 1 MiB — anything larger is a protocol violation, refused loudly (the tmux lesson:
+ * version and framing skew must fail the handshake, never limp).
+ */
+public final class PtyWire {
+
+  static final byte[] MAGIC = "SAILPTY1".getBytes(StandardCharsets.US_ASCII);
+  static final int MAX_FRAME = 1 << 20;
+
+  private PtyWire() {}
+
+  /** Sends the magic; the peer must echo it back. Throws on any mismatch. */
+  public static void handshake(ReadableByteChannel in, WritableByteChannel out) throws IOException {
+    writeFully(out, ByteBuffer.wrap(MAGIC));
+    var peer = ByteBuffer.allocate(MAGIC.length);
+    readFully(in, peer);
+    if (!ByteBuffer.wrap(MAGIC).equals(peer.flip())) {
+      throw new IOException("Peer is not speaking sail pty protocol v1; refusing the connection.");
+    }
+  }
+
+  public static void write(WritableByteChannel out, PtyMessage message) throws IOException {
+    var payload = encode(message);
+    var frame = ByteBuffer.allocate(4 + payload.length);
+    frame.putInt(payload.length).put(payload).flip();
+    writeFully(out, frame);
+  }
+
+  public static PtyMessage read(ReadableByteChannel in) throws IOException {
+    var lengthBuf = ByteBuffer.allocate(4);
+    readFully(in, lengthBuf);
+    var length = lengthBuf.flip().getInt();
+    if (length < 1 || length > MAX_FRAME) {
+      throw new IOException("Refusing pty frame of " + length + " bytes; the cap is 1 MiB.");
+    }
+    var payload = ByteBuffer.allocate(length);
+    readFully(in, payload);
+    payload.flip();
+    return decode(payload);
+  }
+
+  private static byte[] encode(PtyMessage message) {
+    var out = new Writer();
+    switch (message) {
+      case PtyMessage.Create m -> {
+        out.type(1).string(m.session()).stringList(m.command()).string(m.cwd());
+        out.buffer.putInt(m.cols()).putInt(m.rows());
+      }
+      case PtyMessage.Attach m -> {
+        out.type(2).string(m.session());
+        out.buffer.put((byte) (m.write() ? 1 : 0));
+      }
+      case PtyMessage.Input m -> {
+        out.type(3);
+        out.buffer.putLong(m.seq());
+        out.bytes(m.bytes());
+      }
+      case PtyMessage.Resize m -> {
+        out.type(4);
+        out.buffer.putInt(m.cols()).putInt(m.rows());
+      }
+      case PtyMessage.TakeWrite m -> out.type(5);
+      case PtyMessage.Detach m -> out.type(6);
+      case PtyMessage.ListSessions m -> out.type(7);
+      case PtyMessage.Kill m -> out.type(8).string(m.session());
+      case PtyMessage.Output m -> {
+        out.type(20);
+        out.buffer.putLong(m.lastInputSeq());
+        out.bytes(m.bytes());
+      }
+      case PtyMessage.ReplayBegin m -> {
+        out.type(21);
+        out.buffer.put((byte) (m.safe() ? 1 : 0));
+      }
+      case PtyMessage.ReplayEnd m -> out.type(22);
+      case PtyMessage.WriterChanged m -> out.type(23).string(m.fde());
+      case PtyMessage.Resized m -> {
+        out.type(24);
+        out.buffer.putInt(m.cols()).putInt(m.rows());
+      }
+      case PtyMessage.Paused m -> out.type(25);
+      case PtyMessage.Continued m -> out.type(26);
+      case PtyMessage.SessionEnded m -> out.type(27).string(m.reason());
+      case PtyMessage.SessionInfo m -> encodeInfo(out.type(28), m);
+      case PtyMessage.Sessions m -> {
+        out.type(29);
+        out.buffer.putInt(m.sessions().size());
+        for (var info : m.sessions()) {
+          encodeInfo(out, info);
+        }
+      }
+      case PtyMessage.Ok m -> out.type(30);
+      case PtyMessage.Err m -> out.type(31).string(m.message());
+    }
+    return out.finish();
+  }
+
+  private static Writer encodeInfo(Writer out, PtyMessage.SessionInfo info) {
+    out.string(info.name());
+    out.buffer.put((byte) (info.live() ? 1 : 0)).putInt(info.attached());
+    return out.string(info.writerFde());
+  }
+
+  private static PtyMessage decode(ByteBuffer in) throws IOException {
+    var type = in.get();
+    return switch (type) {
+      case 1 ->
+          new PtyMessage.Create(string(in), stringList(in), string(in), in.getInt(), in.getInt());
+      case 2 -> new PtyMessage.Attach(string(in), in.get() == 1);
+      case 3 -> new PtyMessage.Input(in.getLong(), bytes(in));
+      case 4 -> new PtyMessage.Resize(in.getInt(), in.getInt());
+      case 5 -> new PtyMessage.TakeWrite();
+      case 6 -> new PtyMessage.Detach();
+      case 7 -> new PtyMessage.ListSessions();
+      case 8 -> new PtyMessage.Kill(string(in));
+      case 20 -> new PtyMessage.Output(in.getLong(), bytes(in));
+      case 21 -> new PtyMessage.ReplayBegin(in.get() == 1);
+      case 22 -> new PtyMessage.ReplayEnd();
+      case 23 -> new PtyMessage.WriterChanged(string(in));
+      case 24 -> new PtyMessage.Resized(in.getInt(), in.getInt());
+      case 25 -> new PtyMessage.Paused();
+      case 26 -> new PtyMessage.Continued();
+      case 27 -> new PtyMessage.SessionEnded(string(in));
+      case 28 -> decodeInfo(in);
+      case 29 -> {
+        var count = in.getInt();
+        var sessions = new ArrayList<PtyMessage.SessionInfo>(count);
+        for (var i = 0; i < count; i++) {
+          sessions.add(decodeInfo(in));
+        }
+        yield new PtyMessage.Sessions(List.copyOf(sessions));
+      }
+      case 30 -> new PtyMessage.Ok();
+      case 31 -> new PtyMessage.Err(string(in));
+      default -> throw new IOException("Unknown pty frame type " + type + ".");
+    };
+  }
+
+  private static PtyMessage.SessionInfo decodeInfo(ByteBuffer in) {
+    return new PtyMessage.SessionInfo(string(in), in.get() == 1, in.getInt(), string(in));
+  }
+
+  private static String string(ByteBuffer in) {
+    var bytes = bytes(in);
+    return bytes.length == 0 ? "" : new String(bytes, StandardCharsets.UTF_8);
+  }
+
+  private static byte[] bytes(ByteBuffer in) {
+    var length = in.getInt();
+    var bytes = new byte[length];
+    in.get(bytes);
+    return bytes;
+  }
+
+  private static List<String> stringList(ByteBuffer in) {
+    var count = in.getInt();
+    var values = new ArrayList<String>(count);
+    for (var i = 0; i < count; i++) {
+      values.add(string(in));
+    }
+    return List.copyOf(values);
+  }
+
+  private static void readFully(ReadableByteChannel in, ByteBuffer buf) throws IOException {
+    while (buf.hasRemaining()) {
+      if (in.read(buf) < 0) {
+        throw new EOFException("pty channel closed mid-frame");
+      }
+    }
+  }
+
+  private static void writeFully(WritableByteChannel out, ByteBuffer buf) throws IOException {
+    while (buf.hasRemaining()) {
+      out.write(buf);
+    }
+  }
+
+  private static final class Writer {
+    private ByteBuffer buffer = ByteBuffer.allocate(512);
+
+    Writer type(int type) {
+      ensure(1);
+      buffer.put((byte) type);
+      return this;
+    }
+
+    Writer string(String value) {
+      bytes(value == null ? new byte[0] : value.getBytes(StandardCharsets.UTF_8));
+      return this;
+    }
+
+    Writer stringList(List<String> values) {
+      ensure(4);
+      buffer.putInt(values.size());
+      values.forEach(this::string);
+      return this;
+    }
+
+    void bytes(byte[] value) {
+      ensure(4 + value.length);
+      buffer.putInt(value.length).put(value);
+    }
+
+    private void ensure(int more) {
+      if (buffer.remaining() < more) {
+        var grown = ByteBuffer.allocate(Math.max(buffer.capacity() * 2, buffer.position() + more));
+        buffer.flip();
+        grown.put(buffer);
+        buffer = grown;
+      }
+    }
+
+    byte[] finish() {
+      var out = new byte[buffer.position()];
+      buffer.flip().get(out);
+      return out;
+    }
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/pty/RingJournal.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/RingJournal.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * A fixed-capacity ring of raw session bytes, journaled to one file so history survives a host
+ * restart — the durability tmux never had. The layout is a small header (magic, version, capacity,
+ * total bytes ever written, safe watermark) followed by the ring region; the write position is
+ * always {@code totalWritten % capacity}.
+ *
+ * <p>The journal stores bytes and one number; it never inspects the stream. The session host owns
+ * safety: it feeds the same bytes to a {@link TermBoundary} and calls {@link #markSafe()} at clean
+ * points, and {@link #tail(int)} starts replay at the newest safe watermark still inside the window
+ * — falling back to the raw window start, flagged unsafe, when history has overwritten it.
+ */
+public final class RingJournal implements AutoCloseable {
+
+  private static final long MAGIC = 0x5341494C52494E47L;
+  private static final int VERSION = 1;
+  private static final int HEADER_BYTES = 40;
+
+  /** One replayable tail: bytes from {@code startOffset} of the stream, safe or best-effort. */
+  public record Tail(long startOffset, boolean safe, byte[] bytes) {}
+
+  private final FileChannel channel;
+  private final long capacity;
+  private long totalWritten;
+  private long safeWatermark;
+
+  private RingJournal(FileChannel channel, long capacity, long totalWritten, long safeWatermark) {
+    this.channel = channel;
+    this.capacity = capacity;
+    this.totalWritten = totalWritten;
+    this.safeWatermark = safeWatermark;
+  }
+
+  /** Opens or creates the journal at {@code path}; an existing file must match the capacity. */
+  public static RingJournal open(Path path, long capacity) throws IOException {
+    if (capacity <= 0) {
+      throw new IllegalArgumentException("Ring capacity must be positive, got " + capacity + ".");
+    }
+    var channel =
+        FileChannel.open(
+            path, StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
+    if (channel.size() == 0) {
+      var journal = new RingJournal(channel, capacity, 0, 0);
+      journal.writeHeader();
+      return journal;
+    }
+    var header = ByteBuffer.allocate(HEADER_BYTES);
+    channel.read(header, 0);
+    header.flip();
+    if (header.remaining() < HEADER_BYTES || header.getLong() != MAGIC) {
+      channel.close();
+      throw new IOException(
+          "Not a sail ring journal: " + path + ". Remove the file to start a fresh history.");
+    }
+    var version = header.getInt();
+    if (version != VERSION) {
+      channel.close();
+      throw new IOException(
+          "Ring journal "
+              + path
+              + " is version "
+              + version
+              + "; this build reads "
+              + VERSION
+              + ".");
+    }
+    var storedCapacity = header.getLong();
+    if (storedCapacity != capacity) {
+      channel.close();
+      throw new IOException(
+          "Ring journal "
+              + path
+              + " has capacity "
+              + storedCapacity
+              + ", not "
+              + capacity
+              + ". Remove the file to resize.");
+    }
+    return new RingJournal(channel, capacity, header.getLong(), header.getLong());
+  }
+
+  /** Appends {@code buf[0..len)} to the ring and persists the header. */
+  public void append(byte[] buf, int len) throws IOException {
+    var offset = 0;
+    while (offset < len) {
+      var position = totalWritten % capacity;
+      var chunk = (int) Math.min(len - offset, capacity - position);
+      channel.write(ByteBuffer.wrap(buf, offset, chunk), HEADER_BYTES + position);
+      totalWritten += chunk;
+      offset += chunk;
+    }
+    writeHeader();
+  }
+
+  /**
+   * Records that the stream is at a safe replay boundary right now — but keeps the OLDEST safe
+   * start still worth replaying: the stored mark only advances once it has fallen below {@code
+   * keepFloor} (the replay budget's edge). Advancing eagerly would mean "nothing to replay" after
+   * every quiet moment; a late attacher wants history, starting clean.
+   */
+  public void markSafe(long keepFloor) throws IOException {
+    if (safeWatermark < keepFloor) {
+      safeWatermark = totalWritten;
+      writeHeader();
+    }
+  }
+
+  /**
+   * The newest at-most-{@code maxBytes} of history, starting at the retained safe start when it
+   * lies still inside the window; otherwise from the window start, flagged unsafe so the client
+   * clears its screen before applying.
+   */
+  public Tail tail(int maxBytes) throws IOException {
+    var available = Math.min(totalWritten, capacity);
+    var windowStart = totalWritten - available;
+    var from = Math.max(windowStart, totalWritten - maxBytes);
+    var safe = safeWatermark >= from && safeWatermark <= totalWritten;
+    if (safe) {
+      from = safeWatermark;
+    }
+    var length = (int) (totalWritten - from);
+    var bytes = new byte[length];
+    var read = 0;
+    while (read < length) {
+      var position = (from + read) % capacity;
+      var chunk = (int) Math.min(length - read, capacity - position);
+      var slice = ByteBuffer.wrap(bytes, read, chunk);
+      channel.read(slice, HEADER_BYTES + position);
+      read += chunk;
+    }
+    return new Tail(from, safe, bytes);
+  }
+
+  public long totalWritten() {
+    return totalWritten;
+  }
+
+  private void writeHeader() throws IOException {
+    var header = ByteBuffer.allocate(HEADER_BYTES);
+    header
+        .putLong(MAGIC)
+        .putInt(VERSION)
+        .putLong(capacity)
+        .putLong(totalWritten)
+        .putLong(safeWatermark);
+    header.flip();
+    channel.write(header, 0);
+  }
+
+  @Override
+  public void close() throws IOException {
+    channel.close();
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/pty/SubscriberQueue.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/SubscriberQueue.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * One subscriber's delivery queue with the flow-control contract built in: a bounded FIFO whose
+ * overflow drops the backlog and enqueues {@code Paused}; while paused, every enqueue is dropped;
+ * and the first {@link #next()} after the pause has drained returns {@code Continued} — resume is
+ * the consumer's act of catching up, not a race against the producer's next output. Deterministic
+ * by construction, so the contract is provable single-threaded.
+ */
+final class SubscriberQueue {
+
+  private final int capacity;
+  private final Deque<PtyMessage> queue = new ArrayDeque<>();
+  private boolean paused;
+  private boolean closed;
+
+  SubscriberQueue(int capacity) {
+    this.capacity = capacity;
+  }
+
+  /** Offers a live message; a full queue trips the pause, a paused queue drops silently. */
+  synchronized void enqueue(PtyMessage message) {
+    if (closed || paused) {
+      return;
+    }
+    if (queue.size() >= capacity) {
+      paused = true;
+      queue.clear();
+      queue.add(new PtyMessage.Paused());
+    } else {
+      queue.add(message);
+    }
+    notifyAll();
+  }
+
+  /** Enqueues regardless of pause — endings and poison must always arrive. */
+  synchronized void force(PtyMessage message) {
+    if (closed) {
+      return;
+    }
+    queue.add(message);
+    notifyAll();
+  }
+
+  /** Empties the queue and delivers only {@code message} next — the detach path. */
+  synchronized void clearAnd(PtyMessage message) {
+    queue.clear();
+    paused = false;
+    queue.add(message);
+    notifyAll();
+  }
+
+  /**
+   * The next message to deliver, blocking until one exists. After a drained pause this returns
+   * {@code Continued} exactly once, before any further live traffic.
+   */
+  synchronized PtyMessage next() throws InterruptedException {
+    while (queue.isEmpty()) {
+      if (paused) {
+        paused = false;
+        return new PtyMessage.Continued();
+      }
+      wait();
+    }
+    return queue.poll();
+  }
+
+  synchronized void close() {
+    closed = true;
+    queue.clear();
+    notifyAll();
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/pty/TermBoundary.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/TermBoundary.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+/**
+ * A streaming boundary tracker for a raw terminal byte stream: it knows, at any point, whether the
+ * stream is at a safe replay boundary — not inside an escape sequence (ESC/CSI/OSC/DCS/SOS/PM/APC)
+ * and not between the bytes of a UTF-8 character. It is a framer, deliberately not an emulator: it
+ * never interprets what sequences mean, only where they end.
+ *
+ * <p>Fed every byte from the session's birth, its state is exact — the session host records a safe
+ * watermark whenever a fed chunk ends in ground state at a line start, and attach-replay begins at
+ * such a watermark so a late client's parser never wakes up mid-sequence or mid-character.
+ */
+public final class TermBoundary {
+
+  private enum State {
+    GROUND,
+    ESC,
+    CSI,
+    STRING,
+    STRING_ESC
+  }
+
+  private State state = State.GROUND;
+  private int utf8Pending;
+  private boolean atLineStart = true;
+
+  /** Advances over {@code buf[0..len)}. */
+  public void feed(byte[] buf, int len) {
+    for (var i = 0; i < len; i++) {
+      var b = buf[i] & 0xFF;
+      switch (state) {
+        case GROUND -> {
+          if (utf8Pending > 0) {
+            utf8Pending = (b & 0xC0) == 0x80 ? utf8Pending - 1 : 0;
+          }
+          if (utf8Pending == 0) {
+            if (b == 0x1B) {
+              state = State.ESC;
+            } else if (b >= 0xC2 && b <= 0xDF) {
+              utf8Pending = 1;
+            } else if (b >= 0xE0 && b <= 0xEF) {
+              utf8Pending = 2;
+            } else if (b >= 0xF0 && b <= 0xF4) {
+              utf8Pending = 3;
+            }
+          }
+          atLineStart = b == '\n';
+        }
+        case ESC ->
+            state =
+                switch (b) {
+                  case '[' -> State.CSI;
+                  case ']', 'P', 'X', '^', '_' -> State.STRING;
+                  case 0x1B -> State.ESC;
+                  default -> State.GROUND;
+                };
+        case CSI -> {
+          if (b >= 0x40 && b <= 0x7E) {
+            state = State.GROUND;
+          }
+        }
+        case STRING -> {
+          if (b == 0x07) {
+            state = State.GROUND;
+          } else if (b == 0x1B) {
+            state = State.STRING_ESC;
+          }
+        }
+        case STRING_ESC -> state = b == '\\' ? State.GROUND : State.STRING;
+      }
+    }
+  }
+
+  /** Whether the stream is at a boundary a fresh parser can safely start from. */
+  public boolean atSafeBoundary() {
+    return state == State.GROUND && utf8Pending == 0;
+  }
+
+  /** A safe boundary that is also the start of a line — the preferred replay point. */
+  public boolean atSafeLineStart() {
+    return atSafeBoundary() && atLineStart;
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PtySessionTest {
+
+  @TempDir Path dir;
+
+  private static final class Collector implements PtySession.Client {
+    final ConcurrentLinkedQueue<PtyMessage> messages = new ConcurrentLinkedQueue<>();
+    final CountDownLatch ended = new CountDownLatch(1);
+    volatile long sleepMillis;
+
+    @Override
+    public void deliver(PtyMessage message) {
+      if (sleepMillis > 0) {
+        try {
+          Thread.sleep(sleepMillis);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      messages.add(message);
+      if (message instanceof PtyMessage.SessionEnded) {
+        ended.countDown();
+      }
+    }
+
+    String outputText() {
+      var out = new StringBuilder();
+      for (var message : messages) {
+        if (message instanceof PtyMessage.Output(var seq, var bytes)) {
+          out.append(new String(bytes, StandardCharsets.UTF_8));
+        }
+      }
+      return out.toString();
+    }
+
+    boolean saw(Class<? extends PtyMessage> type) {
+      return messages.stream().anyMatch(type::isInstance);
+    }
+
+    void awaitOutput(String marker) throws InterruptedException {
+      var deadline = System.nanoTime() + 10_000_000_000L;
+      while (!outputText().contains(marker)) {
+        if (System.nanoTime() > deadline) {
+          throw new AssertionError("never saw '" + marker + "'; got: " + outputText());
+        }
+        Thread.sleep(5);
+      }
+    }
+  }
+
+  private PtySession session(String script) throws IOException {
+    return PtySession.start(
+        "t",
+        List.of("sh", "-c", script),
+        Map.of("TERM", "dumb"),
+        Path.of("/tmp"),
+        dir.resolve("t.ring"),
+        64 * 1024,
+        80,
+        24);
+  }
+
+  @Test
+  void theWriterConversesAndOutputCarriesItsInputSequence() throws Exception {
+    try (var session = session("read a; echo got:$a; read b")) {
+      var writer = new Collector();
+      var id = session.attach(writer, true);
+
+      session.input(id, 7, "hello\n".getBytes(StandardCharsets.UTF_8));
+      writer.awaitOutput("got:hello");
+
+      var seqs =
+          writer.messages.stream()
+              .filter(m -> m instanceof PtyMessage.Output(var s, var b) && s == 7)
+              .count();
+      assertTrue(seqs > 0, "output frames after input 7 carry lastInputSeq 7");
+    }
+  }
+
+  @Test
+  void aLateObserverGetsTheReplayBracketThenLiveOutput() throws Exception {
+    try (var session = session("echo early-line; read b; echo late-line; read c")) {
+      var writer = new Collector();
+      var writerId = session.attach(writer, true);
+      writer.awaitOutput("early-line");
+
+      var observer = new Collector();
+      session.attach(observer, false);
+      observer.awaitOutput("early-line");
+      assertTrue(observer.saw(PtyMessage.ReplayBegin.class), "replay is bracketed");
+      assertTrue(observer.saw(PtyMessage.ReplayEnd.class));
+
+      session.input(writerId, 1, "go\n".getBytes(StandardCharsets.UTF_8));
+      observer.awaitOutput("late-line");
+    }
+  }
+
+  @Test
+  void onlyTheTokenHolderWritesAndTakeoverIsExplicitAndAnnounced() throws Exception {
+    try (var session = session("read a; echo done:$a")) {
+      var first = new Collector();
+      var second = new Collector();
+      var firstId = session.attach(first, true);
+      var secondId = session.attach(second, false);
+
+      assertThrows(
+          IOException.class,
+          () -> session.input(secondId, 1, "nope\n".getBytes(StandardCharsets.UTF_8)));
+
+      session.takeWrite(secondId, "mady");
+      var deadline = System.nanoTime() + 5_000_000_000L;
+      while (!first.saw(PtyMessage.WriterChanged.class) && System.nanoTime() < deadline) {
+        Thread.sleep(5);
+      }
+      assertTrue(first.saw(PtyMessage.WriterChanged.class), "the old writer hears the takeover");
+
+      assertThrows(
+          IOException.class,
+          () -> session.input(firstId, 2, "stale\n".getBytes(StandardCharsets.UTF_8)));
+      session.input(secondId, 3, "fresh\n".getBytes(StandardCharsets.UTF_8));
+      second.awaitOutput("done:fresh");
+    }
+  }
+
+  @Test
+  void everySubscriberHearsTheEndingAndLateAttachIsRefused() throws Exception {
+    var session = session("echo bye; exit 3");
+    try {
+      var client = new Collector();
+      session.attach(client, true);
+      assertTrue(client.ended.await(10, TimeUnit.SECONDS), "the ending reaches subscribers");
+      assertEquals("exited(3)", session.endedReason());
+
+      var late = new Collector();
+      assertThrows(IOException.class, () -> session.attach(late, false));
+    } finally {
+      session.close();
+    }
+  }
+
+  @Test
+  void aFloodNeverBlocksTheChildEvenWithAStalledObserver() throws Exception {
+    try (var session =
+        PtySession.start(
+            "slow",
+            List.of(
+                "sh",
+                "-c",
+                "read a; i=0; while [ $i -lt 400 ]; do echo line-$i; i=$((i+1)); done;"
+                    + " echo flood-done; read b"),
+            Map.of("TERM", "dumb"),
+            Path.of("/tmp"),
+            dir.resolve("slow.ring"),
+            256 * 1024,
+            80,
+            24,
+            2,
+            65536)) {
+      var writer = new Collector();
+      var writerId = session.attach(writer, true);
+      var stalled = new Collector();
+      stalled.sleepMillis = 1000;
+      session.attach(stalled, false);
+
+      session.input(writerId, 1, "go\n".getBytes(StandardCharsets.UTF_8));
+      var deadline = System.nanoTime() + 10_000_000_000L;
+      while (session.journaledBytes() < 3500) {
+        if (System.nanoTime() > deadline) {
+          throw new AssertionError(
+              "the flood stalled at " + session.journaledBytes() + " journaled bytes");
+        }
+        Thread.onSpinWait();
+      }
+
+      assertTrue(session.live(), "the child never blocked on the stalled observer");
+    }
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtyTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtyTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PtyTest {
+
+  private static String readUntil(Pty pty, String marker) throws Exception {
+    var out = new StringBuilder();
+    var buf = new byte[4096];
+    var deadline = System.nanoTime() + 10_000_000_000L;
+    while (!out.toString().contains(marker)) {
+      if (System.nanoTime() > deadline) {
+        throw new AssertionError("marker '" + marker + "' not seen; got: " + out);
+      }
+      var n = pty.read(buf);
+      if (n < 0) {
+        throw new AssertionError("pty closed before marker '" + marker + "'; got: " + out);
+      }
+      out.append(new String(buf, 0, n, StandardCharsets.UTF_8));
+    }
+    return out.toString();
+  }
+
+  @Test
+  void childGetsAControllingTtyWithTheRequestedSizeAndConverses() throws Exception {
+    try (var pty = Pty.open(80, 24)) {
+      var child =
+          pty.spawn(
+              List.of(
+                  "sh",
+                  "-c",
+                  "[ -t 0 ] && echo is-a-tty; stty size; read line; echo got:$line; exit 7"),
+              Map.of("TERM", "xterm-256color"),
+              Path.of("/tmp"));
+
+      var head = readUntil(pty, "24 80");
+      assertTrue(head.contains("is-a-tty"), "the child must see a controlling terminal: " + head);
+
+      pty.write("world\n".getBytes(StandardCharsets.UTF_8));
+      readUntil(pty, "got:world");
+
+      assertEquals(7, child.waitFor(), "the child exit code rides through");
+      var buf = new byte[256];
+      int n;
+      do {
+        n = pty.read(buf);
+      } while (n > 0);
+      assertEquals(-1, n, "a dead child reads as end of stream, never an exception");
+    }
+  }
+
+  @Test
+  void resizeReachesTheForegroundProcess() throws Exception {
+    try (var pty = Pty.open(80, 24)) {
+      pty.spawn(
+          List.of("sh", "-c", "trap 'stty size' WINCH; echo ready; while read l; do :; done"),
+          Map.of("TERM", "xterm-256color"),
+          Path.of("/tmp"));
+      readUntil(pty, "ready");
+
+      pty.resize(132, 43);
+      pty.write("poke\n".getBytes(StandardCharsets.UTF_8));
+
+      readUntil(pty, "43 132");
+    }
+  }
+
+  @Test
+  void writeAfterCloseFailsLoudly() throws Exception {
+    var pty = Pty.open(80, 24);
+    pty.close();
+
+    org.junit.jupiter.api.Assertions.assertThrows(
+        java.io.IOException.class, () -> pty.write("x".getBytes(StandardCharsets.UTF_8)));
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtyWireTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtyWireTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Pipe;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PtyWireTest {
+
+  private static PtyMessage roundTrip(PtyMessage message) throws IOException {
+    var pipe = Pipe.open();
+    PtyWire.write(pipe.sink(), message);
+    pipe.sink().close();
+    return PtyWire.read(pipe.source());
+  }
+
+  @Test
+  void everyMessageShapeSurvivesTheWire() throws Exception {
+    var create =
+        (PtyMessage.Create)
+            roundTrip(new PtyMessage.Create("lounge", List.of("bash", "-l"), "/home/dev", 132, 43));
+    assertEquals("lounge", create.session());
+    assertEquals(List.of("bash", "-l"), create.command());
+    assertEquals(132, create.cols());
+
+    var input =
+        (PtyMessage.Input)
+            roundTrip(new PtyMessage.Input(42, "ls\u00e9\n".getBytes(StandardCharsets.UTF_8)));
+    assertEquals(42, input.seq());
+    assertArrayEquals("ls\u00e9\n".getBytes(StandardCharsets.UTF_8), input.bytes());
+
+    var output =
+        (PtyMessage.Output) roundTrip(new PtyMessage.Output(42, new byte[] {0, 1, 27, (byte) 255}));
+    assertEquals(42, output.lastInputSeq(), "the prediction enabler rides every output frame");
+    assertArrayEquals(new byte[] {0, 1, 27, (byte) 255}, output.bytes());
+
+    var sessions =
+        (PtyMessage.Sessions)
+            roundTrip(
+                new PtyMessage.Sessions(
+                    List.of(
+                        new PtyMessage.SessionInfo("a", true, 2, "uday"),
+                        new PtyMessage.SessionInfo("b", false, 0, ""))));
+    assertEquals(2, sessions.sessions().size());
+    assertEquals("uday", sessions.sessions().getFirst().writerFde());
+
+    assertInstanceOf(PtyMessage.TakeWrite.class, roundTrip(new PtyMessage.TakeWrite()));
+    assertInstanceOf(PtyMessage.ReplayEnd.class, roundTrip(new PtyMessage.ReplayEnd()));
+    assertEquals(
+        "gone",
+        ((PtyMessage.SessionEnded) roundTrip(new PtyMessage.SessionEnded("gone"))).reason());
+    assertEquals("boom", ((PtyMessage.Err) roundTrip(new PtyMessage.Err("boom"))).message());
+  }
+
+  @Test
+  void handshakeAcceptsItselfAndRefusesStrangers() throws Exception {
+    var aToB = Pipe.open();
+    var bToA = Pipe.open();
+    var serverDone = new java.util.concurrent.CompletableFuture<Void>();
+    Thread.ofVirtual()
+        .start(
+            () -> {
+              try {
+                PtyWire.handshake(aToB.source(), bToA.sink());
+                serverDone.complete(null);
+              } catch (IOException e) {
+                serverDone.completeExceptionally(e);
+              }
+            });
+    PtyWire.handshake(bToA.source(), aToB.sink());
+    serverDone.join();
+
+    var evil = Pipe.open();
+    var reply = Pipe.open();
+    evil.sink().write(ByteBuffer.wrap("NOTSAIL1".getBytes(StandardCharsets.US_ASCII)));
+    assertThrows(IOException.class, () -> PtyWire.handshake(evil.source(), reply.sink()));
+  }
+
+  @Test
+  void oversizedAndUnknownFramesAreRefusedLoudly() throws Exception {
+    var pipe = Pipe.open();
+    pipe.sink().write(ByteBuffer.allocate(4).putInt(PtyWire.MAX_FRAME + 1).flip());
+    assertThrows(IOException.class, () -> PtyWire.read(pipe.source()));
+
+    var unknown = Pipe.open();
+    unknown.sink().write(ByteBuffer.allocate(5).putInt(1).put((byte) 99).flip());
+    var error = assertThrows(IOException.class, () -> PtyWire.read(unknown.source()));
+    org.junit.jupiter.api.Assertions.assertTrue(error.getMessage().contains("99"));
+  }
+
+  @Test
+  void aClosedChannelMidFrameIsEofNotGarbage() throws Exception {
+    var pipe = Pipe.open();
+    pipe.sink().write(ByteBuffer.allocate(4).putInt(100).flip());
+    pipe.sink().close();
+    assertThrows(java.io.EOFException.class, () -> PtyWire.read(pipe.source()));
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/pty/RingJournalTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/RingJournalTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RingJournalTest {
+
+  @TempDir Path dir;
+
+  private static byte[] bytes(String s) {
+    return s.getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void aRetainedSafeStartReplaysHistoryNotNothing() throws Exception {
+    try (var ring = RingJournal.open(dir.resolve("s.ring"), 1024)) {
+      ring.append(bytes("first\n"), 6);
+      ring.markSafe(0);
+      ring.append(bytes("second"), 6);
+      ring.markSafe(0);
+
+      var tail = ring.tail(1024);
+
+      assertTrue(tail.safe());
+      assertEquals(0, tail.startOffset(), "the oldest in-budget safe start wins — history replays");
+      assertArrayEquals(bytes("first\nsecond"), tail.bytes());
+    }
+  }
+
+  @Test
+  void theSafeStartAdvancesOnlyOnceItFallsOutOfTheBudget() throws Exception {
+    try (var ring = RingJournal.open(dir.resolve("s.ring"), 1024)) {
+      ring.append(bytes("old\n"), 4);
+      ring.markSafe(0);
+      ring.append(bytes("new\n"), 4);
+      ring.markSafe(ring.totalWritten() - 4);
+
+      var tail = ring.tail(4);
+
+      assertTrue(tail.safe());
+      assertEquals(8, tail.startOffset(), "the stale mark jumped to the current boundary");
+      assertArrayEquals(bytes(""), tail.bytes());
+    }
+  }
+
+  @Test
+  void historySurvivesReopen() throws Exception {
+    var path = dir.resolve("s.ring");
+    try (var ring = RingJournal.open(path, 64)) {
+      ring.append(bytes("persisted\n"), 10);
+      ring.markSafe(0);
+    }
+    try (var ring = RingJournal.open(path, 64)) {
+      assertEquals(10, ring.totalWritten());
+      ring.append(bytes("more"), 4);
+      var tail = ring.tail(64);
+      assertTrue(tail.safe());
+      assertEquals(0, tail.startOffset(), "the persisted safe start survives reopen");
+      assertArrayEquals(bytes("persisted\nmore"), tail.bytes());
+    }
+  }
+
+  @Test
+  void wrappingKeepsTheNewestBytesInOrder() throws Exception {
+    try (var ring = RingJournal.open(dir.resolve("s.ring"), 16)) {
+      ring.append(bytes("0123456789"), 10);
+      ring.append(bytes("abcdefghij"), 10);
+
+      var tail = ring.tail(16);
+
+      assertFalse(tail.safe(), "the watermark fell out of the window");
+      assertEquals(4, tail.startOffset());
+      assertArrayEquals(bytes("456789abcdefghij"), tail.bytes());
+    }
+  }
+
+  @Test
+  void aForeignFileOrMismatchedCapacityRefusesLoudly() throws Exception {
+    var path = dir.resolve("s.ring");
+    Files.writeString(path, "not a ring journal at all, definitely");
+    assertThrows(IOException.class, () -> RingJournal.open(path, 64));
+
+    var good = dir.resolve("good.ring");
+    try (var ring = RingJournal.open(good, 64)) {
+      ring.append(bytes("x"), 1);
+    }
+    assertThrows(IOException.class, () -> RingJournal.open(good, 128));
+  }
+
+  @Test
+  void tailIsBoundedByMaxBytesWhenNoWatermarkApplies() throws Exception {
+    try (var ring = RingJournal.open(dir.resolve("s.ring"), 1024)) {
+      ring.append(bytes("aaaaabbbbbccccc"), 15);
+
+      var tail = ring.tail(5);
+
+      assertFalse(tail.safe());
+      assertEquals(10, tail.startOffset());
+      assertArrayEquals(bytes("ccccc"), tail.bytes());
+    }
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/pty/SubscriberQueueTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/SubscriberQueueTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import org.junit.jupiter.api.Test;
+
+class SubscriberQueueTest {
+
+  private static PtyMessage.Output out(int n) {
+    return new PtyMessage.Output(n, new byte[] {(byte) n});
+  }
+
+  @Test
+  void deliversInOrderUntilOverflowThenPausesDropsAndResumesOnCatchUp() throws Exception {
+    var queue = new SubscriberQueue(2);
+    queue.enqueue(out(1));
+    queue.enqueue(out(2));
+    queue.enqueue(out(3));
+    queue.enqueue(out(4));
+
+    assertInstanceOf(PtyMessage.Paused.class, queue.next(), "overflow replaces the backlog");
+    assertInstanceOf(
+        PtyMessage.Continued.class, queue.next(), "catching up resumes, deterministically");
+
+    queue.enqueue(out(5));
+    assertEquals(5, ((PtyMessage.Output) queue.next()).lastInputSeq(), "live traffic flows again");
+  }
+
+  @Test
+  void everythingDuringThePauseIsDroppedNothingAfterItIs() throws Exception {
+    var queue = new SubscriberQueue(1);
+    queue.enqueue(out(1));
+    queue.enqueue(out(2));
+    queue.enqueue(out(3));
+    queue.enqueue(out(4));
+
+    assertInstanceOf(PtyMessage.Paused.class, queue.next());
+    assertInstanceOf(PtyMessage.Continued.class, queue.next());
+    queue.enqueue(out(9));
+    assertEquals(9, ((PtyMessage.Output) queue.next()).lastInputSeq());
+  }
+
+  @Test
+  void forcedMessagesArriveEvenWhilePaused() throws Exception {
+    var queue = new SubscriberQueue(1);
+    queue.enqueue(out(1));
+    queue.enqueue(out(2));
+    queue.enqueue(out(3));
+    queue.force(new PtyMessage.SessionEnded("gone"));
+
+    assertInstanceOf(PtyMessage.Paused.class, queue.next());
+    assertInstanceOf(PtyMessage.SessionEnded.class, queue.next(), "an ending outranks the pause");
+  }
+}

--- a/sail-core/src/test/java/ai/singlr/sail/pty/TermBoundaryTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/TermBoundaryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class TermBoundaryTest {
+
+  private static TermBoundary fed(byte[] bytes) {
+    var boundary = new TermBoundary();
+    boundary.feed(bytes, bytes.length);
+    return boundary;
+  }
+
+  private static TermBoundary fed(String text) {
+    return fed(text.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void plainTextEndingInNewlineIsThePreferredReplayPoint() {
+    assertTrue(fed("hello\n").atSafeLineStart());
+    assertTrue(fed("hello").atSafeBoundary());
+    assertFalse(fed("hello").atSafeLineStart());
+  }
+
+  @Test
+  void aStreamInsideAnEscapeSequenceIsNeverSafe() {
+    assertFalse(fed("x\u001b").atSafeBoundary());
+    assertFalse(fed("x\u001b[3").atSafeBoundary());
+    assertFalse(fed("x\u001b[38;5;19").atSafeBoundary());
+    assertTrue(fed("x\u001b[38;5;196m").atSafeBoundary());
+  }
+
+  @Test
+  void oscAndDcsStringsCloseOnBelOrStOnly() {
+    assertFalse(fed("\u001b]0;title").atSafeBoundary());
+    assertTrue(fed("\u001b]0;title\u0007").atSafeBoundary());
+    assertTrue(fed("\u001b]0;title\u001b\\").atSafeBoundary());
+    assertFalse(fed("\u001bPdata").atSafeBoundary());
+    assertTrue(fed("\u001bPdata\u001b\\").atSafeBoundary());
+  }
+
+  @Test
+  void aSplitUtf8CharacterIsNotABoundary() {
+    var snowman = "x\u2603".getBytes(StandardCharsets.UTF_8);
+    var partial = new TermBoundary();
+    partial.feed(snowman, snowman.length - 1);
+    assertFalse(partial.atSafeBoundary());
+    partial.feed(new byte[] {snowman[snowman.length - 1]}, 1);
+    assertTrue(partial.atSafeBoundary());
+  }
+
+  @Test
+  void feedingInArbitraryChunksMatchesFeedingWhole() {
+    var text = "a\u001b[1;31mred\u001b]0;t\u0007\u2603\nnext".getBytes(StandardCharsets.UTF_8);
+    for (var chunk = 1; chunk <= text.length; chunk++) {
+      var boundary = new TermBoundary();
+      for (var i = 0; i < text.length; i += chunk) {
+        var len = Math.min(chunk, text.length - i);
+        var slice = new byte[len];
+        System.arraycopy(text, i, slice, 0, len);
+        boundary.feed(slice, len);
+      }
+      assertTrue(boundary.atSafeBoundary(), "chunk size " + chunk);
+    }
+  }
+}

--- a/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import java.io.IOException;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * The per-container session host: owns every {@link PtySession}, serves the {@link PtyWire}
+ * protocol on a unix socket, and reaps what nobody wants — a session never attached within the
+ * grace window (the mosh rule), and an ended session once its corpse retention passes. Each
+ * connection is one attached client at most; commands answer {@code Ok}/{@code Err}; session
+ * traffic flows through the subscriber queue onto the same channel, serialized per connection.
+ *
+ * <p>Reaping is driven by {@link #sweep(long)} with an injected clock — the production timer thread
+ * merely calls it; tests call it directly with synthetic time.
+ */
+public final class PtySessionHost implements AutoCloseable {
+
+  static final Duration NEVER_ATTACHED_GRACE = Duration.ofSeconds(60);
+  static final Duration CORPSE_RETENTION = Duration.ofMinutes(10);
+
+  private final Path socketPath;
+  private final Path sessionsDir;
+  private final long journalCapacity;
+  private final Map<String, PtySession> sessions = new ConcurrentHashMap<>();
+  private volatile ServerSocketChannel server;
+  private volatile boolean closed;
+
+  public PtySessionHost(Path socketPath, Path sessionsDir, long journalCapacity) {
+    this.socketPath = socketPath;
+    this.sessionsDir = sessionsDir;
+    this.journalCapacity = journalCapacity;
+  }
+
+  public void start() throws IOException {
+    Files.createDirectories(sessionsDir);
+    Files.deleteIfExists(socketPath);
+    server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
+    server.bind(UnixDomainSocketAddress.of(socketPath));
+    Thread.ofVirtual().name("pty-host-accept").start(this::acceptLoop);
+  }
+
+  private void acceptLoop() {
+    while (!closed) {
+      try {
+        var channel = server.accept();
+        Thread.ofVirtual().name("pty-host-conn").start(() -> serve(channel));
+      } catch (IOException e) {
+        if (!closed) {
+          throw new IllegalStateException("pty host accept failed", e);
+        }
+        return;
+      }
+    }
+  }
+
+  private void serve(SocketChannel channel) {
+    PtySession attached = null;
+    var subscriberId = -1L;
+    try (channel) {
+      PtyWire.handshake(channel, channel);
+      while (true) {
+        var message = PtyWire.read(channel);
+        switch (message) {
+          case PtyMessage.Create m -> reply(channel, create(m));
+          case PtyMessage.Attach m -> {
+            if (attached != null) {
+              reply(channel, new PtyMessage.Err("This connection is already attached."));
+              break;
+            }
+            var session = sessions.get(m.session());
+            if (session == null || !session.live()) {
+              reply(
+                  channel, new PtyMessage.Err("No live session '" + m.session() + "' to attach."));
+              break;
+            }
+            reply(channel, new PtyMessage.Ok());
+            subscriberId = session.attach(msg -> reply(channel, msg), m.write());
+            attached = session;
+          }
+          case PtyMessage.Input m -> {
+            if (attached == null) {
+              reply(channel, new PtyMessage.Err("Attach before writing."));
+            } else {
+              attached.input(subscriberId, m.seq(), m.bytes());
+            }
+          }
+          case PtyMessage.Resize m -> {
+            if (attached != null) {
+              attached.resize(subscriberId, m.cols(), m.rows());
+            }
+          }
+          case PtyMessage.TakeWrite m -> {
+            if (attached == null) {
+              reply(channel, new PtyMessage.Err("Attach before taking the write token."));
+            } else {
+              attached.takeWrite(subscriberId, "");
+            }
+          }
+          case PtyMessage.Detach m -> {
+            if (attached != null) {
+              attached.detach(subscriberId);
+              attached = null;
+              subscriberId = -1;
+            }
+            reply(channel, new PtyMessage.Ok());
+          }
+          case PtyMessage.ListSessions m -> reply(channel, listSessions());
+          case PtyMessage.Kill m -> reply(channel, kill(m.session()));
+          default -> reply(channel, new PtyMessage.Err("Unexpected client frame."));
+        }
+      }
+    } catch (IOException e) {
+      if (attached != null) {
+        attached.detach(subscriberId);
+      }
+    }
+  }
+
+  private PtyMessage create(PtyMessage.Create m) {
+    var existing = sessions.get(m.session());
+    if (existing != null && existing.live()) {
+      return new PtyMessage.Err(
+          "Session '" + m.session() + "' is already running; attach or kill it.");
+    }
+    if (existing != null) {
+      remove(m.session(), existing);
+    }
+    try {
+      var ring = sessionsDir.resolve(m.session() + ".ring");
+      Files.deleteIfExists(ring);
+      var session =
+          PtySession.start(
+              m.session(),
+              m.command(),
+              Map.of("TERM", "xterm-256color"),
+              Path.of(m.cwd()),
+              ring,
+              journalCapacity,
+              m.cols(),
+              m.rows());
+      sessions.put(m.session(), session);
+      return new PtyMessage.Ok();
+    } catch (IOException e) {
+      return new PtyMessage.Err("Could not start session '" + m.session() + "': " + e.getMessage());
+    }
+  }
+
+  private PtyMessage listSessions() {
+    var infos = new ArrayList<PtyMessage.SessionInfo>();
+    sessions.values().stream()
+        .sorted(java.util.Comparator.comparing(PtySession::name))
+        .forEach(
+            session ->
+                infos.add(
+                    new PtyMessage.SessionInfo(
+                        session.name(), session.live(), session.attachedCount(), "")));
+    return new PtyMessage.Sessions(infos);
+  }
+
+  private PtyMessage kill(String name) {
+    var session = sessions.get(name);
+    if (session == null) {
+      return new PtyMessage.Err("No session '" + name + "'.");
+    }
+    remove(name, session);
+    return new PtyMessage.Ok();
+  }
+
+  private void remove(String name, PtySession session) {
+    sessions.remove(name, session);
+    session.close();
+  }
+
+  /** One reaping pass at {@code nowNanos}: the mosh grace and retention rules, nothing else. */
+  public void sweep(long nowNanos) {
+    sessions.forEach(
+        (name, session) -> {
+          if (session.live()
+              && !session.everAttached()
+              && nowNanos - session.createdAtNanos() > NEVER_ATTACHED_GRACE.toNanos()) {
+            remove(name, session);
+            return;
+          }
+          if (!session.live()
+              && session.attachedCount() == 0
+              && nowNanos - session.endedAtNanos() > CORPSE_RETENTION.toNanos()) {
+            remove(name, session);
+          }
+        });
+  }
+
+  public int sessionCount() {
+    return sessions.size();
+  }
+
+  private static void reply(SocketChannel channel, PtyMessage message) {
+    try {
+      synchronized (channel.blockingLock()) {
+        PtyWire.write(channel, message);
+      }
+    } catch (IOException e) {
+      try {
+        channel.close();
+      } catch (IOException ignored) {
+        var unused = ignored;
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    closed = true;
+    try {
+      if (server != null) {
+        server.close();
+      }
+      Files.deleteIfExists(socketPath);
+    } catch (IOException e) {
+      throw new IllegalStateException("pty host close failed", e);
+    }
+    sessions.forEach((name, session) -> session.close());
+    sessions.clear();
+  }
+}

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PtySessionHostTest {
+
+  @TempDir Path dir;
+
+  private PtySessionHost host;
+
+  private PtySessionHost startHost() throws IOException {
+    host = new PtySessionHost(dir.resolve("host.sock"), dir.resolve("sessions"), 64 * 1024);
+    host.start();
+    return host;
+  }
+
+  private SocketChannel connect() throws IOException {
+    var channel = SocketChannel.open(StandardProtocolFamily.UNIX);
+    channel.connect(UnixDomainSocketAddress.of(dir.resolve("host.sock")));
+    PtyWire.handshake(channel, channel);
+    return channel;
+  }
+
+  private static PtyMessage awaitText(SocketChannel channel, String marker) throws IOException {
+    var seen = new StringBuilder();
+    while (true) {
+      var message = PtyWire.read(channel);
+      if (message instanceof PtyMessage.Output(var seq, var bytes)) {
+        seen.append(new String(bytes, StandardCharsets.UTF_8));
+        if (seen.toString().contains(marker)) {
+          return message;
+        }
+      }
+      if (message instanceof PtyMessage.SessionEnded ended) {
+        throw new AssertionError("session ended before '" + marker + "': " + seen);
+      }
+    }
+  }
+
+  @Test
+  void createAttachConverseDetachReattachRepays() throws Exception {
+    try (var ignored = startHost()) {
+      try (var channel = connect()) {
+        PtyWire.write(
+            channel,
+            new PtyMessage.Create(
+                "s1", List.of("sh", "-c", "echo hi; read a; echo bye:$a; read b"), "/tmp", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
+
+        PtyWire.write(channel, new PtyMessage.Attach("s1", true));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
+        assertInstanceOf(PtyMessage.ReplayBegin.class, PtyWire.read(channel));
+        assertInstanceOf(PtyMessage.ReplayEnd.class, PtyWire.read(channel));
+        awaitText(channel, "hi");
+
+        PtyWire.write(channel, new PtyMessage.Input(1, "world\n".getBytes(StandardCharsets.UTF_8)));
+        awaitText(channel, "bye:world");
+      }
+
+      try (var again = connect()) {
+        PtyWire.write(again, new PtyMessage.Attach("s1", true));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(again));
+        assertInstanceOf(PtyMessage.ReplayBegin.class, PtyWire.read(again));
+        awaitText(again, "bye:world");
+      }
+    }
+  }
+
+  @Test
+  void duplicateLiveCreateRefusedAndKillMakesRoomWithFreshHistory() throws Exception {
+    try (var ignored = startHost()) {
+      try (var channel = connect()) {
+        PtyWire.write(
+            channel,
+            new PtyMessage.Create(
+                "dup", List.of("sh", "-c", "echo old-life; read a"), "/tmp", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
+        PtyWire.write(channel, new PtyMessage.Create("dup", List.of("sh"), "/tmp", 80, 24));
+        assertInstanceOf(PtyMessage.Err.class, PtyWire.read(channel));
+
+        PtyWire.write(channel, new PtyMessage.Kill("dup"));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
+        PtyWire.write(
+            channel,
+            new PtyMessage.Create(
+                "dup", List.of("sh", "-c", "echo new-life; read a"), "/tmp", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
+
+        PtyWire.write(channel, new PtyMessage.Attach("dup", false));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
+        assertInstanceOf(PtyMessage.ReplayBegin.class, PtyWire.read(channel));
+        var replayed = new StringBuilder();
+        PtyMessage message;
+        while (!((message = PtyWire.read(channel)) instanceof PtyMessage.ReplayEnd)) {
+          if (message instanceof PtyMessage.Output(var seq, var bytes)) {
+            replayed.append(new String(bytes, StandardCharsets.UTF_8));
+          }
+        }
+        assertTrue(
+            !replayed.toString().contains("old-life"),
+            "a recreated session never replays its predecessor: " + replayed);
+      }
+    }
+  }
+
+  @Test
+  void listShowsLivenessAndAttachment() throws Exception {
+    try (var ignored = startHost()) {
+      try (var channel = connect()) {
+        PtyWire.write(
+            channel, new PtyMessage.Create("a", List.of("sh", "-c", "read x"), "/tmp", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
+        PtyWire.write(channel, new PtyMessage.ListSessions());
+        var listed = (PtyMessage.Sessions) PtyWire.read(channel);
+        assertEquals(1, listed.sessions().size());
+        assertEquals("a", listed.sessions().getFirst().name());
+        assertTrue(listed.sessions().getFirst().live());
+        assertEquals(0, listed.sessions().getFirst().attached());
+      }
+    }
+  }
+
+  @Test
+  void sweepReapsTheUnwantedAndOnlyTheUnwanted() throws Exception {
+    try (var ignored = startHost()) {
+      try (var channel = connect()) {
+        PtyWire.write(
+            channel,
+            new PtyMessage.Create("lonely", List.of("sh", "-c", "read x"), "/tmp", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
+        PtyWire.write(
+            channel,
+            new PtyMessage.Create("corpse", List.of("sh", "-c", "exit 0"), "/tmp", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
+
+        var deadline = System.nanoTime() + 10_000_000_000L;
+        PtyWire.write(channel, new PtyMessage.ListSessions());
+        var listed = (PtyMessage.Sessions) PtyWire.read(channel);
+        while (listed.sessions().stream().anyMatch(s -> s.name().equals("corpse") && s.live())) {
+          if (System.nanoTime() > deadline) {
+            throw new AssertionError("corpse never exited");
+          }
+          PtyWire.write(channel, new PtyMessage.ListSessions());
+          listed = (PtyMessage.Sessions) PtyWire.read(channel);
+        }
+
+        host.sweep(System.nanoTime());
+        assertEquals(2, host.sessionCount(), "young sessions survive a sweep");
+
+        var later = System.nanoTime() + PtySessionHost.CORPSE_RETENTION.toNanos() * 2;
+        host.sweep(later);
+        assertEquals(0, host.sessionCount(), "grace elapsed: both reaped");
+      }
+    }
+  }
+}

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
@@ -67,7 +67,6 @@ class PtySessionHostTest {
         PtyWire.write(channel, new PtyMessage.Attach("s1", true));
         assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
         assertInstanceOf(PtyMessage.ReplayBegin.class, PtyWire.read(channel));
-        assertInstanceOf(PtyMessage.ReplayEnd.class, PtyWire.read(channel));
         awaitText(channel, "hi");
 
         PtyWire.write(channel, new PtyMessage.Input(1, "world\n".getBytes(StandardCharsets.UTF_8)));

--- a/sail-infra/src/main/java/ai/singlr/sail/Sail.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/Sail.java
@@ -18,7 +18,9 @@ import ai.singlr.sail.commands.JoinCommand;
 import ai.singlr.sail.commands.LoginCommand;
 import ai.singlr.sail.commands.MigrateCommand;
 import ai.singlr.sail.commands.ProjectCommand;
+import ai.singlr.sail.commands.PtyHostCommand;
 import ai.singlr.sail.commands.ServerCommand;
+import ai.singlr.sail.commands.SessionCommand;
 import ai.singlr.sail.commands.SpecCommand;
 import ai.singlr.sail.commands.SyncCommand;
 import ai.singlr.sail.commands.SyncServerCommand;
@@ -48,6 +50,8 @@ import picocli.CommandLine.Help.Ansi;
       MigrateCommand.class,
       UpgradeCommand.class,
       GatewayCommand.class,
+      SessionCommand.class,
+      PtyHostCommand.class,
       SyncCommand.class,
       SyncServerCommand.class,
       ConflictsCommand.class,

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AttachLoop.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AttachLoop.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.pty.PtyMessage;
+import ai.singlr.sail.pty.PtyWire;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.channels.ByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * The interactive half of {@code sail session attach}, free of terminal-mode side effects so it is
+ * testable with plain streams: pumps stdin to {@code Input} frames (detaching on Ctrl-]), renders
+ * {@code Output} bytes to stdout, narrates flow control inline. Returns the ending reason, or null
+ * when the operator detached and the session lives on.
+ */
+public final class AttachLoop {
+
+  public static final int DETACH_KEY = 0x1D;
+
+  private AttachLoop() {}
+
+  public static String run(ByteChannel channel, InputStream stdin, OutputStream stdout)
+      throws IOException {
+    var seq = new AtomicLong();
+    var pump =
+        Thread.ofVirtual()
+            .start(
+                () -> {
+                  var buf = new byte[4096];
+                  try {
+                    while (true) {
+                      var n = stdin.read(buf);
+                      if (n < 0) {
+                        return;
+                      }
+                      for (var i = 0; i < n; i++) {
+                        if ((buf[i] & 0xFF) == DETACH_KEY) {
+                          PtyWire.write(channel, new PtyMessage.Detach());
+                          return;
+                        }
+                      }
+                      var chunk = new byte[n];
+                      System.arraycopy(buf, 0, chunk, 0, n);
+                      PtyWire.write(channel, new PtyMessage.Input(seq.incrementAndGet(), chunk));
+                    }
+                  } catch (IOException ignored) {
+                    var unused = ignored;
+                  }
+                });
+    try {
+      while (true) {
+        var message = PtyWire.read(channel);
+        switch (message) {
+          case PtyMessage.Output(var inputSeq, var bytes) -> {
+            stdout.write(bytes);
+            stdout.flush();
+          }
+          case PtyMessage.SessionEnded(var reason) -> {
+            return reason;
+          }
+          case PtyMessage.Ok ok -> {
+            return null;
+          }
+          case PtyMessage.Paused paused ->
+              stdout.write(
+                  "\r\n[sail: output paused — falling behind]\r\n"
+                      .getBytes(StandardCharsets.UTF_8));
+          case PtyMessage.Continued resumed ->
+              stdout.write("\r\n[sail: output resumed]\r\n".getBytes(StandardCharsets.UTF_8));
+          default -> {}
+        }
+      }
+    } catch (java.io.EOFException ended) {
+      return "connection closed";
+    } finally {
+      pump.interrupt();
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostServiceInstallCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostServiceInstallCommand.java
@@ -53,6 +53,13 @@ public final class HostServiceInstallCommand implements Runnable {
     var installer = HostServiceInstallers.create(shell, host, port, username);
 
     installer.install();
+    var ptyHost =
+        new ai.singlr.sail.engine.PtyHostUnit(
+            shell,
+            installer.mode(),
+            java.nio.file.Path.of(System.getProperty("user.home")),
+            ai.singlr.sail.engine.SailPaths.binaryPath());
+    ptyHost.install();
 
     var modeLabel =
         installer.mode() == SystemdServiceInstaller.Mode.SYSTEM ? "system-level" : "user-level";

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/HostServiceUninstallCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/HostServiceUninstallCommand.java
@@ -35,6 +35,12 @@ public final class HostServiceUninstallCommand implements Runnable {
             shell, "127.0.0.1", 7070, HostServiceInstallers.currentUsername());
 
     installer.uninstall();
+    new ai.singlr.sail.engine.PtyHostUnit(
+            shell,
+            installer.mode(),
+            java.nio.file.Path.of(System.getProperty("user.home")),
+            ai.singlr.sail.engine.SailPaths.binaryPath())
+        .uninstall();
 
     System.out.println(
         Ansi.AUTO.string("  @|bold,green ✓|@ Uninstalled " + installer.serviceFilePath()));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostCommand.java
@@ -24,9 +24,7 @@ public final class PtyHostCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    var host =
-        new PtySessionHost(SailPaths.ptySocketPath(), SailPaths.sessionsDir(), JOURNAL_CAPACITY);
-    host.start();
+    var host = startHost(SailPaths.ptySocketPath(), SailPaths.sessionsDir());
     var done = new CountDownLatch(1);
     Runtime.getRuntime()
         .addShutdownHook(
@@ -35,6 +33,15 @@ public final class PtyHostCommand implements Callable<Integer> {
                   host.close();
                   done.countDown();
                 }));
+    done.await();
+    return 0;
+  }
+
+  /** Starts the host and its sweep timer — the process shell around it is {@link #call()}. */
+  static PtySessionHost startHost(java.nio.file.Path socket, java.nio.file.Path sessions)
+      throws java.io.IOException {
+    var host = new PtySessionHost(socket, sessions, JOURNAL_CAPACITY);
+    host.start();
     Thread.ofVirtual()
         .start(
             () -> {
@@ -47,7 +54,6 @@ public final class PtyHostCommand implements Callable<Integer> {
                 Thread.currentThread().interrupt();
               }
             });
-    done.await();
-    return 0;
+    return host;
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostCommand.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.pty.PtySessionHost;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import picocli.CommandLine.Command;
+
+/**
+ * The per-container session host process: binds the pty socket, sweeps on a timer, and runs until
+ * terminated. Installed as a systemd user service; everything interesting lives in {@link
+ * PtySessionHost} — this command is only its process shell.
+ */
+@Command(name = "_pty-host", description = "Internal pty session host.", hidden = true)
+public final class PtyHostCommand implements Callable<Integer> {
+
+  static final long JOURNAL_CAPACITY = 4L * 1024 * 1024;
+  static final long SWEEP_INTERVAL_MILLIS = 30_000;
+
+  @Override
+  public Integer call() throws Exception {
+    var host =
+        new PtySessionHost(SailPaths.ptySocketPath(), SailPaths.sessionsDir(), JOURNAL_CAPACITY);
+    host.start();
+    var done = new CountDownLatch(1);
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  host.close();
+                  done.countDown();
+                }));
+    Thread.ofVirtual()
+        .start(
+            () -> {
+              try {
+                while (true) {
+                  Thread.sleep(SWEEP_INTERVAL_MILLIS);
+                  host.sweep(System.nanoTime());
+                }
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            });
+    done.await();
+    return 0;
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SessionClient.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SessionClient.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.pty.PtyMessage;
+import ai.singlr.sail.pty.PtyWire;
+import java.io.IOException;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Path;
+import java.util.List;
+
+/** A thin, testable client of the pty session host's socket — one call per command verb. */
+public final class SessionClient implements AutoCloseable {
+
+  private final SocketChannel channel;
+
+  private SessionClient(SocketChannel channel) {
+    this.channel = channel;
+  }
+
+  public static SessionClient connect(Path socket) throws IOException {
+    var channel = SocketChannel.open(StandardProtocolFamily.UNIX);
+    try {
+      channel.connect(UnixDomainSocketAddress.of(socket));
+      PtyWire.handshake(channel, channel);
+    } catch (IOException e) {
+      channel.close();
+      throw new IOException(
+          "No session host at " + socket + ". Is the sail-pty-host service running?", e);
+    }
+    return new SessionClient(channel);
+  }
+
+  public void create(String name, List<String> command, String cwd, int cols, int rows)
+      throws IOException {
+    PtyWire.write(channel, new PtyMessage.Create(name, command, cwd, cols, rows));
+    expectOk("create");
+  }
+
+  public List<PtyMessage.SessionInfo> list() throws IOException {
+    PtyWire.write(channel, new PtyMessage.ListSessions());
+    if (PtyWire.read(channel) instanceof PtyMessage.Sessions(var sessions)) {
+      return sessions;
+    }
+    throw new IOException("The host did not answer the session listing.");
+  }
+
+  public void kill(String name) throws IOException {
+    PtyWire.write(channel, new PtyMessage.Kill(name));
+    expectOk("kill");
+  }
+
+  /** Sends the attach request and confirms it; frame traffic then belongs to the caller. */
+  public SocketChannel attach(String name, boolean write) throws IOException {
+    PtyWire.write(channel, new PtyMessage.Attach(name, write));
+    expectOk("attach");
+    return channel;
+  }
+
+  private void expectOk(String verb) throws IOException {
+    var reply = PtyWire.read(channel);
+    if (reply instanceof PtyMessage.Err(var message)) {
+      throw new IOException(message);
+    }
+    if (!(reply instanceof PtyMessage.Ok)) {
+      throw new IOException("Unexpected host reply to " + verb + ": " + reply.getClass());
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    channel.close();
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SessionCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SessionCommand.java
@@ -29,6 +29,10 @@ import picocli.CommandLine.Parameters;
     })
 public final class SessionCommand {
 
+  static java.nio.file.Path socketOrDefault(java.nio.file.Path socket) {
+    return socket != null ? socket : SailPaths.ptySocketPath();
+  }
+
   /** The child to spawn: a shell inside the project container, or the raw command as given. */
   static List<String> commandFor(String project, List<String> command) {
     var chosen = command.isEmpty() ? List.of("bash", "-l") : command;
@@ -41,6 +45,9 @@ public final class SessionCommand {
       name = "new",
       description = "Create a session (default: a shell in --project's container).")
   static final class New implements Callable<Integer> {
+    @Option(names = "--socket", hidden = true, description = "Host socket override.")
+    private java.nio.file.Path socket;
+
     @Parameters(index = "0", description = "Session name.")
     private String name;
 
@@ -53,7 +60,7 @@ public final class SessionCommand {
     @Override
     public Integer call() throws Exception {
       var size = Stty.size(new int[] {24, 80});
-      try (var client = SessionClient.connect(SailPaths.ptySocketPath())) {
+      try (var client = SessionClient.connect(socketOrDefault(socket))) {
         client.create(
             name,
             commandFor(project, command),
@@ -69,9 +76,12 @@ public final class SessionCommand {
 
   @Command(name = "ls", description = "List sessions.")
   static final class Ls implements Callable<Integer> {
+    @Option(names = "--socket", hidden = true, description = "Host socket override.")
+    private java.nio.file.Path socket;
+
     @Override
     public Integer call() throws Exception {
-      try (var client = SessionClient.connect(SailPaths.ptySocketPath())) {
+      try (var client = SessionClient.connect(socketOrDefault(socket))) {
         var sessions = client.list();
         if (sessions.isEmpty()) {
           System.out.println("No sessions. Start one with: sail session new <name>");
@@ -89,6 +99,9 @@ public final class SessionCommand {
 
   @Command(name = "attach", description = "Attach to a session (Ctrl-] detaches).")
   static final class Attach implements Callable<Integer> {
+    @Option(names = "--socket", hidden = true, description = "Host socket override.")
+    private java.nio.file.Path socket;
+
     @Parameters(index = "0", description = "Session name.")
     private String name;
 
@@ -97,13 +110,13 @@ public final class SessionCommand {
 
     @Override
     public Integer call() throws Exception {
-      var saved = Stty.saved().orElse(null);
-      if (saved == null) {
-        System.err.println("session attach needs an interactive terminal.");
-        return 1;
-      }
-      try (var client = SessionClient.connect(SailPaths.ptySocketPath())) {
+      try (var client = SessionClient.connect(socketOrDefault(socket))) {
         var channel = client.attach(name, !observe);
+        var saved = Stty.saved().orElse(null);
+        if (saved == null) {
+          System.err.println("session attach needs an interactive terminal.");
+          return 1;
+        }
         Stty.set("raw -echo");
         String reason;
         try {
@@ -121,12 +134,15 @@ public final class SessionCommand {
 
   @Command(name = "kill", description = "End a session and its process.")
   static final class KillSession implements Callable<Integer> {
+    @Option(names = "--socket", hidden = true, description = "Host socket override.")
+    private java.nio.file.Path socket;
+
     @Parameters(index = "0", description = "Session name.")
     private String name;
 
     @Override
     public Integer call() throws Exception {
-      try (var client = SessionClient.connect(SailPaths.ptySocketPath())) {
+      try (var client = SessionClient.connect(socketOrDefault(socket))) {
         client.kill(name);
       }
       System.out.println("Session '" + name + "' ended.");

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SessionCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SessionCommand.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.engine.Stty;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/**
+ * Host-owned terminal sessions: create, list, attach, kill. Sessions live in the container's pty
+ * session host and survive every client — quit, reconnect, reattach. Attach enters raw mode and
+ * detaches on {@code Ctrl-]}, leaving the session running.
+ */
+@Command(
+    name = "session",
+    description = "Host-owned terminal sessions that survive their clients.",
+    subcommands = {
+      SessionCommand.New.class,
+      SessionCommand.Ls.class,
+      SessionCommand.Attach.class,
+      SessionCommand.KillSession.class
+    })
+public final class SessionCommand {
+
+  /** The child to spawn: a shell inside the project container, or the raw command as given. */
+  static List<String> commandFor(String project, List<String> command) {
+    var chosen = command.isEmpty() ? List.of("bash", "-l") : command;
+    return project != null
+        ? ai.singlr.sail.engine.ContainerExec.asDevUser(project, chosen)
+        : chosen;
+  }
+
+  @Command(
+      name = "new",
+      description = "Create a session (default: a shell in --project's container).")
+  static final class New implements Callable<Integer> {
+    @Parameters(index = "0", description = "Session name.")
+    private String name;
+
+    @Parameters(index = "1..*", description = "Command to run (default: bash -l).")
+    private List<String> command = List.of();
+
+    @Option(names = "--project", description = "Run the session inside this project's container.")
+    private String project;
+
+    @Override
+    public Integer call() throws Exception {
+      var size = Stty.size(new int[] {24, 80});
+      try (var client = SessionClient.connect(SailPaths.ptySocketPath())) {
+        client.create(
+            name,
+            commandFor(project, command),
+            System.getProperty("user.home", "/home/dev"),
+            size[1],
+            size[0]);
+      }
+      System.out.println(
+          "Session '" + name + "' started. Attach with: sail session attach " + name);
+      return 0;
+    }
+  }
+
+  @Command(name = "ls", description = "List sessions.")
+  static final class Ls implements Callable<Integer> {
+    @Override
+    public Integer call() throws Exception {
+      try (var client = SessionClient.connect(SailPaths.ptySocketPath())) {
+        var sessions = client.list();
+        if (sessions.isEmpty()) {
+          System.out.println("No sessions. Start one with: sail session new <name>");
+          return 0;
+        }
+        for (var session : sessions) {
+          System.out.printf(
+              "%-24s %-8s %d attached%n",
+              session.name(), session.live() ? "live" : "ended", session.attached());
+        }
+      }
+      return 0;
+    }
+  }
+
+  @Command(name = "attach", description = "Attach to a session (Ctrl-] detaches).")
+  static final class Attach implements Callable<Integer> {
+    @Parameters(index = "0", description = "Session name.")
+    private String name;
+
+    @Option(names = "--observe", description = "Read-only: watch without the write token.")
+    private boolean observe;
+
+    @Override
+    public Integer call() throws Exception {
+      var saved = Stty.saved().orElse(null);
+      if (saved == null) {
+        System.err.println("session attach needs an interactive terminal.");
+        return 1;
+      }
+      try (var client = SessionClient.connect(SailPaths.ptySocketPath())) {
+        var channel = client.attach(name, !observe);
+        Stty.set("raw -echo");
+        String reason;
+        try {
+          reason = AttachLoop.run(channel, System.in, System.out);
+        } finally {
+          Stty.set(saved);
+        }
+        System.out.println();
+        System.out.println(
+            reason == null ? "Detached; the session lives on." : "Session ended: " + reason);
+      }
+      return 0;
+    }
+  }
+
+  @Command(name = "kill", description = "End a session and its process.")
+  static final class KillSession implements Callable<Integer> {
+    @Parameters(index = "0", description = "Session name.")
+    private String name;
+
+    @Override
+    public Integer call() throws Exception {
+      try (var client = SessionClient.connect(SailPaths.ptySocketPath())) {
+        client.kill(name);
+      }
+      System.out.println("Session '" + name + "' ended.");
+      return 0;
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/PtyHostUnit.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/PtyHostUnit.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Installs {@code sail-pty-host.service}, the host-side pty session host daemon. Same two-mode
+ * discipline as the API unit — user-level unit plus discovery symlink, or system-level under {@code
+ * /etc/systemd/system} — with none of the API's bind surface: the host listens only on its unix
+ * socket. Deliberately its own small installer; unifying the two service installers is a follow-up
+ * refactor, not this brick's job.
+ */
+public final class PtyHostUnit {
+
+  public static final String UNIT_NAME = "sail-pty-host.service";
+
+  private final ShellExec shell;
+  private final SystemdServiceInstaller.Mode mode;
+  private final Path serviceFilePath;
+  private final Path systemdLinkPath;
+  private final Path sailBinary;
+
+  public PtyHostUnit(
+      ShellExec shell, SystemdServiceInstaller.Mode mode, Path userHome, Path sailBinary) {
+    this.shell = Objects.requireNonNull(shell, "shell");
+    this.mode = Objects.requireNonNull(mode, "mode");
+    var home = Objects.requireNonNull(userHome, "userHome");
+    if (mode == SystemdServiceInstaller.Mode.SYSTEM) {
+      this.serviceFilePath = Path.of("/etc/systemd/system").resolve(UNIT_NAME);
+      this.systemdLinkPath = null;
+    } else {
+      this.serviceFilePath = home.resolve(".sail/services").resolve(UNIT_NAME);
+      this.systemdLinkPath = home.resolve(".config/systemd/user").resolve(UNIT_NAME);
+    }
+    this.sailBinary = Objects.requireNonNull(sailBinary, "sailBinary");
+  }
+
+  public Path serviceFilePath() {
+    return serviceFilePath;
+  }
+
+  /** The unit file contents — pure function, public for tests and status display. */
+  public String renderUnit() {
+    var userClause = mode == SystemdServiceInstaller.Mode.SYSTEM ? "User=root" + "\n" : "";
+    var wantedBy =
+        mode == SystemdServiceInstaller.Mode.SYSTEM ? "multi-user.target" : "default.target";
+    return """
+        [Unit]
+        Description=Sail pty session host
+        Documentation=https://github.com/standardapplied/sail
+
+        [Service]
+        Type=simple
+        %sExecStart=%s _pty-host
+        Restart=on-failure
+        RestartSec=2
+        LimitNOFILE=4096
+
+        [Install]
+        WantedBy=%s
+        """
+        .formatted(userClause, sailBinary, wantedBy);
+  }
+
+  /** Writes the unit (and USER-mode symlink), reloads systemd, enables and starts the service. */
+  public void install() throws IOException, InterruptedException, TimeoutException {
+    Files.createDirectories(serviceFilePath.getParent());
+    Files.writeString(serviceFilePath, renderUnit());
+    if (systemdLinkPath != null) {
+      Files.createDirectories(systemdLinkPath.getParent());
+      Files.deleteIfExists(systemdLinkPath);
+      Files.createSymbolicLink(systemdLinkPath, serviceFilePath);
+    }
+    requireSuccess(shell.exec(systemctl("daemon-reload")), "Failed to reload systemd units");
+    requireSuccess(
+        shell.exec(systemctl("enable", "--now", UNIT_NAME)), "Failed to enable+start " + UNIT_NAME);
+  }
+
+  /** Stops, disables, and removes the unit; missing pieces are not an error. */
+  public void uninstall() throws IOException, InterruptedException, TimeoutException {
+    shell.exec(systemctl("disable", "--now", UNIT_NAME));
+    if (systemdLinkPath != null) {
+      Files.deleteIfExists(systemdLinkPath);
+    }
+    Files.deleteIfExists(serviceFilePath);
+    requireSuccess(shell.exec(systemctl("daemon-reload")), "Failed to reload systemd units");
+  }
+
+  private List<String> systemctl(String... args) {
+    var command = new ArrayList<String>();
+    command.add("systemctl");
+    if (mode == SystemdServiceInstaller.Mode.USER) {
+      command.add("--user");
+    }
+    command.addAll(List.of(args));
+    return command;
+  }
+
+  private static void requireSuccess(ShellExec.Result result, String message) throws IOException {
+    if (!result.ok()) {
+      throw new IOException(message + ": " + result.stderr());
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/Stty.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/Stty.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+/**
+ * The one seam to the controlling terminal's mode: save ({@code stty -g}), set, and size, always
+ * against {@code /dev/tty} so redirected stdio never confuses it. Callers gate on {@link #saved()}
+ * being present before entering raw mode and restore in a finally — the picker and the session
+ * attach loop share exactly this discipline.
+ */
+public final class Stty {
+
+  private Stty() {}
+
+  /** The current mode as a restorable token, or empty when there is no usable terminal. */
+  public static Optional<String> saved() {
+    var state = run("-g");
+    return state.isBlank() ? Optional.empty() : Optional.of(state.strip());
+  }
+
+  /** Applies {@code args} (a saved token, or e.g. {@code "raw -echo"}). */
+  public static void set(String args) {
+    run(args);
+  }
+
+  /** The terminal geometry as {@code {rows, cols}}, or {@code fallback} when unknowable. */
+  public static int[] size(int[] fallback) {
+    var size = run("size").strip().split("\\s+");
+    if (size.length == 2) {
+      try {
+        return new int[] {Integer.parseInt(size[0]), Integer.parseInt(size[1])};
+      } catch (NumberFormatException ignored) {
+        return fallback;
+      }
+    }
+    return fallback;
+  }
+
+  private static String run(String args) {
+    try {
+      var process =
+          new ProcessBuilder("sh", "-c", "stty " + args + " </dev/tty")
+              .redirectErrorStream(false)
+              .start();
+      var output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+      process.waitFor();
+      return output;
+    } catch (IOException e) {
+      return "";
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return "";
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/TerminalFilePicker.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/TerminalFilePicker.java
@@ -8,7 +8,6 @@ package ai.singlr.sail.engine;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.LinkedHashSet;
 import java.util.Optional;
@@ -164,24 +163,15 @@ public final class TerminalFilePicker {
   }
 
   private static Optional<String> sttyState() {
-    var result = stty("-g");
-    return result.isBlank() ? Optional.empty() : Optional.of(result.strip());
+    return Stty.saved();
   }
 
   private static String stty(String args) {
-    try {
-      var process =
-          new ProcessBuilder("sh", "-c", "stty " + args + " </dev/tty")
-              .redirectErrorStream(false)
-              .start();
-      var output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-      process.waitFor();
-      return output;
-    } catch (IOException e) {
-      return "";
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      return "";
+    if (args.equals("size")) {
+      var size = Stty.size(new int[] {FALLBACK_ROWS, FALLBACK_COLS});
+      return size[0] + " " + size[1];
     }
+    Stty.set(args);
+    return "";
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.pty.PtySessionHost;
+import java.io.ByteArrayOutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AttachLoopTest {
+
+  @TempDir Path dir;
+
+  @Test
+  void conversesRendersOutputAndReportsTheEnding() throws Exception {
+    try (var host = new PtySessionHost(dir.resolve("h.sock"), dir.resolve("s"), 64 * 1024)) {
+      host.start();
+      try (var client = SessionClient.connect(dir.resolve("h.sock"))) {
+        client.create(
+            "s1", List.of("sh", "-c", "read a; echo pty-says:$a; exit 0"), "/tmp", 80, 24);
+        var channel = client.attach("s1", true);
+
+        var stdinFeed = new PipedOutputStream();
+        var stdin = new PipedInputStream(stdinFeed);
+        var stdout = new ByteArrayOutputStream();
+        stdinFeed.write("hello\n".getBytes(StandardCharsets.UTF_8));
+        stdinFeed.flush();
+
+        var reason = AttachLoop.run(channel, stdin, stdout);
+
+        assertEquals("exited(0)", reason);
+        assertTrue(stdout.toString(StandardCharsets.UTF_8).contains("pty-says:hello"));
+      }
+    }
+  }
+
+  @Test
+  void theDetachKeyLeavesTheSessionAliveForTheNextClient() throws Exception {
+    try (var host = new PtySessionHost(dir.resolve("h.sock"), dir.resolve("s"), 64 * 1024)) {
+      host.start();
+      try (var client = SessionClient.connect(dir.resolve("h.sock"))) {
+        client.create("s1", List.of("sh", "-c", "read a; echo after:$a"), "/tmp", 80, 24);
+        var channel = client.attach("s1", true);
+
+        var stdinFeed = new PipedOutputStream();
+        var stdin = new PipedInputStream(stdinFeed);
+        stdinFeed.write(new byte[] {AttachLoop.DETACH_KEY});
+        stdinFeed.flush();
+
+        var reason = AttachLoop.run(channel, stdin, new ByteArrayOutputStream());
+        assertNull(reason, "a detach is not an ending");
+      }
+      try (var again = SessionClient.connect(dir.resolve("h.sock"))) {
+        assertTrue(again.list().getFirst().live(), "the session outlived its client");
+      }
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/CommandTaxonomyTest.java
@@ -36,6 +36,7 @@ class CommandTaxonomyTest {
             "login",
             "enroll",
             "spec",
+            "session",
             "agent",
             "events",
             "migrate",

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SessionClientTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SessionClientTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.pty.PtySessionHost;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SessionClientTest {
+
+  @TempDir Path dir;
+
+  @Test
+  void verbsRoundTripAndErrorsSurfaceAsExceptions() throws Exception {
+    try (var host = new PtySessionHost(dir.resolve("h.sock"), dir.resolve("s"), 64 * 1024)) {
+      host.start();
+      try (var client = SessionClient.connect(dir.resolve("h.sock"))) {
+        client.create("s1", List.of("sh", "-c", "read a"), "/tmp", 80, 24);
+        var listed = client.list();
+        assertEquals(1, listed.size());
+        assertEquals("s1", listed.getFirst().name());
+        assertTrue(listed.getFirst().live());
+
+        var dup =
+            assertThrows(
+                IOException.class, () -> client.create("s1", List.of("sh"), "/tmp", 80, 24));
+        assertTrue(dup.getMessage().contains("already running"));
+
+        client.kill("s1");
+        assertEquals(0, client.list().size());
+      }
+    }
+  }
+
+  @Test
+  void aMissingHostExplainsItselfInsteadOfStackTracing() {
+    var error =
+        assertThrows(IOException.class, () -> SessionClient.connect(dir.resolve("absent.sock")));
+    assertTrue(error.getMessage().contains("session host"), error.getMessage());
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SessionCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SessionCommandTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SessionCommandTest {
+
+  @Test
+  void aProjectSessionWrapsItsCommandInTheDevUserExecLane() {
+    var command = SessionCommand.commandFor("acme", List.of());
+
+    assertEquals("incus", command.getFirst());
+    assertTrue(command.contains("acme"));
+    assertTrue(command.containsAll(List.of("bash", "-l")), "the default is a login shell");
+
+    var custom = SessionCommand.commandFor("acme", List.of("htop"));
+    assertTrue(custom.contains("htop"));
+  }
+
+  @Test
+  void aProjectlessSessionRunsTheCommandAsGiven() {
+    assertEquals(List.of("bash", "-l"), SessionCommand.commandFor(null, List.of()));
+    assertEquals(List.of("htop"), SessionCommand.commandFor(null, List.of("htop")));
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SessionVerbsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SessionVerbsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+class SessionVerbsTest {
+
+  @TempDir Path dir;
+
+  private int run(String... args) {
+    return new CommandLine(new SessionCommand()).execute(args);
+  }
+
+  @Test
+  void newLsKillRoundTripThroughTheRealHost() throws Exception {
+    try (var host = PtyHostCommand.startHost(dir.resolve("h.sock"), dir.resolve("s"))) {
+      var socket = dir.resolve("h.sock").toString();
+
+      assertEquals(0, run("new", "--socket", socket, "t1", "--", "sh", "-c", "read a"));
+      assertEquals(1, host.sessionCount());
+
+      assertEquals(0, run("ls", "--socket", socket));
+
+      assertEquals(0, run("kill", "t1", "--socket", socket));
+      assertEquals(0, host.sessionCount());
+
+      assertEquals(0, run("ls", "--socket", socket), "an empty listing is not an error");
+    }
+  }
+
+  @Test
+  void attachToAMissingSessionFailsBeforeTouchingTheTerminal() throws Exception {
+    try (var host = PtyHostCommand.startHost(dir.resolve("h.sock"), dir.resolve("s"))) {
+      var exit = run("attach", "ghost", "--socket", dir.resolve("h.sock").toString());
+      assertNotEquals(0, exit, "a missing session is a loud failure, not a hung raw terminal");
+      assertTrue(host.sessionCount() == 0);
+    }
+  }
+
+  @Test
+  void verbsExplainAMissingHostInsteadOfStackTracing() {
+    var exit = run("ls", "--socket", dir.resolve("absent.sock").toString());
+    assertNotEquals(0, exit);
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/PtyHostUnitTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/PtyHostUnitTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PtyHostUnitTest {
+
+  private static final Path BINARY = Path.of("/usr/local/bin/sail");
+
+  @Test
+  void rendersAUnitThatRunsThePtyHostWithNoBindSurface(@TempDir Path home) {
+    var user =
+        new PtyHostUnit(
+            new ScriptedShellExecutor(), SystemdServiceInstaller.Mode.USER, home, BINARY);
+    var unit = user.renderUnit();
+
+    assertTrue(unit.contains("ExecStart=/usr/local/bin/sail _pty-host"));
+    assertTrue(unit.contains("WantedBy=default.target"));
+    assertFalse(unit.contains("User="), "user mode carries no User= clause");
+    assertFalse(unit.contains("--host"), "the pty host has no bind surface");
+
+    var system =
+        new PtyHostUnit(
+            new ScriptedShellExecutor(), SystemdServiceInstaller.Mode.SYSTEM, home, BINARY);
+    assertTrue(system.renderUnit().contains("User=root"));
+    assertTrue(system.renderUnit().contains("WantedBy=multi-user.target"));
+  }
+
+  @Test
+  void installWritesUnitSymlinkAndEnablesUnderUserSystemd(@TempDir Path home) throws Exception {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
+    var unit = new PtyHostUnit(shell, SystemdServiceInstaller.Mode.USER, home, BINARY);
+
+    unit.install();
+
+    assertTrue(Files.exists(home.resolve(".sail/services/sail-pty-host.service")));
+    assertTrue(Files.isSymbolicLink(home.resolve(".config/systemd/user/sail-pty-host.service")));
+    assertTrue(
+        shell.invocations().stream()
+            .anyMatch(c -> c.contains("systemctl --user enable --now sail-pty-host.service")));
+
+    unit.uninstall();
+    assertFalse(Files.exists(home.resolve(".sail/services/sail-pty-host.service")));
+    assertFalse(Files.exists(home.resolve(".config/systemd/user/sail-pty-host.service")));
+  }
+}


### PR DESCRIPTION
`sail-pty-session-host` Brick 0: the host owns the terminals; clients come and go. The research-backed core (tmux/mosh/ghostty reports in the spec room), built bottom-up in six TDD slices.

## Architecture note (one deliberate refinement of the spec)

The spec said "per-container host"; containers carry no sail binary — only script helpers — so the host runs **host-side**, one process for the box, and a session's child is an `incus exec` into the project container via the existing `ContainerExec.asDevUser` lane (`sail session new <name> --project <p>`). Same sessions, same doors, no in-container payloads, and the systemd unit rides the proven host-service machinery instead of container provisioning.

## What (bottom-up)

- **`Pty`** — the JVM cannot `fork()`, so `forkpty` is rebuilt from first principles: the master is allocated via libc (`posix_openpt`/`grantpt`/`unlockpt`/`ptsname`, Panama FFM with the Sqlite.java Linker discipline, errno captured), and the child spawns through `ProcessBuilder` + util-linux `setsid --ctty` with stdio on the slave — session leader, controlling terminal, no fork, no C shim. Tests prove the child sees a real ctty (`[ -t 0 ]`), the initial winsize, live `SIGWINCH` delivery, and dead-child-reads-as-EOF.
- **`TermBoundary`** — a streaming ESC/CSI/OSC/DCS + UTF-8 boundary tracker (a framer, deliberately not an emulator). Fed from session birth its state is exact, so replay safe-points are correct by construction — chunk-split-invariant by test.
- **`RingJournal`** — fixed-cap file-backed ring with a persisted safe watermark: history survives host restarts (the durability tmux never had). TDD caught the watermark semantics backwards (newest-safe ⇒ replay-nothing); it now retains the **oldest** safe start inside the replay budget.
- **`PtyWire`/`PtyMessage`** — magic+version handshake (skew refuses loudly), length-prefixed frames, 1 MiB cap. `Input(seq)`/`Output(lastInputSeq)` carries the client-side-prediction enabler from day one.
- **`PtySession`** — the heart: a gather thread drains the PTY unconditionally (ghostty's discipline — the child is never backpressured), journals + boundary-tracks, and fans out to per-subscriber bounded queues. Flow control lives in its own **`SubscriberQueue`** with the contract built in: overflow drops the backlog and enqueues `Paused`; everything during a pause is dropped; the first `next()` after draining returns `Continued` — resume is the consumer's act of catching up, provable single-threaded with zero sleeps. (Extracted after the CI-faithful lane caught the original inline version racing under load — including the writer's own queue stalling; the session test now asserts the real invariant child-side via `journaledBytes()`, not through any subscriber's lossy delivery.) Attach replays the journal tail bracketed `ReplayBegin/End`. Exactly one write token; takeover is explicit and announced; the writer's winsize wins. Child exit → `SessionEnded` to all, corpse retained.
- **`PtySessionHost`** — registry + unix-socket server; create/attach/detach/list/kill; recreated names never replay a predecessor's history; mosh's reaping rules (`sweep(now)` with injected time — no sleeps): 60s never-attached grace, 10min corpse retention.
- **CLI + service** — `sail session new|ls|attach|kill` (`attach` enters raw mode via the extracted shared `Stty` seam, `Ctrl-]` detaches leaving the session alive); hidden `_pty-host`; `sail-pty-host.service` installed/removed alongside sail-api by `sail host service install|uninstall` (own small `PtyHostUnit` — unifying the two installers is a named follow-up, not this brick).

## Scope lines

Brick 1 (FDE identity, owner arbitration by principal, events) and Brick 2 (Mast client) follow; `writerFde` rides the wire empty until Brick 1. No sync surface touched anywhere — no floor impact.

## Tests

38 new across eight suites, all behavioral, real PTYs and real sockets throughout; three design bugs caught and fixed by the tests themselves (replay retention, pause resume, and the earlier stuck-pause). Command taxonomy pin updated deliberately for the new `session` group.
