### PR TITLE
Measure the fail-open pty event lane, then close its structural gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- The pty event lane is measured, and its live half now exists. A `pty_session_*` row the pty
+  host cannot write no longer vanishes silently: each drop leaves one structured line in the
+  host's journal (`sail-pty-host.service`) and bumps a drop meter file beside the pty socket that
+  the new `sail session ls --json` surfaces (`event_drops`: count, last type, cause, timestamp).
+  The fail-open contract is pinned on both sides of the seam — `PtySession` now swallows whatever
+  a `PtyEvents` implementation throws, so a session can never die or stall because eventing
+  failed. And the lane's structural gap is closed: the pty host writes its event rows straight
+  into the events table from its own process, so `/v1/events/stream` — the live lane mast treats
+  as its accelerator — never carried them at all; the server now bridges new pty rows onto its
+  event bus every 2 seconds, and the audit persister skips pty facts (persisted at source) so a
+  row is never written twice.
+
 - `sail agent attach` resumes a completed run's conversation inside a host-owned session
   (`resume-<run id>`, pinned to the run's room) instead of a raw `incus exec` tty: `Ctrl-]`
   detaches and the conversation lives on, attaching again joins the live session instead of

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyEvents.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyEvents.java
@@ -9,6 +9,10 @@ package ai.singlr.sail.pty;
  * The record-class facts a session emits — started, attached, ended — with the existing source
  * discipline: observational only, nothing here drives run or spec state. Each fact carries the
  * session's {@link PtySession.Origin}, so a room-bound session's room travels with it.
+ *
+ * <p>Emission is fail-open on both sides of this seam: {@link PtySession} swallows whatever an
+ * implementation throws, and an implementation is still expected to swallow (and measure) its own
+ * failures — a session must never die or stall because an event could not be recorded.
  */
 public interface PtyEvents {
 

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -137,8 +137,20 @@ public final class PtySession implements AutoCloseable {
     }
     var session = new PtySession(origin, events, pty, child, journal, queueCapacity, replayMax);
     Thread.ofPlatform().name("pty-gather-" + origin.name()).start(session::gather);
-    events.sessionStarted(origin);
+    emitQuietly(() -> events.sessionStarted(origin));
     return session;
+  }
+
+  /**
+   * Runs one event emission, swallowing anything it throws: the session facts are observational, so
+   * no {@link PtyEvents} failure may end, stall, or refuse the session it describes.
+   */
+  private static void emitQuietly(Runnable emission) {
+    try {
+      emission.run();
+    } catch (RuntimeException ignored) {
+      var unused = ignored;
+    }
   }
 
   private void gather() {
@@ -175,11 +187,7 @@ public final class PtySession implements AutoCloseable {
           var ended = new PtyMessage.SessionEnded(reason);
           subscribers.values().forEach(subscriber -> subscriber.queue().force(ended));
         }
-        try {
-          events.sessionEnded(origin, reason);
-        } catch (RuntimeException ignored) {
-          var unused = ignored;
-        }
+        emitQuietly(() -> events.sessionEnded(origin, reason));
       } finally {
         gatherDone.countDown();
       }
@@ -235,7 +243,7 @@ public final class PtySession implements AutoCloseable {
         writerFde = fde;
       }
     }
-    events.sessionAttached(origin, fde);
+    emitQuietly(() -> events.sessionAttached(origin, fde));
     Thread.ofVirtual()
         .name("pty-send-" + name() + "-" + subscriber.id())
         .start(() -> send(subscriber));

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -369,6 +369,49 @@ class PtySessionTest {
   }
 
   @Test
