### PR TITLE
fix(pty): restart the pty-host on upgrade so the new binary takes effect

### DIFF
--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -107,9 +107,10 @@ public final class MigrateCommand implements Runnable {
    * Installs {@code sail-pty-host.service} on a provisioned box. The unit is newer than most
    * existing boxes were provisioned, and {@code sail upgrade} spawns the new binary's {@code
    * migrate} — so this is the one place that can bring the host up on an upgrade without a manual
-   * step. Gated on the API service being present (a real host, not a stray {@code sail migrate} in
-   * some directory), idempotent ({@code enable --now} never restarts a running host, so live
-   * sessions survive), and fail-soft (a systemd hiccup warns rather than aborting the migration).
+   * step. It also restarts the host so the new binary takes effect (an upgrade rewrites the binary
+   * but the old process keeps running until restarted). Gated on the API service being present (a
+   * real host, not a stray {@code sail migrate} in some directory) and fail-soft (a systemd hiccup
+   * warns rather than aborting the migration).
    */
   private static void ensurePtyHostService(boolean jsonOutput) {
     var shell = new ShellExecutor(false);

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/PtyHostUnit.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/PtyHostUnit.java
@@ -72,7 +72,14 @@ public final class PtyHostUnit {
         .formatted(userClause, sailBinary, wantedBy);
   }
 
-  /** Writes the unit (and USER-mode symlink), reloads systemd, enables and starts the service. */
+  /**
+   * Writes the unit (and USER-mode symlink), reloads systemd, enables the service, and {@code
+   * restart}s it. Restart, not {@code enable --now}: an upgrade rewrites the binary on disk but the
+   * running host keeps executing the old process, so it must be restarted to pick up the new code —
+   * {@code restart} also starts a stopped service, so it is correct on a first install too. (Live
+   * sessions do not survive a host restart regardless — there is no rehydration — so this loses
+   * nothing an upgrade wasn't already going to lose.)
+   */
   public void install() throws IOException, InterruptedException, TimeoutException {
     Files.createDirectories(serviceFilePath.getParent());
     Files.writeString(serviceFilePath, renderUnit());
@@ -82,8 +89,8 @@ public final class PtyHostUnit {
       Files.createSymbolicLink(systemdLinkPath, serviceFilePath);
     }
     requireSuccess(shell.exec(systemctl("daemon-reload")), "Failed to reload systemd units");
-    requireSuccess(
-        shell.exec(systemctl("enable", "--now", UNIT_NAME)), "Failed to enable+start " + UNIT_NAME);
+    requireSuccess(shell.exec(systemctl("enable", UNIT_NAME)), "Failed to enable " + UNIT_NAME);
+    requireSuccess(shell.exec(systemctl("restart", UNIT_NAME)), "Failed to (re)start " + UNIT_NAME);
   }
 
   /** Stops, disables, and removes the unit; missing pieces are not an error. */

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
@@ -92,8 +92,8 @@ class MigrateCommandTest {
         "a provisioned host gets the pty-host unit");
     assertTrue(
         shell.invocations().stream()
-            .anyMatch(c -> c.contains("systemctl --user enable --now sail-pty-host.service")),
-        "and it is enabled and started");
+            .anyMatch(c -> c.contains("systemctl --user restart sail-pty-host.service")),
+        "and it is enabled and (re)started so the upgraded binary takes effect");
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/PtyHostUnitTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/PtyHostUnitTest.java
@@ -47,7 +47,11 @@ class PtyHostUnitTest {
     assertTrue(Files.isSymbolicLink(home.resolve(".config/systemd/user/sail-pty-host.service")));
     assertTrue(
         shell.invocations().stream()
-            .anyMatch(c -> c.contains("systemctl --user enable --now sail-pty-host.service")));
+            .anyMatch(c -> c.contains("systemctl --user enable sail-pty-host.service")));
+    assertTrue(
+        shell.invocations().stream()
+            .anyMatch(c -> c.contains("systemctl --user restart sail-pty-host.service")),
+        "restart, so an upgrade's new binary takes effect");
 
     unit.uninstall();
     assertFalse(Files.exists(home.resolve(".sail/services/sail-pty-host.service")));


### PR DESCRIPTION
migrate's `ensurePtyHostService` used `enable --now`, which starts a stopped service but never restarts a running one. So `sail upgrade` swapped the binary on disk while the host kept executing the **old process** — the reason v0.35.1's FFM fix needed a manual `systemctl restart sail-pty-host` to actually take hold on the box.

`PtyHostUnit.install()` now `enable`s then `restart`s (restart also starts a stopped service, so a first install is unaffected). Live sessions don't survive a host restart regardless (no rehydration yet), so an upgrade loses nothing it wasn't already going to.

Tests updated (`enable` + `restart` asserted in PtyHostUnitTest and MigrateCommandTest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)