### PR TITLE
test(pty): gate native-pty tests to Linux

### DIFF
--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtyConcurrencyTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtyConcurrencyTest.java
@@ -16,7 +16,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
+@EnabledOnOs(OS.LINUX)
 class PtyConcurrencyTest {
 
   /**

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -20,8 +20,11 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
+@EnabledOnOs(OS.LINUX)
 class PtySessionTest {
 
   @TempDir Path dir;

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtyTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtyTest.java
@@ -13,7 +13,10 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
+@EnabledOnOs(OS.LINUX)
 class PtyTest {
 
   private static String readUntil(Pty pty, String marker) throws Exception {

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
@@ -18,8 +18,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
+@EnabledOnOs(OS.LINUX)
 class PtySessionHostTest {
 
   @TempDir Path dir;

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySocketPermissionsTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySocketPermissionsTest.java
@@ -14,8 +14,11 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
+@EnabledOnOs(OS.LINUX)
 class PtySocketPermissionsTest {
 
   @TempDir Path dir;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
@@ -17,8 +17,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
+@EnabledOnOs(OS.LINUX)
 class AttachLoopTest {
 
   @TempDir Path dir;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SessionClientTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SessionClientTest.java
@@ -14,8 +14,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
+@EnabledOnOs(OS.LINUX)
 class SessionClientTest {
 
   @TempDir Path dir;

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SessionVerbsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SessionVerbsTest.java
@@ -11,9 +11,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
 
+@EnabledOnOs(OS.LINUX)
 class SessionVerbsTest {
 
   @TempDir Path dir;


### PR DESCRIPTION
The pty host is Linux-only (Pty uses the Linux `TIOCSWINSZ` ioctl value and `setsid --ctty`; the host runs only inside the Linux container — the macOS binary is the CLI client that never creates a local pty). The v0.35.0 release's macOS `mvn clean test` ran those tests on the runner and every real-pty test errored with `TIOCSWINSZ failed on the pty master` — surfacing only at release because PR CI is Ubuntu-only and this stack had never been cut before.

Gate the eight real-pty/host/socket test classes `@EnabledOnOs(OS.LINUX)`: PtyTest, PtySessionTest, PtyConcurrencyTest, PtySessionHostTest, PtySocketPermissionsTest, AttachLoopTest, SessionClientTest, SessionVerbsTest. They still run+pass on Linux (PR CI, the ubuntu release build, the devbox) and skip on macOS. The pure tests (PtyWire, TermBoundary, RingJournal, SubscriberQueue) stay cross-platform. `mvn clean test` (no jacoco) is the release step, so skipped tests don't trip a coverage gate.

Unblocks the v0.35.0 re-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)