### PR TITLE
fix(pty): resync a paused subscriber from the journal instead of leaving it corrupt

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -187,6 +187,29 @@ public final class PtySession implements AutoCloseable {
     }
   }
 
+  /**
+   * Re-baselines a subscriber whose pause dropped part of the stream: under the fanout lock, the
+   * journal tail replaces whatever accumulated in its queue (those bytes are inside the snapshot),
+   * so the client hears {@code Continued}, a bracketed replay, then live traffic — exactly-once
+   * against the journal, never a screen with its middle missing.
+   */
+  private void resync(Subscriber subscriber) {
+    synchronized (fanout) {
+      try {
+        var tail = journal.tail(replayMax);
+        var messages = new java.util.ArrayList<PtyMessage>(3);
+        messages.add(new PtyMessage.ReplayBegin(tail.safe()));
+        if (tail.bytes().length > 0) {
+          messages.add(new PtyMessage.Output(lastInputSeq.get(), tail.bytes()));
+        }
+        messages.add(new PtyMessage.ReplayEnd());
+        subscriber.queue().replaceWith(List.copyOf(messages));
+      } catch (IOException e) {
+        subscriber.queue().force(new PtyMessage.SessionEnded("resync failed: " + e.getMessage()));
+      }
+    }
+  }
+
   /** Attaches a client: replay first, live stream after, write token if free and requested. */
   public long attach(Client client, boolean wantsWrite, String fde) throws IOException {
     if (endedReason != null) {
@@ -230,6 +253,9 @@ public final class PtySession implements AutoCloseable {
         subscriber.client().deliver(message);
         if (message instanceof PtyMessage.SessionEnded) {
           return;
+        }
+        if (message instanceof PtyMessage.Continued) {
+          resync(subscriber);
         }
       }
     } catch (InterruptedException e) {

--- a/sail-core/src/main/java/ai/singlr/sail/pty/SubscriberQueue.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/SubscriberQueue.java
@@ -46,6 +46,23 @@ final class SubscriberQueue {
     notifyAll();
   }
 
+  /**
+   * Replaces the pending backlog with {@code messages} — the resync-after-pause path, where the
+   * backlog's bytes are already covered by the journal snapshot being installed. Terminal messages
+   * ({@code Ok}, {@code SessionEnded}) survive the swap, re-queued after the replacement: a detach
+   * or an ending must never be lost to a resync racing it.
+   */
+  synchronized void replaceWith(java.util.List<PtyMessage> messages) {
+    var terminal =
+        queue.stream()
+            .filter(m -> m instanceof PtyMessage.Ok || m instanceof PtyMessage.SessionEnded)
+            .toList();
+    queue.clear();
+    queue.addAll(messages);
+    queue.addAll(terminal);
+    notifyAll();
+  }
+
   /** Empties the queue and delivers only {@code message} next — the detach path. */
   synchronized void clearAnd(PtyMessage message) {
     queue.clear();

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -33,9 +33,18 @@ class PtySessionTest {
     final ConcurrentLinkedQueue<PtyMessage> messages = new ConcurrentLinkedQueue<>();
     final CountDownLatch ended = new CountDownLatch(1);
     volatile long sleepMillis;
+    volatile CountDownLatch gate;
 
     @Override
     public void deliver(PtyMessage message) {
+      var g = gate;
+      if (g != null) {
+        try {
+          g.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
       if (sleepMillis > 0) {
         try {
           Thread.sleep(sleepMillis);
@@ -295,5 +304,64 @@ class PtySessionTest {
         java.time.Duration.ofSeconds(10),
         session::close,
         "close must not hang when the end-of-session event throws");
+  }
+
+  @Test
+  void aPausedSubscriberIsResyncedFromTheJournalNotLeftCorrupt() throws Exception {
+    var session =
+        PtySession.start(
+            "resync",
+            "uday",
+            "acme",
+            PtyEvents.NONE,
+            List.of(
+                "sh",
+                "-c",
+                "read _; i=0; while [ $i -lt 300 ]; do printf '%01000d' $i; i=$((i+1)); done;"
+                    + " printf BURST-END; read _; printf PHASE2; read _"),
+            Map.of("TERM", "dumb"),
+            Path.of("/tmp"),
+            dir.resolve("resync.ring"),
+            1024 * 1024,
+            80,
+            24,
+            1,
+            64 * 1024);
+    try {
+      var client = new Collector();
+      var gate = new CountDownLatch(1);
+      client.gate = gate;
+      var id = session.attach(client, true, "uday");
+
+      session.input(id, 1, "\n".getBytes(StandardCharsets.UTF_8));
+      var deadline = System.nanoTime() + 10_000_000_000L;
+      while (session.journaledBytes() < 300_000) {
+        if (System.nanoTime() > deadline) {
+          throw new AssertionError("burst never landed; journaled=" + session.journaledBytes());
+        }
+        Thread.onSpinWait();
+      }
+
+      client.gate = null;
+      gate.countDown();
+
+      client.awaitOutput("BURST-END");
+      assertTrue(client.saw(PtyMessage.Paused.class), "the overflow paused the subscriber");
+      assertTrue(client.saw(PtyMessage.Continued.class), "the drain resumed it");
+      var kinds = client.messages.stream().map(m -> m.getClass().getSimpleName()).toList();
+      var continuedAt = kinds.indexOf("Continued");
+      assertTrue(
+          kinds.subList(continuedAt, kinds.size()).contains("ReplayBegin"),
+          "the resync is bracketed as a replay after Continued, got: " + kinds);
+
+      session.input(id, 2, "\n".getBytes(StandardCharsets.UTF_8));
+      client.awaitOutput("PHASE2");
+      var text = client.outputText();
+      assertEquals(text.indexOf("PHASE2"), text.lastIndexOf("PHASE2"), "no duplicated bytes");
+      assertEquals(
+          text.indexOf("BURST-END"), text.lastIndexOf("BURST-END"), "no duplicated resync");
+    } finally {
+      session.close();
+    }
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/pty/SubscriberQueueTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/SubscriberQueueTest.java
@@ -47,6 +47,32 @@ class SubscriberQueueTest {
   }
 
   @Test
+  void replaceWithSwapsTheBacklogButTerminalMessagesSurvive() throws Exception {
+    var queue = new SubscriberQueue(8);
+    queue.enqueue(out(1));
+    queue.enqueue(out(2));
+    queue.force(new PtyMessage.SessionEnded("gone"));
+    queue.replaceWith(
+        java.util.List.of(new PtyMessage.ReplayBegin(true), out(9), new PtyMessage.ReplayEnd()));
+
+    assertInstanceOf(PtyMessage.ReplayBegin.class, queue.next(), "the resync leads");
+    assertEquals(9, ((PtyMessage.Output) queue.next()).lastInputSeq());
+    assertInstanceOf(PtyMessage.ReplayEnd.class, queue.next());
+    assertInstanceOf(PtyMessage.SessionEnded.class, queue.next(), "the ending survives the swap");
+  }
+
+  @Test
+  void replaceWithKeepsTheDetachPoisonAlive() throws Exception {
+    var queue = new SubscriberQueue(8);
+    queue.enqueue(out(1));
+    queue.force(new PtyMessage.Ok());
+    queue.replaceWith(java.util.List.of(new PtyMessage.ReplayBegin(true)));
+
+    assertInstanceOf(PtyMessage.ReplayBegin.class, queue.next());
+    assertInstanceOf(PtyMessage.Ok.class, queue.next(), "detach still terminates the send loop");
+  }
+
+  @Test
   void forcedMessagesArriveEvenWhilePaused() throws Exception {
     var queue = new SubscriberQueue(1);
     queue.enqueue(out(1));


### PR DESCRIPTION
## The field bug

Mast's WebGPU terminal rendered a permanently garbled screen after claude-code's splash (overlapped rows, fragment strings like `ror?"`). Root cause is host-side: `SubscriberQueue`'s flow-control contract **drops bytes by design** — overflow clears the backlog and every enqueue during the pause is dropped — and nothing ever repaired the gap. The subscriber resumed the live stream with its middle missing; a VT stream with a hole is a corrupt terminal forever. claude-code's splash is exactly the burst that outruns a webview subscriber.

## The fix

A drained pause now **re-baselines the subscriber from the journal**: when the sender delivers `Continued`, it snapshots the journal tail under the fanout lock and *replaces* the subscriber's queue with a bracketed replay (`ReplayBegin`/`Output`/`ReplayEnd`).

- **Exactly-once by construction**: anything already queued was enqueued before the snapshot (journal append and fanout share the lock), so its bytes are inside the snapshot — replaced, not duplicated; post-snapshot fanout lands after the replay.
- **Terminal messages survive the swap** (`Ok`, `SessionEnded`): a detach or an ending can never be lost to a racing resync.
- A journal read failure ends the session loudly (`resync failed: …`) instead of a silent desync.

Protocol-compatible: the frames already exist; clients that ignore replay markers keep working (mast's companion PR resets its terminal on a mid-stream `ReplayBegin` so the snapshot lands clean).

## Tests (reproduction-first)

- New `PtySessionTest`: a gated client with a tiny queue, a 300KB burst — **with the resync removed the test fails with the exact field symptom** (`never saw 'BURST-END'`, the whole burst dropped); with it, the tail returns via a `ReplayBegin` after `Continued` and post-resync traffic flows exactly once (no duplicated bytes).
- `SubscriberQueueTest`: `replaceWith` swaps the backlog, keeps `SessionEnded` and the detach `Ok` alive.
- sail-core 1704 tests, full `mvn clean verify` green.