### PR TITLE
fix(pty): register pty FFM downcalls for the native image + smoke-test them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,4 +91,6 @@ jobs:
         run: mvn package -Pnative -DskipTests
 
       - name: Smoke test
-        run: ./sail-infra/target/sail -V
+        run: |
+          ./sail-infra/target/sail -V
+          ./sail-infra/target/sail _pty-selftest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,9 @@ jobs:
         run: mvn package -Pnative -DskipTests
 
       - name: Smoke test
-        run: ./sail-infra/target/sail -V
+        run: |
+          ./sail-infra/target/sail -V
+          ./sail-infra/target/sail _pty-selftest
 
       - name: Rename binary
         run: mv sail-infra/target/sail sail-infra/target/${{ matrix.binary-name }}

--- a/sail-core/src/main/resources/META-INF/native-image/ai.singlr/sail-core/reachability-metadata.json
+++ b/sail-core/src/main/resources/META-INF/native-image/ai.singlr/sail-core/reachability-metadata.json
@@ -3,43 +3,112 @@
     "downcalls": [
       {
         "returnType": "jint",
-        "parameterTypes": ["void*", "void*", "jint", "void*"]
+        "parameterTypes": [
+          "void*",
+          "void*",
+          "jint",
+          "void*"
+        ]
       },
       {
         "returnType": "jint",
-        "parameterTypes": ["void*", "void*", "jint", "void*", "void*"]
+        "parameterTypes": [
+          "void*",
+          "void*",
+          "jint",
+          "void*",
+          "void*"
+        ]
       },
       {
         "returnType": "jint",
-        "parameterTypes": ["void*"]
+        "parameterTypes": [
+          "void*"
+        ]
       },
       {
         "returnType": "jint",
-        "parameterTypes": ["void*", "jint"]
+        "parameterTypes": [
+          "void*",
+          "jint"
+        ]
       },
       {
         "returnType": "jint",
-        "parameterTypes": ["void*", "jint", "void*", "jint", "void*"]
+        "parameterTypes": [
+          "void*",
+          "jint",
+          "void*",
+          "jint",
+          "void*"
+        ]
       },
       {
         "returnType": "jint",
-        "parameterTypes": ["void*", "jint", "jlong"]
+        "parameterTypes": [
+          "void*",
+          "jint",
+          "jlong"
+        ]
       },
       {
         "returnType": "jint",
-        "parameterTypes": ["void*", "jint", "jdouble"]
+        "parameterTypes": [
+          "void*",
+          "jint",
+          "jdouble"
+        ]
       },
       {
         "returnType": "jlong",
-        "parameterTypes": ["void*", "jint"]
+        "parameterTypes": [
+          "void*",
+          "jint"
+        ]
       },
       {
         "returnType": "void*",
-        "parameterTypes": ["void*", "jint"]
+        "parameterTypes": [
+          "void*",
+          "jint"
+        ]
       },
       {
         "returnType": "void*",
-        "parameterTypes": ["void*"]
+        "parameterTypes": [
+          "void*"
+        ]
+      },
+      {
+        "returnType": "void*",
+        "parameterTypes": [
+          "jint"
+        ]
+      },
+      {
+        "returnType": "jint",
+        "parameterTypes": [
+          "jint"
+        ]
+      },
+      {
+        "returnType": "jlong",
+        "parameterTypes": [
+          "jint",
+          "void*",
+          "jlong"
+        ],
+        "options": {
+          "captureCallState": true
+        }
+      },
+      {
+        "returnType": "jint",
+        "parameterTypes": [
+          "jint",
+          "jlong",
+          "void*"
+        ]
       }
     ]
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/Sail.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/Sail.java
@@ -19,6 +19,7 @@ import ai.singlr.sail.commands.LoginCommand;
 import ai.singlr.sail.commands.MigrateCommand;
 import ai.singlr.sail.commands.ProjectCommand;
 import ai.singlr.sail.commands.PtyHostCommand;
