### PR TITLE
PTY session host brick 1: identity-first sessions

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyEvents.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyEvents.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+/**
+ * The record-class facts a session emits — started, attached, ended — with the existing source
+ * discipline: observational only, nothing here drives run or spec state.
+ */
+public interface PtyEvents {
+
+  PtyEvents NONE =
+      new PtyEvents() {
+        @Override
+        public void sessionStarted(String session, String project, String fde) {}
+
+        @Override
+        public void sessionAttached(String session, String project, String fde) {}
+
+        @Override
+        public void sessionEnded(String session, String project, String reason) {}
+      };
+
+  void sessionStarted(String session, String project, String fde);
+
+  void sessionAttached(String session, String project, String fde);
+
+  void sessionEnded(String session, String project, String reason);
+}

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyIdentity.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyIdentity.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import java.io.IOException;
+
+/**
+ * The authenticated FDE behind a pty-host connection. Identity is resolved from a verifiable
+ * credential by the host's {@link Resolver} — never from anything the client claims: a session
+ * token minted by the gateway, or the box's ambient owner when the connection carries none.
+ */
+public record PtyIdentity(String fde, boolean admin) {
+
+  public interface Resolver {
+    PtyIdentity resolve(String token) throws IOException;
+  }
+}

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyMessage.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyMessage.java
@@ -15,7 +15,10 @@ import java.util.List;
  */
 public sealed interface PtyMessage {
 
-  record Create(String session, List<String> command, String cwd, int cols, int rows)
+  record Hello(String token) implements PtyMessage {}
+
+  record Create(
+      String session, List<String> command, String cwd, String project, int cols, int rows)
       implements PtyMessage {}
 
   record Attach(String session, boolean write) implements PtyMessage {}

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -38,6 +38,9 @@ public final class PtySession implements AutoCloseable {
   private record Subscriber(long id, Client client, SubscriberQueue queue) {}
 
   private final String name;
+  private final String ownerFde;
+  private final String project;
+  private final PtyEvents events;
   private final Pty pty;
   private final Process child;
   private final RingJournal journal;
@@ -51,13 +54,25 @@ public final class PtySession implements AutoCloseable {
   private final CountDownLatch gatherDone = new CountDownLatch(1);
   private final long createdAt = System.nanoTime();
   private volatile long writerId = -1;
+  private volatile String writerFde = "";
   private volatile String endedReason;
   private volatile long endedAtNanos;
   private volatile boolean everAttached;
 
   private PtySession(
-      String name, Pty pty, Process child, RingJournal journal, int queueCapacity, int replayMax) {
+      String name,
+      String ownerFde,
+      String project,
+      PtyEvents events,
+      Pty pty,
+      Process child,
+      RingJournal journal,
+      int queueCapacity,
+      int replayMax) {
     this.name = name;
+    this.ownerFde = ownerFde;
+    this.project = project;
+    this.events = events;
     this.pty = pty;
     this.child = child;
     this.journal = journal;
@@ -67,6 +82,9 @@ public final class PtySession implements AutoCloseable {
 
   public static PtySession start(
       String name,
+      String ownerFde,
+      String project,
+      PtyEvents events,
       List<String> command,
       Map<String, String> env,
       Path cwd,
@@ -75,11 +93,27 @@ public final class PtySession implements AutoCloseable {
       int cols,
       int rows)
       throws IOException {
-    return start(name, command, env, cwd, journalPath, journalCapacity, cols, rows, 4096, 262_144);
+    return start(
+        name,
+        ownerFde,
+        project,
+        events,
+        command,
+        env,
+        cwd,
+        journalPath,
+        journalCapacity,
+        cols,
+        rows,
+        4096,
+        262_144);
   }
 
   static PtySession start(
       String name,
+      String ownerFde,
+      String project,
+      PtyEvents events,
       List<String> command,
       Map<String, String> env,
       Path cwd,
@@ -100,8 +134,11 @@ public final class PtySession implements AutoCloseable {
       journal.close();
       throw e;
     }
-    var session = new PtySession(name, pty, child, journal, queueCapacity, replayMax);
+    var session =
+        new PtySession(
+            name, ownerFde, project, events, pty, child, journal, queueCapacity, replayMax);
     Thread.ofPlatform().name("pty-gather-" + name).start(session::gather);
+    events.sessionStarted(name, project, ownerFde);
     return session;
   }
 
@@ -136,12 +173,13 @@ public final class PtySession implements AutoCloseable {
       pty.close();
       var ended = new PtyMessage.SessionEnded(endedReason);
       subscribers.values().forEach(subscriber -> subscriber.queue().force(ended));
+      events.sessionEnded(name, project, endedReason);
       gatherDone.countDown();
     }
   }
 
   /** Attaches a client: replay first, live stream after, write token if free and requested. */
-  public long attach(Client client, boolean wantsWrite) throws IOException {
+  public long attach(Client client, boolean wantsWrite, String fde) throws IOException {
     if (endedReason != null) {
       throw new IOException("Session '" + name + "' has ended: " + endedReason + ".");
     }
@@ -160,8 +198,10 @@ public final class PtySession implements AutoCloseable {
     synchronized (this) {
       if (wantsWrite && writerId < 0) {
         writerId = subscriber.id;
+        writerFde = fde;
       }
     }
+    events.sessionAttached(name, project, fde);
     Thread.ofVirtual()
         .name("pty-send-" + name + "-" + subscriber.id())
         .start(() -> send(subscriber));
@@ -200,6 +240,7 @@ public final class PtySession implements AutoCloseable {
       throw new IllegalArgumentException("No attached subscriber " + subscriberId + ".");
     }
     writerId = subscriberId;
+    writerFde = fde;
     var changed = new PtyMessage.WriterChanged(fde);
     subscribers.values().forEach(subscriber -> subscriber.queue().force(changed));
   }
@@ -223,6 +264,7 @@ public final class PtySession implements AutoCloseable {
     }
     if (writerId == subscriberId) {
       writerId = -1;
+      writerFde = "";
     }
   }
 
@@ -245,6 +287,18 @@ public final class PtySession implements AutoCloseable {
 
   public int attachedCount() {
     return subscribers.size();
+  }
+
+  public String ownerFde() {
+    return ownerFde;
+  }
+
+  public String project() {
+    return project;
+  }
+
+  public String writerFde() {
+    return writerFde;
   }
 
   public long writerId() {

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyWire.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyWire.java
@@ -60,8 +60,9 @@ public final class PtyWire {
   private static byte[] encode(PtyMessage message) {
     var out = new Writer();
     switch (message) {
+      case PtyMessage.Hello m -> out.type(9).string(m.token());
       case PtyMessage.Create m -> {
-        out.type(1).string(m.session()).stringList(m.command()).string(m.cwd());
+        out.type(1).string(m.session()).stringList(m.command()).string(m.cwd()).string(m.project());
         out.buffer.putInt(m.cols()).putInt(m.rows());
       }
       case PtyMessage.Attach m -> {
@@ -122,8 +123,10 @@ public final class PtyWire {
   private static PtyMessage decode(ByteBuffer in) throws IOException {
     var type = in.get();
     return switch (type) {
+      case 9 -> new PtyMessage.Hello(string(in));
       case 1 ->
-          new PtyMessage.Create(string(in), stringList(in), string(in), in.getInt(), in.getInt());
+          new PtyMessage.Create(
+              string(in), stringList(in), string(in), string(in), in.getInt(), in.getInt());
       case 2 -> new PtyMessage.Attach(string(in), in.get() == 1);
       case 3 -> new PtyMessage.Input(in.getLong(), bytes(in));
       case 4 -> new PtyMessage.Resize(in.getInt(), in.getInt());

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -72,6 +72,9 @@ class PtySessionTest {
   private PtySession session(String script) throws IOException {
     return PtySession.start(
         "t",
+        "uday",
+        "acme",
+        PtyEvents.NONE,
         List.of("sh", "-c", script),
         Map.of("TERM", "dumb"),
         Path.of("/tmp"),
@@ -82,10 +85,65 @@ class PtySessionTest {
   }
 
   @Test
+  void ownershipEventsAndWriterPrincipalAreObservable() throws Exception {
+    var events = new java.util.concurrent.ConcurrentLinkedQueue<String>();
+    var recorder =
+        new PtyEvents() {
+          @Override
+          public void sessionStarted(String session, String project, String fde) {
+            events.add("started:" + session + ":" + project + ":" + fde);
+          }
+
+          @Override
+          public void sessionAttached(String session, String project, String fde) {
+            events.add("attached:" + session + ":" + fde);
+          }
+
+          @Override
+          public void sessionEnded(String session, String project, String reason) {
+            events.add("ended:" + session + ":" + reason);
+          }
+        };
+    var session =
+        PtySession.start(
+            "owned",
+            "mady",
+            "acme",
+            recorder,
+            List.of("sh", "-c", "read a"),
+            Map.of("TERM", "dumb"),
+            Path.of("/tmp"),
+            dir.resolve("owned.ring"),
+            64 * 1024,
+            80,
+            24);
+    try {
+      assertEquals("mady", session.ownerFde());
+      assertEquals("acme", session.project());
+      assertTrue(events.contains("started:owned:acme:mady"), events.toString());
+
+      var writer = new Collector();
+      session.attach(writer, true, "mady");
+      assertEquals("mady", session.writerFde(), "the token records its principal");
+      assertTrue(events.contains("attached:owned:mady"), events.toString());
+    } finally {
+      session.close();
+    }
+    var deadline = System.nanoTime() + 5_000_000_000L;
+    while (events.stream().noneMatch(e -> e.startsWith("ended:owned:"))
+        && System.nanoTime() < deadline) {
+      Thread.onSpinWait();
+    }
+    assertTrue(
+        events.stream().anyMatch(e -> e.startsWith("ended:owned:")),
+        "the ending is a recorded fact: " + events);
+  }
+
+  @Test
   void theWriterConversesAndOutputCarriesItsInputSequence() throws Exception {
     try (var session = session("read a; echo got:$a; read b")) {
       var writer = new Collector();
-      var id = session.attach(writer, true);
+      var id = session.attach(writer, true, "uday");
 
       session.input(id, 7, "hello\n".getBytes(StandardCharsets.UTF_8));
       writer.awaitOutput("got:hello");
@@ -102,11 +160,11 @@ class PtySessionTest {
   void aLateObserverGetsTheReplayBracketThenLiveOutput() throws Exception {
     try (var session = session("echo early-line; read b; echo late-line; read c")) {
       var writer = new Collector();
-      var writerId = session.attach(writer, true);
+      var writerId = session.attach(writer, true, "uday");
       writer.awaitOutput("early-line");
 
       var observer = new Collector();
-      session.attach(observer, false);
+      session.attach(observer, false, "uday");
       observer.awaitOutput("early-line");
       assertTrue(observer.saw(PtyMessage.ReplayBegin.class), "replay is bracketed");
       assertTrue(observer.saw(PtyMessage.ReplayEnd.class));
@@ -121,8 +179,8 @@ class PtySessionTest {
     try (var session = session("read a; echo done:$a")) {
       var first = new Collector();
       var second = new Collector();
-      var firstId = session.attach(first, true);
-      var secondId = session.attach(second, false);
+      var firstId = session.attach(first, true, "uday");
+      var secondId = session.attach(second, false, "uday");
 
       assertThrows(
           IOException.class,
@@ -148,12 +206,12 @@ class PtySessionTest {
     var session = session("echo bye; exit 3");
     try {
       var client = new Collector();
-      session.attach(client, true);
+      session.attach(client, true, "uday");
       assertTrue(client.ended.await(10, TimeUnit.SECONDS), "the ending reaches subscribers");
       assertEquals("exited(3)", session.endedReason());
 
       var late = new Collector();
-      assertThrows(IOException.class, () -> session.attach(late, false));
+      assertThrows(IOException.class, () -> session.attach(late, false, "uday"));
     } finally {
       session.close();
     }
@@ -164,6 +222,9 @@ class PtySessionTest {
     try (var session =
         PtySession.start(
             "slow",
+            "uday",
+            "acme",
+            PtyEvents.NONE,
             List.of(
                 "sh",
                 "-c",
@@ -178,10 +239,10 @@ class PtySessionTest {
             2,
             65536)) {
       var writer = new Collector();
-      var writerId = session.attach(writer, true);
+      var writerId = session.attach(writer, true, "uday");
       var stalled = new Collector();
       stalled.sleepMillis = 1000;
-      session.attach(stalled, false);
+      session.attach(stalled, false, "uday");
 
       session.input(writerId, 1, "go\n".getBytes(StandardCharsets.UTF_8));
       var deadline = System.nanoTime() + 10_000_000_000L;

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtyWireTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtyWireTest.java
@@ -30,9 +30,12 @@ class PtyWireTest {
   void everyMessageShapeSurvivesTheWire() throws Exception {
     var create =
         (PtyMessage.Create)
-            roundTrip(new PtyMessage.Create("lounge", List.of("bash", "-l"), "/home/dev", 132, 43));
+            roundTrip(
+                new PtyMessage.Create(
+                    "lounge", List.of("bash", "-l"), "/home/dev", "chorus", 132, 43));
     assertEquals("lounge", create.session());
     assertEquals(List.of("bash", "-l"), create.command());
+    assertEquals("chorus", create.project());
     assertEquals(132, create.cols());
 
     var input =
@@ -56,6 +59,7 @@ class PtyWireTest {
     assertEquals(2, sessions.sessions().size());
     assertEquals("uday", sessions.sessions().getFirst().writerFde());
 
+    assertEquals("tok", ((PtyMessage.Hello) roundTrip(new PtyMessage.Hello("tok"))).token());
     assertInstanceOf(PtyMessage.TakeWrite.class, roundTrip(new PtyMessage.TakeWrite()));
     assertInstanceOf(PtyMessage.ReplayEnd.class, roundTrip(new PtyMessage.ReplayEnd()));
     assertEquals(

--- a/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
@@ -35,14 +35,23 @@ public final class PtySessionHost implements AutoCloseable {
   private final Path socketPath;
   private final Path sessionsDir;
   private final long journalCapacity;
+  private final PtyIdentity.Resolver identity;
+  private final PtyEvents events;
   private final Map<String, PtySession> sessions = new ConcurrentHashMap<>();
   private volatile ServerSocketChannel server;
   private volatile boolean closed;
 
-  public PtySessionHost(Path socketPath, Path sessionsDir, long journalCapacity) {
+  public PtySessionHost(
+      Path socketPath,
+      Path sessionsDir,
+      long journalCapacity,
+      PtyIdentity.Resolver identity,
+      PtyEvents events) {
     this.socketPath = socketPath;
     this.sessionsDir = sessionsDir;
     this.journalCapacity = journalCapacity;
+    this.identity = identity;
+    this.events = events;
   }
 
   public void start() throws IOException {
@@ -72,10 +81,23 @@ public final class PtySessionHost implements AutoCloseable {
     var subscriberId = -1L;
     try (channel) {
       PtyWire.handshake(channel, channel);
+      PtyIdentity who;
+      if (PtyWire.read(channel) instanceof PtyMessage.Hello(var token)) {
+        try {
+          who = identity.resolve(token);
+        } catch (IOException refused) {
+          reply(channel, new PtyMessage.Err(refused.getMessage()));
+          return;
+        }
+        reply(channel, new PtyMessage.Ok());
+      } else {
+        reply(channel, new PtyMessage.Err("The first frame must identify you: send Hello."));
+        return;
+      }
       while (true) {
         var message = PtyWire.read(channel);
         switch (message) {
-          case PtyMessage.Create m -> reply(channel, create(m));
+          case PtyMessage.Create m -> reply(channel, create(m, who));
           case PtyMessage.Attach m -> {
             if (attached != null) {
               reply(channel, new PtyMessage.Err("This connection is already attached."));
@@ -87,8 +109,15 @@ public final class PtySessionHost implements AutoCloseable {
                   channel, new PtyMessage.Err("No live session '" + m.session() + "' to attach."));
               break;
             }
+            if (!admitted(who, session)) {
+              reply(
+                  channel,
+                  new PtyMessage.Err(
+                      "Session '" + m.session() + "' belongs to " + session.ownerFde() + "."));
+              break;
+            }
             reply(channel, new PtyMessage.Ok());
-            subscriberId = session.attach(msg -> reply(channel, msg), m.write());
+            subscriberId = session.attach(msg -> reply(channel, msg), m.write(), who.fde());
             attached = session;
           }
           case PtyMessage.Input m -> {
@@ -107,7 +136,7 @@ public final class PtySessionHost implements AutoCloseable {
             if (attached == null) {
               reply(channel, new PtyMessage.Err("Attach before taking the write token."));
             } else {
-              attached.takeWrite(subscriberId, "");
+              attached.takeWrite(subscriberId, who.fde());
             }
           }
           case PtyMessage.Detach m -> {
@@ -119,7 +148,7 @@ public final class PtySessionHost implements AutoCloseable {
             reply(channel, new PtyMessage.Ok());
           }
           case PtyMessage.ListSessions m -> reply(channel, listSessions());
-          case PtyMessage.Kill m -> reply(channel, kill(m.session()));
+          case PtyMessage.Kill m -> reply(channel, kill(m.session(), who));
           default -> reply(channel, new PtyMessage.Err("Unexpected client frame."));
         }
       }
@@ -130,7 +159,11 @@ public final class PtySessionHost implements AutoCloseable {
     }
   }
 
-  private PtyMessage create(PtyMessage.Create m) {
+  private static boolean admitted(PtyIdentity who, PtySession session) {
+    return who.admin() || who.fde().equals(session.ownerFde());
+  }
+
+  private PtyMessage create(PtyMessage.Create m, PtyIdentity who) {
     var existing = sessions.get(m.session());
     if (existing != null && existing.live()) {
       return new PtyMessage.Err(
@@ -145,6 +178,9 @@ public final class PtySessionHost implements AutoCloseable {
       var session =
           PtySession.start(
               m.session(),
+              who.fde(),
+              m.project(),
+              events,
               m.command(),
               Map.of("TERM", "xterm-256color"),
               Path.of(m.cwd()),
@@ -167,14 +203,20 @@ public final class PtySessionHost implements AutoCloseable {
             session ->
                 infos.add(
                     new PtyMessage.SessionInfo(
-                        session.name(), session.live(), session.attachedCount(), "")));
+                        session.name(),
+                        session.live(),
+                        session.attachedCount(),
+                        session.writerFde())));
     return new PtyMessage.Sessions(infos);
   }
 
-  private PtyMessage kill(String name) {
+  private PtyMessage kill(String name, PtyIdentity who) {
     var session = sessions.get(name);
     if (session == null) {
       return new PtyMessage.Err("No session '" + name + "'.");
+    }
+    if (!admitted(who, session)) {
+      return new PtyMessage.Err("Session '" + name + "' belongs to " + session.ownerFde() + ".");
     }
     remove(name, session);
     return new PtyMessage.Ok();

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.pty;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -24,17 +25,58 @@ class PtySessionHostTest {
   @TempDir Path dir;
 
   private PtySessionHost host;
+  private final java.util.concurrent.ConcurrentLinkedQueue<String> events =
+      new java.util.concurrent.ConcurrentLinkedQueue<>();
+
+  private static final PtyIdentity.Resolver RESOLVER =
+      token ->
+          switch (token) {
+            case "", "tok-uday" -> new PtyIdentity("uday", false);
+            case "tok-mady" -> new PtyIdentity("mady", false);
+            case "tok-root" -> new PtyIdentity("root", true);
+            default -> throw new IOException("Session token is not valid or has expired.");
+          };
 
   private PtySessionHost startHost() throws IOException {
-    host = new PtySessionHost(dir.resolve("host.sock"), dir.resolve("sessions"), 64 * 1024);
+    host =
+        new PtySessionHost(
+            dir.resolve("host.sock"),
+            dir.resolve("sessions"),
+            64 * 1024,
+            RESOLVER,
+            new PtyEvents() {
+              @Override
+              public void sessionStarted(String session, String project, String fde) {
+                events.add("started:" + session + ":" + fde);
+              }
+
+              @Override
+              public void sessionAttached(String session, String project, String fde) {
+                events.add("attached:" + session + ":" + fde);
+              }
+
+              @Override
+              public void sessionEnded(String session, String project, String reason) {
+                events.add("ended:" + session);
+              }
+            });
     host.start();
     return host;
   }
 
   private SocketChannel connect() throws IOException {
+    return connect("tok-uday");
+  }
+
+  private SocketChannel connect(String token) throws IOException {
     var channel = SocketChannel.open(StandardProtocolFamily.UNIX);
     channel.connect(UnixDomainSocketAddress.of(dir.resolve("host.sock")));
     PtyWire.handshake(channel, channel);
+    PtyWire.write(channel, new PtyMessage.Hello(token));
+    var reply = PtyWire.read(channel);
+    if (reply instanceof PtyMessage.Err(var message)) {
+      throw new IOException(message);
+    }
     return channel;
   }
 
@@ -55,13 +97,81 @@ class PtySessionHostTest {
   }
 
   @Test
+  void identityComesFirstAndAdmissionIsOwnerOrAdmin() throws Exception {
+    try (var ignored = startHost()) {
+      var rude = SocketChannel.open(StandardProtocolFamily.UNIX);
+      rude.connect(UnixDomainSocketAddress.of(dir.resolve("host.sock")));
+      PtyWire.handshake(rude, rude);
+      PtyWire.write(rude, new PtyMessage.ListSessions());
+      assertInstanceOf(PtyMessage.Err.class, PtyWire.read(rude), "hello must come first");
+      rude.close();
+
+      assertThrows(IOException.class, () -> connect("tok-forged"), "unknown tokens are refused");
+
+      try (var owner = connect("tok-uday")) {
+        PtyWire.write(
+            owner,
+            new PtyMessage.Create("mine", List.of("sh", "-c", "read a"), "/tmp", "acme", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(owner));
+        assertTrue(events.contains("started:mine:uday"), events.toString());
+      }
+
+      try (var foreign = connect("tok-mady")) {
+        PtyWire.write(foreign, new PtyMessage.Attach("mine", false));
+        assertInstanceOf(
+            PtyMessage.Err.class, PtyWire.read(foreign), "a foreign member cannot observe");
+        PtyWire.write(foreign, new PtyMessage.Kill("mine"));
+        assertInstanceOf(PtyMessage.Err.class, PtyWire.read(foreign), "nor kill");
+      }
+
+      try (var admin = connect("tok-root")) {
+        PtyWire.write(admin, new PtyMessage.Attach("mine", false));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(admin), "an admin observes anywhere");
+        PtyWire.write(admin, new PtyMessage.TakeWrite());
+        var deadline = System.nanoTime() + 5_000_000_000L;
+        while (!events.contains("attached:mine:root") && System.nanoTime() < deadline) {
+          Thread.onSpinWait();
+        }
+        assertTrue(events.contains("attached:mine:root"), events.toString());
+
+        try (var owner = connect("tok-uday")) {
+          PtyWire.write(owner, new PtyMessage.ListSessions());
+          var listed = (PtyMessage.Sessions) PtyWire.read(owner);
+          assertEquals(
+              "root", listed.sessions().getFirst().writerFde(), "the token names its holder");
+        }
+      }
+
+      try (var owner = connect("tok-uday")) {
+        PtyWire.write(owner, new PtyMessage.ListSessions());
+        var listed = (PtyMessage.Sessions) PtyWire.read(owner);
+        var freed = System.nanoTime() + 5_000_000_000L;
+        while (!listed.sessions().getFirst().writerFde().isEmpty() && System.nanoTime() < freed) {
+          Thread.onSpinWait();
+          PtyWire.write(owner, new PtyMessage.ListSessions());
+          listed = (PtyMessage.Sessions) PtyWire.read(owner);
+        }
+        assertEquals(
+            "", listed.sessions().getFirst().writerFde(), "a departed holder releases the token");
+        PtyWire.write(owner, new PtyMessage.Kill("mine"));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(owner), "the owner always may");
+      }
+    }
+  }
+
+  @Test
   void createAttachConverseDetachReattachRepays() throws Exception {
     try (var ignored = startHost()) {
       try (var channel = connect()) {
         PtyWire.write(
             channel,
             new PtyMessage.Create(
-                "s1", List.of("sh", "-c", "echo hi; read a; echo bye:$a; read b"), "/tmp", 80, 24));
+                "s1",
+                List.of("sh", "-c", "echo hi; read a; echo bye:$a; read b"),
+                "/tmp",
+                "acme",
+                80,
+                24));
         assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
 
         PtyWire.write(channel, new PtyMessage.Attach("s1", true));
@@ -89,9 +199,9 @@ class PtySessionHostTest {
         PtyWire.write(
             channel,
             new PtyMessage.Create(
-                "dup", List.of("sh", "-c", "echo old-life; read a"), "/tmp", 80, 24));
+                "dup", List.of("sh", "-c", "echo old-life; read a"), "/tmp", "acme", 80, 24));
         assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
-        PtyWire.write(channel, new PtyMessage.Create("dup", List.of("sh"), "/tmp", 80, 24));
+        PtyWire.write(channel, new PtyMessage.Create("dup", List.of("sh"), "/tmp", "acme", 80, 24));
         assertInstanceOf(PtyMessage.Err.class, PtyWire.read(channel));
 
         PtyWire.write(channel, new PtyMessage.Kill("dup"));
@@ -99,7 +209,7 @@ class PtySessionHostTest {
         PtyWire.write(
             channel,
             new PtyMessage.Create(
-                "dup", List.of("sh", "-c", "echo new-life; read a"), "/tmp", 80, 24));
+                "dup", List.of("sh", "-c", "echo new-life; read a"), "/tmp", "acme", 80, 24));
         assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
 
         PtyWire.write(channel, new PtyMessage.Attach("dup", false));
@@ -124,7 +234,8 @@ class PtySessionHostTest {
     try (var ignored = startHost()) {
       try (var channel = connect()) {
         PtyWire.write(
-            channel, new PtyMessage.Create("a", List.of("sh", "-c", "read x"), "/tmp", 80, 24));
+            channel,
+            new PtyMessage.Create("a", List.of("sh", "-c", "read x"), "/tmp", "acme", 80, 24));
         assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
         PtyWire.write(channel, new PtyMessage.ListSessions());
         var listed = (PtyMessage.Sessions) PtyWire.read(channel);
@@ -142,11 +253,11 @@ class PtySessionHostTest {
       try (var channel = connect()) {
         PtyWire.write(
             channel,
-            new PtyMessage.Create("lonely", List.of("sh", "-c", "read x"), "/tmp", 80, 24));
+            new PtyMessage.Create("lonely", List.of("sh", "-c", "read x"), "/tmp", "acme", 80, 24));
         assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
         PtyWire.write(
             channel,
-            new PtyMessage.Create("corpse", List.of("sh", "-c", "exit 0"), "/tmp", 80, 24));
+            new PtyMessage.Create("corpse", List.of("sh", "-c", "exit 0"), "/tmp", "acme", 80, 24));
         assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
 
         var deadline = System.nanoTime() + 10_000_000_000L;

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostCommand.java
@@ -24,7 +24,12 @@ public final class PtyHostCommand implements Callable<Integer> {
 
   @Override
   public Integer call() throws Exception {
-    var host = startHost(SailPaths.ptySocketPath(), SailPaths.sessionsDir());
+    var host =
+        startHost(
+            SailPaths.ptySocketPath(),
+            SailPaths.sessionsDir(),
+            new PtyHostIdentity(),
+            new PtyHostEvents());
     var done = new CountDownLatch(1);
     Runtime.getRuntime()
         .addShutdownHook(
@@ -38,9 +43,13 @@ public final class PtyHostCommand implements Callable<Integer> {
   }
 
   /** Starts the host and its sweep timer — the process shell around it is {@link #call()}. */
-  static PtySessionHost startHost(java.nio.file.Path socket, java.nio.file.Path sessions)
+  static PtySessionHost startHost(
+      java.nio.file.Path socket,
+      java.nio.file.Path sessions,
+      ai.singlr.sail.pty.PtyIdentity.Resolver identity,
+      ai.singlr.sail.pty.PtyEvents events)
       throws java.io.IOException {
-    var host = new PtySessionHost(socket, sessions, JOURNAL_CAPACITY);
+    var host = new PtySessionHost(socket, sessions, JOURNAL_CAPACITY, identity, events);
     host.start();
     Thread.ofVirtual()
         .start(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostEvents.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostEvents.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.HostInfo;
+import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.pty.PtyEvents;
+import ai.singlr.sail.store.EventStore;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * The production {@link PtyEvents}: each session fact becomes one record-class event row — {@code
+ * pty_session_started|attached|ended} — observational only, never driving run or spec state.
+ * Failures are swallowed by design: a session must never die because an event row could not be
+ * written.
+ */
+final class PtyHostEvents implements PtyEvents {
+
+  private final Path dbPath;
+
+  PtyHostEvents() {
+    this(SailPaths.controlPlaneDb());
+  }
+
+  PtyHostEvents(Path dbPath) {
+    this.dbPath = dbPath;
+  }
+
+  @Override
+  public void sessionStarted(String session, String project, String fde) {
+    insert("pty_session_started", project, fde, Map.of("session", session));
+  }
+
+  @Override
+  public void sessionAttached(String session, String project, String fde) {
+    insert("pty_session_attached", project, fde, Map.of("session", session));
+  }
+
+  @Override
+  public void sessionEnded(String session, String project, String reason) {
+    insert("pty_session_ended", project, "sail", Map.of("session", session, "reason", reason));
+  }
+
+  private void insert(String type, String project, String agent, Map<String, Object> data) {
+    try (var db = Sqlite.open(dbPath)) {
+      new EventStore(db)
+          .insert(
+              new EventStore.EventRow(
+                  0,
+                  DateTimeUtils.now().toString(),
+                  type,
+                  project,
+                  null,
+                  agent,
+                  HostInfo.hostname(),
+                  YamlUtil.dumpJson(data)));
+    } catch (RuntimeException swallowed) {
+      var unused = swallowed;
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostIdentity.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostIdentity.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.common.Strings;
+import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.pty.PtyIdentity;
+import ai.singlr.sail.store.AuthSessionStore;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+/**
+ * The production {@link PtyIdentity.Resolver}: a gateway-minted session token resolves through the
+ * control-plane sessions table to its FDE; a blank token is the box's ambient owner (the sync
+ * handle). Never a client claim — the token is validated, the handle read from this box's own
+ * configuration, and the admin bit from the FDE roster.
+ */
+final class PtyHostIdentity implements PtyIdentity.Resolver {
+
+  private final Supplier<String> boxHandle;
+  private final Path dbPath;
+
+  PtyHostIdentity() {
+    this(HostSync::handle, SailPaths.controlPlaneDb());
+  }
+
+  PtyHostIdentity(Supplier<String> boxHandle, Path dbPath) {
+    this.boxHandle = boxHandle;
+    this.dbPath = dbPath;
+  }
+
+  @Override
+  public PtyIdentity resolve(String token) throws IOException {
+    try (var db = Sqlite.open(dbPath)) {
+      var fdes = new FdeStore(db);
+      if (Strings.isBlank(token)) {
+        var handle = boxHandle.get();
+        if (Strings.isBlank(handle)) {
+          throw new IOException(
+              "This box has no FDE identity. Set one with 'sail host config set sync-handle' or"
+                  + " connect through the gateway.");
+        }
+        return new PtyIdentity(handle, isAdmin(fdes, handle));
+      }
+      var session =
+          new AuthSessionStore(db)
+              .validate(token)
+              .orElseThrow(() -> new IOException("Session token is not valid or has expired."));
+      var fde =
+          fdes.byId(session.fdeId())
+              .orElseThrow(() -> new IOException("The session's FDE no longer exists."));
+      return new PtyIdentity(fde.handle(), "admin".equals(fde.role()));
+    }
+  }
+
+  private static boolean isAdmin(FdeStore fdes, String handle) {
+    return fdes.byHandle(handle).map(fde -> "admin".equals(fde.role())).orElse(false);
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SessionClient.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SessionClient.java
@@ -24,6 +24,11 @@ public final class SessionClient implements AutoCloseable {
   }
 
   public static SessionClient connect(Path socket) throws IOException {
+    return connect(socket, java.util.Objects.toString(System.getenv("SAIL_TOKEN"), ""));
+  }
+
+  /** Connects, handshakes, and identifies with {@code token} — blank means the box's owner. */
+  public static SessionClient connect(Path socket, String token) throws IOException {
     var channel = SocketChannel.open(StandardProtocolFamily.UNIX);
     try {
       channel.connect(UnixDomainSocketAddress.of(socket));
@@ -33,12 +38,16 @@ public final class SessionClient implements AutoCloseable {
       throw new IOException(
           "No session host at " + socket + ". Is the sail-pty-host service running?", e);
     }
-    return new SessionClient(channel);
+    var client = new SessionClient(channel);
+    PtyWire.write(channel, new PtyMessage.Hello(token));
+    client.expectOk("hello");
+    return client;
   }
 
-  public void create(String name, List<String> command, String cwd, int cols, int rows)
+  public void create(
+      String name, List<String> command, String cwd, String project, int cols, int rows)
       throws IOException {
-    PtyWire.write(channel, new PtyMessage.Create(name, command, cwd, cols, rows));
+    PtyWire.write(channel, new PtyMessage.Create(name, command, cwd, project, cols, rows));
     expectOk("create");
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SessionCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SessionCommand.java
@@ -65,6 +65,7 @@ public final class SessionCommand {
             name,
             commandFor(project, command),
             System.getProperty("user.home", "/home/dev"),
+            project == null ? "" : project,
             size[1],
             size[0]);
       }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
@@ -25,11 +25,17 @@ class AttachLoopTest {
 
   @Test
   void conversesRendersOutputAndReportsTheEnding() throws Exception {
-    try (var host = new PtySessionHost(dir.resolve("h.sock"), dir.resolve("s"), 64 * 1024)) {
+    try (var host =
+        new PtySessionHost(
+            dir.resolve("h.sock"),
+            dir.resolve("s"),
+            64 * 1024,
+            token -> new ai.singlr.sail.pty.PtyIdentity("uday", true),
+            ai.singlr.sail.pty.PtyEvents.NONE)) {
       host.start();
       try (var client = SessionClient.connect(dir.resolve("h.sock"))) {
         client.create(
-            "s1", List.of("sh", "-c", "read a; echo pty-says:$a; exit 0"), "/tmp", 80, 24);
+            "s1", List.of("sh", "-c", "read a; echo pty-says:$a; exit 0"), "/tmp", "acme", 80, 24);
         var channel = client.attach("s1", true);
 
         var stdinFeed = new PipedOutputStream();
@@ -48,10 +54,16 @@ class AttachLoopTest {
 
   @Test
   void theDetachKeyLeavesTheSessionAliveForTheNextClient() throws Exception {
-    try (var host = new PtySessionHost(dir.resolve("h.sock"), dir.resolve("s"), 64 * 1024)) {
+    try (var host =
+        new PtySessionHost(
+            dir.resolve("h.sock"),
+            dir.resolve("s"),
+            64 * 1024,
+            token -> new ai.singlr.sail.pty.PtyIdentity("uday", true),
+            ai.singlr.sail.pty.PtyEvents.NONE)) {
       host.start();
       try (var client = SessionClient.connect(dir.resolve("h.sock"))) {
-        client.create("s1", List.of("sh", "-c", "read a; echo after:$a"), "/tmp", 80, 24);
+        client.create("s1", List.of("sh", "-c", "read a; echo after:$a"), "/tmp", "acme", 80, 24);
         var channel = client.attach("s1", true);
 
         var stdinFeed = new PipedOutputStream();

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyHostEventsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyHostEventsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.store.EventStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PtyHostEventsTest {
+
+  @TempDir Path dir;
+
+  @Test
+  void theThreeSessionFactsBecomeRecordClassRows() {
+    var path = dir.resolve("cp.db");
+    try (var db = Sqlite.open(path)) {
+      new SchemaManager(db).migrate();
+    }
+    var events = new PtyHostEvents(path);
+
+    events.sessionStarted("lounge", "acme", "uday");
+    events.sessionAttached("lounge", "acme", "mady");
+    events.sessionEnded("lounge", "acme", "exited(0)");
+
+    try (var db = Sqlite.open(path)) {
+      var recent = new EventStore(db).recent(10);
+      assertEquals(3, recent.size());
+      assertTrue(
+          recent.stream()
+              .anyMatch(
+                  e ->
+                      e.type().equals("pty_session_started")
+                          && e.agent().equals("uday")
+                          && e.data().contains("lounge")));
+      assertTrue(
+          recent.stream()
+              .anyMatch(e -> e.type().equals("pty_session_attached") && e.agent().equals("mady")));
+      assertTrue(
+          recent.stream()
+              .anyMatch(
+                  e -> e.type().equals("pty_session_ended") && e.data().contains("exited(0)")));
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyHostIdentityTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyHostIdentityTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.store.AuthSessionStore;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PtyHostIdentityTest {
+
+  @TempDir Path dir;
+
+  private Path db() {
+    var path = dir.resolve("cp.db");
+    try (var db = Sqlite.open(path)) {
+      new SchemaManager(db).migrate();
+    }
+    return path;
+  }
+
+  @Test
+  void aGatewayTokenResolvesToItsFdeWithItsRole() throws Exception {
+    var path = db();
+    String token;
+    try (var db = Sqlite.open(path)) {
+      var fde = new FdeStore(db).add("mady", "Mady", null, "admin");
+      token = new AuthSessionStore(db).create(fde.id(), Duration.ofMinutes(5)).token();
+    }
+
+    var identity = new PtyHostIdentity(() -> "uday", path).resolve(token);
+
+    assertEquals("mady", identity.fde());
+    assertTrue(identity.admin());
+  }
+
+  @Test
+  void aBlankTokenIsTheBoxOwnerWithTheRosterRole() throws Exception {
+    var path = db();
+    try (var db = Sqlite.open(path)) {
+      new FdeStore(db).add("uday", "Uday", null, "member");
+    }
+
+    var identity = new PtyHostIdentity(() -> "uday", path).resolve("");
+
+    assertEquals("uday", identity.fde());
+    assertFalse(identity.admin());
+  }
+
+  @Test
+  void forgedTokensAndOwnerlessBoxesRefuseWithActionableMessages() {
+    var path = db();
+
+    var forged =
+        assertThrows(
+            IOException.class, () -> new PtyHostIdentity(() -> "uday", path).resolve("nope"));
+    assertTrue(forged.getMessage().contains("not valid"), forged.getMessage());
+
+    var ownerless =
+        assertThrows(IOException.class, () -> new PtyHostIdentity(() -> null, path).resolve(""));
+    assertTrue(ownerless.getMessage().contains("sync-handle"), ownerless.getMessage());
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SessionClientTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SessionClientTest.java
@@ -22,10 +22,16 @@ class SessionClientTest {
 
   @Test
   void verbsRoundTripAndErrorsSurfaceAsExceptions() throws Exception {
-    try (var host = new PtySessionHost(dir.resolve("h.sock"), dir.resolve("s"), 64 * 1024)) {
+    try (var host =
+        new PtySessionHost(
+            dir.resolve("h.sock"),
+            dir.resolve("s"),
+            64 * 1024,
+            token -> new ai.singlr.sail.pty.PtyIdentity("uday", true),
+            ai.singlr.sail.pty.PtyEvents.NONE)) {
       host.start();
       try (var client = SessionClient.connect(dir.resolve("h.sock"))) {
-        client.create("s1", List.of("sh", "-c", "read a"), "/tmp", 80, 24);
+        client.create("s1", List.of("sh", "-c", "read a"), "/tmp", "acme", 80, 24);
         var listed = client.list();
         assertEquals(1, listed.size());
         assertEquals("s1", listed.getFirst().name());
@@ -33,7 +39,8 @@ class SessionClientTest {
 
         var dup =
             assertThrows(
-                IOException.class, () -> client.create("s1", List.of("sh"), "/tmp", 80, 24));
+                IOException.class,
+                () -> client.create("s1", List.of("sh"), "/tmp", "acme", 80, 24));
         assertTrue(dup.getMessage().contains("already running"));
 
         client.kill("s1");

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SessionVerbsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SessionVerbsTest.java
@@ -24,7 +24,12 @@ class SessionVerbsTest {
 
   @Test
   void newLsKillRoundTripThroughTheRealHost() throws Exception {
-    try (var host = PtyHostCommand.startHost(dir.resolve("h.sock"), dir.resolve("s"))) {
+    try (var host =
+        PtyHostCommand.startHost(
+            dir.resolve("h.sock"),
+            dir.resolve("s"),
+            token -> new ai.singlr.sail.pty.PtyIdentity("uday", true),
+            ai.singlr.sail.pty.PtyEvents.NONE)) {
       var socket = dir.resolve("h.sock").toString();
 
       assertEquals(0, run("new", "--socket", socket, "t1", "--", "sh", "-c", "read a"));
@@ -41,7 +46,12 @@ class SessionVerbsTest {
 
   @Test
   void attachToAMissingSessionFailsBeforeTouchingTheTerminal() throws Exception {
-    try (var host = PtyHostCommand.startHost(dir.resolve("h.sock"), dir.resolve("s"))) {
+    try (var host =
+        PtyHostCommand.startHost(
+            dir.resolve("h.sock"),
+            dir.resolve("s"),
+            token -> new ai.singlr.sail.pty.PtyIdentity("uday", true),
+            ai.singlr.sail.pty.PtyEvents.NONE)) {
       var exit = run("attach", "ghost", "--socket", dir.resolve("h.sock").toString());
       assertNotEquals(0, exit, "a missing session is a loud failure, not a hung raw terminal");
       assertTrue(host.sessionCount() == 0);


### PR DESCRIPTION
`sail-pty-session-host` Brick 1: identity-first sessions. Every connection proves who it is before anything else; ownership, admission, and the write token all speak FDE principals; the three session facts become record-class events.

## What

- **Hello-first protocol.** After the magic handshake, the first frame must be `Hello(token)`; anything else is refused. The token is a gateway-minted session credential the host validates through the control-plane sessions table (`AuthSessionStore` → `FdeStore`, handle + role); a blank token resolves to the box's ambient owner (the sync handle) with its roster role. Identity is never a client claim — the Omnigent guardrail from the spec, enforced at the door. A box with no sync handle refuses with the exact command to fix it.
- **Ownership + admission.** `Create` stamps the session with its creator's FDE and project. `Attach` and `Kill` admit the owner or an admin; a foreign member is told whose session it is. Any authenticated FDE may create.
- **The write token has a principal.** Granted on attach or explicit `TakeWrite`, it records the holder's handle, `WriterChanged` announces takeovers by name, `SessionInfo.writerFde` shows the holder in listings, and a departing holder releases it — all pinned by the admission-matrix test.
- **Record-class events.** `pty_session_started|attached|ended` rows via `EventStore`, agent = the acting FDE (endings are `sail`), data carrying the session name — observational only, and an event-write failure can never kill a session (swallowed by design, per the relay's fail-open precedent).
- **Seams (SRP/DRY):** `PtyIdentity.Resolver` and `PtyEvents` are two small interfaces in core; the host takes both; production impls (`PtyHostIdentity`, `PtyHostEvents`) live beside the command that wires them and are injectable-tested against real temp control-plane databases. Test hosts use inline fakes.

## Tests

26 across the pty suites now: the host admission matrix (hello-first, forged-token refusal, foreign member refused attach and kill, admin observes and takes the token with the takeover announced, owner always may, holder departure frees the token), session ownership/events at the core layer, prod resolver against seeded FDE + session rows (admin bit included, actionable refusals asserted), and the three event rows verified in a real store. Wire round-trips extended for `Hello` and `Create.project`.

Brick 2 (Mast client, ghostty-web evaluation gate) is next; observer admission via run policy arrives with Brick 3's agent-resume sessions, as scoped.
