### PR TITLE
pty: an attach replays everything the journal holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **An attach replays everything the journal holds.** The pty host used to replay at most 256 KB of a
+  session's 4 MB journal on attach and on a flow-control resync, because the tail crossed as one
+  frame and the wire refuses frames over 1 MiB. The tail now crosses as a run of `Output` frames of at
+  most 256 KiB inside the same `ReplayBegin`/`ReplayEnd` bracket, so a client that reconnects (a Mast
+  relaunch) sees the whole history the host has. No wire change.
+
 - **Pty sessions tell programs what terminal they are in.** The child of every host-owned session
   now inherits `COLORTERM=truecolor`, `TERM_PROGRAM=mast` and `TERM_PROGRAM_VERSION=<sail
   version>` beside `TERM=xterm-256color` (which stays: containers ship no other terminfo), so

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -180,7 +180,7 @@ public final class PtySession implements AutoCloseable {
           journal.append(buf, n);
           boundary.feed(buf, n);
           if (boundary.atSafeLineStart()) {
-            journal.markSafe(Math.max(0, journal.totalWritten() - replayMax));
+            journal.markSafe();
           }
           var chunk = new byte[n];
           System.arraycopy(buf, 0, chunk, 0, n);

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -73,7 +73,13 @@ public final class PtySession implements AutoCloseable {
   private final RingJournal journal;
   private final TermBoundary boundary = new TermBoundary();
   private final int queueCapacity;
+
+  /** A replayed journal crosses the wire in frames this large — well under the 1 MiB frame cap. */
+  static final int REPLAY_CHUNK = 256 * 1024;
+
+  /** The replay window: everything the journal holds. */
   private final int replayMax;
+
   private final Map<Long, Subscriber> subscribers = new ConcurrentHashMap<>();
   private final Object fanout = new Object();
   private final AtomicLong subscriberIds = new AtomicLong();
@@ -93,15 +99,14 @@ public final class PtySession implements AutoCloseable {
       Pty pty,
       Process child,
       RingJournal journal,
-      int queueCapacity,
-      int replayMax) {
+      int queueCapacity) {
     this.origin = origin;
     this.events = events;
     this.pty = pty;
     this.child = child;
     this.journal = journal;
     this.queueCapacity = queueCapacity;
-    this.replayMax = replayMax;
+    this.replayMax = (int) Math.min(journal.capacity(), Integer.MAX_VALUE);
   }
 
   /**
@@ -119,8 +124,7 @@ public final class PtySession implements AutoCloseable {
       int cols,
       int rows)
       throws IOException {
-    return start(
-        origin, events, argv, env, cwd, journalPath, journalCapacity, cols, rows, 4096, 262_144);
+    return start(origin, events, argv, env, cwd, journalPath, journalCapacity, cols, rows, 4096);
   }
 
   static PtySession start(
@@ -133,8 +137,7 @@ public final class PtySession implements AutoCloseable {
       long journalCapacity,
       int cols,
       int rows,
-      int queueCapacity,
-      int replayMax)
+      int queueCapacity)
       throws IOException {
     var journal = RingJournal.open(journalPath, journalCapacity);
     var pty = Pty.open(cols, rows);
@@ -146,7 +149,7 @@ public final class PtySession implements AutoCloseable {
       journal.close();
       throw e;
     }
-    var session = new PtySession(origin, events, pty, child, journal, queueCapacity, replayMax);
+    var session = new PtySession(origin, events, pty, child, journal, queueCapacity);
     Thread.ofPlatform().name("pty-gather-" + origin.name()).start(session::gather);
     emitQuietly(() -> events.sessionStarted(origin));
     return session;
@@ -214,18 +217,32 @@ public final class PtySession implements AutoCloseable {
   private void resync(Subscriber subscriber) {
     synchronized (fanout) {
       try {
-        var tail = journal.tail(replayMax);
-        var messages = new java.util.ArrayList<PtyMessage>(3);
-        messages.add(new PtyMessage.ReplayBegin(tail.safe()));
-        if (tail.bytes().length > 0) {
-          messages.add(new PtyMessage.Output(lastInputSeq.get(), tail.bytes()));
-        }
-        messages.add(new PtyMessage.ReplayEnd());
-        subscriber.queue().replaceWith(List.copyOf(messages));
+        subscriber.queue().replaceWith(replayMessages());
       } catch (IOException e) {
         subscriber.queue().force(new PtyMessage.SessionEnded("resync failed: " + e.getMessage()));
       }
     }
+  }
+
+  /**
+   * The journal's whole history as a bracketed replay: {@code ReplayBegin}, then the tail in {@code
+   * Output} frames of at most {@link #REPLAY_CHUNK} bytes each, then {@code ReplayEnd}. The wire
+   * refuses frames over 1 MiB, so a 4 MB journal must cross as a run of frames; a client
+   * concatenates {@code Output} frames regardless, so the bracket is all it sees.
+   */
+  private List<PtyMessage> replayMessages() throws IOException {
+    var tail = journal.tail(replayMax);
+    var messages = new java.util.ArrayList<PtyMessage>();
+    messages.add(new PtyMessage.ReplayBegin(tail.safe()));
+    var bytes = tail.bytes();
+    for (var offset = 0; offset < bytes.length; offset += REPLAY_CHUNK) {
+      var chunk =
+          java.util.Arrays.copyOfRange(
+              bytes, offset, Math.min(bytes.length, offset + REPLAY_CHUNK));
+      messages.add(new PtyMessage.Output(lastInputSeq.get(), chunk));
+    }
+    messages.add(new PtyMessage.ReplayEnd());
+    return List.copyOf(messages);
   }
 
   /** Attaches a client: replay first, live stream after, write token if free and requested. */
@@ -237,12 +254,7 @@ public final class PtySession implements AutoCloseable {
     var subscriber =
         new Subscriber(subscriberIds.incrementAndGet(), client, new SubscriberQueue(queueCapacity));
     synchronized (fanout) {
-      var tail = journal.tail(replayMax);
-      subscriber.queue().force(new PtyMessage.ReplayBegin(tail.safe()));
-      if (tail.bytes().length > 0) {
-        subscriber.queue().force(new PtyMessage.Output(lastInputSeq.get(), tail.bytes()));
-      }
-      subscriber.queue().force(new PtyMessage.ReplayEnd());
+      replayMessages().forEach(subscriber.queue()::force);
       subscribers.put(subscriber.id, subscriber);
       if (endedReason != null) {
         subscriber.queue().force(new PtyMessage.SessionEnded(endedReason));

--- a/sail-core/src/main/java/ai/singlr/sail/pty/RingJournal.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/RingJournal.java
@@ -10,6 +10,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayDeque;
 
 /**
  * A fixed-capacity ring of raw session bytes, journaled to one file so history survives a host
@@ -34,13 +35,33 @@ public final class RingJournal implements AutoCloseable {
   private final FileChannel channel;
   private final long capacity;
   private long totalWritten;
+
+  /**
+   * The oldest safe replay start still inside the ring; the one checkpoint that survives a restart.
+   */
   private long safeWatermark;
+
+  /** Safe replay starts inside the ring, oldest first, at least a stride apart. */
+  private final ArrayDeque<Long> checkpoints = new ArrayDeque<>();
 
   private RingJournal(FileChannel channel, long capacity, long totalWritten, long safeWatermark) {
     this.channel = channel;
     this.capacity = capacity;
     this.totalWritten = totalWritten;
     this.safeWatermark = safeWatermark;
+    if (safeWatermark >= windowStart()) {
+      checkpoints.add(safeWatermark);
+    }
+  }
+
+  /** Checkpoints are spaced so the ring never holds more than a few dozen of them. */
+  private long checkpointStride() {
+    return Math.max(1, capacity / 64);
+  }
+
+  /** The oldest offset still in the ring. */
+  private long windowStart() {
+    return totalWritten - Math.min(totalWritten, capacity);
   }
 
   /** Opens or creates the journal at {@code path}; an existing file must match the capacity. */
@@ -110,25 +131,42 @@ public final class RingJournal implements AutoCloseable {
    * keepFloor} (the replay budget's edge). Advancing eagerly would mean "nothing to replay" after
    * every quiet moment; a late attacher wants history, starting clean.
    */
-  public void markSafe(long keepFloor) throws IOException {
-    if (safeWatermark < keepFloor) {
-      safeWatermark = totalWritten;
+  /**
+   * Records that the stream is at a safe replay boundary right now. The journal keeps every such
+   * boundary still inside the ring (a stride apart, so the set stays small); a replay of any width
+   * then starts at the oldest boundary inside its window, so a late attacher gets the most history
+   * the ring can offer, and never a screen that begins mid-sequence.
+   */
+  public void markSafe() throws IOException {
+    var boundary = totalWritten;
+    var start = windowStart();
+    while (!checkpoints.isEmpty() && checkpoints.peekFirst() < start) {
+      checkpoints.pollFirst();
+    }
+    if (checkpoints.isEmpty() || boundary - checkpoints.peekLast() >= checkpointStride()) {
+      checkpoints.addLast(boundary);
+    }
+    var oldest = checkpoints.peekFirst();
+    if (oldest != safeWatermark) {
+      safeWatermark = oldest;
       writeHeader();
     }
   }
 
   /**
-   * The newest at-most-{@code maxBytes} of history, starting at the retained safe start when it
-   * lies still inside the window; otherwise from the window start, flagged unsafe so the client
+   * The newest at-most-{@code maxBytes} of history, starting at the oldest safe boundary inside
+   * that window when there is one; otherwise from the window start, flagged unsafe so the client
    * clears its screen before applying.
    */
   public Tail tail(int maxBytes) throws IOException {
-    var available = Math.min(totalWritten, capacity);
-    var windowStart = totalWritten - available;
-    var from = Math.max(windowStart, totalWritten - maxBytes);
-    var safe = safeWatermark >= from && safeWatermark <= totalWritten;
-    if (safe) {
-      from = safeWatermark;
+    var from = Math.max(windowStart(), totalWritten - maxBytes);
+    var safe = false;
+    for (var checkpoint : checkpoints) {
+      if (checkpoint >= from) {
+        from = checkpoint;
+        safe = true;
+        break;
+      }
     }
     var length = (int) (totalWritten - from);
     var bytes = new byte[length];

--- a/sail-core/src/main/java/ai/singlr/sail/pty/RingJournal.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/RingJournal.java
@@ -143,6 +143,10 @@ public final class RingJournal implements AutoCloseable {
     return new Tail(from, safe, bytes);
   }
 
+  public long capacity() {
+    return capacity;
+  }
+
   public long totalWritten() {
     return totalWritten;
   }

--- a/sail-core/src/main/java/ai/singlr/sail/pty/SubscriberQueue.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/SubscriberQueue.java
@@ -17,32 +17,43 @@ import java.util.Deque;
  */
 final class SubscriberQueue {
 
+  /** One queued message; {@code live} marks stream output that counts toward the backlog cap. */
+  private record Entry(PtyMessage message, boolean live) {}
+
   private final int capacity;
-  private final Deque<PtyMessage> queue = new ArrayDeque<>();
+  private final Deque<Entry> queue = new ArrayDeque<>();
+  private int live;
   private boolean paused;
 
   SubscriberQueue(int capacity) {
     this.capacity = capacity;
   }
 
-  /** Offers a live message; a full queue trips the pause, a paused queue drops silently. */
+  /**
+   * Offers a live message; a full backlog of live messages trips the pause, a paused queue drops
+   * silently. Only live messages count: a replay installed with {@link #replaceWith} or a forced
+   * message may exceed the cap without tripping a second pause behind the first (which would resync
+   * again, and again).
+   */
   synchronized void enqueue(PtyMessage message) {
     if (paused) {
       return;
     }
-    if (queue.size() >= capacity) {
+    if (live >= capacity) {
       paused = true;
       queue.clear();
-      queue.add(new PtyMessage.Paused());
+      live = 0;
+      queue.add(new Entry(new PtyMessage.Paused(), false));
     } else {
-      queue.add(message);
+      queue.add(new Entry(message, true));
+      live++;
     }
     notifyAll();
   }
 
   /** Enqueues regardless of pause — endings and poison must always arrive. */
   synchronized void force(PtyMessage message) {
-    queue.add(message);
+    queue.add(new Entry(message, false));
     notifyAll();
   }
 
@@ -55,19 +66,22 @@ final class SubscriberQueue {
   synchronized void replaceWith(java.util.List<PtyMessage> messages) {
     var terminal =
         queue.stream()
+            .map(Entry::message)
             .filter(m -> m instanceof PtyMessage.Ok || m instanceof PtyMessage.SessionEnded)
             .toList();
     queue.clear();
-    queue.addAll(messages);
-    queue.addAll(terminal);
+    live = 0;
+    messages.forEach(m -> queue.add(new Entry(m, false)));
+    terminal.forEach(m -> queue.add(new Entry(m, false)));
     notifyAll();
   }
 
   /** Empties the queue and delivers only {@code message} next — the detach path. */
   synchronized void clearAnd(PtyMessage message) {
     queue.clear();
+    live = 0;
     paused = false;
-    queue.add(message);
+    queue.add(new Entry(message, false));
     notifyAll();
   }
 
@@ -83,6 +97,10 @@ final class SubscriberQueue {
       }
       wait();
     }
-    return queue.poll();
+    var entry = queue.poll();
+    if (entry.live()) {
+      live--;
+    }
+    return entry.message();
   }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -256,6 +256,50 @@ class PtySessionTest {
   }
 
   @Test
+  void aLateAttacherReceivesTheWholeJournalInChunkedFrames() throws Exception {
+    var payload = 1_572_864; // 1.5 MiB: past the wire's 1 MiB frame cap
+    try (var session =
+        PtySession.start(
+            origin("big", "uday", "acme"),
+            PtyEvents.NONE,
+            List.of(
+                "sh",
+                "-c",
+                "head -c " + payload + " /dev/zero | tr '\\0' x; echo; echo BIG-DONE; read a"),
+            Map.of("TERM", "dumb"),
+            Path.of("/tmp"),
+            dir.resolve("big.ring"),
+            4L * 1024 * 1024,
+            80,
+            24)) {
+      var writer = new Collector();
+      session.attach(writer, true, "uday");
+      writer.awaitOutput("BIG-DONE");
+
+      var late = new Collector();
+      session.attach(late, false, "uday");
+      late.awaitOutput("BIG-DONE");
+
+      var text = late.outputText();
+      assertTrue(text.chars().filter(c -> c == 'x').count() >= payload, "every byte replayed");
+      var frames =
+          late.messages.stream()
+              .filter(m -> m instanceof PtyMessage.Output)
+              .map(m -> (PtyMessage.Output) m)
+              .toList();
+      assertTrue(frames.size() > 1, "the tail crossed as several frames, not one oversized frame");
+      assertTrue(
+          frames.stream().allMatch(f -> f.bytes().length <= PtySession.REPLAY_CHUNK),
+          "every replay frame fits the chunk");
+      var kinds = late.messages.stream().map(m -> m.getClass().getSimpleName()).toList();
+      assertEquals("ReplayBegin", kinds.getFirst(), "still bracketed: " + kinds);
+      assertTrue(
+          kinds.indexOf("ReplayEnd") > kinds.lastIndexOf("Output") - 1,
+          "ends the bracket after the tail");
+    }
+  }
+
+  @Test
   void onlyTheTokenHolderWritesAndTakeoverIsExplicitAndAnnounced() throws Exception {
     try (var session = session("read a; echo done:$a")) {
       var first = new Collector();
@@ -315,8 +359,7 @@ class PtySessionTest {
             256 * 1024,
             80,
             24,
-            2,
-            65536)) {
+            2)) {
       var writer = new Collector();
       var writerId = session.attach(writer, true, "uday");
       var stalled = new Collector();
@@ -429,8 +472,7 @@ class PtySessionTest {
             1024 * 1024,
             80,
             24,
-            1,
-            64 * 1024);
+            1);
     try {
       var client = new Collector();
       var gate = new CountDownLatch(1);

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -58,10 +58,13 @@ class PtySessionTest {
       }
     }
 
+    /** The screen a client would show: a replay bracket replaces everything before it. */
     String outputText() {
       var out = new StringBuilder();
       for (var message : messages) {
-        if (message instanceof PtyMessage.Output(var seq, var bytes)) {
+        if (message instanceof PtyMessage.ReplayBegin) {
+          out.setLength(0);
+        } else if (message instanceof PtyMessage.Output(var seq, var bytes)) {
           out.append(new String(bytes, StandardCharsets.UTF_8));
         }
       }
@@ -504,8 +507,11 @@ class PtySessionTest {
       client.awaitOutput("PHASE2");
       var text = client.outputText();
       assertEquals(text.indexOf("PHASE2"), text.lastIndexOf("PHASE2"), "no duplicated bytes");
+      var kindsAfter = client.messages.stream().map(m -> m.getClass().getSimpleName()).toList();
       assertEquals(
-          text.indexOf("BURST-END"), text.lastIndexOf("BURST-END"), "no duplicated resync");
+          text.indexOf("BURST-END"),
+          text.lastIndexOf("BURST-END"),
+          "no duplicated resync; messages: " + kindsAfter);
     } finally {
       session.close();
     }

--- a/sail-core/src/test/java/ai/singlr/sail/pty/RingJournalTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/RingJournalTest.java
@@ -30,9 +30,9 @@ class RingJournalTest {
   void aRetainedSafeStartReplaysHistoryNotNothing() throws Exception {
     try (var ring = RingJournal.open(dir.resolve("s.ring"), 1024)) {
       ring.append(bytes("first\n"), 6);
-      ring.markSafe(0);
+      ring.markSafe();
       ring.append(bytes("second"), 6);
-      ring.markSafe(0);
+      ring.markSafe();
 
       var tail = ring.tail(1024);
 
@@ -43,18 +43,43 @@ class RingJournalTest {
   }
 
   @Test
-  void theSafeStartAdvancesOnlyOnceItFallsOutOfTheBudget() throws Exception {
+  void aNarrowerWindowStartsAtTheOldestSafeBoundaryInsideIt() throws Exception {
+    // capacity 1024 → checkpoints at least 16 bytes apart; each line below is 20 bytes.
     try (var ring = RingJournal.open(dir.resolve("s.ring"), 1024)) {
-      ring.append(bytes("old\n"), 4);
-      ring.markSafe(0);
-      ring.append(bytes("new\n"), 4);
-      ring.markSafe(ring.totalWritten() - 4);
+      for (var i = 0; i < 4; i++) {
+        ring.append(bytes("line-" + i + "-aaaaaaaaaaaa\n"), 20);
+        ring.markSafe();
+      }
 
-      var tail = ring.tail(4);
+      var whole = ring.tail(1024);
+      assertTrue(whole.safe());
+      assertEquals(0, whole.startOffset(), "the stream start is a safe start");
 
+      var narrow = ring.tail(50); // the window begins at 30, inside line 1
+      assertTrue(narrow.safe());
+      assertEquals(40, narrow.startOffset(), "starts at the first boundary inside the window");
+      assertArrayEquals(bytes("line-2-aaaaaaaaaaaa\nline-3-aaaaaaaaaaaa\n"), narrow.bytes());
+
+      ring.append(bytes("x".repeat(30)), 30); // a partial line, no boundary yet
+      var tiny = ring.tail(10); // no boundary inside: from the window start, flagged unsafe
+      assertFalse(tiny.safe());
+      assertEquals(100, tiny.startOffset());
+    }
+  }
+
+  @Test
+  void safeStartsThatLeaveTheRingAreForgottenAndTheNextOneInsideWins() throws Exception {
+    try (var ring = RingJournal.open(dir.resolve("s.ring"), 100)) {
+      for (var i = 0; i < 12; i++) {
+        ring.append(bytes(String.format("%09d\n", i)), 10);
+        ring.markSafe();
+      }
+      // 120 bytes written into a 100-byte ring: offsets below 20 are gone.
+      var tail = ring.tail(100);
       assertTrue(tail.safe());
-      assertEquals(8, tail.startOffset(), "the stale mark jumped to the current boundary");
-      assertArrayEquals(bytes(""), tail.bytes());
+      assertEquals(20, tail.startOffset(), "the oldest boundary still in the ring");
+      assertEquals(100, tail.bytes().length);
+      assertEquals("000000002\n", new String(tail.bytes(), 0, 10, StandardCharsets.UTF_8));
     }
   }
 
@@ -63,7 +88,7 @@ class RingJournalTest {
     var path = dir.resolve("s.ring");
     try (var ring = RingJournal.open(path, 64)) {
       ring.append(bytes("persisted\n"), 10);
-      ring.markSafe(0);
+      ring.markSafe();
     }
     try (var ring = RingJournal.open(path, 64)) {
       assertEquals(10, ring.totalWritten());

--- a/sail-core/src/test/java/ai/singlr/sail/pty/SubscriberQueueTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/SubscriberQueueTest.java
@@ -8,9 +8,14 @@ package ai.singlr.sail.pty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class SubscriberQueueTest {
+
+  private static PtyMessage.Output output(String text) {
+    return new PtyMessage.Output(0, text.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+  }
 
   private static PtyMessage.Output out(int n) {
     return new PtyMessage.Output(n, new byte[] {(byte) n});
@@ -70,6 +75,29 @@ class SubscriberQueueTest {
 
     assertInstanceOf(PtyMessage.ReplayBegin.class, queue.next());
     assertInstanceOf(PtyMessage.Ok.class, queue.next(), "detach still terminates the send loop");
+  }
+
+  @Test
+  void aReplayLargerThanTheCapDoesNotTripAnotherPause() throws Exception {
+    var queue = new SubscriberQueue(2);
+    queue.replaceWith(
+        List.of(
+            new PtyMessage.ReplayBegin(true),
+            output("a"),
+            output("b"),
+            output("c"),
+            new PtyMessage.ReplayEnd()));
+    queue.enqueue(output("live-1"));
+    queue.enqueue(output("live-2"));
+
+    var kinds = new java.util.ArrayList<String>();
+    for (int i = 0; i < 7; i++) {
+      kinds.add(queue.next().getClass().getSimpleName());
+    }
+    assertEquals(
+        List.of("ReplayBegin", "Output", "Output", "Output", "ReplayEnd", "Output", "Output"),
+        kinds,
+        "a five-message replay in a two-message queue is delivered whole, then live output");
   }
 
   @Test


### PR DESCRIPTION
Spec `sail-pty-replay-window`. Three commits, each with its own red-first test.

## Why

The pty host keeps a 4 MB ring journal per session but replayed at most 256 KB of it on attach and on a flow-control resync. With Mast now holding 20 MB of scrollback, a relaunch threw away history the host still had. The cap existed because the tail crossed as one `Output` frame and the wire refuses frames over 1 MiB.

## What

1. **Replay the whole journal, in chunks.** One helper builds the bracket for attach and resync: `ReplayBegin`, the tail as `Output` frames of at most 256 KiB, `ReplayEnd`. Clients already concatenate `Output` frames, so nothing changes on the wire. The hard-coded cap and its constructor parameter are gone.
2. **The backlog cap counts live output only.** The chunked replay exposed a queue defect: every queued message counted toward the pause threshold, so a replay wider than the cap tripped a second pause on the next live frame, which resynced again (the paused-subscriber test saw the burst twice). Forced messages and replays no longer count.
3. **Checkpointed safe starts.** The single watermark advanced by jumping to "now" once it fell out of the window, so replayable history oscillated between the whole window and nothing — and with the window equal to the ring it never advanced. The journal now keeps every safe boundary inside the ring, a stride apart (`capacity / 64`); a replay of any width starts at the oldest checkpoint inside its window, or from the window start flagged unsafe. The header still persists one offset (the oldest checkpoint), so history survives a host restart as before.

The paused-subscriber test's collector now models a client: a replay bracket replaces what came before it, which is the invariant the resync design promises.

## Tests

Late attacher after 1.5 MiB gets every byte across several frames within the chunk, still bracketed; a five-message replay in a two-message queue delivers whole; journal oldest-in-window rule, unsafe fallback, and eviction on wrap. `mvn clean verify` green locally (Incus and multi-node lanes run in CI).

No wire change. Field: relaunch Mast after a long Claude Code session and scroll to the start of the journal.
