### PR TITLE
fix(pty): harden the session host and CLI attach (Brick 0-2 review)

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/pty/Pty.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/Pty.java
@@ -138,17 +138,22 @@ public final class Pty implements AutoCloseable {
         throw new IOException("posix_openpt failed; no pseudo-terminals available.");
       }
       if ((int) LIBC.grantpt().invokeExact(fd) != 0 || (int) LIBC.unlockpt().invokeExact(fd) != 0) {
-        LIBC.close().invokeExact(fd);
+        var unused = (int) LIBC.close().invokeExact(fd);
         throw new IOException("grantpt/unlockpt failed for the new pseudo-terminal.");
       }
       var name = (MemorySegment) LIBC.ptsname().invokeExact(fd);
       if (name.equals(MemorySegment.NULL)) {
-        LIBC.close().invokeExact(fd);
+        var unused = (int) LIBC.close().invokeExact(fd);
         throw new IOException("ptsname returned no slave path for fd " + fd + ".");
       }
       var slave = name.reinterpret(256).getString(0);
       var pty = new Pty(fd, slave);
-      pty.resize(cols, rows);
+      try {
+        pty.resize(cols, rows);
+      } catch (IOException e) {
+        pty.close();
+        throw e;
+      }
       return pty;
     } catch (IOException e) {
       throw e;

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -144,6 +144,7 @@ public final class PtySession implements AutoCloseable {
 
   private void gather() {
     var buf = new byte[65536];
+    String failure = null;
     try {
       while (true) {
         var n = pty.read(buf);
@@ -163,18 +164,26 @@ public final class PtySession implements AutoCloseable {
         }
       }
     } catch (IOException e) {
-      endedReason = "pty failed: " + e.getMessage();
+      failure = "pty failed: " + e.getMessage();
     } finally {
-      var exit = child.onExit().join().exitValue();
-      if (endedReason == null) {
-        endedReason = "exited(" + exit + ")";
+      try {
+        var reason =
+            failure != null ? failure : "exited(" + child.onExit().join().exitValue() + ")";
+        pty.close();
+        synchronized (fanout) {
+          endedAtNanos = System.nanoTime();
+          endedReason = reason;
+          var ended = new PtyMessage.SessionEnded(reason);
+          subscribers.values().forEach(subscriber -> subscriber.queue().force(ended));
+        }
+        try {
+          events.sessionEnded(name, project, reason);
+        } catch (RuntimeException ignored) {
+          var unused = ignored;
+        }
+      } finally {
+        gatherDone.countDown();
       }
-      endedAtNanos = System.nanoTime();
-      pty.close();
-      var ended = new PtyMessage.SessionEnded(endedReason);
-      subscribers.values().forEach(subscriber -> subscriber.queue().force(ended));
-      events.sessionEnded(name, project, endedReason);
-      gatherDone.countDown();
     }
   }
 
@@ -194,6 +203,9 @@ public final class PtySession implements AutoCloseable {
       }
       subscriber.queue().force(new PtyMessage.ReplayEnd());
       subscribers.put(subscriber.id, subscriber);
+      if (endedReason != null) {
+        subscriber.queue().force(new PtyMessage.SessionEnded(endedReason));
+      }
     }
     synchronized (this) {
       if (wantsWrite && writerId < 0) {
@@ -225,13 +237,19 @@ public final class PtySession implements AutoCloseable {
     }
   }
 
-  /** Writes input; only the write-token holder may, and the sequence rides future output. */
-  public void input(long subscriberId, long seq, byte[] bytes) throws IOException {
+  /**
+   * Writes input on behalf of {@code subscriberId}; only the write-token holder may. Returns {@code
+   * false} — never throws — when the caller does not hold the token, so a non-writer's stray input
+   * is a refusable outcome, not a fatal error that tears down its connection. An {@link
+   * IOException} means the pty write itself failed. The sequence rides future output.
+   */
+  public boolean input(long subscriberId, long seq, byte[] bytes) throws IOException {
     if (subscriberId != writerId) {
-      throw new IOException("Subscriber " + subscriberId + " does not hold the write token.");
+      return false;
     }
     lastInputSeq.set(seq);
     pty.write(bytes);
+    return true;
   }
 
   /** Transfers the write token to {@code subscriberId}; everyone hears about it. */
@@ -245,16 +263,21 @@ public final class PtySession implements AutoCloseable {
     subscribers.values().forEach(subscriber -> subscriber.queue().force(changed));
   }
 
-  /** Resizes; only the write-token holder may, and observers hear the new geometry. */
-  public void resize(long subscriberId, int cols, int rows) throws IOException {
+  /**
+   * Resizes on behalf of {@code subscriberId}; only the write-token holder may, and observers hear
+   * the new geometry. Returns {@code false} — never throws — for a non-writer, so an observer's own
+   * window change is a silent no-op rather than a fatal error: the writer's window wins.
+   */
+  public boolean resize(long subscriberId, int cols, int rows) throws IOException {
     if (subscriberId != writerId) {
-      throw new IOException("Only the writer resizes; the writer's window wins.");
+      return false;
     }
     pty.resize(cols, rows);
     var resized = new PtyMessage.Resized(cols, rows);
     subscribers.values().stream()
         .filter(subscriber -> subscriber.id() != subscriberId)
         .forEach(subscriber -> subscriber.queue().force(resized));
+    return true;
   }
 
   public synchronized void detach(long subscriberId) {

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyWire.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyWire.java
@@ -39,6 +39,10 @@ public final class PtyWire {
 
   public static void write(WritableByteChannel out, PtyMessage message) throws IOException {
     var payload = encode(message);
+    if (payload.length > MAX_FRAME) {
+      throw new IOException(
+          "Refusing to send a pty frame of " + payload.length + " bytes; the cap is 1 MiB.");
+    }
     var frame = ByteBuffer.allocate(4 + payload.length);
     frame.putInt(payload.length).put(payload).flip();
     writeFully(out, frame);
@@ -144,7 +148,7 @@ public final class PtyWire {
       case 27 -> new PtyMessage.SessionEnded(string(in));
       case 28 -> decodeInfo(in);
       case 29 -> {
-        var count = in.getInt();
+        var count = bounded(in);
         var sessions = new ArrayList<PtyMessage.SessionInfo>(count);
         for (var i = 0; i < count; i++) {
           sessions.add(decodeInfo(in));
@@ -157,29 +161,47 @@ public final class PtyWire {
     };
   }
 
-  private static PtyMessage.SessionInfo decodeInfo(ByteBuffer in) {
+  private static PtyMessage.SessionInfo decodeInfo(ByteBuffer in) throws IOException {
     return new PtyMessage.SessionInfo(string(in), in.get() == 1, in.getInt(), string(in));
   }
 
-  private static String string(ByteBuffer in) {
+  private static String string(ByteBuffer in) throws IOException {
     var bytes = bytes(in);
     return bytes.length == 0 ? "" : new String(bytes, StandardCharsets.UTF_8);
   }
 
-  private static byte[] bytes(ByteBuffer in) {
-    var length = in.getInt();
-    var bytes = new byte[length];
+  private static byte[] bytes(ByteBuffer in) throws IOException {
+    var bytes = new byte[bounded(in)];
     in.get(bytes);
     return bytes;
   }
 
-  private static List<String> stringList(ByteBuffer in) {
-    var count = in.getInt();
+  private static List<String> stringList(ByteBuffer in) throws IOException {
+    var count = bounded(in);
     var values = new ArrayList<String>(count);
     for (var i = 0; i < count; i++) {
       values.add(string(in));
     }
     return List.copyOf(values);
+  }
+
+  /**
+   * A length or element count read from within a frame, validated before it sizes any allocation: a
+   * corrupt inner field can never exceed what the (already-capped) frame still holds, so a tiny
+   * frame can never drive a giant array. Fails loud rather than throwing an unchecked {@code
+   * NegativeArraySizeException} or {@code OutOfMemoryError} past the {@code read} contract.
+   */
+  private static int bounded(ByteBuffer in) throws IOException {
+    var value = in.getInt();
+    if (value < 0 || value > in.remaining()) {
+      throw new IOException(
+          "Corrupt pty frame: a field claims "
+              + value
+              + " bytes but only "
+              + in.remaining()
+              + " remain.");
+    }
+    return value;
   }
 
   private static void readFully(ReadableByteChannel in, ByteBuffer buf) throws IOException {

--- a/sail-core/src/main/java/ai/singlr/sail/pty/SubscriberQueue.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/SubscriberQueue.java
@@ -20,7 +20,6 @@ final class SubscriberQueue {
   private final int capacity;
   private final Deque<PtyMessage> queue = new ArrayDeque<>();
   private boolean paused;
-  private boolean closed;
 
   SubscriberQueue(int capacity) {
     this.capacity = capacity;
@@ -28,7 +27,7 @@ final class SubscriberQueue {
 
   /** Offers a live message; a full queue trips the pause, a paused queue drops silently. */
   synchronized void enqueue(PtyMessage message) {
-    if (closed || paused) {
+    if (paused) {
       return;
     }
     if (queue.size() >= capacity) {
@@ -43,9 +42,6 @@ final class SubscriberQueue {
 
   /** Enqueues regardless of pause — endings and poison must always arrive. */
   synchronized void force(PtyMessage message) {
-    if (closed) {
-      return;
-    }
     queue.add(message);
     notifyAll();
   }
@@ -71,11 +67,5 @@ final class SubscriberQueue {
       wait();
     }
     return queue.poll();
-  }
-
-  synchronized void close() {
-    closed = true;
-    queue.clear();
-    notifyAll();
   }
 }

--- a/sail-core/src/main/java/ai/singlr/sail/pty/TermBoundary.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/TermBoundary.java
@@ -28,6 +28,7 @@ public final class TermBoundary {
   private State state = State.GROUND;
   private int utf8Pending;
   private boolean atLineStart = true;
+  private boolean stringIsOsc;
 
   /** Advances over {@code buf[0..len)}. */
   public void feed(byte[] buf, int len) {
@@ -51,21 +52,28 @@ public final class TermBoundary {
           }
           atLineStart = b == '\n';
         }
-        case ESC ->
-            state =
-                switch (b) {
-                  case '[' -> State.CSI;
-                  case ']', 'P', 'X', '^', '_' -> State.STRING;
-                  case 0x1B -> State.ESC;
-                  default -> State.GROUND;
-                };
+        case ESC -> {
+          switch (b) {
+            case '[' -> state = State.CSI;
+            case ']' -> {
+              stringIsOsc = true;
+              state = State.STRING;
+            }
+            case 'P', 'X', '^', '_' -> {
+              stringIsOsc = false;
+              state = State.STRING;
+            }
+            case 0x1B -> state = State.ESC;
+            default -> state = State.GROUND;
+          }
+        }
         case CSI -> {
           if (b >= 0x40 && b <= 0x7E) {
             state = State.GROUND;
           }
         }
         case STRING -> {
-          if (b == 0x07) {
+          if (b == 0x07 && stringIsOsc) {
             state = State.GROUND;
           } else if (b == 0x1B) {
             state = State.STRING_ESC;

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -6,7 +6,9 @@
 package ai.singlr.sail.pty;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -182,9 +184,9 @@ class PtySessionTest {
       var firstId = session.attach(first, true, "uday");
       var secondId = session.attach(second, false, "uday");
 
-      assertThrows(
-          IOException.class,
-          () -> session.input(secondId, 1, "nope\n".getBytes(StandardCharsets.UTF_8)));
+      assertFalse(
+          session.input(secondId, 1, "nope\n".getBytes(StandardCharsets.UTF_8)),
+          "a non-writer's input is refused, not fatal");
 
       session.takeWrite(secondId, "mady");
       var deadline = System.nanoTime() + 5_000_000_000L;
@@ -193,9 +195,9 @@ class PtySessionTest {
       }
       assertTrue(first.saw(PtyMessage.WriterChanged.class), "the old writer hears the takeover");
 
-      assertThrows(
-          IOException.class,
-          () -> session.input(firstId, 2, "stale\n".getBytes(StandardCharsets.UTF_8)));
+      assertFalse(
+          session.input(firstId, 2, "stale\n".getBytes(StandardCharsets.UTF_8)),
+          "the demoted writer can no longer write");
       session.input(secondId, 3, "fresh\n".getBytes(StandardCharsets.UTF_8));
       second.awaitOutput("done:fresh");
     }
@@ -256,5 +258,39 @@ class PtySessionTest {
 
       assertTrue(session.live(), "the child never blocked on the stalled observer");
     }
+  }
+
+  @Test
+  void aFailingEndEventStillReleasesTheSessionInsteadOfWedgingClose() throws Exception {
+    var brittle =
+        new PtyEvents() {
+          @Override
+          public void sessionStarted(String session, String project, String fde) {}
+
+          @Override
+          public void sessionAttached(String session, String project, String fde) {}
+
+          @Override
+          public void sessionEnded(String session, String project, String reason) {
+            throw new RuntimeException("the event sink is down");
+          }
+        };
+    var session =
+        PtySession.start(
+            "brittle",
+            "uday",
+            "acme",
+            brittle,
+            List.of("sh", "-c", "exit 0"),
+            Map.of("TERM", "dumb"),
+            Path.of("/tmp"),
+            dir.resolve("brittle.ring"),
+            64 * 1024,
+            80,
+            24);
+    assertTimeoutPreemptively(
+        java.time.Duration.ofSeconds(10),
+        session::close,
+        "close must not hang when the end-of-session event throws");
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtyWireTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtyWireTest.java
@@ -111,4 +111,33 @@ class PtyWireTest {
     pipe.sink().close();
     assertThrows(java.io.EOFException.class, () -> PtyWire.read(pipe.source()));
   }
+
+  @Test
+  void aLyingInnerLengthIsRefusedNotAllocated() throws Exception {
+    assertThrows(
+        IOException.class,
+        () ->
+            readFramed(ByteBuffer.allocate(13).put((byte) 3).putLong(7).putInt(Integer.MAX_VALUE)),
+        "a tiny Input frame claiming 2 GiB of bytes must fail loud, never allocate");
+
+    assertThrows(
+        IOException.class,
+        () -> readFramed(ByteBuffer.allocate(5).put((byte) 29).putInt(Integer.MAX_VALUE)),
+        "a tiny Sessions frame claiming 2 billion entries must fail loud, never pre-size a list");
+
+    assertThrows(
+        IOException.class,
+        () -> readFramed(ByteBuffer.allocate(13).put((byte) 3).putLong(7).putInt(-1)),
+        "a negative inner length must fail loud, never throw NegativeArraySizeException");
+  }
+
+  private static void readFramed(ByteBuffer payload) throws IOException {
+    payload.flip();
+    var frame = ByteBuffer.allocate(4 + payload.remaining());
+    frame.putInt(payload.remaining()).put(payload).flip();
+    var pipe = Pipe.open();
+    pipe.sink().write(frame);
+    pipe.sink().close();
+    PtyWire.read(pipe.source());
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/pty/TermBoundaryTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/TermBoundaryTest.java
@@ -13,6 +13,9 @@ import org.junit.jupiter.api.Test;
 
 class TermBoundaryTest {
 
+  private static final byte ESC = 0x1b;
+  private static final byte BEL = 0x07;
+
   private static TermBoundary fed(byte[] bytes) {
     var boundary = new TermBoundary();
     boundary.feed(bytes, bytes.length);
@@ -32,24 +35,46 @@ class TermBoundaryTest {
 
   @Test
   void aStreamInsideAnEscapeSequenceIsNeverSafe() {
-    assertFalse(fed("x\u001b").atSafeBoundary());
-    assertFalse(fed("x\u001b[3").atSafeBoundary());
-    assertFalse(fed("x\u001b[38;5;19").atSafeBoundary());
-    assertTrue(fed("x\u001b[38;5;196m").atSafeBoundary());
+    assertFalse(fed(new byte[] {'x', ESC}).atSafeBoundary());
+    assertFalse(fed(new byte[] {'x', ESC, '[', '3'}).atSafeBoundary());
+    assertFalse(
+        fed(new byte[] {'x', ESC, '[', '3', '8', ';', '5', ';', '1', '9'}).atSafeBoundary());
+    assertTrue(
+        fed(new byte[] {'x', ESC, '[', '3', '8', ';', '5', ';', '1', '9', '6', 'm'})
+            .atSafeBoundary());
   }
 
   @Test
-  void oscAndDcsStringsCloseOnBelOrStOnly() {
-    assertFalse(fed("\u001b]0;title").atSafeBoundary());
-    assertTrue(fed("\u001b]0;title\u0007").atSafeBoundary());
-    assertTrue(fed("\u001b]0;title\u001b\\").atSafeBoundary());
-    assertFalse(fed("\u001bPdata").atSafeBoundary());
-    assertTrue(fed("\u001bPdata\u001b\\").atSafeBoundary());
+  void oscClosesOnBelOrSt() {
+    assertFalse(fed(new byte[] {ESC, ']', '0', ';', 't'}).atSafeBoundary());
+    assertTrue(fed(new byte[] {ESC, ']', '0', ';', 't', BEL}).atSafeBoundary());
+    assertTrue(fed(new byte[] {ESC, ']', '0', ';', 't', ESC, '\\'}).atSafeBoundary());
+  }
+
+  @Test
+  void dcsIgnoresBelAndClosesOnStOnly() {
+    assertFalse(
+        fed(new byte[] {ESC, 'P', 'd', BEL, 'a'}).atSafeBoundary(),
+        "BEL is data inside a DCS, not a terminator");
+    assertTrue(fed(new byte[] {ESC, 'P', 'd', 'a', ESC, '\\'}).atSafeBoundary());
+    for (var opener : new byte[] {'X', '^', '_'}) {
+      assertFalse(
+          fed(new byte[] {ESC, opener, 'd', BEL, 'a'}).atSafeBoundary(),
+          "BEL must not terminate the string opener " + (char) opener);
+    }
+  }
+
+  @Test
+  void aBelThenNewlineInsideADcsIsNeverASafeLineStart() {
+    assertFalse(
+        fed(new byte[] {ESC, 'P', 'q', BEL, '\n'}).atSafeLineStart(),
+        "a newline in DCS payload after an embedded BEL is not a safe replay point");
+    assertTrue(fed(new byte[] {ESC, 'P', 'q', ESC, '\\', '\n'}).atSafeLineStart());
   }
 
   @Test
   void aSplitUtf8CharacterIsNotABoundary() {
-    var snowman = "x\u2603".getBytes(StandardCharsets.UTF_8);
+    var snowman = "x☃".getBytes(StandardCharsets.UTF_8);
     var partial = new TermBoundary();
     partial.feed(snowman, snowman.length - 1);
     assertFalse(partial.atSafeBoundary());
@@ -59,7 +84,7 @@ class TermBoundaryTest {
 
   @Test
   void feedingInArbitraryChunksMatchesFeedingWhole() {
-    var text = "a\u001b[1;31mred\u001b]0;t\u0007\u2603\nnext".getBytes(StandardCharsets.UTF_8);
+    var text = "a[1;31mred]0;t☃\nnext".getBytes(StandardCharsets.UTF_8);
     for (var chunk = 1; chunk <= text.length; chunk++) {
       var boundary = new TermBoundary();
       for (var i = 0; i < text.length; i += chunk) {

--- a/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
@@ -149,13 +149,13 @@ public final class PtySessionHost implements AutoCloseable {
           case PtyMessage.Input m -> {
             if (attached == null) {
               reply(channel, new PtyMessage.Err("Attach before writing."));
-            } else {
-              attached.input(subscriberId, m.seq(), m.bytes());
+            } else if (!attached.input(subscriberId, m.seq(), m.bytes())) {
+              reply(channel, new PtyMessage.Err("You do not hold the write token."));
             }
           }
           case PtyMessage.Resize m -> {
             if (attached != null) {
-              attached.resize(subscriberId, m.cols(), m.rows());
+              var unused = attached.resize(subscriberId, m.cols(), m.rows());
             }
           }
           case PtyMessage.TakeWrite m -> {
@@ -173,7 +173,7 @@ public final class PtySessionHost implements AutoCloseable {
             }
             reply(channel, new PtyMessage.Ok());
           }
-          case PtyMessage.ListSessions m -> reply(channel, listSessions());
+          case PtyMessage.ListSessions m -> reply(channel, listSessions(who));
           case PtyMessage.Kill m -> reply(channel, kill(m.session(), who));
           default -> reply(channel, new PtyMessage.Err("Unexpected client frame."));
         }
@@ -191,6 +191,10 @@ public final class PtySessionHost implements AutoCloseable {
 
   private PtyMessage create(PtyMessage.Create m, PtyIdentity who) {
     var existing = sessions.get(m.session());
+    if (existing != null && !admitted(who, existing)) {
+      return new PtyMessage.Err(
+          "Session '" + m.session() + "' belongs to " + existing.ownerFde() + ".");
+    }
     if (existing != null && existing.live()) {
       return new PtyMessage.Err(
           "Session '" + m.session() + "' is already running; attach or kill it.");
@@ -221,9 +225,10 @@ public final class PtySessionHost implements AutoCloseable {
     }
   }
 
-  private PtyMessage listSessions() {
+  private PtyMessage listSessions(PtyIdentity who) {
     var infos = new ArrayList<PtyMessage.SessionInfo>();
     sessions.values().stream()
+        .filter(session -> admitted(who, session))
         .sorted(java.util.Comparator.comparing(PtySession::name))
         .forEach(
             session ->

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
@@ -159,6 +159,114 @@ class PtySessionHostTest {
     }
   }
 
+  private static PtyMessage readControl(SocketChannel channel) throws IOException {
+    while (true) {
+      var m = PtyWire.read(channel);
+      if (m instanceof PtyMessage.Ok
+          || m instanceof PtyMessage.Err
+          || m instanceof PtyMessage.Sessions
+          || m instanceof PtyMessage.SessionEnded) {
+        return m;
+      }
+    }
+  }
+
+  private static PtyMessage.Sessions awaitCorpse(SocketChannel channel, String name)
+      throws IOException {
+    var deadline = System.nanoTime() + 10_000_000_000L;
+    while (System.nanoTime() < deadline) {
+      PtyWire.write(channel, new PtyMessage.ListSessions());
+      var listed = (PtyMessage.Sessions) readControl(channel);
+      if (listed.sessions().stream().anyMatch(s -> s.name().equals(name) && !s.live())) {
+        return listed;
+      }
+    }
+    throw new AssertionError("session '" + name + "' never became a corpse");
+  }
+
+  @Test
+  void aNonWritersInputIsRefusedWithoutKillingTheConnection() throws Exception {
+    try (var ignored = startHost()) {
+      try (var owner = connect("tok-uday")) {
+        PtyWire.write(
+            owner,
+            new PtyMessage.Create(
+                "shared", List.of("sh", "-c", "read a; read b"), "/tmp", "acme", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, readControl(owner));
+      }
+      try (var observer = connect("tok-uday")) {
+        PtyWire.write(observer, new PtyMessage.Attach("shared", false));
+        assertInstanceOf(PtyMessage.Ok.class, readControl(observer));
+
+        PtyWire.write(observer, new PtyMessage.Input(1, "nope\n".getBytes(StandardCharsets.UTF_8)));
+        assertInstanceOf(
+            PtyMessage.Err.class, readControl(observer), "a non-writer's input is refused");
+
+        PtyWire.write(observer, new PtyMessage.ListSessions());
+        assertInstanceOf(
+            PtyMessage.Sessions.class,
+            readControl(observer),
+            "the connection survives the refusal and still answers");
+      }
+    }
+  }
+
+  @Test
+  void listSessionsShowsOnlyYourOwnUnlessAdmin() throws Exception {
+    try (var ignored = startHost()) {
+      try (var uday = connect("tok-uday")) {
+        PtyWire.write(
+            uday,
+            new PtyMessage.Create("udays", List.of("sh", "-c", "read a"), "/tmp", "acme", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, readControl(uday));
+      }
+      try (var mady = connect("tok-mady")) {
+        PtyWire.write(
+            mady,
+            new PtyMessage.Create("madys", List.of("sh", "-c", "read a"), "/tmp", "acme", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, readControl(mady));
+
+        PtyWire.write(mady, new PtyMessage.ListSessions());
+        var listed = (PtyMessage.Sessions) readControl(mady);
+        assertEquals(
+            List.of("madys"),
+            listed.sessions().stream().map(PtyMessage.SessionInfo::name).toList(),
+            "a member sees only their own sessions, never another owner's");
+      }
+      try (var admin = connect("tok-root")) {
+        PtyWire.write(admin, new PtyMessage.ListSessions());
+        var listed = (PtyMessage.Sessions) readControl(admin);
+        assertEquals(2, listed.sessions().size(), "an admin sees every owner's sessions");
+      }
+    }
+  }
+
+  @Test
+  void aForeignMemberCannotEvictAnothersCorpseByReusingItsName() throws Exception {
+    try (var ignored = startHost()) {
+      try (var uday = connect("tok-uday")) {
+        PtyWire.write(
+            uday,
+            new PtyMessage.Create("keep", List.of("sh", "-c", "exit 0"), "/tmp", "acme", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, readControl(uday));
+        awaitCorpse(uday, "keep");
+      }
+      try (var mady = connect("tok-mady")) {
+        PtyWire.write(mady, new PtyMessage.Create("keep", List.of("sh"), "/tmp", "acme", 80, 24));
+        assertInstanceOf(
+            PtyMessage.Err.class,
+            readControl(mady),
+            "a foreign member cannot reuse an owner's name, even a corpse");
+      }
+      try (var uday = connect("tok-uday")) {
+        PtyWire.write(uday, new PtyMessage.ListSessions());
+        var listed = (PtyMessage.Sessions) readControl(uday);
+        assertEquals(1, listed.sessions().size(), "the owner's corpse is left intact");
+        assertEquals("keep", listed.sessions().getFirst().name());
+      }
+    }
+  }
+
   @Test
   void createAttachConverseDetachReattachRepays() throws Exception {
     try (var ignored = startHost()) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AttachLoop.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AttachLoop.java
@@ -24,11 +24,31 @@ public final class AttachLoop {
 
   public static final int DETACH_KEY = 0x1D;
 
+  /**
+   * A source of terminal-size changes to forward to the remote pty. {@link #next()} blocks until
+   * the next size, returning {@code {cols, rows}}, or {@code null} once there are no more — so the
+   * loop's resize thread ends cleanly. {@link #NONE} never resizes, for callers with no live
+   * terminal.
+   */
+  @FunctionalInterface
+  public interface Resizes {
+    int[] next() throws InterruptedException;
+
+    Resizes NONE = () -> null;
+  }
+
   private AttachLoop() {}
 
   public static String run(ByteChannel channel, InputStream stdin, OutputStream stdout)
       throws IOException {
+    return run(channel, stdin, stdout, Resizes.NONE);
+  }
+
+  public static String run(
+      ByteChannel channel, InputStream stdin, OutputStream stdout, Resizes resizes)
+      throws IOException {
     var seq = new AtomicLong();
+    var writeLock = new Object();
     var pump =
         Thread.ofVirtual()
             .start(
@@ -42,15 +62,34 @@ public final class AttachLoop {
                       }
                       for (var i = 0; i < n; i++) {
                         if ((buf[i] & 0xFF) == DETACH_KEY) {
-                          PtyWire.write(channel, new PtyMessage.Detach());
+                          synchronized (writeLock) {
+                            PtyWire.write(channel, new PtyMessage.Detach());
+                          }
                           return;
                         }
                       }
                       var chunk = new byte[n];
                       System.arraycopy(buf, 0, chunk, 0, n);
-                      PtyWire.write(channel, new PtyMessage.Input(seq.incrementAndGet(), chunk));
+                      synchronized (writeLock) {
+                        PtyWire.write(channel, new PtyMessage.Input(seq.incrementAndGet(), chunk));
+                      }
                     }
                   } catch (IOException ignored) {
+                    var unused = ignored;
+                  }
+                });
+    var resizer =
+        Thread.ofVirtual()
+            .start(
+                () -> {
+                  try {
+                    int[] size;
+                    while ((size = resizes.next()) != null) {
+                      synchronized (writeLock) {
+                        PtyWire.write(channel, new PtyMessage.Resize(size[0], size[1]));
+                      }
+                    }
+                  } catch (InterruptedException | IOException ignored) {
                     var unused = ignored;
                   }
                 });
@@ -81,6 +120,7 @@ public final class AttachLoop {
       return "connection closed";
     } finally {
       pump.interrupt();
+      resizer.interrupt();
     }
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SessionCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SessionCommand.java
@@ -121,7 +121,7 @@ public final class SessionCommand {
         Stty.set("raw -echo");
         String reason;
         try {
-          reason = AttachLoop.run(channel, System.in, System.out);
+          reason = AttachLoop.run(channel, System.in, System.out, terminalResizes());
         } finally {
           Stty.set(saved);
         }
@@ -131,6 +131,30 @@ public final class SessionCommand {
       }
       return 0;
     }
+  }
+
+  /**
+   * The controlling terminal's live geometry as {@code {cols, rows}} resize events: the current
+   * size up front (so the remote pty matches this terminal, not the size it was created at), then
+   * one on every {@code SIGWINCH}. Degrades to no resizes when signals are unavailable (native
+   * image edge, no controlling tty) — the pty simply keeps its last known size.
+   */
+  static AttachLoop.Resizes terminalResizes() {
+    var fallback = new int[] {24, 80};
+    var changes = new java.util.concurrent.LinkedBlockingQueue<int[]>();
+    try {
+      sun.misc.Signal.handle(
+          new sun.misc.Signal("WINCH"),
+          signal -> {
+            var size = Stty.size(fallback);
+            changes.offer(new int[] {size[1], size[0]});
+          });
+    } catch (IllegalArgumentException | IllegalStateException e) {
+      return AttachLoop.Resizes.NONE;
+    }
+    var initial = Stty.size(fallback);
+    changes.offer(new int[] {initial[1], initial[0]});
+    return changes::take;
   }
 
   @Command(name = "kill", description = "End a session and its process.")

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
@@ -79,4 +79,57 @@ class AttachLoopTest {
       }
     }
   }
+
+  @Test
+  void aTerminalResizeReachesTheRemotePty() throws Exception {
+    try (var host =
+        new PtySessionHost(
+            dir.resolve("h.sock"),
+            dir.resolve("s"),
+            64 * 1024,
+            token -> new ai.singlr.sail.pty.PtyIdentity("uday", true),
+            ai.singlr.sail.pty.PtyEvents.NONE)) {
+      host.start();
+      try (var client = SessionClient.connect(dir.resolve("h.sock"))) {
+        client.create(
+            "s1",
+            List.of("sh", "-c", "trap 'stty size; exit 0' WINCH; echo ready; read a"),
+            "/tmp",
+            "acme",
+            80,
+            24);
+        var channel = client.attach("s1", true);
+
+        var ready = new java.util.concurrent.CountDownLatch(1);
+        var stdout =
+            new ByteArrayOutputStream() {
+              @Override
+              public synchronized void write(byte[] b, int off, int len) {
+                super.write(b, off, len);
+                if (toString(StandardCharsets.UTF_8).contains("ready")) {
+                  ready.countDown();
+                }
+              }
+            };
+        var fired = new java.util.concurrent.atomic.AtomicBoolean();
+        AttachLoop.Resizes resizes =
+            () -> {
+              if (!fired.compareAndSet(false, true)) {
+                return null;
+              }
+              ready.await();
+              return new int[] {100, 40};
+            };
+
+        var stdin = new PipedInputStream(new PipedOutputStream());
+        var reason = AttachLoop.run(channel, stdin, stdout, resizes);
+
+        assertEquals("exited(0)", reason);
+        assertTrue(
+            stdout.toString(StandardCharsets.UTF_8).contains("40 100"),
+            "the child's SIGWINCH trap saw the forwarded 100x40 geometry: "
+                + stdout.toString(StandardCharsets.UTF_8));
+      }
+    }
+  }
 }


### PR DESCRIPTION
Adversarial review of the pty session host (Bricks 0-2) with 5 independent reviewers; every plausible finding was verified against source before any change, false positives discarded, and confirmed defects fixed TDD-first.

## Fixed (confirmed real)
**Native + wire (`sail-core`)**
- **`Pty.open()` — `WrongMethodTypeException` + fd leak on the error path.** `close()` was called via a bare `invokeExact` on the `(int)int` handle (the `close()` method casts it correctly; these two sites didn't), so a `grantpt`/`unlockpt`/`ptsname` failure threw the wrong exception and leaked the master fd. Also closes the fd when the initial `resize` fails.
- **`PtyWire.decode()` — untrusted inner length/count → OOM / `NegativeArraySizeException`.** A tiny frame could declare a 2 GiB byte length or a 2-billion element count and drive the allocation *before* any bounds check, escaping the `read()` `IOException` contract. New `bounded()` validates every field against the bytes remaining; `write()` now enforces the same 1 MiB cap as `read()`.
- **`PtySession` — `SessionEnded` lost on an attach-vs-exit race.** The end broadcast and the attach guard both sat outside `fanout`; a client attaching as the child exits could stream replay then hang forever. The ending now publishes under `fanout`, attach re-checks after inserting, `countDown` moved to a guaranteeing inner `finally` (a throwing end-event no longer wedges `close()`), and `endedAtNanos` publishes before `endedReason`.
- **`TermBoundary` — BEL falsely terminated DCS/SOS/PM/APC.** BEL is data inside those; only OSC ends on BEL. A DCS carrying BEL could mark a safe replay boundary mid-sequence → garbled replay.
- **`SubscriberQueue.close()`** was dead code hiding a latent deadlock; removed.

**Host (`sail-harness`)**
- **Non-writer `Input`/`Resize` killed the connection** (IOException escaped to the connection-closing catch). `input()`/`resize()` now return a boolean; the host replies `Err` to a non-writer's input and silently ignores a non-writer's resize.
- **`listSessions` leaked every owner's session metadata** to any authenticated member — now filtered by admission (admins still see all).
- **`create()` let a foreign FDE evict/delete another owner's corpse** (and its replay history) by reusing the name — now refused unless admitted.

**CLI attach (`sail-infra`)**
- **`session attach` never forwarded terminal resizes**, freezing the remote pty at attach-time size. `AttachLoop` gained a testable `Resizes` seam with serialized channel writes; the attach command drives it from a `SIGWINCH` watch (current size up front, then on every change).

## Deferred (documented, not defects)
Host-restart journal rehydration (child is dead post-restart anyway); the "any subscriber can resize" review note was a **false positive** — `PtySession.resize` already gates on the write token.

## Tests / gates
New tests for each fix (lying inner length; DCS-BEL boundary; end-event-can't-wedge-close; non-writer refusal survives; tenant-scoped list; foreign corpse protection; SIGWINCH resize reaches the pty). `mvn verify` green (JaCoCo gate incl.), 2989 unit tests across the three modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
