### PR TITLE
pty: the session's child learns what terminal it is in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Pty sessions tell programs what terminal they are in.** The child of every host-owned session
+  now inherits `COLORTERM=truecolor`, `TERM_PROGRAM=mast` and `TERM_PROGRAM_VERSION=<sail
+  version>` beside `TERM=xterm-256color` (which stays: containers ship no other terminfo), so
+  agent TUIs detect truecolor and identify the host without probing.
+
 ## 0.39.1
 
 - **Fix: `sail session ls --json` and `sail dispatch --json` died in the native binary** with a

--- a/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
@@ -54,6 +54,7 @@ public final class PtySessionHost implements AutoCloseable {
   private final PtyIdentity.Resolver identity;
   private final PtyRooms rooms;
   private final PtyEvents events;
+  private final String version;
   private final Map<String, PtySession> sessions = new ConcurrentHashMap<>();
   private final String bootId = Ids.newId().toString();
   private volatile ServerSocketChannel server;
@@ -66,13 +67,15 @@ public final class PtySessionHost implements AutoCloseable {
       long journalCapacity,
       PtyIdentity.Resolver identity,
       PtyRooms rooms,
-      PtyEvents events) {
+      PtyEvents events,
+      String version) {
     this.socketPath = socketPath;
     this.sessionsDir = sessionsDir;
     this.journalCapacity = journalCapacity;
     this.identity = identity;
     this.rooms = rooms;
     this.events = events;
+    this.version = version;
   }
 
   /**
@@ -267,13 +270,19 @@ public final class PtySessionHost implements AutoCloseable {
   }
 
   /**
-   * The environment a session's child inherits: a terminal type, plus {@code SAIL_ROOM_ID} when the
-   * session is room-bound — the one fact that lets everything the child creates ({@code spec
-   * create} above all) land in the room the session serves.
+   * The environment a session's child inherits: what terminal it is in ({@code TERM} stays {@code
+   * xterm-256color} because containers ship no other terminfo; {@code COLORTERM}, {@code
+   * TERM_PROGRAM} and {@code TERM_PROGRAM_VERSION} say truecolor, Mast, and this host's version so
+   * programs stop probing), plus {@code SAIL_ROOM_ID} when the session is room-bound — the one fact
+   * that lets everything the child creates ({@code spec create} above all) land in the room the
+   * session serves.
    */
-  static Map<String, String> childEnv(String room) {
+  static Map<String, String> childEnv(String room, String version) {
     var env = new java.util.LinkedHashMap<String, String>();
     env.put("TERM", "xterm-256color");
+    env.put("COLORTERM", "truecolor");
+    env.put("TERM_PROGRAM", "mast");
+    env.put("TERM_PROGRAM_VERSION", version);
     if (room != null && !room.isBlank()) {
       env.put("SAIL_ROOM_ID", room);
     }
@@ -338,7 +347,7 @@ public final class PtySessionHost implements AutoCloseable {
               m.project(),
               room,
               requestedOrShell(m.command()));
-      var env = childEnv(room);
+      var env = childEnv(room, version);
       var session =
           PtySession.start(
               origin,

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostChildCommandTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostChildCommandTest.java
@@ -36,13 +36,17 @@ class PtySessionHostChildCommandTest {
   @Test
   void aProjectSessionWrapsTheCommandInTheDevUserTtyExecLane() {
     var command =
-        PtySessionHost.childCommand(origin("acme", "", "bash", "-l"), PtySessionHost.childEnv(""));
+        PtySessionHost.childCommand(
+            origin("acme", "", "bash", "-l"), PtySessionHost.childEnv("", "0.39.2"));
 
     assertEquals("incus", command.getFirst());
     assertTrue(command.contains("-t"), "a container session needs its own tty");
     assertTrue(command.contains("acme"));
     assertTrue(command.containsAll(List.of("bash", "-l")), "the default is a login shell");
     assertTrue(command.contains("TERM=xterm-256color"), "the terminal type crosses explicitly");
+    assertTrue(command.contains("COLORTERM=truecolor"), "truecolor is declared, not probed");
+    assertTrue(command.contains("TERM_PROGRAM=mast"), command.toString());
+    assertTrue(command.contains("TERM_PROGRAM_VERSION=0.39.2"), command.toString());
     assertFalse(
         command.stream().anyMatch(arg -> arg.startsWith("SAIL_ROOM_ID=")),
         "an unbound session exports no room: " + command);
@@ -50,13 +54,24 @@ class PtySessionHostChildCommandTest {
 
   @Test
   void aRoomBoundProjectSessionCarriesTheRoomIntoTheContainer() {
-    var env = PtySessionHost.childEnv("design-talk");
+    var env = PtySessionHost.childEnv("design-talk", "0.39.2");
     var command = PtySessionHost.childCommand(origin("acme", "design-talk", "claude"), env);
 
     assertEquals("design-talk", env.get("SAIL_ROOM_ID"));
     assertTrue(command.contains("SAIL_ROOM_ID=design-talk"), command.toString());
     assertEquals("--env", command.get(command.indexOf("SAIL_ROOM_ID=design-talk") - 1));
     assertEquals("claude", command.getLast());
+  }
+
+  @Test
+  void theChildLearnsWhatTerminalItIsIn() {
+    var env = PtySessionHost.childEnv("", "0.39.2");
+
+    assertEquals("xterm-256color", env.get("TERM"), "containers ship no other terminfo");
+    assertEquals("truecolor", env.get("COLORTERM"));
+    assertEquals("mast", env.get("TERM_PROGRAM"));
+    assertEquals("0.39.2", env.get("TERM_PROGRAM_VERSION"));
+    assertFalse(env.containsKey("SAIL_ROOM_ID"));
   }
 
   @Test

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
@@ -76,7 +76,8 @@ class PtySessionHostTest {
               public void sessionEnded(PtySession.Origin origin, String reason) {
                 events.add("ended:" + origin.name());
               }
-            });
+            },
+            "0.0.0-test");
     host.start();
     return host;
   }

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySocketPermissionsTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySocketPermissionsTest.java
@@ -40,7 +40,8 @@ class PtySocketPermissionsTest {
             64 * 1024,
             token -> new PtyIdentity("uday", true),
             PtyRooms.NONE,
-            PtyEvents.NONE)) {
+            PtyEvents.NONE,
+            "0.0.0-test")) {
       host.start();
 
       assertGroupAndOtherDenied(Files.getPosixFilePermissions(socket), "socket");

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/PtyHostCommand.java
@@ -5,6 +5,7 @@
 
 package ai.singlr.sail.commands;
 
+import ai.singlr.sail.SailVersion;
 import ai.singlr.sail.engine.SailPaths;
 import ai.singlr.sail.pty.PtySessionHost;
 import java.util.concurrent.Callable;
@@ -51,7 +52,9 @@ public final class PtyHostCommand implements Callable<Integer> {
       ai.singlr.sail.pty.PtyRooms rooms,
       ai.singlr.sail.pty.PtyEvents events)
       throws java.io.IOException {
-    var host = new PtySessionHost(socket, sessions, JOURNAL_CAPACITY, identity, rooms, events);
+    var host =
+        new PtySessionHost(
+            socket, sessions, JOURNAL_CAPACITY, identity, rooms, events, SailVersion.version());
     host.start();
     Thread.ofVirtual()
         .start(

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AgentResumeSessionIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AgentResumeSessionIT.java
@@ -89,7 +89,8 @@ class AgentResumeSessionIT extends AbstractIncusIT {
               64 * 1024,
               token -> new PtyIdentity("it", true),
               new PtyHostRooms(dbPath),
-              new PtyHostEvents(dbPath, dir.resolve("pty-events.drops")))) {
+              new PtyHostEvents(dbPath, dir.resolve("pty-events.drops")),
+              "0.0.0-test")) {
         host.start();
         launchPrepared(CONTAINER);
         installDevUserAndStandInClaude();

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
@@ -35,7 +35,8 @@ class AttachLoopTest {
             64 * 1024,
             token -> new ai.singlr.sail.pty.PtyIdentity("uday", true),
             ai.singlr.sail.pty.PtyRooms.NONE,
-            ai.singlr.sail.pty.PtyEvents.NONE)) {
+            ai.singlr.sail.pty.PtyEvents.NONE,
+            "0.0.0-test")) {
       host.start();
       try (var client = SessionClient.connect(dir.resolve("h.sock"))) {
         client.create(
@@ -65,7 +66,8 @@ class AttachLoopTest {
             64 * 1024,
             token -> new ai.singlr.sail.pty.PtyIdentity("uday", true),
             ai.singlr.sail.pty.PtyRooms.NONE,
-            ai.singlr.sail.pty.PtyEvents.NONE)) {
+            ai.singlr.sail.pty.PtyEvents.NONE,
+            "0.0.0-test")) {
       host.start();
       try (var client = SessionClient.connect(dir.resolve("h.sock"))) {
         client.create("s1", List.of("sh", "-c", "read a; echo after:$a"), "/tmp", "", "", 80, 24);
@@ -94,7 +96,8 @@ class AttachLoopTest {
             64 * 1024,
             token -> new ai.singlr.sail.pty.PtyIdentity("uday", true),
             ai.singlr.sail.pty.PtyRooms.NONE,
-            ai.singlr.sail.pty.PtyEvents.NONE)) {
+            ai.singlr.sail.pty.PtyEvents.NONE,
+            "0.0.0-test")) {
       host.start();
       try (var client = SessionClient.connect(dir.resolve("h.sock"))) {
         client.create(

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyContainerSessionIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyContainerSessionIT.java
@@ -43,7 +43,8 @@ class PtyContainerSessionIT extends AbstractIncusIT {
             64 * 1024,
             token -> new PtyIdentity("uday", true),
             PtyRooms.NONE,
-            PtyEvents.NONE);
+            PtyEvents.NONE,
+            "0.0.0-test");
     host.start();
     return host;
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyLifecycleIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyLifecycleIT.java
@@ -44,7 +44,8 @@ class PtyLifecycleIT extends AbstractIncusIT {
             64 * 1024,
             token -> new PtyIdentity("uday", true),
             PtyRooms.NONE,
-            PtyEvents.NONE);
+            PtyEvents.NONE,
+            "0.0.0-test");
     host.start();
     return host;
   }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/PtyRoomSessionIT.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/PtyRoomSessionIT.java
@@ -107,7 +107,8 @@ class PtyRoomSessionIT extends AbstractIncusIT {
                   64 * 1024,
                   token -> new PtyIdentity(token.isBlank() ? "it" : "mady", true),
                   new PtyHostRooms(dbPath),
-                  new PtyHostEvents(dbPath, dir.resolve("pty-events.drops")))) {
+                  new PtyHostEvents(dbPath, dir.resolve("pty-events.drops")),
+                  "0.0.0-test")) {
         api.start();
         host.start();
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/SessionClientTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/SessionClientTest.java
@@ -32,7 +32,8 @@ class SessionClientTest {
             64 * 1024,
             token -> new ai.singlr.sail.pty.PtyIdentity("uday", true),
             (room, project, who) -> {},
-            ai.singlr.sail.pty.PtyEvents.NONE)) {
+            ai.singlr.sail.pty.PtyEvents.NONE,
+            "0.0.0-test")) {
       host.start();
       try (var client = SessionClient.connect(dir.resolve("h.sock"))) {
         client.create("s1", List.of("sh", "-c", "read a"), "/tmp", "", "lounge", 80, 24);


### PR DESCRIPTION
Spec `sail-pty-child-env` (Brick 6 of the terminal fidelity plan).

## Why

Agent TUIs read `COLORTERM`, `TERM_PROGRAM` and `TERM_PROGRAM_VERSION` to decide on truecolor and to identify the host. The pty host set only `TERM`, so programs probed or assumed the worst.

## What

The child of every host-owned session now inherits `COLORTERM=truecolor`, `TERM_PROGRAM=mast` and `TERM_PROGRAM_VERSION=<this host's sail version>` beside `TERM=xterm-256color`, which stays because containers ship no other terminfo. The host takes its version at construction (`PtyHostCommand` passes `SailVersion.version()`); `childEnv(room, version)` remains the one place the child's environment is assembled, and the incus exec lane carries every entry explicitly as before.

## Tests

`PtySessionHostChildCommandTest` pins the environment and its crossing into the `incus exec` lane; every host construction in tests names a version. `mvn clean verify` green locally.

No wire change, no lockstep with Mast. Applies to sessions created after the pty host restarts on `sail upgrade`.
