### PR TITLE
pty: SAILPTY3 — Hello is answered with the host's boot id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Breaking (pty wire): SAILPTY3.** The session host answers an admitted `Hello` with `Welcome`
+  carrying its boot id — a fresh id per run of the host process, the same on every connection
+  until the host restarts — so a terminal client that remembers the id a session was last seen
+  under can tell "the host restarted and lost it" from "it ended". The handshake magic moves to
+  `SAILPTY3`; a client speaking `SAILPTY2` is refused by name (Mast renders its skew card until
+  one side is upgraded). `sail session ls --json` now includes `host_boot_id`. The pty host
+  restarts on `sail upgrade`, as before.
+
 - **Breaking (CLI + API):** the one-shot invite lane is gone — one verb per primitive. `sail spec
   invite` no longer exists and `POST /v1/rooms/{id}/invite` answers 404 with a pointer to the two
   verbs that remain: add a member (`sail spec engage`, `POST /v1/rooms/{id}/members`) to converse,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   `SAILPTY3`; a client speaking `SAILPTY2` is refused by name (Mast renders its skew card until
   one side is upgraded). `sail session ls --json` now includes `host_boot_id`. The pty host
   restarts on `sail upgrade`, as before.
+- **Pty sessions carry an incarnation id.** Every create mints an `instance_id` for that life of
+  the (reusable) session name; it rides `SessionInfo` on the wire (SAILPTY3), `sail session ls
+  --json`, and the data of every `pty_session_started/attached/ended` event. A client that only
+  ever saw two corpses of one name can now tell which life each belonged to — the fact Mast's
+  ended cards settle their reason on, instead of the name's newest event.
 
 - **Breaking (CLI + API):** the one-shot invite lane is gone — one verb per primitive. `sail spec
   invite` no longer exists and `POST /v1/rooms/{id}/invite` answers 404 with a pointer to the two

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyMessage.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyMessage.java
@@ -9,9 +9,10 @@ import java.util.List;
 
 /**
  * The session-host wire vocabulary — one sealed hierarchy for both directions. Client to host:
- * create, attach, input, resize, write-token, detach, list, kill, yield. Host to client: output
- * (carrying the last applied input sequence — the one enabler client-side predictive echo needs),
- * replay bracketing, writer and size changes, flow control, endings, listings, and errors.
+ * create, attach, input, resize, write-token, detach, list, kill, yield. Host to client: welcome
+ * (the host's boot id), output (carrying the last applied input sequence — the one enabler
+ * client-side predictive echo needs), replay bracketing, writer and size changes, flow control,
+ * endings, listings, and errors.
  */
 public sealed interface PtyMessage {
 
@@ -19,6 +20,14 @@ public sealed interface PtyMessage {
   int MAX_COMMAND_BYTES = 32 * 1024;
 
   record Hello(String token) implements PtyMessage {}
+
+  /**
+   * The host's answer to an admitted {@link Hello}: {@code hostBootId} names this run of the host
+   * process, minted at start and shared by every connection until the host restarts. A client that
+   * remembers the id a session was last seen under can tell a session that died from one the host
+   * lost by restarting. Served only after identity, never before.
+   */
+  record Welcome(String hostBootId) implements PtyMessage {}
 
   /**
    * Starts a session. {@code room} is the room this session is pinned to — blank for none. The host

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyMessage.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyMessage.java
@@ -94,12 +94,20 @@ public sealed interface PtyMessage {
   record SessionEnded(String reason) implements PtyMessage {}
 
   /**
-   * One listed session. {@code command} is the child as requested (the default login shell when
-   * none was), so a client can tell an agent session from a plain shell; {@code room} is blank when
-   * the session is not room-bound.
+   * One listed session. {@code name} is reusable across lives; {@code instanceId} names this life
+   * of it (see {@link PtySession.Origin}), so two corpses of one name are distinguishable. {@code
+   * command} is the child as requested (the default login shell when none was), so a client can
+   * tell an agent session from a plain shell; {@code room} is blank when the session is not
+   * room-bound.
    */
   record SessionInfo(
-      String name, boolean live, int attached, String writerFde, String room, List<String> command)
+      String name,
+      String instanceId,
+      boolean live,
+      int attached,
+      String writerFde,
+      String room,
+      List<String> command)
       implements PtyMessage {}
 
   /** One page of sessions; {@code next} is blank on the last page, else the cursor to continue. */

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -40,13 +40,24 @@ public final class PtySession implements AutoCloseable {
   private record Subscriber(long id, Client client, SubscriberQueue queue) {}
 
   /**
-   * What a session was born as: its name, the FDE who created it, the project whose container it
-   * runs in (blank for the node itself), the room it is pinned to (blank for none), and the child
-   * as requested — the facts every listing and every emitted event carry.
+   * What a session was born as: its name, the id of this incarnation of that name, the FDE who
+   * created it, the project whose container it runs in (blank for the node itself), the room it is
+   * pinned to (blank for none), and the child as requested — the facts every listing and every
+   * emitted event carry. Names are reusable (a corpse's name may be created again); {@code
+   * instanceId} is minted once per create and never reused, so a client that only ever saw two
+   * corpses of one name can still tell which life each belonged to.
    */
   public record Origin(
-      String name, String ownerFde, String project, String room, List<String> command) {
+      String name,
+      String instanceId,
+      String ownerFde,
+      String project,
+      String room,
+      List<String> command) {
     public Origin {
+      if (instanceId == null || instanceId.isBlank()) {
+        throw new IllegalArgumentException("A session incarnation needs a non-blank instance id.");
+      }
       command = List.copyOf(command);
     }
 

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyWire.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyWire.java
@@ -142,7 +142,7 @@ public final class PtyWire {
   }
 
   private static Writer encodeInfo(Writer out, PtyMessage.SessionInfo info) {
-    out.string(info.name());
+    out.string(info.name()).string(info.instanceId());
     out.buffer.put((byte) (info.live() ? 1 : 0)).putInt(info.attached());
     return out.string(info.writerFde()).string(info.room()).stringList(info.command());
   }
@@ -194,7 +194,7 @@ public final class PtyWire {
 
   private static PtyMessage.SessionInfo decodeInfo(ByteBuffer in) throws IOException {
     return new PtyMessage.SessionInfo(
-        string(in), in.get() == 1, in.getInt(), string(in), string(in), stringList(in));
+        string(in), string(in), in.get() == 1, in.getInt(), string(in), string(in), stringList(in));
   }
 
   private static String string(ByteBuffer in) throws IOException {

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyWire.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyWire.java
@@ -22,7 +22,7 @@ import java.util.List;
  */
 public final class PtyWire {
 
-  static final byte[] MAGIC = "SAILPTY2".getBytes(StandardCharsets.US_ASCII);
+  static final byte[] MAGIC = "SAILPTY3".getBytes(StandardCharsets.US_ASCII);
   static final int MAX_FRAME = 1 << 20;
 
   private PtyWire() {}
@@ -33,7 +33,7 @@ public final class PtyWire {
     var peer = ByteBuffer.allocate(MAGIC.length);
     readFully(in, peer);
     if (!ByteBuffer.wrap(MAGIC).equals(peer.flip())) {
-      throw new IOException("Peer is not speaking sail pty protocol v2; refusing the connection.");
+      throw new IOException("Peer is not speaking sail pty protocol v3; refusing the connection.");
     }
   }
 
@@ -136,6 +136,7 @@ public final class PtyWire {
       }
       case PtyMessage.Ok m -> out.type(30);
       case PtyMessage.Err m -> out.type(31).string(m.message());
+      case PtyMessage.Welcome m -> out.type(32).string(m.hostBootId());
     }
     return out.finish();
   }
@@ -186,6 +187,7 @@ public final class PtyWire {
       }
       case 30 -> new PtyMessage.Ok();
       case 31 -> new PtyMessage.Err(string(in));
+      case 32 -> new PtyMessage.Welcome(string(in));
       default -> throw new IOException("Unknown pty frame type " + type + ".");
     };
   }

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -84,7 +84,7 @@ class PtySessionTest {
   }
 
   private static PtySession.Origin origin(String name, String owner, String project) {
-    return new PtySession.Origin(name, owner, project, "", List.of("sh"));
+    return new PtySession.Origin(name, "inst-" + name, owner, project, "", List.of("sh"));
   }
 
   private PtySession session(String script) throws IOException {
@@ -184,7 +184,8 @@ class PtySessionTest {
         };
     var session =
         PtySession.start(
-            new PtySession.Origin("owned", "mady", "acme", "lounge", List.of("claude")),
+            new PtySession.Origin(
+                "owned", "inst-owned", "mady", "acme", "lounge", List.of("claude")),
             recorder,
             List.of("sh", "-c", "read a"),
             Map.of("TERM", "dumb"),

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtyWireTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtyWireTest.java
@@ -82,6 +82,10 @@ class PtyWireTest {
         "", ((PtyMessage.Sessions) roundTrip(new PtyMessage.Sessions(List.of(), ""))).next());
     assertEquals("tok", ((PtyMessage.Hello) roundTrip(new PtyMessage.Hello("tok"))).token());
     assertEquals(
+        "boot-7",
+        ((PtyMessage.Welcome) roundTrip(new PtyMessage.Welcome("boot-7"))).hostBootId(),
+        "the host's boot id rides the Hello reply");
+    assertEquals(
         new PtyMessage.Yield("resume-1", "yielded to dispatch 2"),
         roundTrip(new PtyMessage.Yield("resume-1", "yielded to dispatch 2")));
     assertInstanceOf(PtyMessage.TakeWrite.class, roundTrip(new PtyMessage.TakeWrite()));
@@ -139,6 +143,15 @@ class PtyWireTest {
     var reply = Pipe.open();
     evil.sink().write(ByteBuffer.wrap("NOTSAIL1".getBytes(StandardCharsets.US_ASCII)));
     assertThrows(IOException.class, () -> PtyWire.handshake(evil.source(), reply.sink()));
+
+    var v2 = Pipe.open();
+    var v2Reply = Pipe.open();
+    v2.sink().write(ByteBuffer.wrap("SAILPTY2".getBytes(StandardCharsets.US_ASCII)));
+    var skew =
+        assertThrows(IOException.class, () -> PtyWire.handshake(v2.source(), v2Reply.sink()));
+    assertTrue(
+        skew.getMessage().contains("v3"),
+        "a v2 peer predates the boot id and is refused by name: " + skew.getMessage());
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtyWireTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtyWireTest.java
@@ -64,10 +64,22 @@ class PtyWireTest {
                 new PtyMessage.Sessions(
                     List.of(
                         new PtyMessage.SessionInfo(
-                            "a", true, 2, "uday", "design", List.of("claude", "--resume")),
-                        new PtyMessage.SessionInfo("b", false, 0, "", "", List.of("bash", "-l"))),
+                            "a",
+                            "inst-a",
+                            true,
+                            2,
+                            "uday",
+                            "design",
+                            List.of("claude", "--resume")),
+                        new PtyMessage.SessionInfo(
+                            "b", "inst-b", false, 0, "", "", List.of("bash", "-l"))),
                     "b"));
     assertEquals(2, sessions.sessions().size());
+    assertEquals(
+        "inst-a",
+        sessions.sessions().getFirst().instanceId(),
+        "the incarnation id rides the listing beside the reusable name");
+    assertEquals("inst-b", sessions.sessions().getLast().instanceId());
     assertEquals("b", sessions.next(), "the page cursor rides the listing");
     assertEquals("uday", sessions.sessions().getFirst().writerFde());
     assertEquals("design", sessions.sessions().getFirst().room());
@@ -113,7 +125,7 @@ class PtyWireTest {
     var name = "n".repeat(255);
     var page = new java.util.ArrayList<PtyMessage.SessionInfo>();
     for (var i = 0; i < PtyMessage.PAGE_LIMIT; i++) {
-      page.add(new PtyMessage.SessionInfo(name + i, true, 3, name, name, densest));
+      page.add(new PtyMessage.SessionInfo(name + i, name, true, 3, name, name, densest));
     }
 
     var listed = (PtyMessage.Sessions) roundTrip(new PtyMessage.Sessions(page, name));

--- a/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.pty;
 
+import ai.singlr.sail.common.Ids;
 import java.io.IOException;
 import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
@@ -54,6 +55,7 @@ public final class PtySessionHost implements AutoCloseable {
   private final PtyRooms rooms;
   private final PtyEvents events;
   private final Map<String, PtySession> sessions = new ConcurrentHashMap<>();
+  private final String bootId = Ids.newId().toString();
   private volatile ServerSocketChannel server;
   private volatile byte[] dispatchCredential = new byte[0];
   private volatile boolean closed;
@@ -71,6 +73,16 @@ public final class PtySessionHost implements AutoCloseable {
     this.identity = identity;
     this.rooms = rooms;
     this.events = events;
+  }
+
+  /**
+   * This run of the host, minted once at construction: every {@code Hello} is answered with it, so
+   * a client comparing ids across connections can tell "the host restarted and lost the session"
+   * from "the session ended". Sessions do not survive a restart, so the id changing is the one fact
+   * that explains every session the previous run held.
+   */
+  public String bootId() {
+    return bootId;
   }
 
   public void start() throws IOException {
@@ -165,7 +177,7 @@ public final class PtySessionHost implements AutoCloseable {
           reply(channel, new PtyMessage.Err(refused.getMessage()));
           return;
         }
-        reply(channel, new PtyMessage.Ok());
+        reply(channel, new PtyMessage.Welcome(bootId));
       } else {
         reply(channel, new PtyMessage.Err("The first frame must identify you: send Hello."));
         return;

--- a/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
@@ -332,7 +332,12 @@ public final class PtySessionHost implements AutoCloseable {
       Files.deleteIfExists(ring);
       var origin =
           new PtySession.Origin(
-              m.session(), who.fde(), m.project(), room, requestedOrShell(m.command()));
+              m.session(),
+              Ids.newId().toString(),
+              who.fde(),
+              m.project(),
+              room,
+              requestedOrShell(m.command()));
       var env = childEnv(room);
       var session =
           PtySession.start(
@@ -375,6 +380,7 @@ public final class PtySessionHost implements AutoCloseable {
   private static PtyMessage.SessionInfo infoOf(PtySession session) {
     return new PtyMessage.SessionInfo(
         session.name(),
+        session.origin().instanceId(),
         session.live(),
         session.attachedCount(),
         session.writerFde(),

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostChildCommandTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostChildCommandTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 class PtySessionHostChildCommandTest {
 
   private static PtySession.Origin origin(String project, String room, String... command) {
-    return new PtySession.Origin("s", "uday", project, room, List.of(command));
+    return new PtySession.Origin("s", "inst-s", "uday", project, room, List.of(command));
   }
 
   @Test

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.pty;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -684,5 +685,47 @@ class PtySessionHostTest {
         assertEquals(0, host.sessionCount(), "grace elapsed: both reaped");
       }
     }
+  }
+
+  @Test
+  void aRecreatedNameIsANewIncarnationTheListingTellsApartByItsInstanceId() throws Exception {
+    try (var ignored = startHost();
+        var owner = connect()) {
+      PtyWire.write(
+          owner,
+          new PtyMessage.Create("again", List.of("sh", "-c", "exit 0"), "/tmp", "", "", 80, 24));
+      assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(owner));
+      var first = listed(owner, "again");
+      assertFalse(first.instanceId().isBlank(), "an incarnation is minted an id at create");
+
+      var deadline = System.nanoTime() + 5_000_000_000L;
+      while (!events.contains("ended:again") && System.nanoTime() < deadline) {
+        Thread.onSpinWait();
+      }
+      var corpse = listed(owner, "again");
+      assertFalse(corpse.live(), "the child exited: " + events);
+      assertEquals(first.instanceId(), corpse.instanceId(), "a corpse keeps the id it lived under");
+
+      PtyWire.write(
+          owner,
+          new PtyMessage.Create("again", List.of("sh", "-c", "read a"), "/tmp", "", "", 80, 24));
+      assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(owner), "a corpse's name may be reused");
+      var second = listed(owner, "again");
+      assertTrue(second.live());
+      assertNotEquals(
+          first.instanceId(),
+          second.instanceId(),
+          "the reused name is a new incarnation — a client that only saw the corpse of one"
+              + " and the corpse of the other can still tell them apart");
+      PtyWire.write(owner, new PtyMessage.Kill("again"));
+      assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(owner));
+    }
+  }
+
+  private static PtyMessage.SessionInfo listed(SocketChannel channel, String name)
+      throws IOException {
+    PtyWire.write(channel, new PtyMessage.ListSessions("", PtyMessage.PAGE_LIMIT));
+    var listed = (PtyMessage.Sessions) PtyWire.read(channel);
+    return listed.sessions().stream().filter(s -> s.name().equals(name)).findFirst().orElseThrow();
   }
 }

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
@@ -7,6 +7,7 @@ package ai.singlr.sail.pty;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -90,13 +91,29 @@ class PtySessionHostTest {
   private SocketChannel connect(String token) throws IOException {
     var channel = SocketChannel.open(StandardProtocolFamily.UNIX);
     channel.connect(UnixDomainSocketAddress.of(dir.resolve("host.sock")));
-    PtyWire.handshake(channel, channel);
-    PtyWire.write(channel, new PtyMessage.Hello(token));
-    var reply = PtyWire.read(channel);
+    var reply = hello(channel, token);
     if (reply instanceof PtyMessage.Err(var message)) {
       throw new IOException(message);
     }
     return channel;
+  }
+
+  private static PtyMessage hello(SocketChannel channel, String token) throws IOException {
+    PtyWire.handshake(channel, channel);
+    PtyWire.write(channel, new PtyMessage.Hello(token));
+    return PtyWire.read(channel);
+  }
+
+  private String welcome() throws IOException {
+    var channel = SocketChannel.open(StandardProtocolFamily.UNIX);
+    channel.connect(UnixDomainSocketAddress.of(dir.resolve("host.sock")));
+    try (channel) {
+      var reply = hello(channel, "tok-uday");
+      if (!(reply instanceof PtyMessage.Welcome(var hostBootId))) {
+        throw new AssertionError("Hello was not answered with Welcome: " + reply);
+      }
+      return hostBootId;
+    }
   }
 
   private static PtyMessage awaitText(SocketChannel channel, String marker) throws IOException {
@@ -112,6 +129,23 @@ class PtySessionHostTest {
       if (message instanceof PtyMessage.SessionEnded ended) {
         throw new AssertionError("session ended before '" + marker + "': " + seen);
       }
+    }
+  }
+
+  @Test
+  void helloIsAnsweredWithTheHostsBootIdWhichEveryConnectionSharesAndARestartChanges()
+      throws Exception {
+    String first;
+    try (var started = startHost()) {
+      first = welcome();
+      assertEquals(started.bootId(), first, "the Hello reply carries this host's boot id");
+      assertEquals(first, welcome(), "every connection to one host sees the same id");
+      assertTrue(!first.isBlank(), "a boot id is never blank");
+    }
+    try (var restarted = startHost()) {
+      var second = welcome();
+      assertEquals(restarted.bootId(), second);
+      assertNotEquals(first, second, "a restarted host is a new boot: the id changes");
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostEvents.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostEvents.java
@@ -66,6 +66,7 @@ final class PtyHostEvents implements PtyEvents {
   private static Map<String, Object> dataFor(PtySession.Origin origin) {
     var data = new LinkedHashMap<String, Object>();
     data.put("session", origin.name());
+    data.put("instance_id", origin.instanceId());
     if (origin.roomBound()) {
       data.put("room_id", origin.room());
     }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SessionClient.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SessionClient.java
@@ -19,9 +19,15 @@ import java.util.List;
 public final class SessionClient implements AutoCloseable {
 
   private final SocketChannel channel;
+  private String hostBootId = "";
 
   private SessionClient(SocketChannel channel) {
     this.channel = channel;
+  }
+
+  /** The boot id the host welcomed this connection with — see {@link PtyMessage.Welcome}. */
+  public String hostBootId() {
+    return hostBootId;
   }
 
   public static SessionClient connect(Path socket) throws IOException {
@@ -41,8 +47,19 @@ public final class SessionClient implements AutoCloseable {
     }
     var client = new SessionClient(channel);
     PtyWire.write(channel, new PtyMessage.Hello(token));
-    client.expectOk("hello");
+    client.hostBootId = client.expectWelcome();
     return client;
+  }
+
+  private String expectWelcome() throws IOException {
+    var reply = PtyWire.read(channel);
+    if (reply instanceof PtyMessage.Err(var message)) {
+      throw new IOException(message);
+    }
+    if (!(reply instanceof PtyMessage.Welcome(var bootId))) {
+      throw new IOException("Unexpected host reply to hello: " + reply.getClass());
+    }
+    return bootId;
   }
 
   public void create(

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/SessionCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/SessionCommand.java
@@ -92,6 +92,7 @@ public final class SessionCommand {
 
     record Listing(
         int schemaVersion,
+        String hostBootId,
         List<ai.singlr.sail.pty.PtyMessage.SessionInfo> sessions,
         PtyEventDrops.Drops eventDrops) {}
 
@@ -102,7 +103,8 @@ public final class SessionCommand {
         var sessions = client.list();
         if (json) {
           var drops = PtyEventDrops.read(PtyEventDrops.fileOf(socketPath));
-          System.out.println(CliJson.stringify(new Listing(1, sessions, drops)));
+          System.out.println(
+              CliJson.stringify(new Listing(1, client.hostBootId(), sessions, drops)));
           return 0;
         }
         if (sessions.isEmpty()) {

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyHostEventsTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyHostEventsTest.java
@@ -49,7 +49,8 @@ class PtyHostEventsTest {
   void theThreeSessionFactsBecomeRecordClassRows() {
     var path = migrated();
     var events = events(path);
-    var origin = new PtySession.Origin("lounge", "uday", "acme", "", List.of("bash", "-l"));
+    var origin =
+        new PtySession.Origin("lounge", "inst-lounge-1", "uday", "acme", "", List.of("bash", "-l"));
 
     events.sessionStarted(origin);
     events.sessionAttached(origin, "mady");
@@ -57,6 +58,14 @@ class PtyHostEventsTest {
 
     var recent = recent(path);
     assertEquals(3, recent.size());
+    for (var row : recent) {
+      assertEquals(
+          "inst-lounge-1",
+          YamlUtil.parseMap(row.data()).get("instance_id"),
+          row.type()
+              + " names the incarnation, so a reader can tell this life of the name from the"
+              + " next one");
+    }
     assertTrue(
         recent.stream()
             .anyMatch(
@@ -87,6 +96,7 @@ class PtyHostEventsTest {
     var origin =
         new PtySession.Origin(
             "brainstorm",
+            "inst-brainstorm-1",
             "uday",
             "acme",
             "design-talk",
@@ -126,7 +136,8 @@ class PtyHostEventsTest {
   @Test
   void aCleanRunLeavesNoDropMeter() {
     var events = events(migrated());
-    var origin = new PtySession.Origin("clean", "uday", "acme", "", List.of("bash", "-l"));
+    var origin =
+        new PtySession.Origin("clean", "inst-clean-1", "uday", "acme", "", List.of("bash", "-l"));
 
     events.sessionStarted(origin);
 
@@ -137,7 +148,8 @@ class PtyHostEventsTest {
   void anInducedInsertFailureIsMeasuredNotThrown() {
     var unmigrated = dir.resolve("unmigrated.db");
     var events = events(unmigrated);
-    var origin = new PtySession.Origin("lounge", "uday", "acme", "", List.of("bash", "-l"));
+    var origin =
+        new PtySession.Origin("lounge", "inst-lounge-2", "uday", "acme", "", List.of("bash", "-l"));
     var stderr = new java.io.ByteArrayOutputStream();
     var original = System.err;
     System.setErr(new java.io.PrintStream(stderr, true, java.nio.charset.StandardCharsets.UTF_8));

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyLifecycleIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyLifecycleIT.java
@@ -6,12 +6,14 @@
 package ai.singlr.sail.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.engine.AbstractIncusIT;
 import ai.singlr.sail.pty.PtyEvents;
 import ai.singlr.sail.pty.PtyIdentity;
+import ai.singlr.sail.pty.PtyMessage;
 import ai.singlr.sail.pty.PtyRooms;
 import ai.singlr.sail.pty.PtySessionHost;
 import java.io.ByteArrayOutputStream;
@@ -47,6 +49,10 @@ class PtyLifecycleIT extends AbstractIncusIT {
     return host;
   }
 
+  private static PtyMessage.SessionInfo listed(SessionClient client, String name) throws Exception {
+    return client.list().stream().filter(s -> s.name().equals(name)).findFirst().orElseThrow();
+  }
+
   private void prepareDevWorkspace(String container) throws Exception {
     var prepared =
         exec(
@@ -66,6 +72,9 @@ class PtyLifecycleIT extends AbstractIncusIT {
       try (var host = startHost();
           var client = SessionClient.connect(dir.resolve("h.sock"))) {
         client.create("c1", List.of("sh", "-c", "read a; exit 3"), "/tmp", container, "", 80, 24);
+        var born = listed(client, "c1");
+        assertTrue(born.live());
+        assertFalse(born.instanceId().isBlank(), "every incarnation is minted an id at create");
         var channel = client.attach("c1", true);
 
         var stdinFeed = new PipedOutputStream();
@@ -80,9 +89,15 @@ class PtyLifecycleIT extends AbstractIncusIT {
             reason,
             "the ending frame carries the child's exit status; a bare EOF would read as"
                 + " 'connection closed' and the client would retry a session that is gone");
-        assertTrue(
-            client.list().stream().anyMatch(s -> s.name().equals("c1") && !s.live()),
+        var corpse = listed(client, "c1");
+        assertFalse(
+            corpse.live(),
             "the corpse stays listed as ended so a later listing explains the absence");
+        assertEquals(
+            born.instanceId(),
+            corpse.instanceId(),
+            "the corpse is the same incarnation the client watched live — a client keyed on the"
+                + " id can tell it from a replacement that dies before anyone sees it run");
       }
     } finally {
       deleteContainerQuietly(container);

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyLifecycleIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyLifecycleIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.singlr.sail.engine.AbstractIncusIT;
+import ai.singlr.sail.pty.PtyEvents;
+import ai.singlr.sail.pty.PtyIdentity;
+import ai.singlr.sail.pty.PtyRooms;
+import ai.singlr.sail.pty.PtySessionHost;
+import java.io.ByteArrayOutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Pins the two lifecycle facts a terminal client builds its ended-versus-lost verdict on, against a
+ * real container child: a clean {@code exit} reaches an attached client as {@code SessionEnded}
+ * before the channel goes quiet (never as a bare EOF the client would misread as a link drop), and
+ * a host restart is detectable by the boot id every connection is welcomed with — the sessions the
+ * previous run held are gone from the listing and the id has changed. Self-cleaning.
+ */
+class PtyLifecycleIT extends AbstractIncusIT {
+
+  @TempDir Path dir;
+
+  private PtySessionHost startHost() throws Exception {
+    var host =
+        new PtySessionHost(
+            dir.resolve("h.sock"),
+            dir.resolve("s"),
+            64 * 1024,
+            token -> new PtyIdentity("uday", true),
+            PtyRooms.NONE,
+            PtyEvents.NONE);
+    host.start();
+    return host;
+  }
+
+  private void prepareDevWorkspace(String container) throws Exception {
+    var prepared =
+        exec(
+            container,
+            List.of("bash", "-c", "mkdir -p /home/dev/workspace && chown -R 1000:1000 /home/dev"));
+    assertTrue(prepared.ok(), "could not prepare the dev workspace: " + prepared.stderr());
+  }
+
+  @Test
+  void aCleanExitInsideTheContainerReachesAnAttachedClientAsSessionEndedNotEof() throws Exception {
+    ensureIncusOrSkip();
+    var container = "sail-it-pty-exit";
+    try {
+      launch(container);
+      prepareDevWorkspace(container);
+
+      try (var host = startHost();
+          var client = SessionClient.connect(dir.resolve("h.sock"))) {
+        client.create("c1", List.of("sh", "-c", "read a; exit 3"), "/tmp", container, "", 80, 24);
+        var channel = client.attach("c1", true);
+
+        var stdinFeed = new PipedOutputStream();
+        var stdin = new PipedInputStream(stdinFeed);
+        stdinFeed.write("go\n".getBytes(StandardCharsets.UTF_8));
+        stdinFeed.flush();
+
+        var reason = AttachLoop.run(channel, stdin, new ByteArrayOutputStream());
+
+        assertEquals(
+            "exited(3)",
+            reason,
+            "the ending frame carries the child's exit status; a bare EOF would read as"
+                + " 'connection closed' and the client would retry a session that is gone");
+        assertTrue(
+            client.list().stream().anyMatch(s -> s.name().equals("c1") && !s.live()),
+            "the corpse stays listed as ended so a later listing explains the absence");
+      }
+    } finally {
+      deleteContainerQuietly(container);
+    }
+  }
+
+  @Test
+  void aHostRestartChangesTheBootIdAndDropsTheSessionsThePreviousRunHeld() throws Exception {
+    ensureIncusOrSkip();
+    var container = "sail-it-pty-reboot";
+    try {
+      launch(container);
+      prepareDevWorkspace(container);
+
+      String firstBoot;
+      try (var host = startHost();
+          var client = SessionClient.connect(dir.resolve("h.sock"))) {
+        client.create("c1", List.of("sh", "-c", "read a"), "/tmp", container, "", 80, 24);
+        firstBoot = client.hostBootId();
+        assertEquals(host.bootId(), firstBoot);
+        assertTrue(client.list().stream().anyMatch(s -> s.name().equals("c1") && s.live()));
+      }
+
+      try (var restarted = startHost();
+          var client = SessionClient.connect(dir.resolve("h.sock"))) {
+        assertNotEquals(firstBoot, client.hostBootId(), "a restart is a new boot id");
+        assertEquals(restarted.bootId(), client.hostBootId());
+        assertTrue(
+            client.list().stream().noneMatch(s -> s.name().equals("c1")),
+            "the previous run's session is absent — together with the changed id, that is"
+                + " 'host restarted', not 'it died'");
+      }
+    } finally {
+      deleteContainerQuietly(container);
+    }
+  }
+}


### PR DESCRIPTION
Spec: `mast-terminal-lifecycle` (Brick B). Pairs with standardapplied/mast#93 (Bricks A + C); the two release together, **sail first** — Mast now speaks SAILPTY3 and renders the "box's sail is older" skew card against a v2 host, while an older Mast against this host renders "Mast is older".

## What changes

- **`Hello` is answered with `Welcome(hostBootId)`** (wire type 32) instead of `Ok`. The id is minted once per run of the host process (`PtySessionHost.bootId()`), identical on every connection until the host restarts. A client that remembers the id a session was last seen under can tell "the host restarted and lost it" from "it ended" — the fact Mast needs to explain an absent pane instead of recreating it or retrying into a link that is fine. Served only after identity, never before; nothing widens who may attach or kill.
- **SAILPTY3.** The handshake magic bumps so a v2 peer is refused by name rather than choking on the new reply.
- `SessionClient.hostBootId()`; `sail session ls --json` carries `host_boot_id`. CHANGELOG entry under Unreleased.
- **Every session incarnation has an id (review round 5).** `PtySession.Origin` gains `instanceId`, minted per create (`Ids.newId()`) and never reused; it rides `SessionInfo` on the wire (still SAILPTY3 — unreleased), `sail session ls --json`, and the `instance_id` of every `pty_session_started/attached/ended` event. A client that only ever saw two corpses of one name can tell which life each belonged to — the fact Mast's ended cards now settle their reason on, instead of the name's newest event.

## Tests (red-first)

- `PtyWireTest`: `Welcome` round-trips; a `SAILPTY2` peer is refused naming v3.
- `PtySessionHostTest`: every connection to one host sees the same boot id, and a restarted host on the same socket answers a different one.
- `PtyWireTest`: `SessionInfo.instanceId` round-trips. `PtySessionHostTest`: a recreated name lists under a new instance id while its corpse kept the old one. `PtyHostEventsTest`: every row's data names its `instance_id`.
- `PtyLifecycleIT` (Incus lane): (a) `exit 3` inside a container reaches the attached client as `SessionEnded("exited(3)")` before EOF — never "connection closed" — and the corpse stays listed under the instance id it lived under; (b) a host restart changes the boot id and drops the sessions the previous run held.

Fail-open discipline unchanged.