+import ai.singlr.sail.commands.PtySelfTestCommand;
 import ai.singlr.sail.commands.ServerCommand;
 import ai.singlr.sail.commands.SessionCommand;
 import ai.singlr.sail.commands.SpecCommand;
@@ -52,6 +53,7 @@ import picocli.CommandLine.Help.Ansi;
       GatewayCommand.class,
       SessionCommand.class,
       PtyHostCommand.class,
+      PtySelfTestCommand.class,
       SyncCommand.class,
       SyncServerCommand.class,
       ConflictsCommand.class,

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PtySelfTestCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PtySelfTestCommand.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.pty.Pty;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+
+/**
+ * A native-image self-check for the FFM pty layer: opens a real pty, spawns a trivial child, and
+ * resizes it. Opening the pty forces {@link Pty}'s static initializer, which builds every libc
+ * downcall handle — so a missing foreign registration (which fails only in the GraalVM native
+ * binary, never the JVM unit tests) is caught by the release smoke test rather than by a user. A
+ * no-op on non-Linux, where the pty host never runs.
+ */
+@Command(name = "_pty-selftest", description = "Internal: verify the pty FFM layer.", hidden = true)
+public final class PtySelfTestCommand implements Callable<Integer> {
+
+  @Override
+  public Integer call() {
+    if (!System.getProperty("os.name", "").toLowerCase(java.util.Locale.ROOT).contains("linux")) {
+      System.out.println("pty-selftest: skipped (non-Linux)");
+      return 0;
+    }
+    try (var pty = Pty.open(80, 24)) {
+      var child = pty.spawn(List.of("true"), Map.of("TERM", "dumb"), Path.of("/"));
+      pty.resize(100, 40);
+      child.destroyForcibly();
+      System.out.println("pty-selftest: ok");
+      return 0;
+    } catch (Exception e) {
+      System.err.println("pty-selftest: FAILED: " + e);
+      return 1;
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtySelfTestCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtySelfTestCommandTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+@EnabledOnOs(OS.LINUX)
+class PtySelfTestCommandTest {
+
+  @Test
+  void openingARealPtySucceeds() {
+    assertEquals(0, new PtySelfTestCommand().call(), "the pty FFM layer initializes and works");
+  }
+}


### PR DESCRIPTION
## Root cause (confirmed from the box's journal)
```
org.graalvm.nativeimage.MissingForeignRegistrationError: Cannot perform downcall ...
    at ai.singlr.sail.pty.Pty.loadLibc(Pty.java:80)
    at ai.singlr.sail.pty.Pty.<clinit>(Pty.java:70)
```
`Pty` calls libc through the FFM API, and GraalVM native-image requires every downcall registered in `reachability-metadata.json` — exactly as the SQLite FFM layer already is. `Pty`'s weren't, so it failed at class-init in the **native binary** and every `session new`/create died (`pty channel closed mid-frame`). The pty host was effectively dead on real boxes since it shipped.

**Why it stayed green:** the JVM unit tests exercise `Pty` and pass, but **nothing ever ran the native pty** — the release smoke test was only `sail -V`. Whole class of native-only failures, invisible until a user hit it.

## Fix
- Registered `Pty`'s four downcalls in the sail-core foreign metadata, captured with the GraalVM **tracing agent** (so the `captureCallState` options on read/write are exact, not hand-guessed).
- Added hidden **`sail _pty-selftest`** — opens a real pty (forcing `Pty`'s init + every downcall), self-skips on non-Linux.
- Wired it into the **CI and release smoke steps**, so a missing registration fails the build, not a user.

## Verified
Installed GraalVM 25 (the CI toolchain) locally, built the native image, ran `sail _pty-selftest` → `pty-selftest: ok` (exit 0). `mvn verify` (JaCoCo) green; the new self-test test passes on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)