### PR TITLE
Fix the Pty read/write native-buffer race and harden the socket

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/pty/Pty.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/Pty.java
@@ -32,6 +32,8 @@ import java.util.Map;
  * <p>Reads block the calling thread (the session host dedicates a platform gather thread per
  * session — the ghostty drain discipline); a read against a dead child reports end of stream
  * ({@code EIO} on Linux) as {@code -1}, never an exception, so the reaper owns the child's ending.
+ * Read and write each allocate their own per-call confined arena, so the two halves — which run on
+ * different threads (gather vs. the writer's connection) — share no native buffer and cannot race.
  */
 public final class Pty implements AutoCloseable {
 
@@ -40,6 +42,7 @@ public final class Pty implements AutoCloseable {
   private static final long TIOCSWINSZ = 0x5414;
   private static final int EINTR = 4;
   private static final int EIO = 5;
+  private static final int EBADF = 9;
 
   private static final StructLayout WINSIZE =
       java.lang.foreign.MemoryLayout.structLayout(
@@ -116,19 +119,15 @@ public final class Pty implements AutoCloseable {
         errnoHandle);
   }
 
+  private static final int MAX_CHUNK = 64 * 1024;
+
   private final int masterFd;
   private final String slavePath;
-  private final Arena arena;
-  private final MemorySegment ioBuffer;
-  private final MemorySegment errnoState;
   private volatile boolean closed;
 
   private Pty(int masterFd, String slavePath) {
     this.masterFd = masterFd;
     this.slavePath = slavePath;
-    this.arena = Arena.ofShared();
-    this.ioBuffer = arena.allocate(64 * 1024);
-    this.errnoState = arena.allocate(LIBC.capturedState());
   }
 
   /** Allocates a master/slave pair and stamps the initial window size on it. */
@@ -189,19 +188,20 @@ public final class Pty implements AutoCloseable {
       }
       long n;
       int err;
-      try {
-        n =
-            (long)
-                LIBC.read()
-                    .invokeExact(
-                        errnoState, masterFd, ioBuffer, (long) Math.min(buf.length, 64 * 1024));
-        err = (int) LIBC.errno().get(errnoState, 0L);
-      } catch (Throwable t) {
-        throw new IOException("pty read failed", t);
-      }
-      if (n > 0) {
-        MemorySegment.ofArray(buf).copyFrom(ioBuffer.asSlice(0, n));
-        return (int) n;
+      try (var arena = Arena.ofConfined()) {
+        var cap = Math.min(buf.length, MAX_CHUNK);
+        var slot = arena.allocate(cap);
+        var errno = arena.allocate(LIBC.capturedState());
+        try {
+          n = (long) LIBC.read().invokeExact(errno, masterFd, slot, (long) cap);
+        } catch (Throwable t) {
+          throw new IOException("pty read failed", t);
+        }
+        err = (int) LIBC.errno().get(errno, 0L);
+        if (n > 0) {
+          MemorySegment.ofArray(buf).copyFrom(slot.asSlice(0, n));
+          return (int) n;
+        }
       }
       if (n == 0) {
         return -1;
@@ -209,7 +209,7 @@ public final class Pty implements AutoCloseable {
       if (err == EINTR) {
         continue;
       }
-      if (err == EIO || closed) {
+      if (err == EIO || err == EBADF || closed) {
         return -1;
       }
       throw new IOException("pty read failed with errno " + err + ".");
@@ -221,15 +221,19 @@ public final class Pty implements AutoCloseable {
     requireOpen();
     var offset = 0;
     while (offset < data.length) {
-      var chunk = Math.min(data.length - offset, 64 * 1024);
-      ioBuffer.asSlice(0, chunk).copyFrom(MemorySegment.ofArray(data).asSlice(offset, chunk));
+      var chunk = Math.min(data.length - offset, MAX_CHUNK);
       long n;
       int err;
-      try {
-        n = (long) LIBC.write().invokeExact(errnoState, masterFd, ioBuffer, (long) chunk);
-        err = (int) LIBC.errno().get(errnoState, 0L);
-      } catch (Throwable t) {
-        throw new IOException("pty write failed", t);
+      try (var arena = Arena.ofConfined()) {
+        var slot = arena.allocate(chunk);
+        var errno = arena.allocate(LIBC.capturedState());
+        slot.copyFrom(MemorySegment.ofArray(data).asSlice(offset, chunk));
+        try {
+          n = (long) LIBC.write().invokeExact(errno, masterFd, slot, (long) chunk);
+        } catch (Throwable t) {
+          throw new IOException("pty write failed", t);
+        }
+        err = (int) LIBC.errno().get(errno, 0L);
       }
       if (n < 0) {
         if (err == EINTR) {
@@ -269,6 +273,12 @@ public final class Pty implements AutoCloseable {
     }
   }
 
+  /**
+   * Closes the master fd. Safe under concurrency: read and write hold no shared native state (each
+   * allocates a per-call confined arena), so a close racing an in-flight op cannot corrupt memory
+   * or throw an arena-in-use error — the fd close simply lands, and a blocked read observes it as
+   * end of stream (a closed fd reports {@code EBADF}).
+   */
   @Override
   public void close() {
     if (closed) {
@@ -280,6 +290,5 @@ public final class Pty implements AutoCloseable {
     } catch (Throwable t) {
       throw new IllegalStateException("pty close failed", t);
     }
-    arena.close();
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtyConcurrencyTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtyConcurrencyTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class PtyConcurrencyTest {
+
+  /**
+   * Types continuously while the child echoes and exits on its own — the read half (a gather
+   * thread) and the write half (a keystroke thread) run at once, the normal interactive case. Every
+   * line must round-trip intact; a shared native buffer between {@link Pty#read} and {@link
+   * Pty#write} corrupts one stream or the other and drops or garbles lines.
+   */
+  @Test
+  void concurrentReadAndWriteNeverCorruptEitherStream() throws Exception {
+    var lines = 1000;
+    try (var pty = Pty.open(80, 24)) {
+      pty.spawn(
+          List.of(
+              "sh",
+              "-c",
+              "i=0; while [ $i -lt "
+                  + lines
+                  + " ]; do IFS= read -r l; printf 'R:%s\\n' \"$l\";"
+                  + " i=$((i+1)); done"),
+          Map.of("TERM", "dumb"),
+          java.nio.file.Path.of("/tmp"));
+
+      var collected = new ByteArrayOutputStream();
+      var readerDone = new CountDownLatch(1);
+      Thread.ofPlatform()
+          .start(
+              () -> {
+                var buf = new byte[8192];
+                try {
+                  int n;
+                  while ((n = pty.read(buf)) >= 0) {
+                    collected.write(buf, 0, n);
+                  }
+                } catch (Exception e) {
+                  throw new RuntimeException(e);
+                } finally {
+                  readerDone.countDown();
+                }
+              });
+
+      for (var i = 0; i < lines; i++) {
+        pty.write(("line-" + String.format("%06d", i) + "\n").getBytes(StandardCharsets.UTF_8));
+      }
+
+      assertTrue(readerDone.await(30, TimeUnit.SECONDS), "the child echoed and exited");
+      var out = collected.toString(StandardCharsets.UTF_8);
+      var missing = new StringBuilder();
+      for (var i = 0; i < lines; i++) {
+        var expected = "R:line-" + String.format("%06d", i);
+        if (!out.contains(expected)) {
+          missing.append(expected).append(' ');
+        }
+      }
+      assertTrue(
+          missing.isEmpty(), "every echoed line must arrive intact; corrupted/lost: " + missing);
+    }
+  }
+
+  /**
+   * Closing the master while a reader is actively draining a flood must never throw an arena-in-use
+   * error and must let the reader observe end of stream — the property that broke when read, write,
+   * and close shared one arena.
+   */
+  @Test
+  void closeWhileAReaderIsActiveIsCleanAndEndsTheStream() throws Exception {
+    var pty = Pty.open(80, 24);
+    pty.spawn(
+        List.of("sh", "-c", "while true; do echo flood; done"),
+        Map.of("TERM", "dumb"),
+        java.nio.file.Path.of("/tmp"));
+
+    var sawFlood = new CountDownLatch(1);
+    var readerDone = new CountDownLatch(1);
+    var failure = new AtomicReference<Throwable>();
+    Thread.ofPlatform()
+        .start(
+            () -> {
+              var buf = new byte[4096];
+              try {
+                int n;
+                while ((n = pty.read(buf)) >= 0) {
+                  if (n > 0) {
+                    sawFlood.countDown();
+                  }
+                }
+              } catch (Throwable t) {
+                failure.set(t);
+              } finally {
+                readerDone.countDown();
+              }
+            });
+
+    assertTrue(sawFlood.await(10, TimeUnit.SECONDS), "the flood is streaming");
+    assertDoesNotThrow(pty::close, "close never throws, even mid-read");
+    assertTrue(readerDone.await(10, TimeUnit.SECONDS), "the reader observes end of stream");
+    assertTrue(
+        failure.get() == null,
+        "a close during read is end of stream, not an error: " + failure.get());
+  }
+}

--- a/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
@@ -12,8 +12,10 @@ import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -56,10 +58,34 @@ public final class PtySessionHost implements AutoCloseable {
 
   public void start() throws IOException {
     Files.createDirectories(sessionsDir);
+    var socketDir = socketPath.getParent();
+    if (socketDir != null) {
+      Files.createDirectories(socketDir);
+      ownerOnly(socketDir);
+    }
     Files.deleteIfExists(socketPath);
     server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
     server.bind(UnixDomainSocketAddress.of(socketPath));
+    ownerOnly(socketPath);
     Thread.ofVirtual().name("pty-host-accept").start(this::acceptLoop);
+  }
+
+  /**
+   * Restricts {@code path} to owner-only. The socket is the identity boundary's only door — a
+   * blank-token connection resolves to the box owner — so no group or other principal may reach it.
+   * A best-effort no-op on a filesystem without POSIX permissions (never the provisioned box).
+   */
+  private static void ownerOnly(java.nio.file.Path path) {
+    try {
+      Files.setPosixFilePermissions(
+          path,
+          EnumSet.of(
+              PosixFilePermission.OWNER_READ,
+              PosixFilePermission.OWNER_WRITE,
+              PosixFilePermission.OWNER_EXECUTE));
+    } catch (UnsupportedOperationException | IOException ignored) {
+      var unused = ignored;
+    }
   }
 
   private void acceptLoop() {

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySocketPermissionsTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySocketPermissionsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PtySocketPermissionsTest {
+
+  @TempDir Path dir;
+
+  /**
+   * The pty socket is the identity boundary's only door: a blank-token connection resolves to the
+   * box owner, so any local process that can open the socket would act as the owner. The socket and
+   * the directory holding it must therefore be owner-only — no group or other access.
+   */
+  @Test
+  void theSocketAndItsDirectoryAreOwnerOnly() throws IOException {
+    var sockDir = dir.resolve("run");
+    var socket = sockDir.resolve("pty.sock");
+    try (var host =
+        new PtySessionHost(
+            socket,
+            dir.resolve("sessions"),
+            64 * 1024,
+            token -> new PtyIdentity("uday", true),
+            PtyEvents.NONE)) {
+      host.start();
+
+      assertGroupAndOtherDenied(Files.getPosixFilePermissions(socket), "socket");
+      assertGroupAndOtherDenied(Files.getPosixFilePermissions(sockDir), "socket directory");
+    }
+  }
+
+  private static void assertGroupAndOtherDenied(Set<PosixFilePermission> perms, String what) {
+    for (var perm : PosixFilePermission.values()) {
+      if (perm.name().startsWith("GROUP") || perm.name().startsWith("OTHERS")) {
+        assertFalse(perms.contains(perm), what + " must not grant " + perm);
+      }
+    }
+    assertTrue(perms.contains(PosixFilePermission.OWNER_READ), what + " stays owner-readable");
+  }
+}


### PR DESCRIPTION
Follow-up to the Brick 0/1 correctness review. Two fixes, each reproduction-first.

## The race (HIGH)
`Pty` shared one 64KB native buffer and one errno segment between `read()` (the per-session gather thread) and `write()` (the write-token holder's connection thread). Typing during output — the normal interactive case — raced the two, corrupting one stream or the other; the test suite never caught it because its I/O is ping-pong with gaps and the flood test is output-only.

Each call now allocates its own confined arena (the pattern `resize()` already used), so the two halves share zero native state. `PtyConcurrencyTest.concurrentReadAndWriteNeverCorruptEitherStream` — 1000 lines written concurrently with a draining reader — errored on every run of the old code and is clean now. The same rewrite killed a second bug the test exposed: `arena.close()` threw `IllegalStateException: Session is acquired` when a downcall was in flight. `close()` now touches no arena, and `read()` treats a closed fd (`EBADF`) as end of stream, so a close racing a blocked read is clean — pinned by `closeWhileAReaderIsActiveIsCleanAndEndsTheStream`.

## The socket (LOW, defensive)
The pty socket is the identity boundary's only door — a blank-token connection resolves to the box owner — so any local process that could open it would act as the owner. `start()` now creates an owner-only socket directory and restricts the socket to `rwx------`; `PtySocketPermissionsTest` asserts no group/other access. This also fixed a latent fragility: `start()` never created the socket's parent directory (worked only because `~/.sail` happens to exist).

Full `mvn clean verify` + integration lanes + GraalVM 25 green.