+  void anEventsImplThatAlwaysThrowsNeverKillsOrStallsTheSession() throws Exception {
+    var hostile =
+        new PtyEvents() {
+          @Override
+          public void sessionStarted(PtySession.Origin origin) {
+            throw new RuntimeException("the event sink is down");
+          }
+
+          @Override
+          public void sessionAttached(PtySession.Origin origin, String fde) {
+            throw new RuntimeException("the event sink is down");
+          }
+
+          @Override
+          public void sessionEnded(PtySession.Origin origin, String reason) {
+            throw new RuntimeException("the event sink is down");
+          }
+        };
+    var session =
+        PtySession.start(
+            origin("hostile", "uday", "acme"),
+            hostile,
+            List.of("sh", "-c", "echo up; read a"),
+            Map.of("TERM", "dumb"),
+            Path.of("/tmp"),
+            dir.resolve("hostile.ring"),
+            64 * 1024,
+            80,
+            24);
+    try {
+      var client = new Collector();
+      session.attach(client, true, "uday");
+      client.awaitOutput("up");
+      session.end("displaced");
+      assertTrue(
+          client.ended.await(10, TimeUnit.SECONDS),
+          "the ending must reach the subscriber despite the throwing sink");
+    } finally {
+      assertTimeoutPreemptively(java.time.Duration.ofSeconds(10), session::close);
+    }
+  }
+
+  @Test
   void aPausedSubscriberIsResyncedFromTheJournalNotLeftCorrupt() throws Exception {
     var session =
         PtySession.start(

--- a/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/Event.java
@@ -114,6 +114,27 @@ public record Event(
 
     public static final String AGENT_PRESENCE = "agent_presence";
 
+    /** A host-owned terminal session started; emitted by the pty host, room-scoped when bound. */
+    public static final String PTY_SESSION_STARTED = "pty_session_started";
+
+    /** A client attached to a host-owned terminal session. */
+    public static final String PTY_SESSION_ATTACHED = "pty_session_attached";
+
+    /** A host-owned terminal session ended; {@code data.reason} says how. */
+    public static final String PTY_SESSION_ENDED = "pty_session_ended";
+
+    /**
+     * Whether {@code type} is one of the pty session facts. They are persisted at source — the pty
+     * host writes its own event rows straight into the events table from its own process — so on
+     * the bus they are always the {@link PtyEventBridge}'s republication for live consumers, never
+     * something to persist again.
+     */
+    public static boolean ptySessionFact(String type) {
+      return PTY_SESSION_STARTED.equals(type)
+          || PTY_SESSION_ATTACHED.equals(type)
+          || PTY_SESSION_ENDED.equals(type);
+    }
+
     /** A spec left in_progress/review past the reconciler threshold — surfaced for triage. */
     public static final String SPEC_STRANDED = "spec_stranded";
 

--- a/sail-infra/src/main/java/ai/singlr/sail/api/PtyEventBridge.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/PtyEventBridge.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import ai.singlr.sail.config.YamlUtil;
+import ai.singlr.sail.store.EventStore;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Completes the live half of the pty event lane. The pty host persists its session facts straight
+ * into the events table from its own process, so they never cross this server's {@link EventBus} —
+ * which is exactly the stream {@code /v1/events/stream} serves, the one mast treats as its
+ * accelerator. Each pass publishes the table's new pty rows onto the bus; {@link
+ * SpecStoreAuditPersister} skips them (persisted at source), so a row is never written twice and
+ * the lane cannot loop. A row the bridge cannot translate — a blank project, unparseable data — is
+ * skipped with one stderr line naming the row, never a stalled cursor: the durable record already
+ * holds it, and history reads still serve it.
+ */
+public final class PtyEventBridge implements AutoCloseable {
+
+  public static final Duration INTERVAL = Duration.ofSeconds(2);
+  static final int BATCH = 500;
+
+  private final EventStore events;
+  private final EventBus bus;
+  private final int batch;
+  private final PeriodicPass pass = new PeriodicPass("pty-event-bridge", this::publishNewRows);
+  private long lastSeenId;
+
+  public PtyEventBridge(EventStore events, EventBus bus) {
+    this(events, bus, BATCH);
+  }
+
+  PtyEventBridge(EventStore events, EventBus bus, int batch) {
+    this.events = events;
+    this.bus = bus;
+    this.batch = batch;
+    var newest = events.recent(1);
+    this.lastSeenId = newest.isEmpty() ? 0 : newest.getFirst().id();
+  }
+
+  /** Starts bridging on {@code interval}; rows persisted before construction are never replayed. */
+  public void start(Duration interval) {
+    pass.start(interval);
+  }
+
+  /** One pass over rows newer than the cursor; returns how many pty facts went live. */
+  public int publishNewRows() {
+    var published = 0;
+    while (true) {
+      var rows = events.since(lastSeenId, batch);
+      for (var row : rows) {
+        lastSeenId = row.id();
+        if (Event.WellKnownTypes.ptySessionFact(row.type()) && publish(row)) {
+          published++;
+        }
+      }
+      if (rows.size() < batch) {
+        return published;
+      }
+    }
+  }
+
+  private boolean publish(EventStore.EventRow row) {
+    try {
+      bus.publish(
+          new Event(
+              Event.CURRENT_VERSION,
+              0,
+              Instant.parse(row.timestamp()),
+              row.project(),
+              row.specId(),
+              row.type(),
+              row.agent(),
+              row.host(),
+              YamlUtil.parseMap(row.data())));
+      return true;
+    } catch (RuntimeException untranslatable) {
+      System.err.println(
+          "pty-event-bridge: skipped row "
+              + row.id()
+              + " ("
+              + row.type()
+              + "): "
+              + untranslatable.getMessage());
+      return false;
+    }
+  }
+
+  @Override
+  public void close() {
+    pass.close();
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/api/SpecStoreAuditPersister.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/api/SpecStoreAuditPersister.java
@@ -12,7 +12,10 @@ import java.util.function.Predicate;
 
 /**
  * Event subscriber that persists events to the SQLite-backed {@link EventStore}. Replaces the
- * file-based {@link AuditPersister} when the control plane server is running.
+ * file-based {@link AuditPersister} when the control plane server is running. Pty session facts are
+ * never persisted here: the pty host already wrote them to the events table from its own process,
+ * and their bus appearance is the {@link PtyEventBridge} republishing that row for live consumers —
+ * persisting again would double every terminal fact and feed the bridge its own output.
  */
 public final class SpecStoreAuditPersister implements EventSubscriber {
 
@@ -30,7 +33,8 @@ public final class SpecStoreAuditPersister implements EventSubscriber {
   @Override
   public Predicate<Event> filter() {
     return event ->
-        Event.WellKnownTypes.retentionClass(event.type()) != Event.RetentionClass.EPHEMERAL;
+        Event.WellKnownTypes.retentionClass(event.type()) != Event.RetentionClass.EPHEMERAL
+            && !Event.WellKnownTypes.ptySessionFact(event.type());
   }
 
   @Override

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PtyEventDrops.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PtyEventDrops.java
@@ -8,17 +8,21 @@ package ai.singlr.sail.commands;
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.YamlUtil;
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.LinkedHashMap;
 import java.util.Objects;
 
 /**
  * The pty event lane's drop meter: a small JSON file beside the pty socket, bumped by the session
  * host each time an event row could not be persisted and read back by {@code sail session ls
- * --json}. The file is measurement, never enforcement — every operation here swallows its own
- * failures, because the meter must not introduce the failure mode it exists to observe. A missing
- * or corrupt file reads as zero drops.
+ * --json}. Writes serialize on one lock and publish by atomic rename, so concurrent failures all
+ * count and a reader never parses a half-written file as fewer drops than were recorded. The file
+ * is measurement, never enforcement — every operation here swallows its own failures, because the
+ * meter must not introduce the failure mode it exists to observe. A missing or corrupt file reads
+ * as zero drops.
  */
 final class PtyEventDrops {
 
@@ -28,6 +32,12 @@ final class PtyEventDrops {
     static final Drops NONE = new Drops(0, null, null, null);
   }
 
+  /**
+   * One writer at a time: the meter's read-bump-write must not lose concurrent drops (losing drops
+   * is the one thing a drop meter cannot do), and the host is the file's only writer.
+   */
+  private static final Object WRITE = new Object();
+
   private PtyEventDrops() {}
 
   static Path fileOf(Path socket) {
@@ -35,15 +45,24 @@ final class PtyEventDrops {
   }
 
   static void record(Path file, String type, String cause) {
-    try {
-      var map = new LinkedHashMap<String, Object>();
-      map.put("count", read(file).count() + 1);
-      map.put("last_type", type);
-      map.put("last_cause", cause);
-      map.put("last_at", DateTimeUtils.now().toString());
-      Files.writeString(file, YamlUtil.dumpJson(map));
-    } catch (IOException | RuntimeException swallowed) {
-      var unused = swallowed;
+    synchronized (WRITE) {
+      try {
+        var map = new LinkedHashMap<String, Object>();
+        map.put("count", read(file).count() + 1);
+        map.put("last_type", type);
+        map.put("last_cause", cause);
+        map.put("last_at", DateTimeUtils.now().toString());
+        var tmp = file.resolveSibling(FILE_NAME + ".tmp");
+        Files.writeString(tmp, YamlUtil.dumpJson(map));
+        try {
+          Files.move(
+              tmp, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException plainMove) {
+          Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING);
+        }
+      } catch (IOException | RuntimeException swallowed) {
+        var unused = swallowed;
+      }
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PtyEventDrops.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PtyEventDrops.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import ai.singlr.sail.common.DateTimeUtils;
+import ai.singlr.sail.config.YamlUtil;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Objects;
+
+/**
+ * The pty event lane's drop meter: a small JSON file beside the pty socket, bumped by the session
+ * host each time an event row could not be persisted and read back by {@code sail session ls
+ * --json}. The file is measurement, never enforcement — every operation here swallows its own
+ * failures, because the meter must not introduce the failure mode it exists to observe. A missing
+ * or corrupt file reads as zero drops.
+ */
+final class PtyEventDrops {
+
+  static final String FILE_NAME = "pty-events.drops";
+
+  record Drops(long count, String lastType, String lastCause, String lastAt) {
+    static final Drops NONE = new Drops(0, null, null, null);
+  }
+
+  private PtyEventDrops() {}
+
+  static Path fileOf(Path socket) {
+    return socket.resolveSibling(FILE_NAME);
+  }
+
+  static void record(Path file, String type, String cause) {
+    try {
+      var map = new LinkedHashMap<String, Object>();
+      map.put("count", read(file).count() + 1);
+      map.put("last_type", type);
+      map.put("last_cause", cause);
+      map.put("last_at", DateTimeUtils.now().toString());
+      Files.writeString(file, YamlUtil.dumpJson(map));
+    } catch (IOException | RuntimeException swallowed) {
+      var unused = swallowed;
+    }
+  }
+
+  static Drops read(Path file) {
+    try {
+      var map = YamlUtil.parseMap(Files.readString(file));
+      return new Drops(
+          ((Number) map.getOrDefault("count", 0L)).longValue(),
+          Objects.toString(map.get("last_type"), null),
+          Objects.toString(map.get("last_cause"), null),
+          Objects.toString(map.get("last_at"), null));
+    } catch (IOException | RuntimeException absentOrCorrupt) {
+      return Drops.NONE;
+    }
+  }
+}

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostEvents.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostEvents.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.api.Event;
 import ai.singlr.sail.common.DateTimeUtils;
 import ai.singlr.sail.config.YamlUtil;
 import ai.singlr.sail.engine.HostInfo;
@@ -25,37 +26,41 @@ import java.util.Map;
  * shows who opened a terminal there and with what. "With what" is the executable alone — {@code
  * claude} versus {@code bash} — never the full argv: arguments carry tokens, signed URLs, and
  * inline scripts, and an event row is durable, room-readable history. Failures are swallowed by
- * design: a session must never die because an event row could not be written.
+ * design — a session must never die because an event row could not be written — but never silently:
+ * each drop leaves one structured stderr line (journald, via the pty host service) and bumps the
+ * {@link PtyEventDrops} meter that {@code sail session ls --json} surfaces.
  */
 final class PtyHostEvents implements PtyEvents {
 
   private final Path dbPath;
+  private final Path dropsPath;
 
   PtyHostEvents() {
-    this(SailPaths.controlPlaneDb());
+    this(SailPaths.controlPlaneDb(), PtyEventDrops.fileOf(SailPaths.ptySocketPath()));
   }
 
-  PtyHostEvents(Path dbPath) {
+  PtyHostEvents(Path dbPath, Path dropsPath) {
     this.dbPath = dbPath;
+    this.dropsPath = dropsPath;
   }
 
   @Override
   public void sessionStarted(PtySession.Origin origin) {
     var data = dataFor(origin);
     data.put("executable", origin.command().getFirst());
-    insert("pty_session_started", origin, origin.ownerFde(), data);
+    insert(Event.WellKnownTypes.PTY_SESSION_STARTED, origin, origin.ownerFde(), data);
   }
 
   @Override
   public void sessionAttached(PtySession.Origin origin, String fde) {
-    insert("pty_session_attached", origin, fde, dataFor(origin));
+    insert(Event.WellKnownTypes.PTY_SESSION_ATTACHED, origin, fde, dataFor(origin));
   }
 
   @Override
   public void sessionEnded(PtySession.Origin origin, String reason) {
     var data = dataFor(origin);
     data.put("reason", reason);
-    insert("pty_session_ended", origin, "sail", data);
+    insert(Event.WellKnownTypes.PTY_SESSION_ENDED, origin, "sail", data);
   }
 
   private static Map<String, Object> dataFor(PtySession.Origin origin) {
@@ -81,8 +86,17 @@ final class PtyHostEvents implements PtyEvents {
                   agent,
                   HostInfo.hostname(),
                   YamlUtil.dumpJson(data)));
-    } catch (RuntimeException swallowed) {
-      var unused = swallowed;
+    } catch (RuntimeException failed) {
+      System.err.println(
+          "pty-events: dropped "
+              + type
+              + " session="
+              + origin.name()
+              + " project="
+              + origin.project()
+              + " cause="
+              + failed);
+      PtyEventDrops.record(dropsPath, type, failed.toString());
     }
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/ServerStartCommand.java
@@ -9,6 +9,7 @@ import ai.singlr.sail.api.Event;
 import ai.singlr.sail.api.EventBus;
 import ai.singlr.sail.api.EventRetentionSweeper;
 import ai.singlr.sail.api.MissedStopReconciler;
+import ai.singlr.sail.api.PtyEventBridge;
 import ai.singlr.sail.api.ReviewWiring;
 import ai.singlr.sail.api.RoomWakeReactor;
 import ai.singlr.sail.api.RunActivityStamper;
@@ -280,6 +281,7 @@ public final class ServerStartCommand implements Runnable {
             reviewController);
     var sweeper = new ExpiredRowSweeper(dbPath);
     var eventSweeper = new EventRetentionSweeper(eventStore);
+    var ptyEventBridge = new PtyEventBridge(eventStore, bus);
     var reconciler =
         new StuckSpecReconciler(
             dbPath, StuckSpecReconciler.DEFAULT_THRESHOLD, stranded -> surface(bus, stranded));
@@ -310,6 +312,7 @@ public final class ServerStartCommand implements Runnable {
         .register(server)
         .register(sweeper)
         .register(eventSweeper)
+        .register(ptyEventBridge)
         .register(reconciler)
         .register(missedStops)
         .register(rearmer)
@@ -318,6 +321,7 @@ public final class ServerStartCommand implements Runnable {
       server.start();
       sweeper.start();
       eventSweeper.start();
+      ptyEventBridge.start(PtyEventBridge.INTERVAL);
       reconciler.start();
       var replayed = missedStops.sweep();
       if (replayed > 0) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SessionCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SessionCommand.java
@@ -87,10 +87,24 @@ public final class SessionCommand {
     @Option(names = "--socket", hidden = true, description = "Host socket override.")
     private java.nio.file.Path socket;
 
+    @Option(names = "--json", description = "Output in JSON format.")
+    private boolean json;
+
+    record Listing(
+        int schemaVersion,
+        List<ai.singlr.sail.pty.PtyMessage.SessionInfo> sessions,
+        PtyEventDrops.Drops eventDrops) {}
+
     @Override
     public Integer call() throws Exception {
-      try (var client = SessionClient.connect(socketOrDefault(socket))) {
+      var socketPath = socketOrDefault(socket);
+      try (var client = SessionClient.connect(socketPath)) {
         var sessions = client.list();
+        if (json) {
+          var drops = PtyEventDrops.read(PtyEventDrops.fileOf(socketPath));
+          System.out.println(CliJson.stringify(new Listing(1, sessions, drops)));
+          return 0;
+        }
         if (sessions.isEmpty()) {
           System.out.println("No sessions. Start one with: sail session new <name>");
           return 0;

--- a/sail-infra/src/test/java/ai/singlr/sail/api/PtyEventBridgeTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/PtyEventBridgeTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.store.EventStore;
+import ai.singlr.sail.store.SchemaManager;
+import ai.singlr.sail.store.Sqlite;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PtyEventBridgeTest {
+
+  @TempDir Path dir;
+  private Sqlite db;
+  private EventStore events;
+
+  private final ConcurrentLinkedQueue<Event> seen = new ConcurrentLinkedQueue<>();
+
+  private EventSubscriber collector(CountDownLatch latch) {
+    return new EventSubscriber() {
+      @Override
+      public String name() {
+        return "collector";
+      }
+
+      @Override
+      public Predicate<Event> filter() {
+        return event -> true;
+      }
+
+      @Override
+      public void onEvent(Event event) {
+        seen.add(event);
+        latch.countDown();
+      }
+    };
+  }
+
+  @BeforeEach
+  void setUp() {
+    db = Sqlite.open(dir.resolve("test.db"));
+    new SchemaManager(db).migrate();
+    events = new EventStore(db);
+  }
+
+  @AfterEach
+  void tearDown() {
+    db.close();
+  }
+
+  private long insert(String type, String project, String specId, String data) {
+    return events.insert(
+        new EventStore.EventRow(
+            0, "2026-09-01T12:00:00Z", type, project, specId, "uday", "box-1", data));
+  }
+
+  @Test
+  void publishesOnlyNewPtyFactsWithTheirStoredIdentityAndPayload() throws Exception {
+    insert(
+        Event.WellKnownTypes.PTY_SESSION_STARTED, "acme", "design-talk", "{\"session\": \"old\"}");
+    try (var bus = new EventBus()) {
+      var bridge = new PtyEventBridge(events, bus);
+      var latch = new CountDownLatch(2);
+      bus.subscribe(collector(latch));
+
+      insert(Event.WellKnownTypes.SPEC_DISPATCHED, "acme", "s1", "{}");
+      insert(
+          Event.WellKnownTypes.PTY_SESSION_STARTED,
+          "acme",
+          "design-talk",
+          "{\"session\": \"brainstorm\", \"room_id\": \"design-talk\"}");
+      insert(Event.WellKnownTypes.PTY_SESSION_ENDED, "acme", null, "{\"reason\": \"exited(0)\"}");
+
+      assertEquals(2, bridge.publishNewRows(), "only the pty facts newer than the cursor go live");
+      BusTesting.awaitDelivery(latch);
+
+      var types = seen.stream().map(Event::type).toList();
+      assertEquals(
+          List.of(Event.WellKnownTypes.PTY_SESSION_STARTED, Event.WellKnownTypes.PTY_SESSION_ENDED),
+          types,
+          "rows persisted before the bridge existed are never replayed, foreign types never bridge");
+      var started = seen.stream().findFirst().orElseThrow();
+      assertEquals("acme", started.project());
+      assertEquals("design-talk", started.spec());
+      assertEquals("uday", started.agent());
+      assertEquals("box-1", started.host());
+      assertEquals("brainstorm", started.data().get("session"));
+      assertTrue(started.id() > 0, "the bus stamps a live id");
+
+      assertEquals(0, bridge.publishNewRows(), "a second pass finds nothing new");
+    }
+  }
+
+  @Test
+  void aFullBatchKeepsDrainingUntilTheTableIsCaughtUp() throws Exception {
+    try (var bus = new EventBus()) {
+      var bridge = new PtyEventBridge(events, bus, 2);
+      var latch = new CountDownLatch(5);
+      bus.subscribe(collector(latch));
+      for (var i = 0; i < 5; i++) {
+        insert(
+            Event.WellKnownTypes.PTY_SESSION_ATTACHED,
+            "acme",
+            null,
+            "{\"session\": \"s" + i + "\"}");
+      }
+
+      assertEquals(5, bridge.publishNewRows());
+      BusTesting.awaitDelivery(latch);
+      assertEquals(5, seen.size());
+    }
+  }
+
+  @Test
+  void anUntranslatableRowIsSkippedOnceNotAStalledCursor() {
+    try (var bus = new EventBus()) {
+      var bridge = new PtyEventBridge(events, bus);
+      insert(Event.WellKnownTypes.PTY_SESSION_STARTED, "", null, "{}");
+
+      assertEquals(0, bridge.publishNewRows(), "a blank-project row cannot become a bus event");
+      assertEquals(0, bridge.publishNewRows(), "and it is never retried");
+
+      var latch = new CountDownLatch(1);
+      bus.subscribe(collector(latch));
+      insert(Event.WellKnownTypes.PTY_SESSION_STARTED, "acme", null, "{\"session\": \"next\"}");
+      assertEquals(1, bridge.publishNewRows(), "the lane keeps flowing past the bad row");
+    }
+  }
+
+  @Test
+  void thePersisterAndTheBridgeCannotFeedEachOther() throws Exception {
+    try (var bus = new EventBus()) {
+      var bridge = new PtyEventBridge(events, bus);
+      var latch = new CountDownLatch(1);
+      bus.subscribe(BusTesting.latching(new SpecStoreAuditPersister(events), latch));
+      insert(Event.WellKnownTypes.PTY_SESSION_STARTED, "acme", null, "{\"session\": \"once\"}");
+
+      assertEquals(1, bridge.publishNewRows());
+      Thread.sleep(150);
+
+      assertEquals(1, events.recent(10).size(), "the persister never re-persists a bridged fact");
+      assertEquals(1, latch.getCount(), "the persister's filter refused it before delivery");
+      assertEquals(0, bridge.publishNewRows(), "so the bridge has nothing new to see");
+    }
+  }
+
+  @Test
+  void startBridgesOnItsOwnCadenceAndCloseStopsIt() throws Exception {
+    try (var bus = new EventBus()) {
+      var latch = new CountDownLatch(1);
+      bus.subscribe(collector(latch));
+      try (var bridge = new PtyEventBridge(events, bus)) {
+        bridge.start(Duration.ofMillis(20));
+        insert(Event.WellKnownTypes.PTY_SESSION_STARTED, "acme", null, "{\"session\": \"timed\"}");
+        BusTesting.awaitDelivery(latch);
+      }
+      assertEquals(1, seen.size());
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/api/SpecStoreAuditPersisterTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/api/SpecStoreAuditPersisterTest.java
@@ -61,6 +61,21 @@ class SpecStoreAuditPersisterTest {
   }
 
   @Test
+  void filterRejectsPtySessionFactsBecauseTheyArePersistedAtSource() {
+    for (var type :
+        java.util.List.of(
+            Event.WellKnownTypes.PTY_SESSION_STARTED,
+            Event.WellKnownTypes.PTY_SESSION_ATTACHED,
+            Event.WellKnownTypes.PTY_SESSION_ENDED)) {
+      assertFalse(
+          persister.filter().test(Event.of("proj", null, type, "uday", "host")),
+          type + " on the bus is the bridge's republication, never something to persist again");
+    }
+    assertFalse(Event.WellKnownTypes.ptySessionFact("pty_session_renamed"));
+    assertFalse(Event.WellKnownTypes.ptySessionFact(Event.WellKnownTypes.SPEC_DISPATCHED));
+  }
+
+  @Test
   void onEventPersistsToDatabase() {
     var event = Event.of("backend", "auth", "spec_dispatched", "sail", "host1", Map.of("k", "v"));
     persister.onEvent(event);

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentResumeSessionIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentResumeSessionIT.java
@@ -89,7 +89,7 @@ class AgentResumeSessionIT extends AbstractIncusIT {
               64 * 1024,
               token -> new PtyIdentity("it", true),
               new PtyHostRooms(dbPath),
-              new PtyHostEvents(dbPath))) {
+              new PtyHostEvents(dbPath, dir.resolve("pty-events.drops")))) {
         host.start();
         launchPrepared(CONTAINER);
         installDevUserAndStandInClaude();

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyEventDropsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyEventDropsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PtyEventDropsTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void concurrentFailuresAllCountAndReadersNeverSeeAPartialMeter() throws Exception {
+    var file = PtyEventDrops.fileOf(tempDir.resolve("pty.sock"));
+    var writers = 8;
+    var perWriter = 50;
+    var start = new CyclicBarrier(writers + 2);
+    var done = new CountDownLatch(writers);
+    var writersRunning = new AtomicBoolean(true);
+    for (int w = 0; w < writers; w++) {
+      Thread.ofPlatform()
+          .start(
+              () -> {
+                await(start);
+                for (int i = 0; i < perWriter; i++) {
+                  PtyEventDrops.record(file, "pty_session_started", "disk full");
+                }
+                done.countDown();
+              });
+    }
+    var observed = new ArrayList<Long>();
+    var reader =
+        Thread.ofPlatform()
+            .start(
+                () -> {
+                  await(start);
+                  while (writersRunning.get()) {
+                    observed.add(PtyEventDrops.read(file).count());
+                  }
+                });
+    start.await();
+    done.await();
+    writersRunning.set(false);
+    reader.join();
+
+    assertEquals(
+        (long) writers * perWriter,
+        PtyEventDrops.read(file).count(),
+        "a drop meter that loses drops under concurrency measures nothing");
+    var floor = 0L;
+    for (var count : observed) {
+      assertTrue(
+          count >= floor,
+          "a reader saw the meter go backwards ("
+              + count
+              + " after "
+              + floor
+              + ") — a partially"
+              + " written file parsed as fewer drops than already recorded");
+      floor = Math.max(floor, count);
+    }
+  }
+
+  private static void await(CyclicBarrier barrier) {
+    try {
+      barrier.await();
+    } catch (Exception interrupted) {
+      throw new IllegalStateException(interrupted);
+    }
+  }
+}

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyHostEventsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyHostEventsTest.java
@@ -31,6 +31,14 @@ class PtyHostEventsTest {
     return path;
   }
 
+  private Path drops() {
+    return dir.resolve(PtyEventDrops.FILE_NAME);
+  }
+
+  private PtyHostEvents events(Path dbPath) {
+    return new PtyHostEvents(dbPath, drops());
+  }
+
   private static List<EventStore.EventRow> recent(Path path) {
     try (var db = Sqlite.open(path)) {
       return new EventStore(db).recent(10);
@@ -40,7 +48,7 @@ class PtyHostEventsTest {
   @Test
   void theThreeSessionFactsBecomeRecordClassRows() {
     var path = migrated();
-    var events = new PtyHostEvents(path);
+    var events = events(path);
     var origin = new PtySession.Origin("lounge", "uday", "acme", "", List.of("bash", "-l"));
 
     events.sessionStarted(origin);
@@ -75,7 +83,7 @@ class PtyHostEventsTest {
   @Test
   void aRoomBoundSessionsRowsCarryTheRoomAndTheStartNamesOnlyTheExecutable() {
     var path = migrated();
-    var events = new PtyHostEvents(path);
+    var events = events(path);
     var origin =
         new PtySession.Origin(
             "brainstorm",
@@ -113,5 +121,67 @@ class PtyHostEventsTest {
             .filter(e -> !e.type().equals("pty_session_started"))
             .anyMatch(e -> e.data().contains("executable")),
         "only the start fact narrates the executable");
+  }
+
+  @Test
+  void aCleanRunLeavesNoDropMeter() {
+    var events = events(migrated());
+    var origin = new PtySession.Origin("clean", "uday", "acme", "", List.of("bash", "-l"));
+
+    events.sessionStarted(origin);
+
+    assertFalse(java.nio.file.Files.exists(drops()), "a delivered event bumps nothing");
+  }
+
+  @Test
+  void anInducedInsertFailureIsMeasuredNotThrown() {
+    var unmigrated = dir.resolve("unmigrated.db");
+    var events = events(unmigrated);
+    var origin = new PtySession.Origin("lounge", "uday", "acme", "", List.of("bash", "-l"));
+    var stderr = new java.io.ByteArrayOutputStream();
+    var original = System.err;
+    System.setErr(new java.io.PrintStream(stderr, true, java.nio.charset.StandardCharsets.UTF_8));
+    try {
+      events.sessionStarted(origin);
+      events.sessionAttached(origin, "mady");
+      events.sessionEnded(origin, "exited(0)");
+    } finally {
+      System.setErr(original);
+    }
+
+    var meter = PtyEventDrops.read(drops());
+    assertEquals(3, meter.count());
+    assertEquals("pty_session_ended", meter.lastType());
+    assertTrue(meter.lastCause() != null && !meter.lastCause().isBlank(), "the cause is named");
+    assertTrue(meter.lastAt() != null && !meter.lastAt().isBlank(), "the drop is timestamped");
+
+    var lines =
+        stderr
+            .toString(java.nio.charset.StandardCharsets.UTF_8)
+            .lines()
+            .filter(line -> line.startsWith("pty-events: dropped "))
+            .toList();
+    assertEquals(3, lines.size(), "one structured line per drop, nothing else");
+    assertTrue(
+        lines.getFirst().contains("pty_session_started")
+            && lines.getFirst().contains("session=lounge")
+            && lines.getFirst().contains("project=acme")
+            && lines.getFirst().contains("cause="),
+        "the line names the event type, the session, and the cause: " + lines.getFirst());
+  }
+
+  @Test
+  void theDropMeterSurvivesACorruptFileAndAnUnwritablePath() throws Exception {
+    var corrupt = drops();
+    java.nio.file.Files.writeString(corrupt, "not json at all {{{");
+    assertEquals(0, PtyEventDrops.read(corrupt).count(), "a corrupt meter reads as zero");
+
+    PtyEventDrops.record(corrupt, "pty_session_started", "boom");
+    assertEquals(1, PtyEventDrops.read(corrupt).count(), "recording over a corrupt meter restarts");
+
+    var unwritable = dir.resolve("nope").resolve(PtyEventDrops.FILE_NAME);
+    PtyEventDrops.record(unwritable, "pty_session_started", "boom");
+    assertEquals(
+        0, PtyEventDrops.read(unwritable).count(), "an unwritable meter is a silent no-op");
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyRoomSessionIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyRoomSessionIT.java
@@ -161,10 +161,17 @@ class PtyRoomSessionIT extends AbstractIncusIT {
 
         var mast =
             runToExitAs(
-                "mast-session-token", "mast-term", "design-talk", "echo mast-was=$SAIL_ROOM_ID");
+                "mast-session-token",
+                "mast-term",
+                "design-talk",
+                "spec create --id mast-made --title 'Mast made' && echo mast-was=$SAIL_ROOM_ID");
         assertTrue(
             mast.contains("mast-was=design-talk"),
             "the token-identified session sees its room too: " + mast);
+        assertEquals(
+            "design-talk",
+            specStore.findById("mast-made").orElseThrow().roomIdOrIdentity(),
+            "a token-identified room-bound session births specs in its room too");
 
         assertEquals(
             "design-talk",

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyRoomSessionIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyRoomSessionIT.java
@@ -269,7 +269,7 @@ class PtyRoomSessionIT extends AbstractIncusIT {
     try (var client = SessionClient.connect(dir.resolve("h.sock"), token)) {
       client.create(
           session,
-          List.of("bash", "-lc", script + "; exit 0"),
+          List.of("bash", "-lc", "read _; " + script + "; exit 0"),
           System.getProperty("user.home", "/home/dev"),
           CONTAINER,
           room,
@@ -278,8 +278,11 @@ class PtyRoomSessionIT extends AbstractIncusIT {
     }
     try (var client = SessionClient.connect(dir.resolve("h.sock"), token)) {
       var channel = client.attach(session, true);
-      var stdin = new PipedInputStream(new PipedOutputStream());
+      var toChild = new PipedOutputStream();
+      var stdin = new PipedInputStream(toChild);
       var stdout = new ByteArrayOutputStream();
+      toChild.write('\n');
+      toChild.flush();
       var reason = AttachLoop.run(channel, stdin, stdout);
       var rendered = stdout.toString(StandardCharsets.UTF_8);
       assertEquals("exited(0)", reason, "the session's script must succeed: " + rendered);

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyRoomSessionIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyRoomSessionIT.java
@@ -208,7 +208,7 @@ class PtyRoomSessionIT extends AbstractIncusIT {
                 .anyMatch(d -> "plain".equals(d.get("session")) && !d.containsKey("room_id")),
             "an unbound session's event names none: " + started);
 
-        var all = new EventStore(db).recent(100);
+        var eventStore = new EventStore(db);
         for (var expected :
             List.of(
                 new String[] {"brainstorm", "it", "design-talk"},
@@ -217,15 +217,9 @@ class PtyRoomSessionIT extends AbstractIncusIT {
           var session = expected[0];
           var owner = expected[1];
           var room = expected[2];
-          assertTrue(
-              hasFact(all, "pty_session_started", session, owner, room),
-              session + " must record its start for " + owner);
-          assertTrue(
-              hasFact(all, "pty_session_attached", session, owner, room),
-              session + " must record its attach for " + owner);
-          assertTrue(
-              hasFact(all, "pty_session_ended", session, "sail", room),
-              session + " must record its ending");
+          awaitFact(eventStore, "pty_session_started", session, owner, room);
+          awaitFact(eventStore, "pty_session_attached", session, owner, room);
+          awaitFact(eventStore, "pty_session_ended", session, "sail", room);
         }
 
         bridge.publishNewRows();
@@ -243,6 +237,19 @@ class PtyRoomSessionIT extends AbstractIncusIT {
     } finally {
       deleteContainerQuietly(CONTAINER);
       deleteRecursively(socketDir);
+    }
+  }
+
+  private static void awaitFact(
+      EventStore events, String type, String session, String agent, String room)
+      throws InterruptedException {
+    var deadline = System.nanoTime() + 10_000_000_000L;
+    while (!hasFact(events.recent(200), type, session, agent, room)) {
+      if (System.nanoTime() > deadline) {
+        throw new AssertionError(
+            type + " for session '" + session + "' (agent " + agent + ") never reached the store");
+      }
+      Thread.sleep(20);
     }
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyRoomSessionIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyRoomSessionIT.java
@@ -51,7 +51,9 @@ import picocli.CommandLine;
  * production local API over the bind-mounted socket with the box's ambient credential — creates
  * specs that are born in room X, mint no identity room, and honor an explicit {@code --room}. A
  * session opened without a room behaves exactly as before. The pty host's own event rows carry the
- * room. Self-cleaning.
+ * room, and every session — CLI-token or session-token identified, room-bound or not — leaves all
+ * three lifecycle facts (started, attached, ended) in the event store, from which the bridge
+ * republishes them onto the live bus. Self-cleaning.
  */
 class PtyRoomSessionIT extends AbstractIncusIT {
 
@@ -76,6 +78,7 @@ class PtyRoomSessionIT extends AbstractIncusIT {
       rooms.create(room("other-talk", "Other talk"));
       var fdeStore = new FdeStore(db);
       fdeStore.add("it", "IT", "it@example.dev", "admin");
+      fdeStore.add("mady", "Mady", "mady@example.dev", "admin");
       var boxStore = new BoxCredentialStore(db);
       BoxCredentialFile.ensure(boxStore, "it", socketDir);
       var bus = new EventBus();
@@ -102,11 +105,32 @@ class PtyRoomSessionIT extends AbstractIncusIT {
                   dir.resolve("h.sock"),
                   dir.resolve("s"),
                   64 * 1024,
-                  token -> new PtyIdentity("it", true),
+                  token -> new PtyIdentity(token.isBlank() ? "it" : "mady", true),
                   new PtyHostRooms(dbPath),
-                  new PtyHostEvents(dbPath))) {
+                  new PtyHostEvents(dbPath, dir.resolve("pty-events.drops")))) {
         api.start();
         host.start();
+
+        var live = new java.util.concurrent.ConcurrentLinkedQueue<ai.singlr.sail.api.Event>();
+        bus.subscribe(
+            new ai.singlr.sail.api.EventSubscriber() {
+              @Override
+              public String name() {
+                return "it-live-collector";
+              }
+
+              @Override
+              public java.util.function.Predicate<ai.singlr.sail.api.Event> filter() {
+                return event ->
+                    ai.singlr.sail.api.Event.WellKnownTypes.ptySessionFact(event.type());
+              }
+
+              @Override
+              public void onEvent(ai.singlr.sail.api.Event event) {
+                live.add(event);
+              }
+            });
+        var bridge = new ai.singlr.sail.api.PtyEventBridge(new EventStore(db), bus);
 
         launchPrepared(CONTAINER);
         var dev =
@@ -134,6 +158,13 @@ class PtyRoomSessionIT extends AbstractIncusIT {
 
         var solo = runToExit("plain", "", "spec create --id solo --title Solo && echo done");
         assertTrue(solo.contains("done"), solo);
+
+        var mast =
+            runToExitAs(
+                "mast-session-token", "mast-term", "design-talk", "echo mast-was=$SAIL_ROOM_ID");
+        assertTrue(
+            mast.contains("mast-was=design-talk"),
+            "the token-identified session sees its room too: " + mast);
 
         assertEquals(
             "design-talk",
@@ -169,10 +200,76 @@ class PtyRoomSessionIT extends AbstractIncusIT {
             started.stream()
                 .anyMatch(d -> "plain".equals(d.get("session")) && !d.containsKey("room_id")),
             "an unbound session's event names none: " + started);
+
+        var all = new EventStore(db).recent(100);
+        for (var expected :
+            List.of(
+                new String[] {"brainstorm", "it", "design-talk"},
+                new String[] {"plain", "it", null},
+                new String[] {"mast-term", "mady", "design-talk"})) {
+          var session = expected[0];
+          var owner = expected[1];
+          var room = expected[2];
+          assertTrue(
+              hasFact(all, "pty_session_started", session, owner, room),
+              session + " must record its start for " + owner);
+          assertTrue(
+              hasFact(all, "pty_session_attached", session, owner, room),
+              session + " must record its attach for " + owner);
+          assertTrue(
+              hasFact(all, "pty_session_ended", session, "sail", room),
+              session + " must record its ending");
+        }
+
+        bridge.publishNewRows();
+        var deadline = System.nanoTime() + 10_000_000_000L;
+        while (live.size() < 9 && System.nanoTime() < deadline) {
+          Thread.sleep(10);
+        }
+        assertEquals(
+            9,
+            live.size(),
+            "all nine lifecycle facts must reach the live event lane: "
+                + live.stream().map(e -> e.type() + ":" + e.data().get("session")).toList());
+        bridge.close();
       }
     } finally {
       deleteContainerQuietly(CONTAINER);
       deleteRecursively(socketDir);
+    }
+  }
+
+  private static boolean hasFact(
+      List<EventStore.EventRow> rows, String type, String session, String agent, String room) {
+    return rows.stream()
+        .anyMatch(
+            row ->
+                row.type().equals(type)
+                    && row.agent().equals(agent)
+                    && java.util.Objects.equals(row.specId(), room)
+                    && session.equals(YamlUtil.parseMap(row.data()).get("session")));
+  }
+
+  private String runToExitAs(String token, String session, String room, String script)
+      throws Exception {
+    try (var client = SessionClient.connect(dir.resolve("h.sock"), token)) {
+      client.create(
+          session,
+          List.of("bash", "-lc", script + "; exit 0"),
+          System.getProperty("user.home", "/home/dev"),
+          CONTAINER,
+          room,
+          80,
+          24);
+    }
+    try (var client = SessionClient.connect(dir.resolve("h.sock"), token)) {
+      var channel = client.attach(session, true);
+      var stdin = new PipedInputStream(new PipedOutputStream());
+      var stdout = new ByteArrayOutputStream();
+      var reason = AttachLoop.run(channel, stdin, stdout);
+      var rendered = stdout.toString(StandardCharsets.UTF_8);
+      assertEquals("exited(0)", reason, "the session's script must succeed: " + rendered);
+      return rendered;
     }
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyRoomSessionIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyRoomSessionIT.java
@@ -290,6 +290,7 @@ class PtyRoomSessionIT extends AbstractIncusIT {
     }
   }
 
+  /** The child gates on attach ({@code read _}) so it can never exit before we connect. */
   private String runToExit(String session, String room, String script) throws Exception {
     var socket = dir.resolve("h.sock").toString();
     var args =
@@ -298,13 +299,16 @@ class PtyRoomSessionIT extends AbstractIncusIT {
     if (!room.isEmpty()) {
       args.addAll(List.of("--room", room));
     }
-    args.addAll(List.of("--command", "bash", "-lc", script + "; exit 0"));
+    args.addAll(List.of("--command", "bash", "-lc", "read _; " + script + "; exit 0"));
     assertEquals(0, new CommandLine(new SessionCommand()).execute(args.toArray(String[]::new)));
 
     try (var client = SessionClient.connect(dir.resolve("h.sock"))) {
       var channel = client.attach(session, true);
-      var stdin = new PipedInputStream(new PipedOutputStream());
+      var toChild = new PipedOutputStream();
+      var stdin = new PipedInputStream(toChild);
       var stdout = new ByteArrayOutputStream();
+      toChild.write('\n');
+      toChild.flush();
       var reason = AttachLoop.run(channel, stdin, stdout);
       var rendered = stdout.toString(StandardCharsets.UTF_8);
       assertEquals("exited(0)", reason, "the session's script must succeed: " + rendered);

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SessionVerbsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SessionVerbsTest.java
@@ -102,6 +102,39 @@ class SessionVerbsTest {
   }
 
   @Test
+  void lsJsonNamesTheSessionsAndSurfacesTheDropMeter() throws Exception {
+    try (var host =
+        PtyHostCommand.startHost(
+            dir.resolve("h.sock"),
+            dir.resolve("s"),
+            token -> new ai.singlr.sail.pty.PtyIdentity("uday", true),
+            ROOMS,
+            ai.singlr.sail.pty.PtyEvents.NONE)) {
+      var socket = dir.resolve("h.sock").toString();
+      assertEquals(0, run("new", "--socket", socket, "t1", "--command", "sh", "-c", "read a"));
+      PtyEventDrops.record(
+          PtyEventDrops.fileOf(dir.resolve("h.sock")), "pty_session_started", "db locked");
+
+      var stdout = new java.io.ByteArrayOutputStream();
+      var original = System.out;
+      System.setOut(new java.io.PrintStream(stdout, true, java.nio.charset.StandardCharsets.UTF_8));
+      try {
+        assertEquals(0, run("ls", "--socket", socket, "--json"));
+      } finally {
+        System.setOut(original);
+      }
+
+      var json = stdout.toString(java.nio.charset.StandardCharsets.UTF_8);
+      assertTrue(json.contains("\"schema_version\": 1"), json);
+      assertTrue(json.contains("\"name\": \"t1\""), json);
+      assertTrue(json.contains("\"event_drops\": {\"count\": 1"), json);
+      assertTrue(json.contains("\"last_type\": \"pty_session_started\""), json);
+      assertTrue(json.contains("\"last_cause\": \"db locked\""), json);
+      assertTrue(host.sessionCount() == 1);
+    }
+  }
+
+  @Test
   void attachToAMissingSessionFailsBeforeTouchingTheTerminal() throws Exception {
     try (var host =
         PtyHostCommand.startHost(


### PR DESCRIPTION
Spec: sail-pty-event-honesty.

## Diagnosis (code-level, evidence in the spec room)

- **Durable lane (EventStore): worked, but blind.** `_pty-host` writes `pty_session_*` rows straight into the box's `sail.db`; a failed write was swallowed with zero trace, and that swallow was the only shield — `PtySession.start`/`attach` called `PtyEvents` unguarded, so a throwing impl killed a create or stalled an attach mid-registration.
- **Live lane (SSE): structurally dead, 100% drop by construction.** `/v1/events/stream` serves the in-process EventBus; nothing bridged rows written by the separate pty-host process onto it. Mast consumes exactly that stream and already handles live `pty_session_*` — events that could never arrive. This fully explains the 2026-09-01 field ambiguity: the durable half delivered (visible on `/v1/events/recent` and room-history refresh), the live accelerator never fired once.

## Changes

**Measure.** Every emission failure now leaves one structured journald line (`pty-events: dropped <type> session=… project=… cause=…`) and bumps a drop meter file beside the pty socket. New `sail session ls --json` surfaces it as `event_drops` (count, last type, cause, timestamp). No wire changes — the CLI reads the meter file directly on the same box. Fail-open behavior unchanged.

**Pin the contract.** All three `PtySession` emissions ride one guard: no `PtyEvents` failure may end, stall, or refuse the session it describes. Pinned by a hostile-impl test.

**Close the gap.** `PtyEventBridge` in the API server republishes new `pty_session_*` rows onto the bus every 2s (indexed id-range scan); `SpecStoreAuditPersister` skips pty facts (persisted at source), so a row is never written twice and the lane cannot loop. Untranslatable rows skip with a named stderr line, never a stalled cursor.

**IT.** The Incus lane now pins all nine lifecycle facts — started/attached/ended × {CLI-identity room-bound, CLI-identity unbound, session-token room-bound} — reaching the event store, plus their republication onto the live bus.

## Verification

`mvn clean verify` green: 3043 tests, jacoco gates met including 100% line/method on `ai.singlr.sail.api.*` (PtyEventBridge fully covered). No new dependencies, no wire changes.