### PR TITLE
fix: --json verbs no longer die in the native binary on record reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **Fix: `sail session ls --json` and `sail dispatch --json` died in the native binary** with a
+  GraalVM unsupported-feature error (record components unavailable for reflection) — the records
+  `CliJson` prints were never registered for reflection, and only the JVM tests exercised them.
+  They are registered now, and `_pty-selftest` (the release smoke test) stringifies one of each
+  on every platform so a future `--json` record cannot ship unregistered.
+
 - **Breaking (pty wire): SAILPTY3.** The session host answers an admitted `Hello` with `Welcome`
   carrying its boot id — a fresh id per run of the host process, the same on every connection
   until the host restarts — so a terminal client that remembers the id a session was last seen

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PtySelfTestCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PtySelfTestCommand.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.commands;
 
 import ai.singlr.sail.pty.Pty;
+import ai.singlr.sail.pty.PtyMessage;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -13,17 +14,41 @@ import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 
 /**
- * A native-image self-check for the FFM pty layer: opens a real pty, spawns a trivial child, and
- * resizes it. Opening the pty forces {@link Pty}'s static initializer, which builds every libc
- * downcall handle — so a missing foreign registration (which fails only in the GraalVM native
- * binary, never the JVM unit tests) is caught by the release smoke test rather than by a user. A
- * no-op on non-Linux, where the pty host never runs.
+ * A native-image self-check for the layers that only fail in the GraalVM binary, never in the JVM
+ * unit tests, so the release smoke test catches them rather than a user.
+ *
+ * <p>The FFM pty layer: opens a real pty, spawns a trivial child, and resizes it. Opening the pty
+ * forces {@link Pty}'s static initializer, which builds every libc downcall handle — a missing
+ * foreign registration surfaces here. A no-op on non-Linux, where the pty host never runs.
+ *
+ * <p>The CLI JSON layer: {@link CliJson} reads record components reflectively, and a record it
+ * serializes that is missing from the reflection configuration dies in the native binary with an
+ * unsupported-feature error (the {@code sail session ls --json} field failure). Every record a
+ * {@code --json} verb prints is stringified here on every platform.
  */
-@Command(name = "_pty-selftest", description = "Internal: verify the pty FFM layer.", hidden = true)
+@Command(
+    name = "_pty-selftest",
+    description = "Internal: verify the pty FFM layer and CLI JSON reflection.",
+    hidden = true)
 public final class PtySelfTestCommand implements Callable<Integer> {
+
+  static final List<String> JSON_KEYS =
+      List.of("host_boot_id", "instance_id", "event_drops", "spec_title", "dispatched");
 
   @Override
   public Integer call() {
+    try {
+      var json = jsonProbe();
+      for (var key : JSON_KEYS) {
+        if (!json.contains("\"" + key + "\"")) {
+          throw new IllegalStateException("CLI JSON lost the key '" + key + "': " + json);
+        }
+      }
+      System.out.println("json-selftest: ok");
+    } catch (Throwable e) {
+      System.err.println("json-selftest: FAILED: " + e);
+      return 1;
+    }
     if (!System.getProperty("os.name", "").toLowerCase(java.util.Locale.ROOT).contains("linux")) {
       System.out.println("pty-selftest: skipped (non-Linux)");
       return 0;
@@ -38,5 +63,15 @@ public final class PtySelfTestCommand implements Callable<Integer> {
       System.err.println("pty-selftest: FAILED: " + e);
       return 1;
     }
+  }
+
+  /** Stringifies one instance of every record a {@code --json} verb prints. */
+  static String jsonProbe() {
+    var info =
+        new PtyMessage.SessionInfo("probe", "instance", true, 0, "fde", "", List.of("bash", "-l"));
+    var listing = new SessionCommand.Ls.Listing(1, "boot", List.of(info), PtyEventDrops.Drops.NONE);
+    var preview = new DispatchCommand.DispatchPreview("box", "spec", "title", "foreground", "task");
+    var idle = new DispatchCommand.NoDispatch("box", false, "no_pending_specs");
+    return CliJson.stringify(List.of(listing, preview, idle));
   }
 }

--- a/sail-infra/src/main/resources/META-INF/native-image/ai.singlr/sail-cli/reflect-config.json
+++ b/sail-infra/src/main/resources/META-INF/native-image/ai.singlr/sail-cli/reflect-config.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "ai.singlr.sail.commands.SessionCommand$Ls$Listing",
+    "allDeclaredMethods": true,
+    "allRecordComponents": true
+  },
+  {
+    "name": "ai.singlr.sail.pty.PtyMessage$SessionInfo",
+    "allDeclaredMethods": true,
+    "allRecordComponents": true
+  },
+  {
+    "name": "ai.singlr.sail.commands.PtyEventDrops$Drops",
+    "allDeclaredMethods": true,
+    "allRecordComponents": true
+  },
+  {
+    "name": "ai.singlr.sail.commands.DispatchCommand$DispatchPreview",
+    "allDeclaredMethods": true,
+    "allRecordComponents": true
+  },
+  {
+    "name": "ai.singlr.sail.commands.DispatchCommand$NoDispatch",
+    "allDeclaredMethods": true,
+    "allRecordComponents": true
+  }
+]

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtySelfTestCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtySelfTestCommandTest.java
@@ -6,16 +6,25 @@
 package ai.singlr.sail.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-@EnabledOnOs(OS.LINUX)
 class PtySelfTestCommandTest {
 
   @Test
+  @EnabledOnOs(OS.LINUX)
   void openingARealPtySucceeds() {
     assertEquals(0, new PtySelfTestCommand().call(), "the pty FFM layer initializes and works");
+  }
+
+  @Test
+  void theJsonProbeCoversEveryJsonVerbsRecord() {
+    var json = PtySelfTestCommand.jsonProbe();
+    for (var key : PtySelfTestCommand.JSON_KEYS) {
+      assertTrue(json.contains("\"" + key + "\""), "expected '" + key + "' in " + json);
+    }
   }
 }


### PR DESCRIPTION
## Why

Field report on sail 0.39.0 (2026-09-04): `sail session ls --json` dies in the native binary with `UnsupportedFeatureError: Record components not available for record class ai.singlr.sail.commands.SessionCommand$Ls$Listing`. `CliJson` reads record components reflectively, and none of the records it prints were ever registered for reflection — `sail dispatch --json` has the same hole. Only the JVM unit tests exercised them, so the gap never showed before a user ran the native binary.

## What

- `reflect-config.json` registers every record a `--json` verb prints (`Listing`, `SessionInfo`, `Drops`, `DispatchPreview`, `NoDispatch`).
- `_pty-selftest` — already the release smoke test on the native binary, Linux and macOS — now stringifies one of each record on every platform before the pty check, so an unregistered `--json` record fails the release build instead of the field.
- CHANGELOG entry.

## Gates

- `mvn -pl sail-infra -am verify` green (unit + coverage); the native smoke runs on CI.
