### PR TITLE
The platform narrator's room verdicts sync from the box that ran the review

### DIFF
--- a/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
+++ b/sail-core/src/main/java/ai/singlr/sail/store/MessageStore.java
@@ -317,12 +317,23 @@ public final class MessageStore implements SyncedStore {
         });
   }
 
+  /** The platform narrator: the review pipeline posts room verdicts under this author. */
+  public static final String SAIL_AUTHOR = "sail";
+
+  /**
+   * Whether {@code peer} may sync a message authored by {@code author} into {@code roomId}. A peer
+   * owns its own handle, the agent principals of runs its box executed (current or historical), and
+   * the platform narrator {@link #SAIL_AUTHOR} — but the narrator only for conversations the peer's
+   * box ran something in: the review pipeline narrates where it executed, and runs sync before
+   * messages, so the run row is the evidence. Posting authority over the room is required on top.
+   */
   private boolean mayPostAs(String peer, String author, String roomId) {
     if (peer == null) {
       return false;
     }
     var ownsAuthor =
         peer.equals(author)
+            || (SAIL_AUTHOR.equals(author) && ranInConversation(peer, roomId))
             || db.queryOne(
                     "SELECT 1 FROM runs r WHERE r.owner = ? AND (r.spec_id = ? OR r.room_id = ?)"
                         + " AND (r.principal = ? OR EXISTS (SELECT 1 FROM run_principals rp"
@@ -339,6 +350,16 @@ public final class MessageStore implements SyncedStore {
     }
     return postAuthority(peer, "FROM rooms s", "s.id = ?", roomId)
         || postAuthority(peer, "FROM specs s", "s.room_id = ?", roomId);
+  }
+
+  private boolean ranInConversation(String peer, String roomId) {
+    return db.queryOne(
+            "SELECT 1 FROM runs r WHERE r.owner = ? AND (r.spec_id = ? OR r.room_id = ?) LIMIT 1",
+            row -> true,
+            peer,
+            roomId,
+            roomId)
+        .orElse(false);
   }
 
   /**

--- a/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/sync/MessageSyncTest.java
@@ -170,6 +170,54 @@ class MessageSyncTest {
   }
 
   @Test
+  void thePipelineNarratorSyncsFromTheBoxThatRanTheReview() {
+    main.db.execute("UPDATE rooms SET assignee = 'node' WHERE id = 'room'");
+    var runs = new ai.singlr.sail.store.RunStore(main.db);
+    runs.createReview(
+        "019fee00-0000-7000-8000-0000000000bb",
+        "acme",
+        "room",
+        "node",
+        "node",
+        "codex",
+        "b",
+        "t",
+        "/log",
+        "unit");
+
+    var accepted =
+        SyncPeer.with(
+            "node",
+            () ->
+                main.messages.commitRevision(
+                    "019fee00-0000-7000-8000-0000000000bc", snapshot("sail", "room"), null));
+
+    assertTrue(
+        accepted instanceof ai.singlr.sail.store.PushOutcome.Accepted,
+        "the review pipeline narrates verdicts as 'sail' on the box that ran the review;"
+            + " refusing those rows wedges that box's sync forever");
+  }
+
+  @Test
+  void theNarratorAuthorCannotBeForgedIntoARoomThePeerNeverRanIn() {
+    main.db.execute("UPDATE rooms SET assignee = 'node' WHERE id = 'room'");
+
+    var error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                SyncPeer.with(
+                    "node",
+                    () ->
+                        main.messages.commitRevision(
+                            "019fee00-0000-7000-8000-0000000000bd",
+                            snapshot("sail", "room"),
+                            null)));
+
+    assertTrue(error.getMessage().contains("may not post as 'sail'"));
+  }
+
+  @Test
   void authenticatedPeerCannotForgeAnotherFdeAuthor() {
     var messageId = "00000000-0000-7000-8000-000000000001";
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/ReviewPipelineController.java
@@ -755,7 +755,7 @@ public final class ReviewPipelineController implements EventSubscriber, AutoClos
   private void postRoom(String specId, String body) {
     if (messageStore == null) return;
     try {
-      messageStore.append(roomOf(specId), Event.SAIL_AGENT, body, null);
+      messageStore.append(roomOf(specId), MessageStore.SAIL_AUTHOR, body, null);
       syncTrigger.run();
     } catch (RuntimeException e) {
       System.err.println(


### PR DESCRIPTION
Field bug (Rajesh's box, first second-FDE sync on 0.36.0): `sync principal 'rajesh' may not post as 'sail'` wedged his sync permanently.

Root cause: the review pipeline posts room verdicts as author `sail` (ReviewPipelineController), but `mayPostAs` at sync commit only accepted the peer's own handle or agent principals recorded on the peer's runs — the narrator was unrepresentable, and immutable message rows retry forever.

Fix: `SAIL_AUTHOR` is accepted only with evidence — the peer's box owns a run in that conversation (runs sync before messages, so the row is present at commit time) — and the existing posting-authority check still applies. Reproduction-first: the new test fails with the exact field error pre-fix; a twin test pins that a peer who never ran anything in a room cannot forge narrator rows into it.

The check runs on the receiving side, so main must run this release for wedged nodes to unwedge; their queued rows then push with no data surgery.
