### PR TITLE
fix(pty): install the pty-host service on upgrade

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -13,10 +13,13 @@ import ai.singlr.sail.engine.DemoSeeder;
 import ai.singlr.sail.engine.FileImporter;
 import ai.singlr.sail.engine.IncusDeviceManager;
 import ai.singlr.sail.engine.ProjectImporter;
+import ai.singlr.sail.engine.PtyHostUnit;
 import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.Spinner;
 import ai.singlr.sail.engine.SshIdentityProvisioner;
+import ai.singlr.sail.engine.SystemdServiceInstaller;
 import ai.singlr.sail.store.DataMigration;
 import ai.singlr.sail.store.DataMigrations;
 import ai.singlr.sail.store.DataMigrator;
@@ -25,6 +28,7 @@ import ai.singlr.sail.store.MigrationRunner;
 import ai.singlr.sail.store.ProjectStore;
 import ai.singlr.sail.store.Sqlite;
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -33,6 +37,7 @@ import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import picocli.CommandLine.Command;
@@ -93,7 +98,55 @@ public final class MigrateCommand implements Runnable {
       relocateHostConfig(jsonOutput);
       syncAuthorizedKeys(db, jsonOutput);
       relocateContainerSockets(jsonOutput);
+      ensurePtyHostService(jsonOutput);
       return runs;
+    }
+  }
+
+  /**
+   * Installs {@code sail-pty-host.service} on a provisioned box. The unit is newer than most
+   * existing boxes were provisioned, and {@code sail upgrade} spawns the new binary's {@code
+   * migrate} — so this is the one place that can bring the host up on an upgrade without a manual
+   * step. Gated on the API service being present (a real host, not a stray {@code sail migrate} in
+   * some directory), idempotent ({@code enable --now} never restarts a running host, so live
+   * sessions survive), and fail-soft (a systemd hiccup warns rather than aborting the migration).
+   */
+  private static void ensurePtyHostService(boolean jsonOutput) {
+    var shell = new ShellExecutor(false);
+    var api =
+        HostServiceInstallers.create(
+            shell, "127.0.0.1", 7070, HostServiceInstallers.currentUsername());
+    ensurePtyHostService(
+        api.isInstalled(),
+        shell,
+        api.mode(),
+        Path.of(System.getProperty("user.home")),
+        SailPaths.binaryPath(),
+        jsonOutput);
+  }
+
+  static void ensurePtyHostService(
+      boolean apiInstalled,
+      ShellExec shell,
+      SystemdServiceInstaller.Mode mode,
+      Path userHome,
+      Path binary,
+      boolean jsonOutput) {
+    if (!apiInstalled) {
+      return;
+    }
+    try {
+      new PtyHostUnit(shell, mode, userHome, binary).install();
+      if (!jsonOutput) {
+        System.out.println(Ansi.AUTO.string("  @|green ✓|@ pty session host service ensured"));
+      }
+    } catch (IOException | TimeoutException e) {
+      if (!jsonOutput) {
+        System.out.println(
+            Ansi.AUTO.string("  @|yellow ⚠|@ pty session host not installed: " + e.getMessage()));
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
@@ -7,13 +7,18 @@ package ai.singlr.sail.commands;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.singlr.sail.engine.ScriptedShellExecutor;
+import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.SystemdServiceInstaller;
 import ai.singlr.sail.store.DataMigration;
 import ai.singlr.sail.store.LegacyDataMigration;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.function.UnaryOperator;
@@ -68,6 +73,27 @@ class MigrateCommandTest {
                 row -> row.integer(0),
                 LegacyDataMigration.NAME)
             .orElseThrow());
+  }
+
+  @Test
+  void ensurePtyHostServiceInstallsOnlyOnAProvisionedHost(@TempDir Path home) {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
+    var binary = Path.of("/usr/local/bin/sail");
+
+    MigrateCommand.ensurePtyHostService(
+        false, shell, SystemdServiceInstaller.Mode.USER, home, binary, true);
+    assertTrue(shell.invocations().isEmpty(), "no systemctl where the box has no api service");
+    assertFalse(Files.exists(home.resolve(".sail/services/sail-pty-host.service")));
+
+    MigrateCommand.ensurePtyHostService(
+        true, shell, SystemdServiceInstaller.Mode.USER, home, binary, true);
+    assertTrue(
+        Files.exists(home.resolve(".sail/services/sail-pty-host.service")),
+        "a provisioned host gets the pty-host unit");
+    assertTrue(
+        shell.invocations().stream()
+            .anyMatch(c -> c.contains("systemctl --user enable --now sail-pty-host.service")),
+        "and it is enabled and started");
   }
 
   @Test


### PR DESCRIPTION
`sail upgrade` spawns the just-installed binary's `migrate` (that's how a release's new migrations run), but migrate reconciled only `sail-api`. The pty session host service — `sail-pty-host.service`, newer than most boxes were provisioned — was therefore **never installed on an existing box during an upgrade**. Its socket wouldn't exist, and any client (the `sail session` CLI, Mast's new terminal) would find nothing to attach to. Only a fresh `sail init` or a manual `sail host service install` brought it up.

## Fix
Add an idempotent `ensurePtyHostService` step to `migrate`:
- **Gated** on the API service being installed, so a stray `sail migrate` run in some directory never touches systemd — only a real provisioned host installs it.
- **Idempotent**: `enable --now` never restarts an already-running host, so live sessions survive the upgrade.
- **Fail-soft**: a systemd hiccup warns rather than aborting the whole migration.

This is the one place that can bring the host up on an upgrade (the running upgrade process is the *old* binary; only the spawned new-binary `migrate` has the new unit).

## Tests
`ensurePtyHostServiceInstallsOnlyOnAProvisionedHost`: nothing happens when the API isn't present; a provisioned host gets the unit written and `systemctl --user enable --now sail-pty-host.service`. `mvn verify` (JaCoCo) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
