### PR TITLE
Agent resume rides the host: sail agent attach opens a room-bound session that yields to dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- `sail agent attach` resumes a completed run's conversation inside a host-owned session
+  (`resume-<run id>`, pinned to the run's room) instead of a raw `incus exec` tty: `Ctrl-]`
+  detaches and the conversation lives on, attaching again joins the live session instead of
+  forking a second agent, the run's room lists it like any room session, and a `spec create` from
+  the resumed conversation is born in the run's room. Host-owned conversations respect the
+  reservation gate: when a dispatch reserves the repos a resumed conversation works in — by exactly
+  the dispatch gate's rules, so a read-only room wake displaces nothing — the reservation ends the
+  session, attached or detached, with the reason in its stream and on its `pty_session_ended` room
+  event, and the dispatch proceeds. New host-inbound pty wire verb `Yield(session, reason)`.
+
 - `agent_session_started` now carries `run_role`, so clients can light presence the moment a run
   launches instead of waiting for its first tool call — the seconds between "message sent" and
   "agent working" shrink to the wake debounce plus launch.

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyIdentity.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyIdentity.java
@@ -8,11 +8,20 @@ package ai.singlr.sail.pty;
 import java.io.IOException;
 
 /**
- * The authenticated FDE behind a pty-host connection. Identity is resolved from a verifiable
+ * The authenticated principal behind a pty-host connection. Identity is resolved from a verifiable
  * credential by the host's {@link Resolver} — never from anything the client claims: a session
- * token minted by the gateway, or the box's ambient owner when the connection carries none.
+ * token minted by the gateway, or the box's ambient owner when the connection carries none. The one
+ * non-FDE principal is {@link #DISPATCH}: the host's own dispatch authority, admitted by the
+ * credential the host mints at start, allowed exactly one verb — yielding a session a reservation
+ * displaced, whoever opened it — and nothing an FDE may do.
  */
-public record PtyIdentity(String fde, boolean admin) {
+public record PtyIdentity(String fde, boolean admin, boolean dispatchAuthority) {
+
+  public static final PtyIdentity DISPATCH = new PtyIdentity("dispatch", false, true);
+
+  public PtyIdentity(String fde, boolean admin) {
+    this(fde, admin, false);
+  }
 
   public interface Resolver {
     PtyIdentity resolve(String token) throws IOException;

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyMessage.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyMessage.java
@@ -9,9 +9,9 @@ import java.util.List;
 
 /**
  * The session-host wire vocabulary — one sealed hierarchy for both directions. Client to host:
- * create, attach, input, resize, write-token, detach, list, kill. Host to client: output (carrying
- * the last applied input sequence — the one enabler client-side predictive echo needs), replay
- * bracketing, writer and size changes, flow control, endings, listings, and errors.
+ * create, attach, input, resize, write-token, detach, list, kill, yield. Host to client: output
+ * (carrying the last applied input sequence — the one enabler client-side predictive echo needs),
+ * replay bracketing, writer and size changes, flow control, endings, listings, and errors.
  */
 public sealed interface PtyMessage {
 
@@ -56,6 +56,16 @@ public sealed interface PtyMessage {
   record ListSessions(String after, int limit) implements PtyMessage {}
 
   record Kill(String session) implements PtyMessage {}
+
+  /**
+   * Ends a live session on behalf of something that displaced it — a dispatch reserving the repos
+   * its conversation works in. Admitted like {@link Kill} (owner or admin), but idempotent: a
+   * session that is not live has nothing to end and answers {@code Ok}. Unlike a kill, every
+   * attached client first sees {@code reason} as a terminal line in the stream, and the session
+   * ends with that reason rather than the child's exit status, so the room's ending event names
+   * why.
+   */
+  record Yield(String session, String reason) implements PtyMessage {}
 
   record Output(long lastInputSeq, byte[] bytes) implements PtyMessage {}
 

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyMessage.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyMessage.java
@@ -59,11 +59,12 @@ public sealed interface PtyMessage {
 
   /**
    * Ends a live session on behalf of something that displaced it — a dispatch reserving the repos
-   * its conversation works in. Admitted like {@link Kill} (owner or admin), but idempotent: a
-   * session that is not live has nothing to end and answers {@code Ok}. Unlike a kill, every
-   * attached client first sees {@code reason} as a terminal line in the stream, and the session
-   * ends with that reason rather than the child's exit status, so the room's ending event names
-   * why.
+   * its conversation works in. Admitted only for the host's dispatch authority — the credential the
+   * host mints at start, the one principal that may yield and do nothing else — never for an owner
+   * or admin, whose verb is {@link Kill}. Idempotent: a session that is not live has nothing to end
+   * and answers {@code Ok}. Unlike a kill, every attached client first sees {@code reason} as a
+   * terminal line in the stream, and the session ends with that reason rather than the child's exit
+   * status, so the room's ending event names why.
    */
   record Yield(String session, String reason) implements PtyMessage {}
 

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -388,7 +388,12 @@ public final class PtySession implements AutoCloseable {
     close();
   }
 
-  /** Ends the child (if alive), waits for the gather thread, and releases the journal. */
+  /**
+   * Ends the child (if alive), waits for the gather thread, and releases the journal. By the time
+   * the gather thread is done it has forced {@code SessionEnded} into every subscriber's queue, so
+   * the subscribers are dropped rather than poisoned: their sender threads end on delivering the
+   * ending, and a detach's queue-clearing poison would race that delivery and lose it.
+   */
   @Override
   public void close() {
     child.destroy();
@@ -400,7 +405,11 @@ public final class PtySession implements AutoCloseable {
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     }
-    subscribers.keySet().forEach(this::detach);
+    synchronized (this) {
+      subscribers.clear();
+      writerId = -1;
+      writerFde = "";
+    }
     try {
       journal.close();
     } catch (IOException e) {

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.pty;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -380,7 +381,7 @@ public final class PtySession implements AutoCloseable {
         yieldedReason = reason;
         var notice =
             ("\r\n[sail: session ended \u2014 " + reason + "]\r\n")
-                .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                .getBytes(StandardCharsets.UTF_8);
         var output = new PtyMessage.Output(lastInputSeq.get(), notice);
         subscribers.values().forEach(subscriber -> subscriber.queue().force(output));
       }

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
@@ -70,6 +71,7 @@ public final class PtySession implements AutoCloseable {
   private volatile long writerId = -1;
   private volatile String writerFde = "";
   private volatile String endedReason;
+  private volatile String yieldedReason;
   private volatile long endedAtNanos;
   private volatile boolean everAttached;
 
@@ -163,8 +165,8 @@ public final class PtySession implements AutoCloseable {
       failure = "pty failed: " + e.getMessage();
     } finally {
       try {
-        var reason =
-            failure != null ? failure : "exited(" + child.onExit().join().exitValue() + ")";
+        var exit = "exited(" + child.onExit().join().exitValue() + ")";
+        var reason = failure != null ? failure : Objects.requireNonNullElse(yieldedReason, exit);
         pty.close();
         synchronized (fanout) {
           endedAtNanos = System.nanoTime();
@@ -364,6 +366,26 @@ public final class PtySession implements AutoCloseable {
 
   public long createdAtNanos() {
     return createdAt;
+  }
+
+  /**
+   * Ends the session because something displaced it: every attached client first sees {@code
+   * reason} as a terminal line in the stream, then the session ends and reports that reason — not
+   * the child's exit status — to its subscribers and its ended event. A session that already ended
+   * keeps its own reason.
+   */
+  public void end(String reason) {
+    synchronized (fanout) {
+      if (endedReason == null && yieldedReason == null) {
+        yieldedReason = reason;
+        var notice =
+            ("\r\n[sail: session ended \u2014 " + reason + "]\r\n")
+                .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        var output = new PtyMessage.Output(lastInputSeq.get(), notice);
+        subscribers.values().forEach(subscriber -> subscriber.queue().force(output));
+      }
+    }
+    close();
   }
 
   /** Ends the child (if alive), waits for the gather thread, and releases the journal. */

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyWire.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyWire.java
@@ -106,6 +106,7 @@ public final class PtyWire {
         out.buffer.putInt(m.limit());
       }
       case PtyMessage.Kill m -> out.type(8).string(m.session());
+      case PtyMessage.Yield m -> out.type(10).string(m.session()).string(m.reason());
       case PtyMessage.Output m -> {
         out.type(20);
         out.buffer.putLong(m.lastInputSeq());
@@ -165,6 +166,7 @@ public final class PtyWire {
       case 6 -> new PtyMessage.Detach();
       case 7 -> new PtyMessage.ListSessions(string(in), in.getInt());
       case 8 -> new PtyMessage.Kill(string(in));
+      case 10 -> new PtyMessage.Yield(string(in), string(in));
       case 20 -> new PtyMessage.Output(in.getLong(), bytes(in));
       case 21 -> new PtyMessage.ReplayBegin(in.get() == 1);
       case 22 -> new PtyMessage.ReplayEnd();

--- a/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/RunStore.java
@@ -693,18 +693,9 @@ public final class RunStore implements ConflictResolver, SyncedStore {
           if (lease.isPresent()) {
             return new Reservation.LeaseHeld(lease.get());
           }
-          var running =
-              db.query(
-                  "SELECT id, IFNULL(spec_id, room_id), role, repos FROM runs"
-                      + " WHERE project = ? AND status IN ('running', 'stopping')"
-                      + " AND IFNULL(node, '') = ?",
-                  row ->
-                      new DispatchGate.RunningRun(
-                          row.text(0), row.text(1), row.text(2), repoList(row.text(3))),
-                  project,
-                  ownerKey(node));
           var conflict =
-              DispatchGate.decide(specId != null ? specId : roomId, role, reserved, running);
+              DispatchGate.decide(
+                  specId != null ? specId : roomId, role, reserved, runningOnNode(project, node));
           if (conflict.isPresent()) {
             return new Reservation.Conflicted(conflict.get());
           }
@@ -733,6 +724,24 @@ public final class RunStore implements ConflictResolver, SyncedStore {
           recordRevision(id, "local", false);
           return new Reservation.Reserved(credential);
         });
+  }
+
+  /**
+   * Every run of {@code project} live on this box, in the gate's terms — every role, review and
+   * invite lanes included, because each one that reserves repos blocks a claim over them. The
+   * reservation reads it inside its transaction; {@code sail agent attach} reads it under the
+   * project's claim lock to refuse resuming a conversation over repos a live run holds.
+   */
+  public List<DispatchGate.RunningRun> runningOnNode(String project, String localHandle) {
+    return db.query(
+        "SELECT id, IFNULL(spec_id, room_id), role, repos FROM runs"
+            + " WHERE project = ? AND status IN ('running', 'stopping')"
+            + " AND IFNULL(node, '') = ?",
+        row ->
+            new DispatchGate.RunningRun(
+                row.text(0), row.text(1), row.text(2), repoList(row.text(3))),
+        project,
+        ownerKey(localHandle));
   }
 
   private static List<String> repoList(String json) {

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -101,6 +101,58 @@ class PtySessionTest {
   }
 
   @Test
+  void endDeliversTheNoticeAndTheReasonEvenToASubscriberStillDraining() throws Exception {
+    var endings = new java.util.concurrent.ConcurrentLinkedQueue<String>();
+    var recorder =
+        new PtyEvents() {
+          @Override
+          public void sessionStarted(PtySession.Origin origin) {}
+
+          @Override
+          public void sessionAttached(PtySession.Origin origin, String fde) {}
+
+          @Override
+          public void sessionEnded(PtySession.Origin origin, String reason) {
+            endings.add(reason);
+          }
+        };
+    var session =
+        PtySession.start(
+            origin("yielded", "uday", "acme"),
+            recorder,
+            List.of("sh", "-c", "echo up; read a"),
+            Map.of("TERM", "dumb"),
+            Path.of("/tmp"),
+            dir.resolve("yielded.ring"),
+            64 * 1024,
+            80,
+            24);
+    var client = new Collector();
+    var gate = new CountDownLatch(1);
+    client.gate = gate;
+    session.attach(client, true, "uday");
+    Thread.sleep(200);
+
+    session.end("yielded to dispatch 2");
+    gate.countDown();
+
+    assertTrue(client.ended.await(10, TimeUnit.SECONDS), "the ending must arrive");
+    assertTrue(
+        client.outputText().contains("[sail: session ended \u2014 yielded to dispatch 2]"),
+        "the notice line reaches a subscriber that was still draining: " + client.messages);
+    assertTrue(
+        client.messages.stream()
+            .anyMatch(
+                m ->
+                    m instanceof PtyMessage.SessionEnded(var reason)
+                        && reason.equals("yielded to dispatch 2")),
+        "the ending carries the displacing reason: " + client.messages);
+    assertFalse(session.live());
+    assertEquals(List.of("yielded to dispatch 2"), List.copyOf(endings));
+    assertEquals("yielded to dispatch 2", session.endedReason());
+  }
+
+  @Test
   void ownershipEventsAndWriterPrincipalAreObservable() throws Exception {
     var events = new java.util.concurrent.ConcurrentLinkedQueue<String>();
     var recorder =

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtyWireTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtyWireTest.java
@@ -81,6 +81,9 @@ class PtyWireTest {
     assertEquals(
         "", ((PtyMessage.Sessions) roundTrip(new PtyMessage.Sessions(List.of(), ""))).next());
     assertEquals("tok", ((PtyMessage.Hello) roundTrip(new PtyMessage.Hello("tok"))).token());
+    assertEquals(
+        new PtyMessage.Yield("resume-1", "yielded to dispatch 2"),
+        roundTrip(new PtyMessage.Yield("resume-1", "yielded to dispatch 2")));
     assertInstanceOf(PtyMessage.TakeWrite.class, roundTrip(new PtyMessage.TakeWrite()));
     assertInstanceOf(PtyMessage.ReplayEnd.class, roundTrip(new PtyMessage.ReplayEnd()));
     assertEquals(

--- a/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
@@ -10,11 +10,16 @@ import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.EnumSet;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,11 +33,19 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * <p>Reaping is driven by {@link #sweep(long)} with an injected clock — the production timer thread
  * merely calls it; tests call it directly with synthetic time.
+ *
+ * <p>Yielding is the one verb no FDE holds. A dispatch that reserves repos must end whichever
+ * resumed conversation sits on them regardless of who opened it, so the host mints a random
+ * dispatch credential at start, keeps it owner-only beside the socket ({@link
+ * #dispatchCredentialOf}), and admits a {@code Hello} carrying it as {@link PtyIdentity#DISPATCH} —
+ * a principal that can yield and do nothing else. Owners and admins keep create, attach, and kill;
+ * a user-issued kill never masquerades as a yield.
  */
 public final class PtySessionHost implements AutoCloseable {
 
   static final Duration NEVER_ATTACHED_GRACE = Duration.ofSeconds(60);
   static final Duration CORPSE_RETENTION = Duration.ofMinutes(10);
+  static final String DISPATCH_CREDENTIAL_FILE = "pty-dispatch.token";
 
   private final Path socketPath;
   private final Path sessionsDir;
@@ -42,6 +55,7 @@ public final class PtySessionHost implements AutoCloseable {
   private final PtyEvents events;
   private final Map<String, PtySession> sessions = new ConcurrentHashMap<>();
   private volatile ServerSocketChannel server;
+  private volatile byte[] dispatchCredential = new byte[0];
   private volatile boolean closed;
 
   public PtySessionHost(
@@ -67,10 +81,43 @@ public final class PtySessionHost implements AutoCloseable {
       ownerOnly(socketDir);
     }
     Files.deleteIfExists(socketPath);
+    mintDispatchCredential();
     server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
     server.bind(UnixDomainSocketAddress.of(socketPath));
     ownerOnly(socketPath);
     Thread.ofVirtual().name("pty-host-accept").start(this::acceptLoop);
+  }
+
+  /**
+   * The dispatch credential of the host serving {@code socket}: an owner-only file beside it, so
+   * exactly the processes that may open the socket may read it — the box's own API and CLI lanes.
+   */
+  public static Path dispatchCredentialOf(Path socket) {
+    return socket.resolveSibling(DISPATCH_CREDENTIAL_FILE);
+  }
+
+  private void mintDispatchCredential() throws IOException {
+    var bytes = new byte[32];
+    new SecureRandom().nextBytes(bytes);
+    var credential = HexFormat.of().formatHex(bytes);
+    var path = dispatchCredentialOf(socketPath);
+    Files.deleteIfExists(path);
+    try {
+      Files.createFile(
+          path, PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
+    } catch (UnsupportedOperationException notPosix) {
+      Files.createFile(path);
+    }
+    Files.writeString(path, credential);
+    dispatchCredential = credential.getBytes(StandardCharsets.UTF_8);
+  }
+
+  private PtyIdentity identify(String token) throws IOException {
+    var presented = token.getBytes(StandardCharsets.UTF_8);
+    if (presented.length > 0 && MessageDigest.isEqual(presented, dispatchCredential)) {
+      return PtyIdentity.DISPATCH;
+    }
+    return identity.resolve(token);
   }
 
   /**
@@ -113,7 +160,7 @@ public final class PtySessionHost implements AutoCloseable {
       PtyIdentity who;
       if (PtyWire.read(channel) instanceof PtyMessage.Hello(var token)) {
         try {
-          who = identity.resolve(token);
+          who = identify(token);
         } catch (IOException refused) {
           reply(channel, new PtyMessage.Err(refused.getMessage()));
           return;
@@ -125,6 +172,10 @@ public final class PtySessionHost implements AutoCloseable {
       }
       while (true) {
         var message = PtyWire.read(channel);
+        if (who.dispatchAuthority() && !(message instanceof PtyMessage.Yield)) {
+          reply(channel, new PtyMessage.Err("The dispatch authority may only yield sessions."));
+          continue;
+        }
         switch (message) {
           case PtyMessage.Create m -> reply(channel, create(m, who));
           case PtyMessage.Attach m -> {
@@ -178,7 +229,12 @@ public final class PtySessionHost implements AutoCloseable {
           }
           case PtyMessage.ListSessions m -> reply(channel, listSessions(who, m));
           case PtyMessage.Kill m -> reply(channel, kill(m.session(), who));
-          case PtyMessage.Yield m -> reply(channel, yieldSession(m.session(), m.reason(), who));
+          case PtyMessage.Yield m ->
+              reply(
+                  channel,
+                  who.dispatchAuthority()
+                      ? yieldSession(m.session(), m.reason())
+                      : new PtyMessage.Err("Yield requires host dispatch authority."));
           default -> reply(channel, new PtyMessage.Err("Unexpected client frame."));
         }
       }
@@ -329,15 +385,13 @@ public final class PtySessionHost implements AutoCloseable {
   /**
    * Ends a live session that a reservation displaced — the reason lands in the stream and on the
    * ended event. Idempotent: a session that is not live has nothing to end, so the answer is {@code
-   * Ok}; the one refusal is admission, which is exactly a kill's.
+   * Ok}. Ownership is not consulted: the dispatch authority ends what the claim displaced,
+   * whichever FDE opened it.
    */
-  private PtyMessage yieldSession(String name, String reason, PtyIdentity who) {
+  private PtyMessage yieldSession(String name, String reason) {
     var session = sessions.get(name);
     if (session == null || !session.live()) {
       return new PtyMessage.Ok();
-    }
-    if (!admitted(who, session)) {
-      return new PtyMessage.Err("Session '" + name + "' belongs to " + session.ownerFde() + ".");
     }
     sessions.remove(name, session);
     session.end(reason);
@@ -393,6 +447,7 @@ public final class PtySessionHost implements AutoCloseable {
         server.close();
       }
       Files.deleteIfExists(socketPath);
+      Files.deleteIfExists(dispatchCredentialOf(socketPath));
     } catch (IOException e) {
       throw new IllegalStateException("pty host close failed", e);
     }

--- a/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
@@ -178,6 +178,7 @@ public final class PtySessionHost implements AutoCloseable {
           }
           case PtyMessage.ListSessions m -> reply(channel, listSessions(who, m));
           case PtyMessage.Kill m -> reply(channel, kill(m.session(), who));
+          case PtyMessage.Yield m -> reply(channel, yieldSession(m.session(), m.reason(), who));
           default -> reply(channel, new PtyMessage.Err("Unexpected client frame."));
         }
       }
@@ -322,6 +323,24 @@ public final class PtySessionHost implements AutoCloseable {
       return new PtyMessage.Err("Session '" + name + "' belongs to " + session.ownerFde() + ".");
     }
     remove(name, session);
+    return new PtyMessage.Ok();
+  }
+
+  /**
+   * Ends a live session that a reservation displaced — the reason lands in the stream and on the
+   * ended event. Idempotent: a session that is not live has nothing to end, so the answer is {@code
+   * Ok}; the one refusal is admission, which is exactly a kill's.
+   */
+  private PtyMessage yieldSession(String name, String reason, PtyIdentity who) {
+    var session = sessions.get(name);
+    if (session == null || !session.live()) {
+      return new PtyMessage.Ok();
+    }
+    if (!admitted(who, session)) {
+      return new PtyMessage.Err("Session '" + name + "' belongs to " + session.ownerFde() + ".");
+    }
+    sessions.remove(name, session);
+    session.end(reason);
     return new PtyMessage.Ok();
   }
 

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
@@ -15,6 +15,7 @@ import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
 import java.nio.channels.SocketChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -80,6 +81,10 @@ class PtySessionHostTest {
 
   private SocketChannel connect() throws IOException {
     return connect("tok-uday");
+  }
+
+  private String dispatchCredential() throws IOException {
+    return Files.readString(PtySessionHost.dispatchCredentialOf(dir.resolve("host.sock")));
   }
 
   private SocketChannel connect(String token) throws IOException {
@@ -187,17 +192,29 @@ class PtySessionHostTest {
         assertInstanceOf(PtyMessage.ReplayBegin.class, PtyWire.read(owner));
         awaitText(owner, "up");
 
-        try (var foreign = connect("tok-mady")) {
-          PtyWire.write(foreign, new PtyMessage.Yield("resume-1", "yielded to dispatch 2"));
-          assertInstanceOf(
-              PtyMessage.Err.class, PtyWire.read(foreign), "yield is admitted exactly like kill");
+        for (var fde : List.of("tok-mady", "tok-uday", "tok-root")) {
+          try (var user = connect(fde)) {
+            PtyWire.write(user, new PtyMessage.Yield("resume-1", "yielded to dispatch 2"));
+            var refused = assertInstanceOf(PtyMessage.Err.class, PtyWire.read(user));
+            assertTrue(
+                refused.message().contains("dispatch authority"),
+                fde + " — no FDE yields, not the owner, not an admin: " + refused.message());
+          }
         }
-        try (var box = connect()) {
-          PtyWire.write(box, new PtyMessage.Yield("ghost", "yielded to dispatch 2"));
+        try (var dispatch = connect(dispatchCredential())) {
+          PtyWire.write(
+              dispatch, new PtyMessage.Create("x", List.of("sh"), "/tmp", "", "", 80, 24));
           assertInstanceOf(
-              PtyMessage.Ok.class, PtyWire.read(box), "nothing live to yield is nothing to do");
-          PtyWire.write(box, new PtyMessage.Yield("resume-1", "yielded to dispatch 2"));
-          assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(box));
+              PtyMessage.Err.class,
+              PtyWire.read(dispatch),
+              "the dispatch authority yields and does nothing else");
+          PtyWire.write(dispatch, new PtyMessage.Yield("ghost", "yielded to dispatch 2"));
+          assertInstanceOf(
+              PtyMessage.Ok.class,
+              PtyWire.read(dispatch),
+              "nothing live to yield is nothing to do");
+          PtyWire.write(dispatch, new PtyMessage.Yield("resume-1", "yielded to dispatch 2"));
+          assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(dispatch));
         }
 
         awaitText(owner, "[sail: session ended \u2014 yielded to dispatch 2]");

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
@@ -173,6 +173,48 @@ class PtySessionHostTest {
     }
   }
 
+  @Test
+  void yieldEndsALiveSessionWithTheReasonInTheStreamAndOnTheEnding() throws Exception {
+    try (var ignored = startHost()) {
+      try (var owner = connect()) {
+        PtyWire.write(
+            owner,
+            new PtyMessage.Create(
+                "resume-1", List.of("sh", "-c", "echo up; read a"), "/tmp", "", "", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(owner));
+        PtyWire.write(owner, new PtyMessage.Attach("resume-1", true));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(owner));
+        assertInstanceOf(PtyMessage.ReplayBegin.class, PtyWire.read(owner));
+        awaitText(owner, "up");
+
+        try (var foreign = connect("tok-mady")) {
+          PtyWire.write(foreign, new PtyMessage.Yield("resume-1", "yielded to dispatch 2"));
+          assertInstanceOf(
+              PtyMessage.Err.class, PtyWire.read(foreign), "yield is admitted exactly like kill");
+        }
+        try (var box = connect()) {
+          PtyWire.write(box, new PtyMessage.Yield("ghost", "yielded to dispatch 2"));
+          assertInstanceOf(
+              PtyMessage.Ok.class, PtyWire.read(box), "nothing live to yield is nothing to do");
+          PtyWire.write(box, new PtyMessage.Yield("resume-1", "yielded to dispatch 2"));
+          assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(box));
+        }
+
+        awaitText(owner, "[sail: session ended \u2014 yielded to dispatch 2]");
+        PtyMessage message;
+        do {
+          message = PtyWire.read(owner);
+        } while (!(message instanceof PtyMessage.SessionEnded));
+        assertEquals(
+            "yielded to dispatch 2",
+            ((PtyMessage.SessionEnded) message).reason(),
+            "the ending carries the displacing reason, not the child's exit status");
+        assertEquals(0, host.sessionCount(), "a yielded session is gone, like a killed one");
+        assertTrue(events.contains("ended:resume-1"), events.toString());
+      }
+    }
+  }
+
   private static PtyMessage readControl(SocketChannel channel) throws IOException {
     while (true) {
       var m = PtyWire.read(channel);

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySocketPermissionsTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySocketPermissionsTest.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.pty;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -44,7 +45,13 @@ class PtySocketPermissionsTest {
 
       assertGroupAndOtherDenied(Files.getPosixFilePermissions(socket), "socket");
       assertGroupAndOtherDenied(Files.getPosixFilePermissions(sockDir), "socket directory");
+      var credential = PtySessionHost.dispatchCredentialOf(socket);
+      assertGroupAndOtherDenied(Files.getPosixFilePermissions(credential), "dispatch credential");
+      assertEquals(64, Files.readString(credential).length(), "256 bits of hex");
     }
+    assertFalse(
+        Files.exists(PtySessionHost.dispatchCredentialOf(socket)),
+        "a closed host leaves no credential behind");
   }
 
   private static void assertGroupAndOtherDenied(Set<PosixFilePermission> perms, String what) {

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -182,6 +182,7 @@ public final class DispatchOperations {
   private final BuildDispatch buildDispatch;
   private MessageStore messageStore;
   private RoomStore roomStore;
+  private SessionYield sessionYield = SessionYield.NONE;
   private final EventSink events;
   private final WatcherSpawner watcherSpawner;
   private final Snapshotter snapshotter;
@@ -224,7 +225,7 @@ public final class DispatchOperations {
     this.roomCommitGuard = new RoomCommitGuard(runStore, projects, this.events, shell);
     this.runLauncher =
         new RunLauncher(shell, file, launcher, listener, watcherSpawner, runStore, this.events);
-    this.runReservation = new RunReservation(runStore, shell, listener);
+    this.runReservation = new RunReservation(runStore, shell, listener, () -> sessionYield);
     this.adhocRunner = new AdhocRunner(projects, runLauncher, runReservation, runStore, listener);
     this.roomWakeLauncher =
         new RoomWakeLauncher(
@@ -271,6 +272,14 @@ public final class DispatchOperations {
   /** Wires the room store — the authoritative home of membership state; returns {@code this}. */
   public DispatchOperations useRooms(RoomStore rooms) {
     this.roomStore = Objects.requireNonNull(rooms, "rooms");
+    return this;
+  }
+
+  /**
+   * Wires the pty host seam a reservation ends displaced sessions through; returns {@code this}.
+   */
+  public DispatchOperations useSessionYield(SessionYield yield) {
+    this.sessionYield = Objects.requireNonNull(yield, "yield");
     return this;
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/DispatchOperations.java
@@ -182,7 +182,7 @@ public final class DispatchOperations {
   private final BuildDispatch buildDispatch;
   private MessageStore messageStore;
   private RoomStore roomStore;
-  private SessionYield sessionYield = SessionYield.NONE;
+  private final SessionYield sessionYield;
   private final EventSink events;
   private final WatcherSpawner watcherSpawner;
   private final Snapshotter snapshotter;
@@ -194,7 +194,9 @@ public final class DispatchOperations {
    * that forgets the run store, the roster, or the watcher) is visible in the diff instead of
    * hidden behind a convenience overload — the #142 lesson. {@code reviewStore}, {@code runStore}
    * and {@code fdeStore} accept {@code null} only for boxes that genuinely keep no such aggregate;
-   * passing {@code null} is an explicit decision, not a default.
+   * passing {@code null} is an explicit decision, not a default. {@code sessionYield} is never
+   * null: every production lane passes the pty host seam, so no launch path can silently skip
+   * yielding a resumed conversation; a lane with no host passes {@link SessionYield#NONE}.
    */
   public DispatchOperations(
       ShellExec shell,
@@ -207,7 +209,8 @@ public final class DispatchOperations {
       WatcherSpawner watcherSpawner,
       Snapshotter snapshotter,
       AgentLauncher launcher,
-      Listener listener) {
+      Listener listener,
+      SessionYield sessionYield) {
     this.shell = Objects.requireNonNull(shell, "shell");
     this.file = Objects.requireNonNull(file, "file");
     this.projects = new ProjectLoader(shell, file);
@@ -220,12 +223,13 @@ public final class DispatchOperations {
     this.snapshotter = Objects.requireNonNull(snapshotter, "snapshotter");
     this.launcher = Objects.requireNonNull(launcher, "launcher");
     this.listener = Objects.requireNonNull(listener, "listener");
+    this.sessionYield = Objects.requireNonNull(sessionYield, "sessionYield");
     this.membership =
         new MembershipService(specStore, () -> roomStore, projects, admission, this.events, shell);
     this.roomCommitGuard = new RoomCommitGuard(runStore, projects, this.events, shell);
     this.runLauncher =
         new RunLauncher(shell, file, launcher, listener, watcherSpawner, runStore, this.events);
-    this.runReservation = new RunReservation(runStore, shell, listener, () -> sessionYield);
+    this.runReservation = new RunReservation(runStore, shell, listener, sessionYield);
     this.adhocRunner = new AdhocRunner(projects, runLauncher, runReservation, runStore, listener);
     this.roomWakeLauncher =
         new RoomWakeLauncher(
@@ -272,14 +276,6 @@ public final class DispatchOperations {
   /** Wires the room store — the authoritative home of membership state; returns {@code this}. */
   public DispatchOperations useRooms(RoomStore rooms) {
     this.roomStore = Objects.requireNonNull(rooms, "rooms");
-    return this;
-  }
-
-  /**
-   * Wires the pty host seam a reservation ends displaced sessions through; returns {@code this}.
-   */
-  public DispatchOperations useSessionYield(SessionYield yield) {
-    this.sessionYield = Objects.requireNonNull(yield, "yield");
     return this;
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RunReservation.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RunReservation.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -35,24 +34,26 @@ import java.util.stream.Collectors;
  * conversation ({@link SessionYield#resumeSession}) whose run the new claim would have conflicted
  * with — by exactly the {@link DispatchGate} rules, the conversation holding its run's repos like a
  * working lane — is ended through the {@link SessionYield} seam, so no interactive agent ever sits
- * on a repo a dispatch is about to work.
+ * on a repo a dispatch is about to work. The claim and the yield run under the seam's per-project
+ * lock, the same lock an attach holds from reading the run rows to creating its session, so an
+ * attach can never slip a resume session in between the scan and the launch.
  */
 public final class RunReservation {
 
   private final RunStore runStore;
   private final ShellExec shell;
   private final DispatchOperations.Listener listener;
-  private final Supplier<SessionYield> sessionYield;
+  private final SessionYield sessionYield;
 
   public RunReservation(
       RunStore runStore,
       ShellExec shell,
       DispatchOperations.Listener listener,
-      Supplier<SessionYield> sessionYield) {
+      SessionYield sessionYield) {
     this.runStore = runStore;
     this.shell = shell;
     this.listener = listener;
-    this.sessionYield = sessionYield;
+    this.sessionYield = Objects.requireNonNull(sessionYield, "sessionYield");
   }
 
   /**
@@ -96,6 +97,35 @@ public final class RunReservation {
       String task,
       AgentUnit unit,
       SailYaml config) {
+    String credential;
+    try (var hold = sessionYield.lock(project)) {
+      credential =
+          claim(
+              runId, project, specId, roomId, node, owner, role, repos, agentType, branch, task,
+              unit, config);
+      yieldDisplacedSessions(runId, project, specId, role, repos);
+    } catch (IOException e) {
+      throw new ApiException(
+          ErrorCode.COMMAND_FAILED, "Could not lock project '" + project + "' to dispatch.", e);
+    }
+    pruneRuns(project);
+    return credential;
+  }
+
+  private String claim(
+      String runId,
+      String project,
+      String specId,
+      String roomId,
+      String node,
+      String owner,
+      String role,
+      List<String> repos,
+      String agentType,
+      String branch,
+      String task,
+      AgentUnit unit,
+      SailYaml config) {
     RunStore.Reservation reservation;
     try {
       reservation =
@@ -123,8 +153,6 @@ public final class RunReservation {
     if (reservation instanceof RunStore.Reservation.LeaseHeld held) {
       throw leaseRefusal(held);
     }
-    yieldDisplacedSessions(runId, project, specId, role, repos);
-    pruneRuns(project);
     return ((RunStore.Reservation.Reserved) reservation).credential();
   }
 
@@ -150,7 +178,7 @@ public final class RunReservation {
     var reason =
         "yielded to dispatch " + runId + (Strings.isBlank(specId) ? "" : " of spec " + specId);
     try {
-      sessionYield.get().end(displaced, reason);
+      sessionYield.end(displaced, reason);
     } catch (IOException e) {
       System.err.println(
           "  [api] Warning: could not yield terminal sessions "

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RunReservation.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RunReservation.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.api;
 
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.Guardrails;
+import ai.singlr.sail.config.Lane;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.engine.AgentSession;
 import ai.singlr.sail.engine.AgentUnit;
@@ -14,8 +15,10 @@ import ai.singlr.sail.engine.RunRetention;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.store.DispatchGate;
 import ai.singlr.sail.store.RunStore;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -26,17 +29,29 @@ import java.util.stream.Collectors;
  * #releaseIfAbsent} is the mirror: on a launch failure it frees the reservation, but only once the
  * agent is proven absent, so a failure that races a live process never pulls the repo out from
  * under it. Kept in one place so the concurrency guarantee has a single definition across lanes.
+ *
+ * <p>Host-owned terminal sessions respect the same gate: once a claim lands, every resumed agent
+ * conversation ({@link SessionYield#resumeSession}) whose run the new claim would have conflicted
+ * with — by exactly the {@link DispatchGate} rules, the conversation holding its run's repos like a
+ * working lane — is ended through the {@link SessionYield} seam, so no interactive agent ever sits
+ * on a repo a dispatch is about to work.
  */
 public final class RunReservation {
 
   private final RunStore runStore;
   private final ShellExec shell;
   private final DispatchOperations.Listener listener;
+  private final Supplier<SessionYield> sessionYield;
 
-  public RunReservation(RunStore runStore, ShellExec shell, DispatchOperations.Listener listener) {
+  public RunReservation(
+      RunStore runStore,
+      ShellExec shell,
+      DispatchOperations.Listener listener,
+      Supplier<SessionYield> sessionYield) {
     this.runStore = runStore;
     this.shell = shell;
     this.listener = listener;
+    this.sessionYield = sessionYield;
   }
 
   /**
@@ -107,8 +122,49 @@ public final class RunReservation {
     if (reservation instanceof RunStore.Reservation.LeaseHeld held) {
       throw leaseRefusal(held);
     }
+    yieldDisplacedSessions(runId, project, specId, role, repos);
     pruneRuns(project);
     return ((RunStore.Reservation.Reserved) reservation).credential();
+  }
+
+  /**
+   * Ends the resumed conversations this claim displaces: a run's resume session is judged as if the
+   * run were still running a working lane over its repos, so a read-only room wake displaces
+   * nothing while a build, full turn, or invite over an overlapping repo (or the same spec) ends
+   * it. Best-effort after the claim, like pruning: the reservation stands either way, and a host
+   * that refuses or cannot be reached is a warning, never a failed launch.
+   */
+  private void yieldDisplacedSessions(
+      String runId, String project, String specId, String role, List<String> repos) {
+    var target = repos == null ? List.<String>of() : repos;
+    var displaced =
+        runStore.listForProject(project).stream()
+            .filter(run -> !run.id().equals(runId))
+            .filter(run -> displaces(specId, role, target, run))
+            .map(run -> SessionYield.resumeSession(run.id()))
+            .toList();
+    if (displaced.isEmpty()) {
+      return;
+    }
+    var reason =
+        "yielded to dispatch " + runId + (Strings.isBlank(specId) ? "" : " of spec " + specId);
+    try {
+      sessionYield.get().end(displaced, reason);
+    } catch (IOException e) {
+      System.err.println(
+          "  [api] Warning: could not yield terminal sessions "
+              + displaced
+              + ": "
+              + e.getMessage());
+    }
+  }
+
+  static boolean displaces(
+      String specId, String role, List<String> repos, RunStore.RunRow resumed) {
+    var conversation =
+        new DispatchGate.RunningRun(
+            resumed.id(), resumed.specId(), Lane.BUILD.wire(), resumed.repos());
+    return DispatchGate.decide(specId, role, repos, List.of(conversation)).isPresent();
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/api/RunReservation.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/RunReservation.java
@@ -18,6 +18,7 @@ import ai.singlr.sail.store.RunStore;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -136,7 +137,7 @@ public final class RunReservation {
    */
   private void yieldDisplacedSessions(
       String runId, String project, String specId, String role, List<String> repos) {
-    var target = repos == null ? List.<String>of() : repos;
+    var target = Objects.requireNonNullElse(repos, List.<String>of());
     var displaced =
         runStore.listForProject(project).stream()
             .filter(run -> !run.id().equals(runId))

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -137,16 +137,18 @@ public final class SailOperations implements Operations {
         null,
         projectStore,
         SyncScheduler.disabled(),
-        null);
+        null,
+        SessionYield.NONE);
   }
 
   /**
    * As {@link #SailOperations(ShellExec, String, EventBus, EventSubscriber, SpecStore, ReviewStore,
-   * ProjectStore)} with the node's sync-on-write scheduler, the run aggregate, and the FDE roster;
-   * used by {@code sail server start} so spec mutations propagate to main, stale reads freshen
-   * without a manual {@code sail sync}, dispatches record their runs — without the run store every
-   * {@code /v1/runs} route refuses and API-lane dispatches silently record no run at all — and
-   * dispatch trusts only handles present in the synced roster.
+   * ProjectStore)} with the node's sync-on-write scheduler, the run aggregate, the FDE roster, and
+   * the pty host seam; used by {@code sail server start} so spec mutations propagate to main, stale
+   * reads freshen without a manual {@code sail sync}, dispatches record their runs — without the
+   * run store every {@code /v1/runs} route refuses and API-lane dispatches silently record no run
+   * at all — dispatch trusts only handles present in the synced roster, and a claim ends the
+   * resumed conversations it displaces. Every other constructor serves lanes with no pty host.
    */
   public SailOperations(
       ShellExec shell,
@@ -158,7 +160,8 @@ public final class SailOperations implements Operations {
       RunStore runStore,
       ProjectStore projectStore,
       SyncScheduler syncScheduler,
-      FdeStore fdeStore) {
+      FdeStore fdeStore,
+      SessionYield sessionYield) {
     this(
         shell,
         file,
@@ -171,7 +174,8 @@ public final class SailOperations implements Operations {
         projectStore,
         ConnectEnvironment::detect,
         syncScheduler,
-        fdeStore);
+        fdeStore,
+        sessionYield);
   }
 
   /** Wires the message store into the operations and dispatch lanes; returns {@code this}. */
@@ -185,14 +189,6 @@ public final class SailOperations implements Operations {
   public SailOperations useRooms(RoomStore roomStore) {
     this.roomStore = Objects.requireNonNull(roomStore, "roomStore");
     this.dispatchOps.useRooms(roomStore);
-    return this;
-  }
-
-  /**
-   * Wires the pty host seam a reservation ends displaced sessions through; returns {@code this}.
-   */
-  public SailOperations useSessionYield(SessionYield sessionYield) {
-    this.dispatchOps.useSessionYield(sessionYield);
     return this;
   }
 
@@ -276,7 +272,8 @@ public final class SailOperations implements Operations {
         null,
         ConnectEnvironment::detect,
         SyncScheduler.disabled(),
-        null);
+        null,
+        SessionYield.NONE);
   }
 
   SailOperations(
@@ -302,7 +299,8 @@ public final class SailOperations implements Operations {
         projectStore,
         connectEnvironment,
         SyncScheduler.disabled(),
-        null);
+        null,
+        SessionYield.NONE);
   }
 
   SailOperations(
@@ -329,7 +327,8 @@ public final class SailOperations implements Operations {
         projectStore,
         connectEnvironment,
         syncScheduler,
-        null);
+        null,
+        SessionYield.NONE);
   }
 
   SailOperations(
@@ -344,7 +343,8 @@ public final class SailOperations implements Operations {
       ProjectStore projectStore,
       Supplier<ConnectEnvironment> connectEnvironment,
       SyncScheduler syncScheduler,
-      FdeStore fdeStore) {
+      FdeStore fdeStore,
+      SessionYield sessionYield) {
     this.shell = shell;
     this.file = file;
     this.watcherSpawner = new WatcherSpawner(shell, watcherFallback);
@@ -374,7 +374,8 @@ public final class SailOperations implements Operations {
             this.watcherSpawner,
             DispatchOperations.autoSnapshotter(shell),
             DispatchOperations.shellLauncher(shell),
-            DispatchOperations.Listener.NONE);
+            DispatchOperations.Listener.NONE,
+            sessionYield);
     this.stopOps =
         specStore != null && runStore != null
             ? new StopOperations(

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SailOperations.java
@@ -189,6 +189,14 @@ public final class SailOperations implements Operations {
   }
 
   /**
+   * Wires the pty host seam a reservation ends displaced sessions through; returns {@code this}.
+   */
+  public SailOperations useSessionYield(SessionYield sessionYield) {
+    this.dispatchOps.useSessionYield(sessionYield);
+    return this;
+  }
+
+  /**
    * Overrides the executor that runs the deferred half of an invite (snapshot + launch). Production
    * keeps the default virtual-thread executor; a test injects {@code Runnable::run} to make the
    * completion run inline, so its assertions and teardown see a finished launch. Returns {@code

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SessionYield.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SessionYield.java
@@ -13,18 +13,47 @@ import java.util.List;
  * the pty session host under a name derived from its run, so when a dispatch reserves the repos
  * that conversation works in, the reservation names the displaced sessions and this seam ends them
  * — the decision stays with {@link RunReservation}, the pty host only executes the kill it is told.
- * The production implementation talks to the host over its socket; a box without a host ends
- * nothing.
+ *
+ * <p>The seam also owns the lock that makes the coupling sound: a claim and a resume session open
+ * are each compound operations (read the run rows, then act on the host), and the two must not
+ * interleave — a dispatch that scans for sessions before an attach creates one would find nothing
+ * to yield, and the resumed agent would then work the repos the dispatch just took. {@link #lock}
+ * serializes both sides per project, across processes, and every production lane wires the one
+ * implementation that talks to the host. {@link #NONE} is for lanes with no host at all — tests —
+ * where there is nothing to end and nothing to race.
  */
-@FunctionalInterface
 public interface SessionYield {
 
-  SessionYield NONE = (sessions, reason) -> {};
+  /** A held per-project claim lock; releasing never throws. */
+  interface Hold extends AutoCloseable {
+    @Override
+    void close();
+  }
+
+  Hold NO_HOLD = () -> {};
+
+  SessionYield NONE =
+      new SessionYield() {
+        @Override
+        public Hold lock(String project) {
+          return NO_HOLD;
+        }
+
+        @Override
+        public void end(List<String> sessions, String reason) {}
+      };
 
   /** The host session {@code sail agent attach} opens for a run's resumed conversation. */
   static String resumeSession(String runId) {
     return "resume-" + runId;
   }
+
+  /**
+   * Acquires the project's claim lock, blocking until it is free: held by a reservation from its
+   * run-row insert through the yield of displaced sessions, and by an attach from its run-row read
+   * through the session create.
+   */
+  Hold lock(String project) throws IOException;
 
   /**
    * Ends every live session among {@code sessions} with {@code reason}; names with no live session

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SessionYield.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SessionYield.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * The reservation's door onto host-owned terminal sessions. A resumed agent conversation lives in
+ * the pty session host under a name derived from its run, so when a dispatch reserves the repos
+ * that conversation works in, the reservation names the displaced sessions and this seam ends them
+ * — the decision stays with {@link RunReservation}, the pty host only executes the kill it is told.
+ * The production implementation talks to the host over its socket; a box without a host ends
+ * nothing.
+ */
+@FunctionalInterface
+public interface SessionYield {
+
+  SessionYield NONE = (sessions, reason) -> {};
+
+  /** The host session {@code sail agent attach} opens for a run's resumed conversation. */
+  static String resumeSession(String runId) {
+    return "resume-" + runId;
+  }
+
+  /**
+   * Ends every live session among {@code sessions} with {@code reason}; names with no live session
+   * are skipped. Throws when the host refused or could not be reached while sessions may still be
+   * live.
+   */
+  void end(List<String> sessions, String reason) throws IOException;
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentAttachCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentAttachCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.api.SessionYield;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.AgentCli;
@@ -14,17 +15,20 @@ import ai.singlr.sail.engine.NameValidator;
 import ai.singlr.sail.engine.NodeIdentity;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
+import ai.singlr.sail.engine.Stty;
+import ai.singlr.sail.store.RoomStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.Sqlite;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -39,12 +43,16 @@ import picocli.CommandLine.Spec;
  *
  * <ul>
  *   <li><b>Completed run with a recorded session:</b> resumes that session exactly ({@code claude
- *       --resume <id>} / {@code codex resume <id>}) in the container under the caller's ambient
- *       identity — never an interactive picker.
- *   <li><b>Completed run without a session:</b> attaches a fresh conversation, loudly.
+ *       --resume <id>} / {@code codex resume <id>}) inside a host-owned session named for the run
+ *       ({@link SessionYield#resumeSession}), pinned to the run's room, and attaches this terminal
+ *       to it. The conversation outlives the terminal: {@code Ctrl-]} detaches, running attach
+ *       again joins the live session rather than forking a second agent, and a dispatch that
+ *       reserves the run's repos ends it with a reason in the stream.
+ *   <li><b>Completed run without a session:</b> attaches a fresh conversation over a raw tty,
+ *       loudly.
  *   <li><b>Live run:</b> refuses — attaching would fork a second concurrent agent over the same
  *       conversation and worktree. The refusal names the real lanes: reply in the spec room to
- *       steer it mid-run, or stop it first; live observe/attach arrives with the PTY session host.
+ *       steer it mid-run, or stop it first.
  * </ul>
  */
 @Command(
@@ -76,7 +84,32 @@ public final class AgentAttachCommand implements Runnable {
   @Option(names = "--json", description = "Print the resolved attach plan as JSON; do not attach.")
   private boolean json;
 
+  @Option(names = "--socket", hidden = true, description = "Host socket override.")
+  private Path socket;
+
   @Spec private CommandSpec commandSpec;
+
+  /** What the resume lane opens: the host session, its child, and the room it is pinned to. */
+  record ResumePlan(String session, List<String> command, String project, String room) {
+
+    /** The {@code sail session} verbs this attach is made of — what {@code --dry-run} prints. */
+    String asSessionCommands() {
+      var open = new ArrayList<>(List.of("sail", "session", "new", session, "--project", project));
+      if (!room.isBlank()) {
+        open.addAll(List.of("--room", room));
+      }
+      open.add("--command");
+      open.addAll(command);
+      return open.stream().map(AgentAttachCommand::shellWord).collect(Collectors.joining(" "))
+          + "\nsail session attach "
+          + session;
+    }
+  }
+
+  /** The latest run and, when its room exists on this box, that room. */
+  record Latest(RunStore.RunRow run, String room) {
+    static final Latest NONE = new Latest(null, "");
+  }
 
   @Override
   public void run() {
@@ -87,26 +120,88 @@ public final class AgentAttachCommand implements Runnable {
     name = CurrentProject.require(name);
     NameValidator.requireValidProjectName(name);
 
-    var run = latestRun().orElse(null);
+    var latest = latest();
+    var run = latest.run();
     if (run != null && LIVE_STATUSES.contains(run.status())) {
       throw new IllegalStateException(refusal(run));
     }
     var agentType = run != null ? AgentCli.fromYamlName(run.agent()) : resolveAgentType();
     var sessionId = validatedSessionId(run);
-    var command = buildIncusExecWithTty(name, buildResumeCommand(agentType, sessionId));
-
+    var command = buildResumeCommand(agentType, sessionId);
+    if (sessionId == null) {
+      attachFresh(run, agentType, buildIncusExecWithTty(name, command));
+      return;
+    }
+    var plan = new ResumePlan(SessionYield.resumeSession(run.id()), command, name, latest.room());
     if (json) {
-      System.out.println(YamlUtil.dumpJson(plan(run, agentType, sessionId, command)));
+      System.out.println(YamlUtil.dumpJson(plan(run, agentType, sessionId, plan)));
+      return;
+    }
+    if (dryRun) {
+      System.out.println(plan.asSessionCommands());
+      return;
+    }
+    if (Stty.saved().isEmpty()) {
+      throw new IllegalStateException(
+          "sail agent attach needs an interactive terminal to open session '"
+              + plan.session()
+              + "'.");
+    }
+    announceResume(run, agentType, sessionId, plan);
+    requireRunning();
+    var size = Stty.size(new int[] {24, 80});
+    try (var client = SessionClient.connect(SessionCommand.socketOrDefault(socket))) {
+      var opened = openOrJoin(client, plan, size[1], size[0]);
+      System.out.println(
+          Ansi.AUTO.string(
+              opened
+                  ? "  @|faint Opened session " + plan.session() + " (Ctrl-] detaches).|@"
+                  : "  @|faint Joined the live session "
+                      + plan.session()
+                      + " (Ctrl-] detaches).|@"));
+      SessionCommand.attachTerminal(client, plan.session(), true);
+    }
+  }
+
+  /**
+   * Opens the resume session, or joins it when it is already live: a create the host refuses
+   * because the session runs — a reattach after detach, or the losing side of two simultaneous
+   * attaches — is the join case, never a second agent. Any other refusal is the error it was.
+   * Returns whether this call opened the session.
+   */
+  static boolean openOrJoin(SessionClient client, ResumePlan plan, int cols, int rows)
+      throws IOException {
+    try {
+      client.create(
+          plan.session(),
+          plan.command(),
+          System.getProperty("user.home", "/home/dev"),
+          plan.project(),
+          plan.room(),
+          cols,
+          rows);
+      return true;
+    } catch (IOException refused) {
+      if (client.list().stream()
+          .anyMatch(info -> info.live() && info.name().equals(plan.session()))) {
+        return false;
+      }
+      throw refused;
+    }
+  }
+
+  private void attachFresh(RunStore.RunRow run, AgentCli agentType, List<String> command)
+      throws Exception {
+    if (json) {
+      System.out.println(YamlUtil.dumpJson(plan(run, agentType, null, command)));
       return;
     }
     if (dryRun) {
       System.out.println(String.join(" ", command));
       return;
     }
-
-    announce(run, agentType, sessionId);
-    var state = new ContainerManager(new ShellExecutor(false)).queryState(name);
-    ContainerStateGuard.requireRunning(state, name);
+    announceFresh(run);
+    requireRunning();
     var process = new ProcessBuilder(command).inheritIO().start();
     var exitCode = process.waitFor();
     if (exitCode != 0) {
@@ -115,31 +210,42 @@ public final class AgentAttachCommand implements Runnable {
     }
   }
 
+  private void requireRunning() throws Exception {
+    var state = new ContainerManager(new ShellExecutor(false)).queryState(name);
+    ContainerStateGuard.requireRunning(state, name);
+  }
+
   /**
-   * The latest local agent session (build or ad-hoc) of the project, read directly from the
-   * control-plane database like the status and log lanes. Empty only when a successful query finds
-   * no row — attach then falls back to a fresh conversation, loudly. An unreadable database
-   * (locked, corrupt, unmigrated) fails closed instead: treating it as "no run" would bypass the
-   * live-run refusal and fork a second agent over the same worktree.
+   * The latest local agent session (build or ad-hoc) of the project with its room, read directly
+   * from the control-plane database like the status and log lanes. A run whose room is not on this
+   * box resolves to no room — the session then opens unbound, announced — so a legacy conversation
+   * is never unreachable for want of a room row. An unreadable database fails closed through {@link
+   * #orRefuse}.
    */
-  private Optional<RunStore.RunRow> latestRun() {
-    return latestRunOrRefuse(
+  private Latest latest() {
+    return orRefuse(
         name,
         () -> {
           try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
-            return new RunStore(db).latestForProjectOnNode(name, NodeIdentity.handle());
+            var run =
+                new RunStore(db).latestForProjectOnNode(name, NodeIdentity.handle()).orElse(null);
+            return run == null ? Latest.NONE : new Latest(run, knownRoom(new RoomStore(db), run));
           }
         });
   }
 
+  static String knownRoom(RoomStore rooms, RunStore.RunRow run) {
+    var conversation = run.conversationId();
+    return conversation != null && rooms.findById(conversation).isPresent() ? conversation : "";
+  }
+
   /**
-   * The fail-closed policy, pure: unknown is never absent. Empty means a successful query found no
-   * run — only then may attach fall back to a fresh conversation. A query failure of any kind
-   * refuses the attach, because treating an unreadable database as "no run" would bypass the
-   * live-run refusal and fork a second agent over the same worktree.
+   * The fail-closed policy, pure: unknown is never absent. A successful query may find no run —
+   * only then may attach fall back to a fresh conversation. A query failure of any kind refuses the
+   * attach, because treating an unreadable database as "no run" would bypass the live-run refusal
+   * and fork a second agent over the same worktree.
    */
-  static Optional<RunStore.RunRow> latestRunOrRefuse(
-      String project, Supplier<Optional<RunStore.RunRow>> query) {
+  static <T> T orRefuse(String project, Supplier<T> query) {
     try {
       return query.get();
     } catch (RuntimeException e) {
@@ -186,21 +292,29 @@ public final class AgentAttachCommand implements Runnable {
         + room
         + " to steer it (delivered mid-run), or stop it first with: sail agent stop "
         + name
-        + ". Live observe/attach arrives with the PTY session host.";
+        + ".";
   }
 
-  private void announce(RunStore.RunRow run, AgentCli agentType, String sessionId) {
+  private void announceFresh(RunStore.RunRow run) {
     if (run == null) {
       System.out.println(
           Ansi.AUTO.string(
               "  @|yellow ⚠|@ No recorded run for '" + name + "'; attaching a fresh session."));
       return;
     }
-    if (sessionId == null) {
+    System.out.println(
+        Ansi.AUTO.string(
+            "  @|yellow ⚠|@ Run " + run.id() + " recorded no session; attaching fresh."));
+  }
+
+  private void announceResume(
+      RunStore.RunRow run, AgentCli agentType, String sessionId, ResumePlan plan) {
+    if (run.conversationId() != null && plan.room().isBlank()) {
       System.out.println(
           Ansi.AUTO.string(
-              "  @|yellow ⚠|@ Run " + run.id() + " recorded no session; attaching fresh."));
-      return;
+              "  @|yellow ⚠|@ Room "
+                  + run.conversationId()
+                  + " is not on this box; the session opens without a room."));
     }
     System.out.println(
         Ansi.AUTO.string(
@@ -213,6 +327,16 @@ public final class AgentAttachCommand implements Runnable {
                 + " in "
                 + name
                 + "...|@"));
+  }
+
+  private LinkedHashMap<String, Object> plan(
+      RunStore.RunRow run, AgentCli agentType, String sessionId, ResumePlan resume) {
+    var map = plan(run, agentType, sessionId, resume.command());
+    map.put("session", resume.session());
+    if (!resume.room().isBlank()) {
+      map.put("room", resume.room());
+    }
+    return map;
   }
 
   private LinkedHashMap<String, Object> plan(
@@ -276,5 +400,9 @@ public final class AgentAttachCommand implements Runnable {
     cmd.add("--");
     cmd.addAll(args);
     return List.copyOf(cmd);
+  }
+
+  private static String shellWord(String word) {
+    return word.matches("[A-Za-z0-9._/=:-]+") ? word : "'" + word.replace("'", "'\\''") + "'";
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentAttachCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentAttachCommand.java
@@ -123,7 +123,7 @@ public final class AgentAttachCommand implements Runnable {
     var latest = latest();
     var run = latest.run();
     if (run != null && LIVE_STATUSES.contains(run.status())) {
-      throw new IllegalStateException(refusal(run));
+      throw new IllegalStateException(refusal(run, name));
     }
     var agentType = run != null ? AgentCli.fromYamlName(run.agent()) : resolveAgentType();
     var sessionId = validatedSessionId(run);
@@ -150,8 +150,11 @@ public final class AgentAttachCommand implements Runnable {
     announceResume(run, agentType, sessionId, plan);
     requireRunning();
     var size = Stty.size(new int[] {24, 80});
-    try (var client = SessionClient.connect(SessionCommand.socketOrDefault(socket))) {
-      var opened = openOrJoin(client, plan, size[1], size[0]);
+    var hostSocket = SessionCommand.socketOrDefault(socket);
+    try (var client = SessionClient.connect(hostSocket)) {
+      var opened =
+          openLocked(
+              new PtyHostYield(hostSocket), this::latest, run, client, plan, size[1], size[0]);
       System.out.println(
           Ansi.AUTO.string(
               opened
@@ -160,6 +163,42 @@ public final class AgentAttachCommand implements Runnable {
                       + plan.session()
                       + " (Ctrl-] detaches).|@"));
       SessionCommand.attachTerminal(client, plan.session(), true);
+    }
+  }
+
+  /**
+   * Opens or joins under the project's claim lock — the lock a dispatch holds from its run-row
+   * insert through the yield of displaced sessions — re-reading the latest run first. The plan was
+   * built from an unlocked read, so a dispatch that reserved in between shows up here as a live
+   * latest run and refuses; a dispatch that reserves after this returns finds the session live and
+   * yields it. Either way no resumed agent ever works repos a claim holds. Returns whether this
+   * call opened the session.
+   */
+  static boolean openLocked(
+      SessionYield hostYield,
+      Supplier<Latest> latest,
+      RunStore.RunRow planned,
+      SessionClient client,
+      ResumePlan plan,
+      int cols,
+      int rows)
+      throws IOException {
+    try (var hold = hostYield.lock(plan.project())) {
+      requireStillLatestAndIdle(planned, latest.get().run(), plan.project());
+      return openOrJoin(client, plan, cols, rows);
+    }
+  }
+
+  static void requireStillLatestAndIdle(
+      RunStore.RunRow planned, RunStore.RunRow current, String project) {
+    if (current != null && LIVE_STATUSES.contains(current.status())) {
+      throw new IllegalStateException(refusal(current, project));
+    }
+    if (current == null || !current.id().equals(planned.id())) {
+      throw new IllegalStateException(
+          "The latest run of '"
+              + project
+              + "' changed while opening the session; run sail agent attach again.");
     }
   }
 
@@ -280,7 +319,7 @@ public final class AgentAttachCommand implements Runnable {
     return SAFE_SESSION_ID.matcher(sessionId).matches();
   }
 
-  private String refusal(RunStore.RunRow run) {
+  private static String refusal(RunStore.RunRow run, String project) {
     var room =
         run.specId() == null
             ? "its spec room"
@@ -291,7 +330,7 @@ public final class AgentAttachCommand implements Runnable {
         + " and worktree. Reply in "
         + room
         + " to steer it (delivered mid-run), or stop it first with: sail agent stop "
-        + name
+        + project
         + ".";
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentAttachCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentAttachCommand.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.SessionYield;
+import ai.singlr.sail.config.Lane;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.AgentCli;
@@ -16,6 +17,7 @@ import ai.singlr.sail.engine.NodeIdentity;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.Stty;
+import ai.singlr.sail.store.DispatchGate;
 import ai.singlr.sail.store.RoomStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.Sqlite;
@@ -106,9 +108,13 @@ public final class AgentAttachCommand implements Runnable {
     }
   }
 
-  /** The latest run and, when its room exists on this box, that room. */
-  record Latest(RunStore.RunRow run, String room) {
-    static final Latest NONE = new Latest(null, "");
+  /**
+   * The latest run, its room when that room exists on this box, and every run live on this box in
+   * the project — all lanes, since a full invite or a full room turn holds repos exactly as a build
+   * does yet never counts as the project's latest session.
+   */
+  record Latest(RunStore.RunRow run, String room, List<DispatchGate.RunningRun> running) {
+    static final Latest NONE = new Latest(null, "", List.of());
   }
 
   @Override
@@ -132,6 +138,7 @@ public final class AgentAttachCommand implements Runnable {
       attachFresh(run, agentType, buildIncusExecWithTty(name, command));
       return;
     }
+    requireNoLiveConflict(run, latest.running(), name);
     var plan = new ResumePlan(SessionYield.resumeSession(run.id()), command, name, latest.room());
     if (json) {
       System.out.println(YamlUtil.dumpJson(plan(run, agentType, sessionId, plan)));
@@ -168,11 +175,12 @@ public final class AgentAttachCommand implements Runnable {
 
   /**
    * Opens or joins under the project's claim lock — the lock a dispatch holds from its run-row
-   * insert through the yield of displaced sessions — re-reading the latest run first. The plan was
-   * built from an unlocked read, so a dispatch that reserved in between shows up here as a live
-   * latest run and refuses; a dispatch that reserves after this returns finds the session live and
-   * yields it. Either way no resumed agent ever works repos a claim holds. Returns whether this
-   * call opened the session.
+   * insert through the yield of displaced sessions — re-reading the run rows first. The plan was
+   * built from an unlocked read, so a claim that landed in between shows up here as a live run and
+   * refuses: as the project's latest session when it is a build, or through the dispatch gate when
+   * it is a lane the latest-session query leaves out, a full invite above all. A dispatch that
+   * reserves after this returns finds the session live and yields it. Either way no resumed agent
+   * ever works repos a claim holds. Returns whether this call opened the session.
    */
   static boolean openLocked(
       SessionYield hostYield,
@@ -184,13 +192,13 @@ public final class AgentAttachCommand implements Runnable {
       int rows)
       throws IOException {
     try (var hold = hostYield.lock(plan.project())) {
-      requireStillLatestAndIdle(planned, latest.get().run(), plan.project());
+      requireStillLatestAndIdle(planned, latest.get(), plan.project());
       return openOrJoin(client, plan, cols, rows);
     }
   }
 
-  static void requireStillLatestAndIdle(
-      RunStore.RunRow planned, RunStore.RunRow current, String project) {
+  static void requireStillLatestAndIdle(RunStore.RunRow planned, Latest latest, String project) {
+    var current = latest.run();
     if (current != null && LIVE_STATUSES.contains(current.status())) {
       throw new IllegalStateException(refusal(current, project));
     }
@@ -200,6 +208,38 @@ public final class AgentAttachCommand implements Runnable {
               + project
               + "' changed while opening the session; run sail agent attach again.");
     }
+    requireNoLiveConflict(planned, latest.running(), project);
+  }
+
+  /**
+   * The dispatch gate read from the conversation's side: resuming {@code run} puts a working agent
+   * on its repos, so any live run the gate would refuse a build of that spec over those repos — a
+   * build, a full invite, a full room turn — refuses the resume. This is the exact mirror of the
+   * rule a reservation uses to yield a live resume session, so the two sides can never disagree.
+   */
+  static void requireNoLiveConflict(
+      RunStore.RunRow run, List<DispatchGate.RunningRun> running, String project) {
+    DispatchGate.decide(run.conversationId(), Lane.BUILD.wire(), run.repos(), running)
+        .ifPresent(
+            conflict -> {
+              throw new IllegalStateException(conflictRefusal(run, conflict, project));
+            });
+  }
+
+  private static String conflictRefusal(
+      RunStore.RunRow run, DispatchGate.Conflict conflict, String project) {
+    var live = conflict.run();
+    return "Run "
+        + live.runId()
+        + " ("
+        + live.role()
+        + ") is live in "
+        + (conflict.overlap().isEmpty()
+            ? "container '" + project + "'"
+            : "repo(s) " + conflict.overlap())
+        + " — resuming run "
+        + run.id()
+        + " would put a second agent on what it holds. Wait for it to finish, or stop it first.";
   }
 
   /**
@@ -266,9 +306,13 @@ public final class AgentAttachCommand implements Runnable {
         name,
         () -> {
           try (var db = Sqlite.open(SailPaths.controlPlaneDb())) {
-            var run =
-                new RunStore(db).latestForProjectOnNode(name, NodeIdentity.handle()).orElse(null);
-            return run == null ? Latest.NONE : new Latest(run, knownRoom(new RoomStore(db), run));
+            var runs = new RunStore(db);
+            var node = NodeIdentity.handle();
+            var run = runs.latestForProjectOnNode(name, node).orElse(null);
+            return run == null
+                ? Latest.NONE
+                : new Latest(
+                    run, knownRoom(new RoomStore(db), run), runs.runningOnNode(name, node));
           }
         });
   }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AgentSweepCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AgentSweepCommand.java
@@ -148,7 +148,8 @@ public final class AgentSweepCommand implements Runnable {
         new WatcherSpawner(shell, WatcherSpawner::spawnProcess),
         (project, config) -> "",
         DispatchOperations.terminalLauncher(),
-        listener);
+        listener,
+        new PtyHostYield());
   }
 
   private void render(DispatchOperations.AdhocSession session, List<String> command) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/DispatchCommand.java
@@ -10,6 +10,7 @@ import ai.singlr.sail.api.ApiException;
 import ai.singlr.sail.api.DispatchOperations;
 import ai.singlr.sail.api.Event;
 import ai.singlr.sail.api.SailEventPublisher;
+import ai.singlr.sail.api.SessionYield;
 import ai.singlr.sail.api.SyncScheduler;
 import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.config.Spec;
@@ -137,7 +138,8 @@ public final class DispatchCommand implements Runnable {
               new WatcherSpawner(shell, WatcherSpawner::spawnProcess),
               snapshotter(shell),
               DispatchOperations.terminalLauncher(),
-              renderer(sync));
+              renderer(sync),
+              new PtyHostYield());
       render(dispatch(operations, request, handle));
     }
   }
@@ -155,7 +157,8 @@ public final class DispatchCommand implements Runnable {
       WatcherSpawner watcherSpawner,
       DispatchOperations.Snapshotter snapshotter,
       DispatchOperations.AgentLauncher launcher,
-      DispatchOperations.Listener listener) {
+      DispatchOperations.Listener listener,
+      SessionYield sessionYield) {
     return new DispatchOperations(
             shell,
             file,
@@ -167,7 +170,8 @@ public final class DispatchCommand implements Runnable {
             watcherSpawner,
             snapshotter,
             launcher,
-            listener)
+            listener,
+            sessionYield)
         .useMessages(new MessageStore(db));
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostYield.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostYield.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.api.SessionYield;
+import ai.singlr.sail.engine.SailPaths;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * The production {@link SessionYield}: the box's own API process speaks to its pty session host
+ * over the socket as the box's ambient owner — a blank token, the same identity a local {@code sail
+ * session} verb carries — lists what is live, and yields the named sessions one by one. No socket
+ * means no host and therefore no sessions: nothing to end, not an error. A refused yield (a session
+ * another FDE owns on this box) surfaces as the exception the reservation warns about.
+ */
+final class PtyHostYield implements SessionYield {
+
+  private final Path socket;
+
+  PtyHostYield() {
+    this(SailPaths.ptySocketPath());
+  }
+
+  PtyHostYield(Path socket) {
+    this.socket = socket;
+  }
+
+  @Override
+  public void end(List<String> sessions, String reason) throws IOException {
+    if (!Files.exists(socket)) {
+      return;
+    }
+    try (var client = SessionClient.connect(socket, "")) {
+      for (var name : sessions) {
+        client.yieldSession(name, reason);
+      }
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostYield.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostYield.java
@@ -7,18 +7,22 @@ package ai.singlr.sail.commands;
 
 import ai.singlr.sail.api.SessionYield;
 import ai.singlr.sail.engine.SailPaths;
+import ai.singlr.sail.pty.PtySessionHost;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The production {@link SessionYield}: the box's own API process speaks to its pty session host
- * over the socket as the box's ambient owner — a blank token, the same identity a local {@code sail
- * session} verb carries — lists what is live, and yields the named sessions one by one. No socket
- * means no host and therefore no sessions: nothing to end, not an error. A refused yield (a session
- * another FDE owns on this box) surfaces as the exception the reservation warns about. The claim
- * lock lives beside the control-plane database, the one place every sail process on the box already
+ * The production {@link SessionYield}: the box's own sail process speaks to its pty session host as
+ * the host's dispatch authority — the credential the host minted at start, owner-only beside the
+ * socket — and yields the named sessions one by one, whichever FDE opened them. No socket means no
+ * host and therefore no sessions: nothing to end, not an error. A socket with no credential beside
+ * it is a host too old to be told — that is an error, reported. Every name is attempted before any
+ * failure is raised, so one refusal never leaves a later displaced session alive. The claim lock
+ * lives beside the control-plane database, the one place every sail process on the box already
  * reaches.
  */
 final class PtyHostYield implements SessionYield {
@@ -49,10 +53,33 @@ final class PtyHostYield implements SessionYield {
     if (!Files.exists(socket)) {
       return;
     }
-    try (var client = SessionClient.connect(socket, "")) {
+    var failures = new ArrayList<String>();
+    try (var client = SessionClient.connect(socket, dispatchCredential())) {
       for (var name : sessions) {
-        client.yieldSession(name, reason);
+        try {
+          client.yieldSession(name, reason);
+        } catch (IOException refused) {
+          failures.add(name + ": " + refused.getMessage());
+        }
       }
+    }
+    if (!failures.isEmpty()) {
+      throw new IOException(String.join("; ", failures));
+    }
+  }
+
+  private String dispatchCredential() throws IOException {
+    var path = PtySessionHost.dispatchCredentialOf(socket);
+    try {
+      return Files.readString(path).strip();
+    } catch (NoSuchFileException missing) {
+      throw new IOException(
+          "The session host at "
+              + socket
+              + " minted no dispatch credential ("
+              + path
+              + "); restart the sail-pty-host service on this sail version.",
+          missing);
     }
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostYield.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostYield.java
@@ -17,18 +17,31 @@ import java.util.List;
  * over the socket as the box's ambient owner — a blank token, the same identity a local {@code sail
  * session} verb carries — lists what is live, and yields the named sessions one by one. No socket
  * means no host and therefore no sessions: nothing to end, not an error. A refused yield (a session
- * another FDE owns on this box) surfaces as the exception the reservation warns about.
+ * another FDE owns on this box) surfaces as the exception the reservation warns about. The claim
+ * lock lives beside the control-plane database, the one place every sail process on the box already
+ * reaches.
  */
 final class PtyHostYield implements SessionYield {
 
   private final Path socket;
+  private final Path lockDir;
 
   PtyHostYield() {
     this(SailPaths.ptySocketPath());
   }
 
   PtyHostYield(Path socket) {
+    this(socket, SailPaths.dataDir().resolve("locks"));
+  }
+
+  PtyHostYield(Path socket, Path lockDir) {
     this.socket = socket;
+    this.lockDir = lockDir;
+  }
+
+  @Override
+  public Hold lock(String project) throws IOException {
+    return SessionDispatchLock.acquire(lockDir, project);
   }
 
   @Override

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/RunCommand.java
@@ -392,7 +392,8 @@ public final class RunCommand implements Runnable {
         new WatcherSpawner(shell, WatcherSpawner::spawnProcess),
         (project, config) -> "",
         DispatchOperations.terminalLauncher(),
-        listener);
+        listener,
+        new PtyHostYield());
   }
 
   private void render(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -204,7 +204,8 @@ public final class ServerStartCommand implements Runnable {
             .useMessages(messageStore)
             .useRooms(roomStore)
             .useBoxCredentials(boxCredentialStore)
-            .useEvents(eventStore);
+            .useEvents(eventStore)
+            .useSessionYield(new PtyHostYield());
     var orphaned = reviewStore.failOrphanedRunning();
     var orphanedRuns = runStore.failRunningReviewsOnNode(NodeIdentity.handle());
     if (orphanedRuns > 0) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -200,12 +200,12 @@ public final class ServerStartCommand implements Runnable {
                 runStore,
                 projectStore,
                 syncScheduler,
-                new FdeStore(db))
+                new FdeStore(db),
+                new PtyHostYield())
             .useMessages(messageStore)
             .useRooms(roomStore)
             .useBoxCredentials(boxCredentialStore)
-            .useEvents(eventStore)
-            .useSessionYield(new PtyHostYield());
+            .useEvents(eventStore);
     var orphaned = reviewStore.failOrphanedRunning();
     var orphanedRuns = runStore.failRunningReviewsOnNode(NodeIdentity.handle());
     if (orphanedRuns > 0) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SessionClient.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SessionClient.java
@@ -84,6 +84,12 @@ public final class SessionClient implements AutoCloseable {
     expectOk("kill");
   }
 
+  /** Ends a live session with {@code reason} in its stream and on its ending event. */
+  public void yieldSession(String name, String reason) throws IOException {
+    PtyWire.write(channel, new PtyMessage.Yield(name, reason));
+    expectOk("yield");
+  }
+
   /** Sends the attach request and confirms it; frame traffic then belongs to the caller. */
   public SocketChannel attach(String name, boolean write) throws IOException {
     PtyWire.write(channel, new PtyMessage.Attach(name, write));

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SessionCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SessionCommand.java
@@ -123,25 +123,34 @@ public final class SessionCommand {
     @Override
     public Integer call() throws Exception {
       try (var client = SessionClient.connect(socketOrDefault(socket))) {
-        var channel = client.attach(name, !observe);
-        var saved = Stty.saved().orElse(null);
-        if (saved == null) {
-          System.err.println("session attach needs an interactive terminal.");
-          return 1;
-        }
-        Stty.set("raw -echo");
-        String reason;
-        try {
-          reason = AttachLoop.run(channel, System.in, System.out, terminalResizes());
-        } finally {
-          Stty.set(saved);
-        }
-        System.out.println();
-        System.out.println(
-            reason == null ? "Detached; the session lives on." : "Session ended: " + reason);
+        return attachTerminal(client, name, !observe);
       }
-      return 0;
     }
+  }
+
+  /**
+   * Attaches the controlling terminal to {@code name} through {@code client}: raw mode for the
+   * duration, {@code Ctrl-]} detaches, and the ending — detach or session end — is narrated on the
+   * way out. Fails before touching the terminal when there is none to put in raw mode.
+   */
+  static int attachTerminal(SessionClient client, String name, boolean write) throws Exception {
+    var channel = client.attach(name, write);
+    var saved = Stty.saved().orElse(null);
+    if (saved == null) {
+      System.err.println("session attach needs an interactive terminal.");
+      return 1;
+    }
+    Stty.set("raw -echo");
+    String reason;
+    try {
+      reason = AttachLoop.run(channel, System.in, System.out, terminalResizes());
+    } finally {
+      Stty.set(saved);
+    }
+    System.out.println();
+    System.out.println(
+        reason == null ? "Detached; the session lives on." : "Session ended: " + reason);
+    return 0;
   }
 
   /**

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SessionDispatchLock.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SessionDispatchLock.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.api.SessionYield;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * The per-project lock a dispatch claim and a resume-session open both hold: an exclusive {@link
+ * java.nio.channels.FileLock} on {@code <dir>/<project>.lock}, so the API server, a CLI dispatch,
+ * and {@code sail agent attach} — separate processes on the same host — serialize on the kernel's
+ * word. A file lock is per JVM, not per thread, so an in-process mutex per lock file fronts it: two
+ * server threads claiming the same project queue on the mutex instead of tripping over an
+ * overlapping lock. Released by closing: closing the channel drops the file lock even when the
+ * close itself reports an error, so the release path swallows that error rather than leaking the
+ * mutex.
+ */
+final class SessionDispatchLock implements SessionYield.Hold {
+
+  private static final Map<Path, ReentrantLock> IN_PROCESS = new ConcurrentHashMap<>();
+
+  private final ReentrantLock inProcess;
+  private final FileChannel channel;
+
+  private SessionDispatchLock(ReentrantLock inProcess, FileChannel channel) {
+    this.inProcess = inProcess;
+    this.channel = channel;
+  }
+
+  static SessionDispatchLock acquire(Path dir, String project) throws IOException {
+    var file = dir.resolve(project + ".lock").toAbsolutePath().normalize();
+    var inProcess = IN_PROCESS.computeIfAbsent(file, f -> new ReentrantLock());
+    inProcess.lock();
+    try {
+      Files.createDirectories(dir);
+      var channel = FileChannel.open(file, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+      try {
+        channel.lock();
+        return new SessionDispatchLock(inProcess, channel);
+      } catch (IOException | RuntimeException e) {
+        channel.close();
+        throw e;
+      }
+    } catch (IOException | RuntimeException e) {
+      inProcess.unlock();
+      throw e;
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      channel.close();
+    } catch (IOException ignored) {
+    } finally {
+      inProcess.unlock();
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AdhocDispatchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AdhocDispatchTest.java
@@ -114,7 +114,8 @@ class AdhocDispatchTest {
         new WatcherSpawner(shell, (command, logPath) -> 4242L),
         (project, config) -> "",
         launcher,
-        listener);
+        listener,
+        SessionYield.NONE);
   }
 
   private static StubShell liveAgentShell() {
@@ -449,7 +450,8 @@ class AdhocDispatchTest {
               public void launching(boolean background, List<String> command) {
                 launchedCommands.add(command);
               }
-            });
+            },
+            SessionYield.NONE);
 
     var session =
         ops.startAdhoc(
@@ -578,7 +580,8 @@ class AdhocDispatchTest {
               commands.add(command);
               return 0;
             },
-            DispatchOperations.Listener.NONE);
+            DispatchOperations.Listener.NONE,
+            SessionYield.NONE);
 
     ops.startAdhoc(
         "acme", new DispatchOperations.AdhocRequest("task", null, "app/api", true, false), HANDLE);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AdhocRunLifecycleIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AdhocRunLifecycleIT.java
@@ -123,7 +123,8 @@ class AdhocRunLifecycleIT extends AbstractIncusIT {
               new WatcherSpawner(refusingShell(), (command, logPath) -> 4242L),
               (project, config) -> "",
               DispatchOperations.shellLauncher(shell),
-              DispatchOperations.Listener.NONE);
+              DispatchOperations.Listener.NONE,
+              SessionYield.NONE);
 
       var session =
           dispatchOps.startAdhoc(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/AgentPrincipalLifecycleTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/AgentPrincipalLifecycleTest.java
@@ -125,7 +125,8 @@ class AgentPrincipalLifecycleTest {
                       .orElse(""));
               return 0;
             },
-            DispatchOperations.Listener.NONE);
+            DispatchOperations.Listener.NONE,
+            SessionYield.NONE);
 
     var outcome =
         dispatchOps.dispatch(
@@ -278,7 +279,8 @@ class AgentPrincipalLifecycleTest {
                       .orElse(""));
               return 0;
             },
-            DispatchOperations.Listener.NONE);
+            DispatchOperations.Listener.NONE,
+            SessionYield.NONE);
 
     var outcome =
         dispatchOps.dispatch(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/BuildDispatchCoverageTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/BuildDispatchCoverageTest.java
@@ -211,7 +211,8 @@ class BuildDispatchCoverageTest {
         new WatcherSpawner(happyPath(), (command, logPath) -> 4242L),
         (project, config) -> "",
         command -> 0,
-        DispatchOperations.Listener.NONE);
+        DispatchOperations.Listener.NONE,
+        SessionYield.NONE);
   }
 
   private static DispatchOperations.Outcome dispatch(DispatchOperations ops) {

--- a/sail-infra/src/test/java/ai/singlr/sail/api/ConcurrentDispatchIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/ConcurrentDispatchIT.java
@@ -127,7 +127,8 @@ class ConcurrentDispatchIT extends AbstractIncusIT {
               new WatcherSpawner(refusingShell(), (command, logPath) -> 4242L),
               (project, config) -> "",
               DispatchOperations.shellLauncher(shell),
-              DispatchOperations.Listener.NONE);
+              DispatchOperations.Listener.NONE,
+              SessionYield.NONE);
 
       var first = dispatchBackground(dispatchOps, "spec-app");
       var second = dispatchBackground(dispatchOps, "spec-web");

--- a/sail-infra/src/test/java/ai/singlr/sail/api/DispatchBranchBaseTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/DispatchBranchBaseTest.java
@@ -148,7 +148,8 @@ class DispatchBranchBaseTest {
             new WatcherSpawner(happyPath(), (command, logPath) -> 4242L),
             (project, config) -> "",
             command -> 0,
-            DispatchOperations.Listener.NONE);
+            DispatchOperations.Listener.NONE,
+            SessionYield.NONE);
 
     var outcome =
         ops.dispatch(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/DispatchLaneParityTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/DispatchLaneParityTest.java
@@ -136,7 +136,8 @@ class DispatchLaneParityTest {
             new WatcherSpawner(shell(), (command, logPath) -> 4242L),
             (project, config) -> "",
             command -> 0,
-            DispatchOperations.Listener.NONE);
+            DispatchOperations.Listener.NONE,
+            SessionYield.NONE);
     var cliOutcome =
         cliOps.dispatch(
             "acme",
@@ -192,7 +193,8 @@ class DispatchLaneParityTest {
               null,
               ConnectEnvironment::detect,
               SyncScheduler.disabled(),
-              new FdeStore(api.db()));
+              new FdeStore(api.db()),
+              SessionYield.NONE);
 
       var result =
           apiOps.dispatch(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/DispatchLaunchCancelRaceTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/DispatchLaunchCancelRaceTest.java
@@ -138,7 +138,8 @@ class DispatchLaunchCancelRaceTest {
               cancelled.set(run.id());
               return 0;
             },
-            DispatchOperations.Listener.NONE);
+            DispatchOperations.Listener.NONE,
+            SessionYield.NONE);
 
     var conflict =
         assertThrows(

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EngagementLifecycleTest.java
@@ -95,7 +95,8 @@ class EngagementLifecycleTest {
             new WatcherSpawner(shell, (command, logPath) -> 4242L),
             (project, config) -> "",
             command -> 0,
-            DispatchOperations.Listener.NONE)
+            DispatchOperations.Listener.NONE,
+            SessionYield.NONE)
         .useMessages(new MessageStore(db))
         .useRooms(roomStore);
   }
@@ -472,7 +473,8 @@ class EngagementLifecycleTest {
                 new WatcherSpawner(shell(), (command, logPath) -> 4242L),
                 (project, config) -> "",
                 command -> 0,
-                DispatchOperations.Listener.NONE)
+                DispatchOperations.Listener.NONE,
+                SessionYield.NONE)
             .useMessages(new MessageStore(db));
     seedSpec("auth");
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/EventEmissionDeliveryIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/EventEmissionDeliveryIT.java
@@ -74,7 +74,8 @@ class EventEmissionDeliveryIT {
                 runStore,
                 new ProjectStore(db),
                 SyncScheduler.disabled(),
-                null)
+                null,
+                SessionYield.NONE)
             .useMessages(new MessageStore(db));
     runId = DateTimeUtils.newId().toString();
     var reservation =

--- a/sail-infra/src/test/java/ai/singlr/sail/api/Fleet.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/Fleet.java
@@ -282,7 +282,8 @@ public final class Fleet implements AutoCloseable {
               new WatcherSpawner(shell, (command, log) -> 4242L),
               (project, config) -> "",
               command -> 0,
-              DispatchOperations.Listener.NONE);
+              DispatchOperations.Listener.NONE,
+              SessionYield.NONE);
       stopper =
           new StopOperations(
               shell,
@@ -305,7 +306,8 @@ public final class Fleet implements AutoCloseable {
                   projects,
                   ai.singlr.sail.engine.ConnectEnvironment::detect,
                   SyncScheduler.disabled(),
-                  fdes)
+                  fdes,
+                  SessionYield.NONE)
               .useMessages(messages);
       slack = new CapturingPoster();
       var syncConfig =

--- a/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/InviteLaunchTest.java
@@ -122,7 +122,8 @@ class InviteLaunchTest {
               order.add("launch");
               return 0;
             },
-            DispatchOperations.Listener.NONE)
+            DispatchOperations.Listener.NONE,
+            SessionYield.NONE)
         .useMessages(messageStore);
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomRelayDeliveryIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomRelayDeliveryIT.java
@@ -76,7 +76,8 @@ class RoomRelayDeliveryIT {
                 runStore,
                 new ProjectStore(db),
                 SyncScheduler.disabled(),
-                null)
+                null,
+                SessionYield.NONE)
             .useMessages(messages);
     runId = DateTimeUtils.newId().toString();
     var reservation =

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomWakeLaunchTest.java
@@ -130,7 +130,8 @@ class RoomWakeLaunchTest {
             new WatcherSpawner(shell, (command, logPath) -> 4242L),
             (project, config) -> "",
             launcher,
-            DispatchOperations.Listener.NONE)
+            DispatchOperations.Listener.NONE,
+            SessionYield.NONE)
         .useMessages(messageStore)
         .useRooms(new RoomStore(db));
   }
@@ -159,7 +160,8 @@ class RoomWakeLaunchTest {
               launched.set(command);
               return 0;
             },
-            DispatchOperations.Listener.NONE);
+            DispatchOperations.Listener.NONE,
+            SessionYield.NONE);
     seedSpec("auth");
 
     ops.startRoomRun("acme", "auth", HANDLE);

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomsSurfaceTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomsSurfaceTest.java
@@ -64,7 +64,8 @@ class RoomsSurfaceTest {
                 new ReviewStore(db),
                 new RunStore(db))
             .useMessages(new MessageStore(db))
-            .useRooms(roomStore);
+            .useRooms(roomStore)
+            .useSessionYield(SessionYield.NONE);
   }
 
   @AfterEach

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RoomsSurfaceTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RoomsSurfaceTest.java
@@ -64,8 +64,7 @@ class RoomsSurfaceTest {
                 new ReviewStore(db),
                 new RunStore(db))
             .useMessages(new MessageStore(db))
-            .useRooms(roomStore)
-            .useSessionYield(SessionYield.NONE);
+            .useRooms(roomStore);
   }
 
   @AfterEach

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RunDeliveryOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RunDeliveryOperationsTest.java
@@ -72,7 +72,8 @@ class RunDeliveryOperationsTest {
                 runStore,
                 new ProjectStore(db),
                 SyncScheduler.disabled(),
-                null)
+                null,
+                SessionYield.NONE)
             .useMessages(messages);
     runId = newRun("room");
     principal = runStore.findById(runId).orElseThrow().principal();

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RunReservationTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RunReservationTest.java
@@ -27,6 +27,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -106,8 +107,27 @@ class RunReservationTest {
     };
   }
 
+  interface Ender {
+    void end(List<String> sessions, String reason) throws IOException;
+  }
+
+  /** A seam with no lock to hold — a box with no host — that ends through {@code ender}. */
+  private static SessionYield ending(Ender ender) {
+    return new SessionYield() {
+      @Override
+      public Hold lock(String project) {
+        return NO_HOLD;
+      }
+
+      @Override
+      public void end(List<String> sessions, String reason) throws IOException {
+        ender.end(sessions, reason);
+      }
+    };
+  }
+
   private RunReservation reservation(ShellExec shell, RunStore store) {
-    return new RunReservation(store, shell, DispatchOperations.Listener.NONE, () -> sessionYield);
+    return new RunReservation(store, shell, DispatchOperations.Listener.NONE, sessionYield);
   }
 
   private String reserve(RunReservation r) {
@@ -190,10 +210,11 @@ class RunReservationTest {
     var ended = new ArrayList<String>();
     var reasons = new ArrayList<String>();
     sessionYield =
-        (sessions, reason) -> {
-          ended.addAll(sessions);
-          reasons.add(reason);
-        };
+        ending(
+            (sessions, reason) -> {
+              ended.addAll(sessions);
+              reasons.add(reason);
+            });
 
     reserveBuild("spec", "build", List.of("app"));
 
@@ -207,7 +228,8 @@ class RunReservationTest {
   @Test
   void aReadOnlyRoomWakeDisplacesNoConversation() {
     completedRun("old-spec", List.of("app"));
-    sessionYield = (sessions, reason) -> fail("a read-only wake reserves nothing and ends nothing");
+    sessionYield =
+        ending((sessions, reason) -> fail("a read-only wake reserves nothing and ends nothing"));
 
     assertNotNull(reserveBuild("old-spec", DispatchGate.ROOM_ROLE, List.of()));
   }
@@ -216,14 +238,67 @@ class RunReservationTest {
   void aWholeContainerClaimDisplacesEveryConversationAndAHostFailureNeverFailsTheClaim() {
     completedRun("old-spec", List.of("app"));
     sessionYield =
-        (sessions, reason) -> {
-          throw new IOException("Session 'resume-x' belongs to mady.");
-        };
+        ending(
+            (sessions, reason) -> {
+              throw new IOException("Session 'resume-x' belongs to mady.");
+            });
 
     var credential = reserve(reservation(quietShell(), runStore));
 
     assertNotNull(credential, "a host that refuses is a warning, never a failed launch");
     assertEquals("running", runStore.findById(RUN_ID).orElseThrow().status());
+  }
+
+  @Test
+  void theClaimAndTheYieldRunUnderTheProjectLockWhichEveryExitReleases() {
+    completedRun("old-spec", List.of("app"));
+    var held = new AtomicBoolean();
+    var locked = new ArrayList<String>();
+    var claimedWhileHeld = new AtomicBoolean();
+    sessionYield =
+        new SessionYield() {
+          @Override
+          public Hold lock(String project) {
+            locked.add(project);
+            held.set(true);
+            return () -> held.set(false);
+          }
+
+          @Override
+          public void end(List<String> sessions, String reason) {
+            claimedWhileHeld.set(
+                held.get() && "running".equals(runStore.findById(RUN_ID).orElseThrow().status()));
+          }
+        };
+
+    reserveBuild("spec", "build", List.of("app"));
+    assertEquals(List.of("acme"), locked);
+    assertTrue(claimedWhileHeld.get(), "the row lands and the yield runs under one hold");
+    assertFalse(held.get(), "released once the yield is done");
+
+    assertThrows(ApiException.class, () -> reserveBuild("spec2", "build", List.of("app")));
+    assertFalse(held.get(), "a refused claim releases the lock too");
+  }
+
+  @Test
+  void anUnlockableProjectRefusesTheClaimBeforeAnyRowIsWritten() {
+    sessionYield =
+        new SessionYield() {
+          @Override
+          public Hold lock(String project) throws IOException {
+            throw new IOException("locks directory is not writable");
+          }
+
+          @Override
+          public void end(List<String> sessions, String reason) {
+            fail("nothing is claimed, so nothing yields");
+          }
+        };
+
+    var ex = assertThrows(ApiException.class, () -> reserve(reservation(quietShell(), runStore)));
+
+    assertEquals(ErrorCode.COMMAND_FAILED, ex.failure().errorCode());
+    assertTrue(runStore.findById(RUN_ID).isEmpty(), "no run row without the lock");
   }
 
   @Test
@@ -285,7 +360,7 @@ class RunReservationTest {
     assertDoesNotThrow(
         () ->
             new RunReservation(
-                    null, quietShell(), DispatchOperations.Listener.NONE, () -> SessionYield.NONE)
+                    null, quietShell(), DispatchOperations.Listener.NONE, SessionYield.NONE)
                 .releaseIfAbsent(RUN_ID, "acme", AgentUnit.forRun(RUN_ID)));
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/RunReservationTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/RunReservationTest.java
@@ -10,17 +10,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.SailYaml;
 import ai.singlr.sail.engine.AgentUnit;
 import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.store.DispatchGate;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SchemaManager;
 import ai.singlr.sail.store.Sqlite;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -39,6 +43,7 @@ class RunReservationTest {
   private Sqlite db;
   private RunStore runStore;
   private static final String RUN_ID = DateTimeUtils.newId().toString();
+  private SessionYield sessionYield = SessionYield.NONE;
 
   private static final SailYaml CONFIG =
       SailYaml.fromMap(
@@ -102,7 +107,7 @@ class RunReservationTest {
   }
 
   private RunReservation reservation(ShellExec shell, RunStore store) {
-    return new RunReservation(store, shell, DispatchOperations.Listener.NONE);
+    return new RunReservation(store, shell, DispatchOperations.Listener.NONE, () -> sessionYield);
   }
 
   private String reserve(RunReservation r) {
@@ -153,6 +158,97 @@ class RunReservationTest {
     assertEquals(ErrorCode.AGENT_ALREADY_RUNNING, ex.failure().errorCode());
   }
 
+  private String completedRun(String specId, List<String> repos) {
+    var id = DateTimeUtils.newId().toString();
+    runStore.reserveDispatch(
+        id, "acme", specId, "node", "node", "build", repos, "codex", null, "task", "log", "unit");
+    runStore.transition(id, "running", "completed", 0);
+    return id;
+  }
+
+  private String reserveBuild(String specId, String role, List<String> repos) {
+    return reservation(quietShell(), runStore)
+        .reserve(
+            RUN_ID,
+            "acme",
+            specId,
+            "node",
+            "node",
+            role,
+            repos,
+            "codex",
+            null,
+            "task",
+            AgentUnit.forRun(RUN_ID),
+            CONFIG);
+  }
+
+  @Test
+  void aClaimEndsTheResumeSessionsItDisplacesAndSparesDisjointOnes() {
+    var overlapping = completedRun("old-spec", List.of("app"));
+    completedRun("other-spec", List.of("web"));
+    var ended = new ArrayList<String>();
+    var reasons = new ArrayList<String>();
+    sessionYield =
+        (sessions, reason) -> {
+          ended.addAll(sessions);
+          reasons.add(reason);
+        };
+
+    reserveBuild("spec", "build", List.of("app"));
+
+    assertEquals(
+        List.of(SessionYield.resumeSession(overlapping)),
+        ended,
+        "only the conversation over the reserved repo yields; the disjoint one lives on");
+    assertEquals(List.of("yielded to dispatch " + RUN_ID + " of spec spec"), reasons);
+  }
+
+  @Test
+  void aReadOnlyRoomWakeDisplacesNoConversation() {
+    completedRun("old-spec", List.of("app"));
+    sessionYield = (sessions, reason) -> fail("a read-only wake reserves nothing and ends nothing");
+
+    assertNotNull(reserveBuild("old-spec", DispatchGate.ROOM_ROLE, List.of()));
+  }
+
+  @Test
+  void aWholeContainerClaimDisplacesEveryConversationAndAHostFailureNeverFailsTheClaim() {
+    completedRun("old-spec", List.of("app"));
+    sessionYield =
+        (sessions, reason) -> {
+          throw new IOException("Session 'resume-x' belongs to mady.");
+        };
+
+    var credential = reserve(reservation(quietShell(), runStore));
+
+    assertNotNull(credential, "a host that refuses is a warning, never a failed launch");
+    assertEquals("running", runStore.findById(RUN_ID).orElseThrow().status());
+  }
+
+  @Test
+  void theDefaultSeamEndsNothingAndTheClaimStands() {
+    completedRun("old-spec", List.of("app"));
+    assertNotNull(reserve(reservation(quietShell(), runStore)));
+  }
+
+  @Test
+  void aConversationYieldsByTheDispatchGateRulesHoldingItsRunsRepos() {
+    var row = runStore.findById(completedRun("spec", List.of("web"))).orElseThrow();
+    assertTrue(
+        RunReservation.displaces("spec", "build", List.of("app"), row),
+        "the same spec displaces its own conversation even over disjoint repos");
+    assertFalse(
+        RunReservation.displaces("other", "build", List.of("app"), row),
+        "another spec over a disjoint repo leaves it alone");
+    assertTrue(
+        RunReservation.displaces("other", DispatchGate.ROOM_FULL_ROLE, List.of("web"), row),
+        "a full chat turn claims its repos like a build");
+    assertTrue(
+        RunReservation.displaces("other", "build", List.of(), row),
+        "a whole-container claim displaces everything");
+  }
+
   @Test
   void aPruneFailureNeverFailsTheReservation() {
     var credential = reserve(reservation(throwingShell(), runStore));
@@ -188,7 +284,8 @@ class RunReservationTest {
   void releaseWithoutARunStoreIsASilentNoOp() {
     assertDoesNotThrow(
         () ->
-            new RunReservation(null, quietShell(), DispatchOperations.Listener.NONE)
+            new RunReservation(
+                    null, quietShell(), DispatchOperations.Listener.NONE, () -> SessionYield.NONE)
                 .releaseIfAbsent(RUN_ID, "acme", AgentUnit.forRun(RUN_ID)));
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SailOperationsTest.java
@@ -230,7 +230,8 @@ class SailOperationsTest {
             new RunStore(db),
             new ProjectStore(db),
             null,
-            fdeStore);
+            fdeStore,
+            SessionYield.NONE);
 
     var roster = (List<Map<String, Object>>) get(operations.fdes(), "fdes");
 
@@ -1588,7 +1589,8 @@ class SailOperationsTest {
             new RunStore(db),
             new ProjectStore(db),
             SyncScheduler.disabled(),
-            new FdeStore(db));
+            new FdeStore(db),
+            SessionYield.NONE);
 
     var result = operations.runs("acme", null);
 
@@ -1614,7 +1616,8 @@ class SailOperationsTest {
                 new RunStore(db),
                 new ProjectStore(db),
                 SyncScheduler.disabled(),
-                new FdeStore(db))
+                new FdeStore(db),
+                SessionYield.NONE)
             .useMessages(new MessageStore(db));
 
     var result =
@@ -1647,7 +1650,8 @@ class SailOperationsTest {
                 new RunStore(db),
                 new ProjectStore(db),
                 SyncScheduler.disabled(),
-                fdeStore)
+                fdeStore,
+                SessionYield.NONE)
             .useBoxCredentials(boxStore);
 
     var credential = boxStore.replace("uday");
@@ -1736,7 +1740,8 @@ class SailOperationsTest {
             new RunStore(db),
             new ProjectStore(db),
             SyncScheduler.disabled(),
-            fdeStore);
+            fdeStore,
+            SessionYield.NONE);
 
     var result =
         dispatch(operations, "acme", new DispatchRequest("auth", "background", false, null, true));

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SessionReportDeliveryIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SessionReportDeliveryIT.java
@@ -76,7 +76,8 @@ class SessionReportDeliveryIT {
                 runStore,
                 new ProjectStore(db),
                 SyncScheduler.disabled(),
-                null)
+                null,
+                SessionYield.NONE)
             .useMessages(new MessageStore(db));
     runId = DateTimeUtils.newId().toString();
     var reservation =

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentAttachCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentAttachCommandTest.java
@@ -11,8 +11,20 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.engine.AgentCli;
+import ai.singlr.sail.pty.PtyEvents;
+import ai.singlr.sail.pty.PtyIdentity;
+import ai.singlr.sail.pty.PtyRooms;
+import ai.singlr.sail.store.RoomStore;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
 
 class AgentAttachCommandTest {
 
@@ -22,7 +34,7 @@ class AgentAttachCommandTest {
         assertThrows(
             IllegalStateException.class,
             () ->
-                AgentAttachCommand.latestRunOrRefuse(
+                AgentAttachCommand.orRefuse(
                     "acme",
                     () -> {
                       throw new IllegalStateException("database disk image is malformed");
@@ -37,7 +49,7 @@ class AgentAttachCommandTest {
   @Test
   void aSuccessfulEmptyQueryAllowsTheFreshFallback() {
     assertTrue(
-        AgentAttachCommand.latestRunOrRefuse("acme", java.util.Optional::empty).isEmpty(),
+        AgentAttachCommand.orRefuse("acme", java.util.Optional::empty).isEmpty(),
         "only a successful empty query means no run — the fresh-attach lane stays open");
   }
 
@@ -111,5 +123,75 @@ class AgentAttachCommandTest {
     var cmd = AgentAttachCommand.buildIncusExecWithTty("proj", List.of("echo", "test"));
     var joined = String.join(" ", cmd);
     assertTrue(joined.contains("HOME=/home/dev"));
+  }
+
+  @Test
+  @EnabledOnOs(OS.LINUX)
+  void openOrJoinOpensOnceThenJoinsTheLiveSessionInsteadOfForking(@TempDir Path dir)
+      throws Exception {
+    try (var host =
+        PtyHostCommand.startHost(
+            dir.resolve("h.sock"),
+            dir.resolve("s"),
+            token -> new PtyIdentity("uday", true),
+            PtyRooms.NONE,
+            PtyEvents.NONE)) {
+      var plan =
+          new AgentAttachCommand.ResumePlan("resume-1", List.of("sh", "-c", "read a"), "", "");
+      try (var client = SessionClient.connect(dir.resolve("h.sock"), "")) {
+        assertTrue(AgentAttachCommand.openOrJoin(client, plan, 80, 24), "the first attach opens");
+        assertFalse(
+            AgentAttachCommand.openOrJoin(client, plan, 80, 24),
+            "a second attach joins the live session, never a second agent");
+        assertEquals(1, host.sessionCount());
+
+        var unbound =
+            new AgentAttachCommand.ResumePlan("resume-2", List.of("sh"), "", "no-such-room");
+        assertThrows(
+            IOException.class,
+            () -> AgentAttachCommand.openOrJoin(client, unbound, 80, 24),
+            "a refusal with nothing live behind it is the error it was");
+      }
+    }
+  }
+
+  @Test
+  void theDryRunPlanIsTheSessionVerbsTheAttachIsMadeOf() {
+    var plan =
+        new AgentAttachCommand.ResumePlan(
+            "resume-1",
+            AgentAttachCommand.buildResumeCommand(AgentCli.CLAUDE_CODE, "abc"),
+            "acme",
+            "spec-x");
+    assertEquals(
+        "sail session new resume-1 --project acme --room spec-x --command bash -lc"
+            + " 'cd ~/workspace && claude --resume abc'\nsail session attach resume-1",
+        plan.asSessionCommands());
+    var unbound = new AgentAttachCommand.ResumePlan("resume-1", List.of("codex"), "acme", "");
+    assertFalse(unbound.asSessionCommands().contains("--room"));
+  }
+
+  @Test
+  void knownRoomIsTheRunsConversationOnlyWhenThatRoomExistsHere(@TempDir Path dir) {
+    try (var db = Sqlite.open(dir.resolve("t.db"))) {
+      new SchemaManager(db).migrate();
+      var rooms = new RoomStore(db);
+      rooms.create(
+          new RoomStore.RoomRow("spec-x", "acme", "X", "it", "on", null, "it", null, null, "it"));
+      var runs = new RunStore(db);
+      runs.create(
+          "r1", "acme", "spec-x", "it", "it", "build", "codex", null, "t", null, null, "l", "u");
+      runs.create(
+          "r2", "acme", "legacy", "it", "it", "build", "codex", null, "t", null, null, "l", "u");
+      runs.create(
+          "r3", "acme", null, "it", "it", "adhoc", "codex", null, "t", null, null, "l", "u");
+      assertEquals(
+          "spec-x", AgentAttachCommand.knownRoom(rooms, runs.findById("r1").orElseThrow()));
+      assertEquals(
+          "",
+          AgentAttachCommand.knownRoom(rooms, runs.findById("r2").orElseThrow()),
+          "a spec without a room here opens unbound rather than unreachable");
+      assertEquals("", AgentAttachCommand.knownRoom(rooms, runs.findById("r3").orElseThrow()));
+    }
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentAttachCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentAttachCommandTest.java
@@ -5,8 +5,10 @@
 
 package ai.singlr.sail.commands;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -21,6 +23,9 @@ import ai.singlr.sail.store.Sqlite;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -153,6 +158,133 @@ class AgentAttachCommandTest {
             "a refusal with nothing live behind it is the error it was");
       }
     }
+  }
+
+  @Test
+  void aCompletedLatestRunIsStillResumableAndAnythingElseRefuses() {
+    var completed = row("r1", "completed");
+    assertDoesNotThrow(
+        () -> AgentAttachCommand.requireStillLatestAndIdle(completed, completed, "acme"));
+
+    var live =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                AgentAttachCommand.requireStillLatestAndIdle(
+                    completed, row("r2", "running"), "acme"));
+    assertTrue(live.getMessage().startsWith("Run r2 is live"), live.getMessage());
+
+    var newer =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                AgentAttachCommand.requireStillLatestAndIdle(
+                    completed, row("r2", "completed"), "acme"));
+    assertTrue(newer.getMessage().contains("changed while opening"), newer.getMessage());
+    assertThrows(
+        IllegalStateException.class,
+        () -> AgentAttachCommand.requireStillLatestAndIdle(completed, null, "acme"));
+  }
+
+  /**
+   * The reviewer's interleaving: attach reads a completed run, a dispatch claims the project and
+   * scans for sessions to yield (finding none), and only then does the attach reach the host. With
+   * the claim lock shared by both, the attach waits behind the dispatch, rereads, sees the live
+   * claim, and refuses — no resumed agent opens over repos the dispatch owns. (The other order — a
+   * session opened under the lock is found and yielded by the claim that follows — runs against a
+   * real container in {@code AgentResumeSessionIT}.)
+   */
+  @Test
+  @EnabledOnOs(OS.LINUX)
+  void anAttachWaitingOnADispatchRereadsTheClaimAndRefuses(@TempDir Path dir) throws Exception {
+    var socket = dir.resolve("h.sock");
+    var hostYield = new PtyHostYield(socket, dir.resolve("locks"));
+    try (var db = Sqlite.open(dir.resolve("t.db"));
+        var host =
+            PtyHostCommand.startHost(
+                socket,
+                dir.resolve("s"),
+                token -> new PtyIdentity("uday", true),
+                PtyRooms.NONE,
+                PtyEvents.NONE)) {
+      new SchemaManager(db).migrate();
+      var runs = new RunStore(db);
+      var planned = completedRun(runs, "r1");
+      Supplier<AgentAttachCommand.Latest> latest =
+          () ->
+              new AgentAttachCommand.Latest(
+                  runs.latestForProjectOnNode("acme", "it").orElse(null), "");
+      var plan =
+          new AgentAttachCommand.ResumePlan("resume-r1", List.of("sh", "-c", "read a"), "acme", "");
+
+      var dispatchClaiming = hostYield.lock("acme");
+      var refused = new AtomicReference<Throwable>();
+      var done = new CountDownLatch(1);
+      try (var client = SessionClient.connect(socket, "")) {
+        var attach =
+            Thread.ofVirtual()
+                .start(
+                    () -> {
+                      try {
+                        AgentAttachCommand.openLocked(
+                            hostYield, latest, planned, client, plan, 80, 24);
+                      } catch (Throwable t) {
+                        refused.set(t);
+                      } finally {
+                        done.countDown();
+                      }
+                    });
+        SessionDispatchLockTest.awaitParked(attach);
+        reserveRunning(runs, "r2");
+        assertEquals(0, host.sessionCount(), "the dispatch's yield scan finds nothing live");
+        dispatchClaiming.close();
+        done.await();
+      }
+      assertInstanceOf(IllegalStateException.class, refused.get());
+      assertTrue(
+          refused.get().getMessage().startsWith("Run r2 is live"), refused.get().getMessage());
+      assertEquals(0, host.sessionCount(), "the stale attach never opened over the claimed repos");
+    }
+  }
+
+  private static RunStore.RunRow completedRun(RunStore runs, String id) {
+    reserveRunning(runs, id);
+    runs.transition(id, "running", "completed", 0);
+    return runs.findById(id).orElseThrow();
+  }
+
+  private static void reserveRunning(RunStore runs, String id) {
+    runs.reserveDispatch(
+        id, "acme", "spec-" + id, "it", "it", "build", List.of(), "codex", null, "t", "l", "u");
+  }
+
+  private static RunStore.RunRow row(String id, String status) {
+    return new RunStore.RunRow(
+        id,
+        "acme",
+        "spec-" + id,
+        "it",
+        "build",
+        "codex",
+        null,
+        "t",
+        null,
+        null,
+        status,
+        null,
+        "l",
+        "u",
+        "t0",
+        null,
+        List.of(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null);
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentAttachCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentAttachCommandTest.java
@@ -16,6 +16,8 @@ import ai.singlr.sail.engine.AgentCli;
 import ai.singlr.sail.pty.PtyEvents;
 import ai.singlr.sail.pty.PtyIdentity;
 import ai.singlr.sail.pty.PtyRooms;
+import ai.singlr.sail.pty.PtySessionHost;
+import ai.singlr.sail.store.DispatchGate;
 import ai.singlr.sail.store.RoomStore;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SchemaManager;
@@ -164,14 +166,14 @@ class AgentAttachCommandTest {
   void aCompletedLatestRunIsStillResumableAndAnythingElseRefuses() {
     var completed = row("r1", "completed");
     assertDoesNotThrow(
-        () -> AgentAttachCommand.requireStillLatestAndIdle(completed, completed, "acme"));
+        () -> AgentAttachCommand.requireStillLatestAndIdle(completed, latest(completed), "acme"));
 
     var live =
         assertThrows(
             IllegalStateException.class,
             () ->
                 AgentAttachCommand.requireStillLatestAndIdle(
-                    completed, row("r2", "running"), "acme"));
+                    completed, latest(row("r2", "running")), "acme"));
     assertTrue(live.getMessage().startsWith("Run r2 is live"), live.getMessage());
 
     var newer =
@@ -179,11 +181,69 @@ class AgentAttachCommandTest {
             IllegalStateException.class,
             () ->
                 AgentAttachCommand.requireStillLatestAndIdle(
-                    completed, row("r2", "completed"), "acme"));
+                    completed, latest(row("r2", "completed")), "acme"));
     assertTrue(newer.getMessage().contains("changed while opening"), newer.getMessage());
     assertThrows(
         IllegalStateException.class,
-        () -> AgentAttachCommand.requireStillLatestAndIdle(completed, null, "acme"));
+        () ->
+            AgentAttachCommand.requireStillLatestAndIdle(
+                completed, AgentAttachCommand.Latest.NONE, "acme"));
+  }
+
+  /**
+   * The lanes the latest-session query leaves out still hold repos: a full invite or a full room
+   * turn over the planned run's repo refuses the resume through the dispatch gate — the same rule a
+   * reservation applies to yield a live resume session — while the read-only lanes, which reserve
+   * nothing, never do.
+   */
+  @Test
+  void aLiveLaneTheLatestQueryHidesStillRefusesThroughTheGate() {
+    var completed = row("r1", "completed", List.of("app"));
+    var fullInvite = running("inv", DispatchGate.FULL_INVITE_ROLE, List.of("app"));
+    var refused =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                AgentAttachCommand.requireStillLatestAndIdle(
+                    completed, latest(completed, fullInvite), "acme"));
+    assertTrue(
+        refused.getMessage().startsWith("Run inv (invite-full) is live in repo(s) [app]"),
+        refused.getMessage());
+
+    var wholeContainer = running("adhoc", "adhoc", List.of());
+    assertTrue(
+        assertThrows(
+                IllegalStateException.class,
+                () ->
+                    AgentAttachCommand.requireStillLatestAndIdle(
+                        completed, latest(completed, wholeContainer), "acme"))
+            .getMessage()
+            .contains("live in container 'acme'"));
+
+    var fullTurn = running("turn", DispatchGate.ROOM_FULL_ROLE, List.of("app"));
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            AgentAttachCommand.requireStillLatestAndIdle(
+                completed, latest(completed, fullTurn), "acme"));
+
+    var elsewhere = running("other", "build", List.of("web"));
+    var readOnlyInvite = running("ro", DispatchGate.READ_ONLY_INVITE_ROLE, List.of("app"));
+    var wake = running("wake", DispatchGate.ROOM_ROLE, List.of());
+    assertDoesNotThrow(
+        () ->
+            AgentAttachCommand.requireStillLatestAndIdle(
+                completed, latest(completed, elsewhere, readOnlyInvite, wake), "acme"),
+        "a disjoint repo and the read-only lanes hold nothing the resume would take");
+  }
+
+  private static AgentAttachCommand.Latest latest(
+      RunStore.RunRow run, DispatchGate.RunningRun... running) {
+    return new AgentAttachCommand.Latest(run, "", List.of(running));
+  }
+
+  private static DispatchGate.RunningRun running(String id, String role, List<String> repos) {
+    return new DispatchGate.RunningRun(id, "spec-" + id, role, repos);
   }
 
   /**
@@ -209,56 +269,112 @@ class AgentAttachCommandTest {
                 PtyEvents.NONE)) {
       new SchemaManager(db).migrate();
       var runs = new RunStore(db);
-      var planned = completedRun(runs, "r1");
-      Supplier<AgentAttachCommand.Latest> latest =
-          () ->
-              new AgentAttachCommand.Latest(
-                  runs.latestForProjectOnNode("acme", "it").orElse(null), "");
-      var plan =
-          new AgentAttachCommand.ResumePlan("resume-r1", List.of("sh", "-c", "read a"), "acme", "");
-
-      var dispatchClaiming = hostYield.lock("acme");
-      var refused = new AtomicReference<Throwable>();
-      var done = new CountDownLatch(1);
-      try (var client = SessionClient.connect(socket, "")) {
-        var attach =
-            Thread.ofVirtual()
-                .start(
-                    () -> {
-                      try {
-                        AgentAttachCommand.openLocked(
-                            hostYield, latest, planned, client, plan, 80, 24);
-                      } catch (Throwable t) {
-                        refused.set(t);
-                      } finally {
-                        done.countDown();
-                      }
-                    });
-        SessionDispatchLockTest.awaitParked(attach);
-        reserveRunning(runs, "r2");
-        assertEquals(0, host.sessionCount(), "the dispatch's yield scan finds nothing live");
-        dispatchClaiming.close();
-        done.await();
-      }
-      assertInstanceOf(IllegalStateException.class, refused.get());
-      assertTrue(
-          refused.get().getMessage().startsWith("Run r2 is live"), refused.get().getMessage());
-      assertEquals(0, host.sessionCount(), "the stale attach never opened over the claimed repos");
+      var refused =
+          attachParkedBehindClaim(
+              socket, host, hostYield, runs, () -> reserve(runs, "r2", "build", List.of()));
+      assertTrue(refused.getMessage().startsWith("Run r2 is live"), refused.getMessage());
     }
   }
 
-  private static RunStore.RunRow completedRun(RunStore runs, String id) {
-    reserveRunning(runs, id);
+  /**
+   * The same interleaving against the claim the latest-session query hides: a full invite reserves
+   * the completed run's repo while the attach waits. The reread still returns the completed run as
+   * the latest session — invites never are — so the refusal must come from the dispatch gate over
+   * every live row, not from the latest run's status.
+   */
+  @Test
+  @EnabledOnOs(OS.LINUX)
+  void anAttachWaitingOnAFullInviteRereadsTheGateAndRefuses(@TempDir Path dir) throws Exception {
+    var socket = dir.resolve("h.sock");
+    var hostYield = new PtyHostYield(socket, dir.resolve("locks"));
+    try (var db = Sqlite.open(dir.resolve("t.db"));
+        var host =
+            PtyHostCommand.startHost(
+                socket,
+                dir.resolve("s"),
+                token -> new PtyIdentity("uday", true),
+                PtyRooms.NONE,
+                PtyEvents.NONE)) {
+      new SchemaManager(db).migrate();
+      var runs = new RunStore(db);
+      var refused =
+          attachParkedBehindClaim(
+              socket,
+              host,
+              hostYield,
+              runs,
+              () -> reserve(runs, "inv", DispatchGate.FULL_INVITE_ROLE, List.of("app")));
+      assertEquals(
+          "r1",
+          runs.latestForProjectOnNode("acme", "it").orElseThrow().id(),
+          "the latest session is still the completed run — the invite is invisible to it");
+      assertTrue(
+          refused.getMessage().startsWith("Run inv (invite-full) is live in repo(s) [app]"),
+          refused.getMessage());
+    }
+  }
+
+  /**
+   * Runs the reviewer's interleaving: an attach planned on completed run {@code r1} parks on the
+   * project's claim lock, {@code claim} lands while it waits (finding nothing to yield), and the
+   * attach then rereads under the lock. Returns the attach's refusal; the host must hold no session
+   * on either side of it.
+   */
+  private static IllegalStateException attachParkedBehindClaim(
+      Path socket, PtySessionHost host, PtyHostYield hostYield, RunStore runs, Runnable claim)
+      throws Exception {
+    var planned = completedRun(runs, "r1", List.of("app"));
+    Supplier<AgentAttachCommand.Latest> latest =
+        () ->
+            new AgentAttachCommand.Latest(
+                runs.latestForProjectOnNode("acme", "it").orElse(null),
+                "",
+                runs.runningOnNode("acme", "it"));
+    var plan =
+        new AgentAttachCommand.ResumePlan("resume-r1", List.of("sh", "-c", "read a"), "acme", "");
+    var dispatchClaiming = hostYield.lock("acme");
+    var refused = new AtomicReference<Throwable>();
+    var done = new CountDownLatch(1);
+    try (var client = SessionClient.connect(socket, "")) {
+      var attach =
+          Thread.ofVirtual()
+              .start(
+                  () -> {
+                    try {
+                      AgentAttachCommand.openLocked(
+                          hostYield, latest, planned, client, plan, 80, 24);
+                    } catch (Throwable t) {
+                      refused.set(t);
+                    } finally {
+                      done.countDown();
+                    }
+                  });
+      SessionDispatchLockTest.awaitParked(attach);
+      claim.run();
+      assertEquals(0, host.sessionCount(), "the claim's yield scan finds nothing live");
+      dispatchClaiming.close();
+      done.await();
+    }
+    assertEquals(0, host.sessionCount(), "the stale attach never opened over the claimed repos");
+    return assertInstanceOf(IllegalStateException.class, refused.get());
+  }
+
+  private static RunStore.RunRow completedRun(RunStore runs, String id, List<String> repos) {
+    reserve(runs, id, "build", repos);
     runs.transition(id, "running", "completed", 0);
     return runs.findById(id).orElseThrow();
   }
 
-  private static void reserveRunning(RunStore runs, String id) {
+  private static void reserve(RunStore runs, String id, String role, List<String> repos) {
     runs.reserveDispatch(
-        id, "acme", "spec-" + id, "it", "it", "build", List.of(), "codex", null, "t", "l", "u");
+        id, "acme", "spec-" + id, "it", "it", role, repos, "codex", null, "t", "l", "u");
   }
 
   private static RunStore.RunRow row(String id, String status) {
+    return row(id, status, List.of());
+  }
+
+  private static RunStore.RunRow row(String id, String status, List<String> repos) {
     return new RunStore.RunRow(
         id,
         "acme",
@@ -276,7 +392,7 @@ class AgentAttachCommandTest {
         "u",
         "t0",
         null,
-        List.of(),
+        repos,
         null,
         null,
         null,

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentResumeSessionIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentResumeSessionIT.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.api.DispatchOperations;
+import ai.singlr.sail.api.RunReservation;
+import ai.singlr.sail.api.SessionYield;
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.config.SailYaml;
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.engine.AbstractIncusIT;
+import ai.singlr.sail.engine.AgentCli;
+import ai.singlr.sail.engine.AgentUnit;
+import ai.singlr.sail.pty.PtyIdentity;
+import ai.singlr.sail.pty.PtySessionHost;
+import ai.singlr.sail.store.EventStore;
+import ai.singlr.sail.store.FdeStore;
+import ai.singlr.sail.store.RoomStore;
+import ai.singlr.sail.store.RunStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.io.ByteArrayOutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Brick 3 end to end: a completed run with a recorded session resumes inside a host-owned,
+ * room-bound session running the resume argv in a real container; the conversation survives a
+ * detach, a second attach joins it (history replayed, still live) rather than forking; and a
+ * dispatch reserving the project ends it — attached or detached — with the reason in the stream and
+ * on the room's {@code pty_session_ended} event. The container gets a stand-in {@code claude} that
+ * echoes its arguments and its input, so the argv and the liveness are both observable.
+ */
+class AgentResumeSessionIT extends AbstractIncusIT {
+
+  private static final String CONTAINER = "sail-it-agent-resume";
+  private static final String ROOM = "resume-talk";
+  private static final SailYaml CONFIG =
+      SailYaml.fromMap(
+          Map.of(
+              "name",
+              CONTAINER,
+              "ssh",
+              Map.of("user", "dev"),
+              "repos",
+              List.of(Map.of("url", "https://example.com/app.git", "path", "app"))));
+
+  @TempDir Path dir;
+
+  @Test
+  void aResumedConversationLivesInTheHostSurvivesDetachAndYieldsToDispatch() throws Exception {
+    ensureIncusOrSkip();
+    var dbPath = dir.resolve("sail.db");
+    var socket = dir.resolve("h.sock");
+
+    try (var db = Sqlite.open(dbPath)) {
+      new SchemaManager(db).migrate();
+      var rooms = new RoomStore(db);
+      rooms.create(
+          new RoomStore.RoomRow(
+              ROOM, CONTAINER, "Resume talk", "it", "on", null, "it", null, null, "it"));
+      new FdeStore(db).add("it", "IT", "it@example.dev", "admin");
+      var runStore = new RunStore(db);
+      var runId = completedRun(runStore, "sess-abc");
+      var run = runStore.findById(runId).orElseThrow();
+      var reservation =
+          new RunReservation(
+              runStore, shell, DispatchOperations.Listener.NONE, () -> new PtyHostYield(socket));
+
+      try (var host =
+          new PtySessionHost(
+              socket,
+              dir.resolve("s"),
+              64 * 1024,
+              token -> new PtyIdentity("it", true),
+              new PtyHostRooms(dbPath),
+              new PtyHostEvents(dbPath))) {
+        host.start();
+        launchPrepared(CONTAINER);
+        installDevUserAndStandInClaude();
+
+        var plan =
+            new AgentAttachCommand.ResumePlan(
+                SessionYield.resumeSession(runId),
+                AgentAttachCommand.buildResumeCommand(AgentCli.CLAUDE_CODE, "sess-abc"),
+                CONTAINER,
+                AgentAttachCommand.knownRoom(rooms, run));
+        assertEquals(ROOM, plan.room(), "the run's room binds the session");
+
+        try (var client = SessionClient.connect(socket)) {
+          assertTrue(AgentAttachCommand.openOrJoin(client, plan, 80, 24), "the first attach opens");
+          var terminal = Terminal.attach(client, plan.session());
+          terminal.await("resumed=--resume sess-abc");
+          terminal.type("hello\n");
+          terminal.await("got:hello");
+          terminal.detach();
+          assertNull(terminal.ending(), "a detach leaves the session running");
+        }
+
+        try (var client = SessionClient.connect(socket)) {
+          assertFalse(AgentAttachCommand.openOrJoin(client, plan, 80, 24), "a second attach joins");
+          var terminal = Terminal.attach(client, plan.session());
+          terminal.await("got:hello");
+          terminal.type("again\n");
+          terminal.await("got:again");
+
+          var dispatched = reserve(reservation, runStore);
+          var reason = "yielded to dispatch " + dispatched + " of spec " + ROOM;
+          terminal.await("[sail: session ended — " + reason + "]");
+          assertEquals(reason, terminal.ending(), "the attached client hears why it ended");
+        }
+        assertEquals(0, host.sessionCount());
+        assertTrue(
+            endedEvents(db).stream()
+                .anyMatch(
+                    d ->
+                        plan.session().equals(d.get("session"))
+                            && ROOM.equals(d.get("room_id"))
+                            && String.valueOf(d.get("reason")).startsWith("yielded to dispatch")),
+            "the room's ending event names the yield: " + endedEvents(db));
+
+        try (var client = SessionClient.connect(socket)) {
+          assertTrue(
+              AgentAttachCommand.openOrJoin(client, plan, 80, 24), "reopened after the yield");
+        }
+        reserve(reservation, runStore);
+        try (var client = SessionClient.connect(socket)) {
+          assertTrue(
+              client.list().stream().noneMatch(info -> info.live()),
+              "a detached-but-live conversation yields identically");
+        }
+      }
+    } finally {
+      deleteContainerQuietly(CONTAINER);
+    }
+  }
+
+  private static String completedRun(RunStore runStore, String sessionId) {
+    var id = DateTimeUtils.newId().toString();
+    runStore.reserveDispatch(
+        id,
+        CONTAINER,
+        ROOM,
+        "it",
+        "it",
+        "build",
+        List.of(),
+        "claude-code",
+        null,
+        "task",
+        "log",
+        "u");
+    runStore.recordSession(id, sessionId, "hook", null);
+    runStore.transition(id, "running", "completed", 0);
+    return id;
+  }
+
+  /** Reserves a whole-container build and completes it at once, so the next claim is free. */
+  private static String reserve(RunReservation reservation, RunStore runStore) {
+    var id = DateTimeUtils.newId().toString();
+    reservation.reserve(
+        id,
+        CONTAINER,
+        ROOM,
+        "it",
+        "it",
+        "build",
+        List.of(),
+        "claude-code",
+        null,
+        "task",
+        AgentUnit.forRun(id),
+        CONFIG);
+    runStore.transition(id, "running", "completed", 0);
+    return id;
+  }
+
+  private void installDevUserAndStandInClaude() throws Exception {
+    var script =
+        """
+        userdel -r ubuntu 2>/dev/null || true
+        id -u dev >/dev/null 2>&1 || useradd -m -u 1000 -s /bin/bash dev
+        mkdir -p /home/dev/workspace && chown -R 1000:1000 /home/dev
+        cat > /usr/local/bin/claude <<'EOF'
+        #!/bin/sh
+        echo "resumed=$*"
+        while read line; do echo "got:$line"; done
+        EOF
+        chmod +x /usr/local/bin/claude
+        """;
+    var result = exec(CONTAINER, List.of("bash", "-c", script));
+    assertTrue(result.ok(), "the dev user and stand-in claude must install: " + result.stderr());
+  }
+
+  private static List<Map<String, Object>> endedEvents(Sqlite db) {
+    return new EventStore(db)
+        .recent(50).stream()
+            .filter(e -> e.type().equals("pty_session_ended"))
+            .map(e -> YamlUtil.parseMap(e.data()))
+            .toList();
+  }
+
+  /** An attach loop driven from the test: typed input in, rendered output polled, ending kept. */
+  private static final class Terminal {
+    private final PipedOutputStream keys = new PipedOutputStream();
+    private final ByteArrayOutputStream screen = new ByteArrayOutputStream();
+    private final AtomicReference<String> ending = new AtomicReference<>();
+    private final Thread loop;
+
+    private Terminal(SessionClient client, String session) throws Exception {
+      var channel = client.attach(session, true);
+      var stdin = new PipedInputStream(keys);
+      loop =
+          Thread.ofVirtual()
+              .start(
+                  () -> {
+                    try {
+                      ending.set(AttachLoop.run(channel, stdin, screen));
+                    } catch (Exception e) {
+                      ending.set("attach loop failed: " + e);
+                    }
+                  });
+    }
+
+    static Terminal attach(SessionClient client, String session) throws Exception {
+      return new Terminal(client, session);
+    }
+
+    void type(String text) throws Exception {
+      keys.write(text.getBytes(StandardCharsets.UTF_8));
+      keys.flush();
+    }
+
+    void detach() throws Exception {
+      keys.write(AttachLoop.DETACH_KEY);
+      keys.flush();
+    }
+
+    void await(String marker) throws Exception {
+      var deadline = System.nanoTime() + 30_000_000_000L;
+      while (!rendered().contains(marker)) {
+        if (System.nanoTime() > deadline || !loop.isAlive()) {
+          throw new AssertionError("never saw '" + marker + "' in: " + rendered());
+        }
+        Thread.sleep(50);
+      }
+    }
+
+    String ending() throws Exception {
+      loop.join(30_000);
+      return ending.get();
+    }
+
+    private String rendered() {
+      return screen.toString(StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentResumeSessionIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentResumeSessionIT.java
@@ -78,9 +78,9 @@ class AgentResumeSessionIT extends AbstractIncusIT {
       var runStore = new RunStore(db);
       var runId = completedRun(runStore, "sess-abc");
       var run = runStore.findById(runId).orElseThrow();
+      var hostYield = new PtyHostYield(socket, dir.resolve("locks"));
       var reservation =
-          new RunReservation(
-              runStore, shell, DispatchOperations.Listener.NONE, () -> new PtyHostYield(socket));
+          new RunReservation(runStore, shell, DispatchOperations.Listener.NONE, hostYield);
 
       try (var host =
           new PtySessionHost(

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandWiringTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/DispatchCommandWiringTest.java
@@ -16,6 +16,7 @@ import ai.singlr.sail.api.DispatchOperations;
 import ai.singlr.sail.api.ErrorCode;
 import ai.singlr.sail.api.Event;
 import ai.singlr.sail.api.SailOperations;
+import ai.singlr.sail.api.SessionYield;
 import ai.singlr.sail.api.SyncScheduler;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.engine.ContainerSailSetup;
@@ -120,7 +121,8 @@ class DispatchCommandWiringTest {
         new WatcherSpawner(shell, (command, logPath) -> 4242L),
         (project, config) -> "",
         command -> 0,
-        DispatchOperations.Listener.NONE);
+        DispatchOperations.Listener.NONE,
+        SessionYield.NONE);
   }
 
   private static StubShell shell() {
@@ -173,7 +175,8 @@ class DispatchCommandWiringTest {
             new RunStore(db),
             new ProjectStore(db),
             SyncScheduler.disabled(),
-            new FdeStore(db));
+            new FdeStore(db),
+            SessionYield.NONE);
     var served = server.runs("acme", null);
     assertTrue(
         served.isSuccess(), "/v1/runs answers from the rows a CLI-lane dispatch just recorded");

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyHostYieldTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyHostYieldTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.pty.PtyEvents;
+import ai.singlr.sail.pty.PtyIdentity;
+import ai.singlr.sail.pty.PtyMessage;
+import ai.singlr.sail.pty.PtyRooms;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+@EnabledOnOs(OS.LINUX)
+class PtyHostYieldTest {
+
+  private static final PtyIdentity.Resolver RESOLVER =
+      token ->
+          switch (token) {
+            case "" -> new PtyIdentity("box", false);
+            case "tok-mady" -> new PtyIdentity("mady", false);
+            default -> throw new IOException("Session token is not valid or has expired.");
+          };
+
+  @TempDir Path dir;
+
+  @Test
+  void endsOnlyTheNamedLiveSessionsAndAMissingHostHasNothingToEnd() throws Exception {
+    assertDoesNotThrow(
+        () -> new PtyHostYield(dir.resolve("absent.sock")).end(List.of("resume-1"), "r"),
+        "no socket means no host and no sessions");
+
+    try (var host =
+        PtyHostCommand.startHost(
+            dir.resolve("h.sock"), dir.resolve("s"), RESOLVER, PtyRooms.NONE, PtyEvents.NONE)) {
+      try (var client = SessionClient.connect(dir.resolve("h.sock"), "")) {
+        client.create("resume-1", List.of("sh", "-c", "read a"), "/tmp", "", "", 80, 24);
+        client.create("shell", List.of("sh", "-c", "read a"), "/tmp", "", "", 80, 24);
+      }
+
+      new PtyHostYield(dir.resolve("h.sock"))
+          .end(List.of("resume-1", "resume-ghost"), "yielded to dispatch 2");
+
+      try (var client = SessionClient.connect(dir.resolve("h.sock"), "")) {
+        assertEquals(
+            List.of("shell"),
+            client.list().stream().map(PtyMessage.SessionInfo::name).toList(),
+            "the named live session ended, the unnamed one lives, the absent one is skipped");
+      }
+      assertEquals(1, host.sessionCount());
+    }
+  }
+
+  @Test
+  void aSessionAnotherFdeOwnsSurfacesTheHostsRefusal() throws Exception {
+    try (var host =
+        PtyHostCommand.startHost(
+            dir.resolve("h.sock"), dir.resolve("s"), RESOLVER, PtyRooms.NONE, PtyEvents.NONE)) {
+      try (var mady = SessionClient.connect(dir.resolve("h.sock"), "tok-mady")) {
+        mady.create("resume-1", List.of("sh", "-c", "read a"), "/tmp", "", "", 80, 24);
+      }
+      var refused =
+          assertThrows(
+              IOException.class,
+              () -> new PtyHostYield(dir.resolve("h.sock")).end(List.of("resume-1"), "r"));
+      assertTrue(refused.getMessage().contains("belongs to mady"), refused.getMessage());
+      assertEquals(1, host.sessionCount(), "the box owner cannot end what it does not own");
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyHostYieldTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyHostYieldTest.java
@@ -14,7 +14,9 @@ import ai.singlr.sail.pty.PtyEvents;
 import ai.singlr.sail.pty.PtyIdentity;
 import ai.singlr.sail.pty.PtyMessage;
 import ai.singlr.sail.pty.PtyRooms;
+import ai.singlr.sail.pty.PtySessionHost;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -62,20 +64,49 @@ class PtyHostYieldTest {
     }
   }
 
+  /**
+   * A resume session opened through the gateway belongs to the FDE who attached, not to the box
+   * owner the API would be. The seam speaks as the host's dispatch authority, so the claim ends
+   * every displaced session whoever opened it — the box owner's, another FDE's, all in one pass.
+   */
   @Test
-  void aSessionAnotherFdeOwnsSurfacesTheHostsRefusal() throws Exception {
+  void theDispatchAuthorityEndsSessionsWhoeverOpenedThem() throws Exception {
     try (var host =
         PtyHostCommand.startHost(
             dir.resolve("h.sock"), dir.resolve("s"), RESOLVER, PtyRooms.NONE, PtyEvents.NONE)) {
       try (var mady = SessionClient.connect(dir.resolve("h.sock"), "tok-mady")) {
         mady.create("resume-1", List.of("sh", "-c", "read a"), "/tmp", "", "", 80, 24);
       }
-      var refused =
+      try (var box = SessionClient.connect(dir.resolve("h.sock"), "")) {
+        box.create("resume-2", List.of("sh", "-c", "read a"), "/tmp", "", "", 80, 24);
+        assertThrows(
+            IOException.class,
+            () -> box.yieldSession("resume-1", "r"),
+            "an FDE, even the box owner, holds no yield authority");
+      }
+
+      new PtyHostYield(dir.resolve("h.sock")).end(List.of("resume-1", "resume-2"), "r");
+
+      assertEquals(0, host.sessionCount(), "both ended, mady's included");
+    }
+  }
+
+  @Test
+  void aHostThatMintedNoCredentialIsAnErrorNotASilentSkip() throws Exception {
+    try (var host =
+        PtyHostCommand.startHost(
+            dir.resolve("h.sock"), dir.resolve("s"), RESOLVER, PtyRooms.NONE, PtyEvents.NONE)) {
+      try (var mady = SessionClient.connect(dir.resolve("h.sock"), "tok-mady")) {
+        mady.create("resume-1", List.of("sh", "-c", "read a"), "/tmp", "", "", 80, 24);
+      }
+      Files.delete(PtySessionHost.dispatchCredentialOf(dir.resolve("h.sock")));
+
+      var failed =
           assertThrows(
               IOException.class,
               () -> new PtyHostYield(dir.resolve("h.sock")).end(List.of("resume-1"), "r"));
-      assertTrue(refused.getMessage().contains("belongs to mady"), refused.getMessage());
-      assertEquals(1, host.sessionCount(), "the box owner cannot end what it does not own");
+      assertTrue(failed.getMessage().contains("dispatch credential"), failed.getMessage());
+      assertEquals(1, host.sessionCount(), "the session it could not end is reported, not hidden");
     }
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyRoomSessionIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyRoomSessionIT.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.singlr.sail.api.EventBus;
 import ai.singlr.sail.api.LocalApiSocket;
 import ai.singlr.sail.api.SailOperations;
+import ai.singlr.sail.api.SessionYield;
 import ai.singlr.sail.api.SyncScheduler;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.AbstractIncusIT;
@@ -89,7 +90,8 @@ class PtyRoomSessionIT extends AbstractIncusIT {
                   new RunStore(db),
                   null,
                   SyncScheduler.disabled(),
-                  fdeStore)
+                  fdeStore,
+                  SessionYield.NONE)
               .useMessages(new MessageStore(db))
               .useBoxCredentials(boxStore)
               .useRooms(rooms);

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SessionDispatchLockTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SessionDispatchLockTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The per-project claim lock: a second holder of the same project waits for the first release, the
+ * lock is a real OS file lock (so a separate process is excluded, not just a thread), and projects
+ * lock independently.
+ */
+class SessionDispatchLockTest {
+
+  @Test
+  void aSecondAcquireOfTheSameProjectWaitsForTheFirstRelease(@TempDir Path dir) throws Exception {
+    var first = SessionDispatchLock.acquire(dir, "acme");
+    var acquired = new CountDownLatch(1);
+    var second =
+        Thread.ofVirtual()
+            .start(
+                () -> {
+                  try (var hold = SessionDispatchLock.acquire(dir, "acme")) {
+                    acquired.countDown();
+                  } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                  }
+                });
+
+    awaitParked(second);
+    assertEquals(1, acquired.getCount(), "the second holder waits while the first holds");
+
+    first.close();
+    assertTrue(acquired.await(30, TimeUnit.SECONDS), "the release admits the waiter");
+    second.join();
+  }
+
+  @Test
+  void theLockIsHeldOnDiskWhileHeldAndFreeOnceReleased(@TempDir Path dir) throws Exception {
+    var file = dir.resolve("acme.lock");
+    var hold = SessionDispatchLock.acquire(dir, "acme");
+    try (var probe = FileChannel.open(file, StandardOpenOption.WRITE)) {
+      assertThrows(
+          OverlappingFileLockException.class,
+          probe::tryLock,
+          "the JVM holds the file lock the kernel shows every other process");
+    }
+    hold.close();
+    try (var probe = FileChannel.open(file, StandardOpenOption.WRITE);
+        var free = probe.tryLock()) {
+      assertNotNull(free, "released on close");
+    }
+  }
+
+  @Test
+  void differentProjectsLockIndependently(@TempDir Path dir) throws Exception {
+    try (var acme = SessionDispatchLock.acquire(dir, "acme");
+        var beta = SessionDispatchLock.acquire(dir, "beta")) {
+      assertNotNull(acme);
+      assertNotNull(beta);
+    }
+    try (var again = SessionDispatchLock.acquire(dir, "acme")) {
+      assertNotNull(again, "a released project lock is reacquirable");
+    }
+  }
+
+  static void awaitParked(Thread thread) {
+    while (thread.isAlive() && thread.getState() != Thread.State.WAITING) {
+      Thread.onSpinWait();
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/SpecCliSocketReachabilityIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/SpecCliSocketReachabilityIT.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import ai.singlr.sail.api.EventBus;
 import ai.singlr.sail.api.LocalApiSocket;
 import ai.singlr.sail.api.SailOperations;
+import ai.singlr.sail.api.SessionYield;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.store.BoxCredentialStore;
 import ai.singlr.sail.store.FdeStore;
@@ -84,7 +85,8 @@ class SpecCliSocketReachabilityIT extends AbstractIncusIT {
                   runStore,
                   null,
                   ai.singlr.sail.api.SyncScheduler.disabled(),
-                  fdeStore)
+                  fdeStore,
+                  SessionYield.NONE)
               .useMessages(new MessageStore(db))
               .useBoxCredentials(boxStore);
       try (var server = new LocalApiSocket(bus, operations, socketDir.resolve("api.sock"))) {

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/StopGateIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/StopGateIT.java
@@ -13,6 +13,7 @@ import ai.singlr.sail.api.EventBus;
 import ai.singlr.sail.api.EventSubscriber;
 import ai.singlr.sail.api.LocalApiSocket;
 import ai.singlr.sail.api.SailOperations;
+import ai.singlr.sail.api.SessionYield;
 import ai.singlr.sail.config.SpecStatus;
 import ai.singlr.sail.store.RunStore;
 import ai.singlr.sail.store.SchemaManager;
@@ -72,7 +73,8 @@ class StopGateIT extends AbstractIncusIT {
               runStore,
               null,
               ai.singlr.sail.api.SyncScheduler.disabled(),
-              null);
+              null,
+              SessionYield.NONE);
       try (var server = new LocalApiSocket(bus, operations, socketDir.resolve("api.sock"))) {
         server.start();
 


### PR DESCRIPTION
Brick 3 of sail-pty-session-host (spec `sail-pty-session-host`).

## What
- **`sail agent attach` resumes in the host.** A completed run with a recorded session opens (or joins) the host-owned session `resume-<runId>` running the resume argv (`claude --resume <id>` / `codex resume <id>`), pinned to the run's room when that room exists on this box. `Ctrl-]` detaches and the conversation lives on; a second attach joins the live session instead of forking (a refused create with a live session behind it is the join — reattach and create-race loser alike). `--json` adds `session`/`room`; `--dry-run` prints the `sail session` verbs the attach is made of. The fresh fallback (no run / no session id) stays a raw tty exec; the live-run refusal is unchanged.
- **Clean-stop yield at reserve time.** `RunReservation.reserve`, once the claim lands, judges every resumed conversation of the project by exactly the `DispatchGate` rules (the conversation holds its run's repos like a working lane): same spec or overlapping repo displaces it, a disjoint repo does not, a read-only room wake never does. The displaced `resume-<runId>` sessions are ended through the new `SessionYield` seam; `PtyHostYield` is the API speaking to the pty host over its socket as the box owner. Attached or detached, the session ends the same way. A refused or unreachable host is a warning; the claim stands.
- **Wire + session.** New host-inbound verb `PtyMessage.Yield(session, reason)` (type 10) — idempotent, admitted like `Kill`. `PtySession.end(reason)` writes `[sail: session ended — <reason>]` to every subscriber, then ends reporting that reason, so `pty_session_ended` carries it into the room as the room event.
- **Fix found on the way:** `PtySession.close()` poisoned subscriber queues with `clearAnd(Ok)`, which could wipe an undelivered `SessionEnded` — a killed client would hear "Detached; the session lives on." Gather always forces the ending before `gatherDone`, so `close()` now drops subscribers instead. Pinned by a failing-first test with a subscriber blocked mid-delivery.

## Tests
- `PtySessionTest`: end() delivers notice + reason to a draining subscriber; ended event carries the reason.
- `PtySessionHostTest`: yield admission (owner/admin), idempotent on nothing-live, notice then `SessionEnded(reason)`.
- `RunReservationTest`: overlapping vs disjoint repos, same spec, read-only wake, whole-container claim, host failure never fails the claim, default seam.
- `PtyHostYieldTest`, `AgentAttachCommandTest` (open-then-join against a live host, dry-run rendering, room resolution).
- `AgentResumeSessionIT` (Incus lane): open → converse → detach → rejoin with history → dispatch reserve ends it with the reason in the stream and on the room event; a detached-but-live session yields identically. Uses a stand-in `claude` in the container.

## Known limit
Yield admission is owner-or-admin, like kill. The API acts as the box owner, so a resume session opened by a *different, non-admin* FDE on this box is refused and surfaces as the reservation's warning rather than ending.