### PR TITLE
pty: a session ends loudly, never wedges, never leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
   - **A pty or journal failure ends the session.** A read error, or a journal append that throws
     (a full disk), used to leave the gather thread joining a still-live child that nobody was
     draining — the session wedged live forever, unreapable, until an explicit kill. It now closes
-    the pty and kills the child first, then every subscriber hears `SessionEnded(reason=io-error)`.
+    the pty, kills the child outright and reaps it first (a child that shrugs off SIGHUP and
+    SIGTERM does not outlive its session), then every subscriber hears
+    `SessionEnded(reason=io-error)`.
   - **Ring files are deleted and never leak.** A session's `~/.sail/sessions/<name>.ring` is removed
     when the session is killed, swept, or re-created, and every orphan ring is swept at host start
     (sessions do not survive a restart — there is no rehydration). New rings are created owner-only
@@ -19,16 +21,20 @@
     growing the host heap — and one stuck writer can no longer freeze the accept lane or every
     other connection.
   - **Unchecked failures answer `Err`, not a silent close.** An invalid session name, project, cwd,
-    or terminal size is validated up front and refused with `Err`; any other runtime exception is a
-    logged last resort that still answers `Err` and closes cleanly, so Mast reads a real refusal
-    rather than a transport fault it retries forever.
+    or terminal size is validated up front and refused with `Err`; any other runtime exception (a
+    truncated frame, say) is a logged last resort that still answers `Err` on the open socket and
+    then closes it cleanly, so Mast reads a real refusal rather than a transport fault it retries
+    forever.
   - **Session names are validated as path segments.** A name like `../foo` is refused before it can
     escape the sessions directory or delete another session's ring.
   - **Backlog is bounded by bytes as well as frames.** A stalled subscriber's queue pauses at 1 MiB
     of live output (not only 4096 frames), and a resync replays a bounded 256 KiB tail rather than
     the whole 4 MB ring on the link that just proved too slow.
-  - **Resource caps.** Sessions per FDE (32), subscribers per session (16), and connections per host
-    (256) are each refused with an `Err` naming the cap.
+  - **Resource caps.** Sessions per FDE (32) and subscribers per session (16) are each refused with
+    an `Err` naming the cap, and each admission is atomic with its registration, so concurrent
+    creates or attaches cannot all take the last slot. A socket over the host's connection cap
+    (256) is closed before a byte of it is read: a peer that opens many and never speaks holds no
+    handler, descriptor, or frame past the cap.
   - **The host logs one line per attach, refusal, and exception** (principal, session, reason) to its
     journald unit; wire `Err` strings no longer name another FDE's ownership.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+- **The pty host ends a session loudly instead of wedging, and never leaks its ring.** A hardening
+  pass over the per-container session host (no wire change):
+  - **A pty or journal failure ends the session.** A read error, or a journal append that throws
+    (a full disk), used to leave the gather thread joining a still-live child that nobody was
+    draining — the session wedged live forever, unreapable, until an explicit kill. It now closes
+    the pty and kills the child first, then every subscriber hears `SessionEnded(reason=io-error)`.
+  - **Ring files are deleted and never leak.** A session's `~/.sail/sessions/<name>.ring` is removed
+    when the session is killed, swept, or re-created, and every orphan ring is swept at host start
+    (sessions do not survive a restart — there is no rehydration). New rings are created owner-only
+    (0600).
+  - **Input never pins a connection.** The write-token holder's keystrokes drain through a dedicated
+    per-session writer thread over a bounded queue, so a child that has stopped reading (Ctrl-S, a
+    stopped job) backs up to an `Err("input backlog")` instead of blocking the writer's connection —
+    and one stuck writer can no longer freeze the accept lane or every other connection.
+  - **Unchecked failures answer `Err`, not a silent close.** An invalid session name, project, cwd,
+    or terminal size is validated up front and refused with `Err`; any other runtime exception is a
+    logged last resort that still answers `Err` and closes cleanly, so Mast reads a real refusal
+    rather than a transport fault it retries forever.
+  - **Session names are validated as path segments.** A name like `../foo` is refused before it can
+    escape the sessions directory or delete another session's ring.
+  - **Backlog is bounded by bytes as well as frames.** A stalled subscriber's queue pauses at 1 MiB
+    of live output (not only 4096 frames), and a resync replays a bounded 256 KiB tail rather than
+    the whole 4 MB ring on the link that just proved too slow.
+  - **Resource caps.** Sessions per FDE (32), subscribers per session (16), and connections per host
+    (256) are each refused with an `Err` naming the cap.
+  - **The host logs one line per attach, refusal, and exception** (principal, session, reason) to its
+    journald unit; wire `Err` strings no longer name another FDE's ownership.
+
 ## 0.39.2
 
 - **An attach replays everything the journal holds.** The pty host used to replay at most 256 KB of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
     SIGTERM does not outlive its session), then every subscriber hears
     `SessionEnded(reason=io-error)`.
   - **Ring files are deleted and never leak.** A session's `~/.sail/sessions/<name>.ring` is removed
-    when the session is killed, swept, or re-created — and when its create fails to spawn, so a
+    when the session is killed, yielded to a dispatch, swept, or re-created — and when its create fails to spawn, so a
     bad working directory cannot litter rings that no quota counts — and every orphan ring is swept
     at host start (sessions do not survive a restart — there is no rehydration). New rings are
     created owner-only (0600).
@@ -38,7 +38,9 @@
     dropped, so a paste that outran the session is visibly incomplete rather than silently short.
   - **Resource caps.** Sessions per FDE (32) and subscribers per session (16) are each refused with
     an `Err` naming the cap, and each admission is atomic with its registration, so concurrent
-    creates or attaches cannot all take the last slot. A socket over the host's connection cap
+    creates or attaches cannot all take the last slot. Recreating another owner's corpse (an admin
+    reusing a name) counts as a new session against the recreator's cap; only replacing your own
+    corpse takes no extra slot. A socket over the host's connection cap
     (256) is closed before a byte of it is read: a peer that opens many and never speaks holds no
     handler, descriptor, or frame past the cap.
   - **The host logs one line per attach, refusal, and exception** (principal, session, reason) to its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@
     SIGTERM does not outlive its session), then every subscriber hears
     `SessionEnded(reason=io-error)`.
   - **Ring files are deleted and never leak.** A session's `~/.sail/sessions/<name>.ring` is removed
-    when the session is killed, swept, or re-created, and every orphan ring is swept at host start
-    (sessions do not survive a restart — there is no rehydration). New rings are created owner-only
-    (0600).
+    when the session is killed, swept, or re-created — and when its create fails to spawn, so a
+    bad working directory cannot litter rings that no quota counts — and every orphan ring is swept
+    at host start (sessions do not survive a restart — there is no rehydration). New rings are
+    created owner-only (0600).
   - **Input never pins a connection.** The write-token holder's keystrokes drain through a dedicated
     per-session writer thread over a queue bounded in frames and bytes (1 MiB queued plus in-flight,
     reserved before the payload is copied), so a child that has stopped reading (Ctrl-S, a stopped
@@ -29,7 +30,12 @@
     escape the sessions directory or delete another session's ring.
   - **Backlog is bounded by bytes as well as frames.** A stalled subscriber's queue pauses at 1 MiB
     of live output (not only 4096 frames), and a resync replays a bounded 256 KiB tail rather than
-    the whole 4 MB ring on the link that just proved too slow.
+    the whole 4 MB ring on the link that just proved too slow. Writer and geometry notifications
+    coalesce to the latest of each, so a client that stops reading and hammers `TakeWrite` or
+    `Resize` cannot grow anyone's queue past the caps.
+  - **`sail session attach` narrates a refused keystroke.** The host's `Err` for a rejected input
+    (no write token, or a full input backlog) is rendered inline as `[sail: …]` instead of being
+    dropped, so a paste that outran the session is visibly incomplete rather than silently short.
   - **Resource caps.** Sessions per FDE (32) and subscribers per session (16) are each refused with
     an `Err` naming the cap, and each admission is atomic with its registration, so concurrent
     creates or attaches cannot all take the last slot. A socket over the host's connection cap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@
     (sessions do not survive a restart — there is no rehydration). New rings are created owner-only
     (0600).
   - **Input never pins a connection.** The write-token holder's keystrokes drain through a dedicated
-    per-session writer thread over a bounded queue, so a child that has stopped reading (Ctrl-S, a
-    stopped job) backs up to an `Err("input backlog")` instead of blocking the writer's connection —
-    and one stuck writer can no longer freeze the accept lane or every other connection.
+    per-session writer thread over a queue bounded in frames and bytes (1 MiB queued plus in-flight,
+    reserved before the payload is copied), so a child that has stopped reading (Ctrl-S, a stopped
+    job) backs up to an `Err("input backlog")` instead of blocking the writer's connection or
+    growing the host heap — and one stuck writer can no longer freeze the accept lane or every
+    other connection.
   - **Unchecked failures answer `Err`, not a silent close.** An invalid session name, project, cwd,
     or terminal size is validated up front and refused with `Err`; any other runtime exception is a
     logged last resort that still answers `Err` and closes cleanly, so Mast reads a real refusal

--- a/sail-core/src/main/java/ai/singlr/sail/engine/NameValidator.java
+++ b/sail-core/src/main/java/ai/singlr/sail/engine/NameValidator.java
@@ -15,6 +15,8 @@ public final class NameValidator {
 
   private static final int MAX_LENGTH = 63;
   public static final int MAX_SPEC_ID_LENGTH = 80;
+  public static final int MAX_SESSION_NAME_LENGTH = 80;
+  private static final Pattern SESSION_NAME = Pattern.compile("^[A-Za-z0-9][A-Za-z0-9._-]*$");
   private static final Pattern PROJECT_NAME = Pattern.compile("^[a-z0-9][a-z0-9-]*$");
   private static final Pattern SPEC_ID = Pattern.compile("^[a-z0-9][a-z0-9-]*$");
   private static final Pattern SNAPSHOT_LABEL = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9._-]*$");
@@ -44,6 +46,28 @@ public final class NameValidator {
               + name
               + "'. Must match [a-z0-9][a-z0-9-]*, max "
               + MAX_LENGTH
+              + " characters.");
+    }
+  }
+
+  /**
+   * Validates a pty session name. The name becomes a file name ({@code <name>.ring}) the host
+   * resolves under its sessions directory and deletes on remove, so the charset (no slash, no
+   * {@code ..}, bounded length) is a path-traversal boundary, not just hygiene — a name like {@code
+   * ../foo} could otherwise escape the directory or delete another session's history. Dots are
+   * allowed (room sessions are named {@code room-<id>.2} upward); {@code ..} is not.
+   */
+  public static void requireValidSessionName(String name) {
+    if (name == null
+        || name.isEmpty()
+        || name.length() > MAX_SESSION_NAME_LENGTH
+        || !SESSION_NAME.matcher(name).matches()
+        || containsDotDot(name)) {
+      throw new IllegalArgumentException(
+          "Invalid session name: '"
+              + name
+              + "'. Must match [A-Za-z0-9][A-Za-z0-9._-]* with no '..' segments, max "
+              + MAX_SESSION_NAME_LENGTH
               + " characters.");
     }
   }

--- a/sail-core/src/main/java/ai/singlr/sail/pty/Journal.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/Journal.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.pty;
+
+import java.io.IOException;
+
+/**
+ * The session's byte history: the append-only sink the gather thread drains a pty into and the
+ * source a replay reads back. {@link RingJournal} is the one production implementation; the seam
+ * exists so a session's failure paths — an append that throws on a full disk, a read that throws on
+ * a corrupt file — are testable without a real disk fault.
+ */
+public interface Journal extends AutoCloseable {
+
+  /** One replayable tail: bytes from {@code startOffset} of the stream, safe or best-effort. */
+  record Tail(long startOffset, boolean safe, byte[] bytes) {}
+
+  /** Appends {@code buf[0..len)} to the history. */
+  void append(byte[] buf, int len) throws IOException;
+
+  /** Records that the stream is at a safe replay boundary right now. */
+  void markSafe() throws IOException;
+
+  /** The newest at-most-{@code maxBytes} of history, starting at a safe boundary when one fits. */
+  Tail tail(int maxBytes) throws IOException;
+
+  /** The fixed capacity of the history window. */
+  long capacity();
+
+  /** Total bytes ever appended — the child's progress, independent of any reader. */
+  long totalWritten();
+
+  @Override
+  void close() throws IOException;
+}

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -15,6 +15,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -28,13 +29,14 @@ import java.util.concurrent.atomic.AtomicLong;
  * everyone else stay live.
  *
  * <p>Exactly one subscriber holds the write token; input from anyone else is refused. Input never
- * blocks the connection that sends it: the write-token holder's keystrokes are offered onto a
- * bounded queue drained by a dedicated platform writer thread (the mirror of the gather thread), so
- * a child that has stopped reading (Ctrl-S, a stopped job) backs up the queue — answered {@code
- * BACKLOG} — rather than pinning the caller's virtual thread inside a blocking foreign write.
- * Attach replays the journal tail bracketed by {@code ReplayBegin}/{@code ReplayEnd}, then streams.
- * When the child exits — or a pty or journal failure ends it — every subscriber hears {@code
- * SessionEnded} and the corpse stays readable until the host reaps it.
+ * blocks the connection that sends it: the write-token holder's keystrokes are offered onto a queue
+ * bounded in frames and bytes, drained by a dedicated platform writer thread (the mirror of the
+ * gather thread), so a child that has stopped reading (Ctrl-S, a stopped job) backs up the queue —
+ * answered {@code BACKLOG} — rather than pinning the caller's virtual thread inside a blocking
+ * foreign write or growing the host heap. Attach replays the journal tail bracketed by {@code
+ * ReplayBegin}/{@code ReplayEnd}, then streams. When the child exits — or a pty or journal failure
+ * ends it — every subscriber hears {@code SessionEnded} and the corpse stays readable until the
+ * host reaps it.
  */
 public final class PtySession implements AutoCloseable {
 
@@ -102,11 +104,18 @@ public final class PtySession implements AutoCloseable {
   /** The writer queue backs up to this many keystrokes before input is refused as backlog. */
   static final int MAX_INPUT_BACKLOG = 512;
 
+  /**
+   * Queued plus in-flight input is held to this many bytes: a writer whose child stopped reading
+   * hears {@code BACKLOG} before it can grow the host heap, however large its legal frames are.
+   */
+  static final int MAX_INPUT_BACKLOG_BYTES = 1 << 20;
+
   /** The attach replay window: everything the journal holds. */
   private final int replayMax;
 
   private final Map<Long, Subscriber> subscribers = new ConcurrentHashMap<>();
   private final BlockingQueue<Keystroke> inputQueue = new ArrayBlockingQueue<>(MAX_INPUT_BACKLOG);
+  private final Semaphore inputBudget = new Semaphore(MAX_INPUT_BACKLOG_BYTES);
   private final Object fanout = new Object();
   private final AtomicLong subscriberIds = new AtomicLong();
   private final AtomicLong lastInputSeq = new AtomicLong(-1);
@@ -280,8 +289,12 @@ public final class PtySession implements AutoCloseable {
     try {
       while (true) {
         var keystroke = inputQueue.take();
-        lastInputSeq.set(keystroke.seq());
-        pty.write(keystroke.bytes());
+        try {
+          lastInputSeq.set(keystroke.seq());
+          pty.write(keystroke.bytes());
+        } finally {
+          inputBudget.release(keystroke.bytes().length);
+        }
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -381,15 +394,22 @@ public final class PtySession implements AutoCloseable {
    * and never throws: a non-writer is {@code NOT_WRITER}, and a writer whose keystrokes have backed
    * up behind a child that stopped reading is {@code BACKLOG} — both refusable outcomes, not a
    * fatal error that tears down the connection or pins its thread in a blocking foreign write.
-   * Accepted keystrokes are drained by the writer thread; the sequence rides future output.
+   * Backlog is bounded in bytes as well as frames, and the bytes are reserved before the payload is
+   * copied — so the budget, not the heap, is what a stalled child exhausts. Accepted keystrokes are
+   * drained by the writer thread; the sequence rides future output.
    */
   public WriteOutcome input(long subscriberId, long seq, byte[] bytes) {
     if (subscriberId != writerId) {
       return WriteOutcome.NOT_WRITER;
     }
-    return inputQueue.offer(new Keystroke(seq, bytes.clone()))
-        ? WriteOutcome.ACCEPTED
-        : WriteOutcome.BACKLOG;
+    if (!inputBudget.tryAcquire(bytes.length)) {
+      return WriteOutcome.BACKLOG;
+    }
+    if (inputQueue.offer(new Keystroke(seq, bytes.clone()))) {
+      return WriteOutcome.ACCEPTED;
+    }
+    inputBudget.release(bytes.length);
+    return WriteOutcome.BACKLOG;
   }
 
   /** Transfers the write token to {@code subscriberId}; everyone hears about it. */

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -269,15 +269,18 @@ public final class PtySession implements AutoCloseable {
 
   /**
    * The reason the session ends, computed with the pty already released so nothing can wedge. On a
-   * pty or journal failure the child may still be alive — kill it and the pty first, never join a
-   * live child while nobody drains the master — and the reason is the failure. Otherwise the child
-   * has exited (or a yield displaced it): close the pty, then read its exit status, which returns
-   * at once because the child is already gone.
+   * pty or journal failure the child may still be alive — close the pty, kill it outright and reap
+   * it before the ending is published, because {@link #close()} skips its escalation once the
+   * gather is done and a child that shrugs off SIGHUP and SIGTERM would otherwise outlive its
+   * session untracked; the reason is the failure. Otherwise the child has exited (or a yield
+   * displaced it): close the pty, then read its exit status, which returns at once because the
+   * child is already gone.
    */
   private String endReason(String failure) {
     if (failure != null) {
       pty.close();
-      child.destroy();
+      child.destroyForcibly();
+      child.onExit().join();
       return failure;
     }
     pty.close();

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -11,6 +11,8 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
@@ -25,10 +27,14 @@ import java.util.concurrent.atomic.AtomicLong;
  * backlog dropped, marked by {@code Paused}/{@code Continued} frames — while the writer and
  * everyone else stay live.
  *
- * <p>Exactly one subscriber holds the write token; input from anyone else is refused. Attach
- * replays the journal tail bracketed by {@code ReplayBegin}/{@code ReplayEnd}, then streams. When
- * the child exits, every subscriber hears {@code SessionEnded} and the corpse (ring included) stays
- * readable until the host reaps it.
+ * <p>Exactly one subscriber holds the write token; input from anyone else is refused. Input never
+ * blocks the connection that sends it: the write-token holder's keystrokes are offered onto a
+ * bounded queue drained by a dedicated platform writer thread (the mirror of the gather thread), so
+ * a child that has stopped reading (Ctrl-S, a stopped job) backs up the queue — answered {@code
+ * BACKLOG} — rather than pinning the caller's virtual thread inside a blocking foreign write.
+ * Attach replays the journal tail bracketed by {@code ReplayBegin}/{@code ReplayEnd}, then streams.
+ * When the child exits — or a pty or journal failure ends it — every subscriber hears {@code
+ * SessionEnded} and the corpse stays readable until the host reaps it.
  */
 public final class PtySession implements AutoCloseable {
 
@@ -37,7 +43,18 @@ public final class PtySession implements AutoCloseable {
     void deliver(PtyMessage message);
   }
 
+  /**
+   * The outcome of offering input: taken onto the writer queue, refused, or refused for backlog.
+   */
+  public enum WriteOutcome {
+    ACCEPTED,
+    NOT_WRITER,
+    BACKLOG
+  }
+
   private record Subscriber(long id, Client client, SubscriberQueue queue) {}
+
+  private record Keystroke(long seq, byte[] bytes) {}
 
   /**
    * What a session was born as: its name, the id of this incarnation of that name, the FDE who
@@ -70,21 +87,31 @@ public final class PtySession implements AutoCloseable {
   private final PtyEvents events;
   private final Pty pty;
   private final Process child;
-  private final RingJournal journal;
+  private final Journal journal;
   private final TermBoundary boundary = new TermBoundary();
   private final int queueCapacity;
 
   /** A replayed journal crosses the wire in frames this large — well under the 1 MiB frame cap. */
   static final int REPLAY_CHUNK = 256 * 1024;
 
-  /** The replay window: everything the journal holds. */
+  /**
+   * A resync replays only this recent a tail — the link just proved too slow for the whole ring.
+   */
+  static final int RESYNC_TAIL = 256 * 1024;
+
+  /** The writer queue backs up to this many keystrokes before input is refused as backlog. */
+  static final int MAX_INPUT_BACKLOG = 512;
+
+  /** The attach replay window: everything the journal holds. */
   private final int replayMax;
 
   private final Map<Long, Subscriber> subscribers = new ConcurrentHashMap<>();
+  private final BlockingQueue<Keystroke> inputQueue = new ArrayBlockingQueue<>(MAX_INPUT_BACKLOG);
   private final Object fanout = new Object();
   private final AtomicLong subscriberIds = new AtomicLong();
   private final AtomicLong lastInputSeq = new AtomicLong(-1);
   private final CountDownLatch gatherDone = new CountDownLatch(1);
+  private volatile Thread writerThread;
   private final long createdAt = System.nanoTime();
   private volatile long writerId = -1;
   private volatile String writerFde = "";
@@ -94,12 +121,7 @@ public final class PtySession implements AutoCloseable {
   private volatile boolean everAttached;
 
   private PtySession(
-      Origin origin,
-      PtyEvents events,
-      Pty pty,
-      Process child,
-      RingJournal journal,
-      int queueCapacity) {
+      Origin origin, PtyEvents events, Pty pty, Process child, Journal journal, int queueCapacity) {
     this.origin = origin;
     this.events = events;
     this.pty = pty;
@@ -139,8 +161,36 @@ public final class PtySession implements AutoCloseable {
       int rows,
       int queueCapacity)
       throws IOException {
-    var journal = RingJournal.open(journalPath, journalCapacity);
-    var pty = Pty.open(cols, rows);
+    return start(
+        origin,
+        events,
+        argv,
+        env,
+        cwd,
+        RingJournal.open(journalPath, journalCapacity),
+        cols,
+        rows,
+        queueCapacity);
+  }
+
+  static PtySession start(
+      Origin origin,
+      PtyEvents events,
+      List<String> argv,
+      Map<String, String> env,
+      Path cwd,
+      Journal journal,
+      int cols,
+      int rows,
+      int queueCapacity)
+      throws IOException {
+    Pty pty;
+    try {
+      pty = Pty.open(cols, rows);
+    } catch (IOException e) {
+      journal.close();
+      throw e;
+    }
     Process child;
     try {
       child = pty.spawn(argv, env, cwd);
@@ -151,6 +201,8 @@ public final class PtySession implements AutoCloseable {
     }
     var session = new PtySession(origin, events, pty, child, journal, queueCapacity);
     Thread.ofPlatform().name("pty-gather-" + origin.name()).start(session::gather);
+    session.writerThread =
+        Thread.ofPlatform().name("pty-write-" + origin.name()).start(session::drainInput);
     emitQuietly(() -> events.sessionStarted(origin));
     return session;
   }
@@ -189,12 +241,10 @@ public final class PtySession implements AutoCloseable {
         }
       }
     } catch (IOException e) {
-      failure = "pty failed: " + e.getMessage();
+      failure = "io-error: " + e.getMessage();
     } finally {
       try {
-        var exit = "exited(" + child.onExit().join().exitValue() + ")";
-        var reason = failure != null ? failure : Objects.requireNonNullElse(yieldedReason, exit);
-        pty.close();
+        var reason = endReason(failure);
         synchronized (fanout) {
           endedAtNanos = System.nanoTime();
           endedReason = reason;
@@ -209,6 +259,38 @@ public final class PtySession implements AutoCloseable {
   }
 
   /**
+   * The reason the session ends, computed with the pty already released so nothing can wedge. On a
+   * pty or journal failure the child may still be alive — kill it and the pty first, never join a
+   * live child while nobody drains the master — and the reason is the failure. Otherwise the child
+   * has exited (or a yield displaced it): close the pty, then read its exit status, which returns
+   * at once because the child is already gone.
+   */
+  private String endReason(String failure) {
+    if (failure != null) {
+      pty.close();
+      child.destroy();
+      return failure;
+    }
+    pty.close();
+    return Objects.requireNonNullElse(
+        yieldedReason, "exited(" + child.onExit().join().exitValue() + ")");
+  }
+
+  private void drainInput() {
+    try {
+      while (true) {
+        var keystroke = inputQueue.take();
+        lastInputSeq.set(keystroke.seq());
+        pty.write(keystroke.bytes());
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    } catch (IOException failed) {
+      var unused = failed;
+    }
+  }
+
+  /**
    * Re-baselines a subscriber whose pause dropped part of the stream: under the fanout lock, the
    * journal tail replaces whatever accumulated in its queue (those bytes are inside the snapshot),
    * so the client hears {@code Continued}, a bracketed replay, then live traffic — exactly-once
@@ -217,7 +299,7 @@ public final class PtySession implements AutoCloseable {
   private void resync(Subscriber subscriber) {
     synchronized (fanout) {
       try {
-        subscriber.queue().replaceWith(replayMessages());
+        subscriber.queue().replaceWith(replayMessages(RESYNC_TAIL));
       } catch (IOException e) {
         subscriber.queue().force(new PtyMessage.SessionEnded("resync failed: " + e.getMessage()));
       }
@@ -225,13 +307,14 @@ public final class PtySession implements AutoCloseable {
   }
 
   /**
-   * The journal's whole history as a bracketed replay: {@code ReplayBegin}, then the tail in {@code
-   * Output} frames of at most {@link #REPLAY_CHUNK} bytes each, then {@code ReplayEnd}. The wire
-   * refuses frames over 1 MiB, so a 4 MB journal must cross as a run of frames; a client
-   * concatenates {@code Output} frames regardless, so the bracket is all it sees.
+   * At most {@code maxBytes} of history as a bracketed replay: {@code ReplayBegin}, then the tail
+   * in {@code Output} frames of at most {@link #REPLAY_CHUNK} bytes each, then {@code ReplayEnd}.
+   * The wire refuses frames over 1 MiB, so a wide replay must cross as a run of frames; a client
+   * concatenates {@code Output} frames regardless, so the bracket is all it sees. Attach replays
+   * the whole ring ({@link #replayMax}); a resync replays only a recent {@link #RESYNC_TAIL} tail.
    */
-  private List<PtyMessage> replayMessages() throws IOException {
-    var tail = journal.tail(replayMax);
+  private List<PtyMessage> replayMessages(int maxBytes) throws IOException {
+    var tail = journal.tail(maxBytes);
     var messages = new java.util.ArrayList<PtyMessage>();
     messages.add(new PtyMessage.ReplayBegin(tail.safe()));
     var bytes = tail.bytes();
@@ -254,7 +337,7 @@ public final class PtySession implements AutoCloseable {
     var subscriber =
         new Subscriber(subscriberIds.incrementAndGet(), client, new SubscriberQueue(queueCapacity));
     synchronized (fanout) {
-      replayMessages().forEach(subscriber.queue()::force);
+      replayMessages(replayMax).forEach(subscriber.queue()::force);
       subscribers.put(subscriber.id, subscriber);
       if (endedReason != null) {
         subscriber.queue().force(new PtyMessage.SessionEnded(endedReason));
@@ -294,18 +377,19 @@ public final class PtySession implements AutoCloseable {
   }
 
   /**
-   * Writes input on behalf of {@code subscriberId}; only the write-token holder may. Returns {@code
-   * false} — never throws — when the caller does not hold the token, so a non-writer's stray input
-   * is a refusable outcome, not a fatal error that tears down its connection. An {@link
-   * IOException} means the pty write itself failed. The sequence rides future output.
+   * Offers input on behalf of {@code subscriberId}; only the write-token holder may. Never blocks
+   * and never throws: a non-writer is {@code NOT_WRITER}, and a writer whose keystrokes have backed
+   * up behind a child that stopped reading is {@code BACKLOG} — both refusable outcomes, not a
+   * fatal error that tears down the connection or pins its thread in a blocking foreign write.
+   * Accepted keystrokes are drained by the writer thread; the sequence rides future output.
    */
-  public boolean input(long subscriberId, long seq, byte[] bytes) throws IOException {
+  public WriteOutcome input(long subscriberId, long seq, byte[] bytes) {
     if (subscriberId != writerId) {
-      return false;
+      return WriteOutcome.NOT_WRITER;
     }
-    lastInputSeq.set(seq);
-    pty.write(bytes);
-    return true;
+    return inputQueue.offer(new Keystroke(seq, bytes.clone()))
+        ? WriteOutcome.ACCEPTED
+        : WriteOutcome.BACKLOG;
   }
 
   /** Transfers the write token to {@code subscriberId}; everyone hears about it. */
@@ -436,6 +520,10 @@ public final class PtySession implements AutoCloseable {
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
+    }
+    var writer = writerThread;
+    if (writer != null) {
+      writer.interrupt();
     }
     synchronized (this) {
       subscribers.clear();

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtyWire.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtyWire.java
@@ -74,7 +74,7 @@ public final class PtyWire {
   }
 
   private static byte[] encode(PtyMessage message) {
-    var out = new Writer();
+    var out = new Writer(sizeHint(message));
     switch (message) {
       case PtyMessage.Hello m -> out.type(9).string(m.token());
       case PtyMessage.Create m -> {
@@ -139,6 +139,20 @@ public final class PtyWire {
       case PtyMessage.Welcome m -> out.type(32).string(m.hostBootId());
     }
     return out.finish();
+  }
+
+  /**
+   * A starting buffer size that fits {@code message} without a realloc for the frames whose length
+   * we know up front — {@code Output}, the hot path, above all, where doubling from 512 would cost
+   * a handful of copies per 64 KiB frame per subscriber. Everything small keeps the modest default.
+   */
+  private static int sizeHint(PtyMessage message) {
+    return switch (message) {
+      case PtyMessage.Output(var seq, var bytes) -> bytes.length + 16;
+      case PtyMessage.SessionEnded(var reason) -> reason.length() + 16;
+      case PtyMessage.Err(var text) -> text.length() + 16;
+      default -> 512;
+    };
   }
 
   private static Writer encodeInfo(Writer out, PtyMessage.SessionInfo info) {
@@ -251,7 +265,11 @@ public final class PtyWire {
   }
 
   private static final class Writer {
-    private ByteBuffer buffer = ByteBuffer.allocate(512);
+    private ByteBuffer buffer;
+
+    Writer(int initialCapacity) {
+      buffer = ByteBuffer.allocate(Math.max(16, initialCapacity));
+    }
 
     Writer type(int type) {
       ensure(1);

--- a/sail-core/src/main/java/ai/singlr/sail/pty/RingJournal.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/RingJournal.java
@@ -10,27 +10,31 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayDeque;
+import java.util.Set;
 
 /**
- * A fixed-capacity ring of raw session bytes, journaled to one file so history survives a host
- * restart — the durability tmux never had. The layout is a small header (magic, version, capacity,
- * total bytes ever written, safe watermark) followed by the ring region; the write position is
- * always {@code totalWritten % capacity}.
+ * A fixed-capacity ring of raw session bytes, journaled to one file that backs a live session's
+ * replay — the whole history the host serves an attacher or a resync from. The layout is a small
+ * header (magic, version, capacity, total bytes ever written, safe watermark) followed by the ring
+ * region; the write position is always {@code totalWritten % capacity}.
+ *
+ * <p>The file is a session's working history, not a durable record: sessions do not survive a host
+ * restart (there is no rehydration), so the host sweeps every ring at start and deletes a session's
+ * ring when it removes the session. The file is created owner-only (0600) — session bytes are as
+ * private as the socket that serves them.
  *
  * <p>The journal stores bytes and one number; it never inspects the stream. The session host owns
  * safety: it feeds the same bytes to a {@link TermBoundary} and calls {@link #markSafe()} at clean
  * points, and {@link #tail(int)} starts replay at the newest safe watermark still inside the window
  * — falling back to the raw window start, flagged unsafe, when history has overwritten it.
  */
-public final class RingJournal implements AutoCloseable {
+public final class RingJournal implements Journal {
 
   private static final long MAGIC = 0x5341494C52494E47L;
   private static final int VERSION = 1;
   private static final int HEADER_BYTES = 40;
-
-  /** One replayable tail: bytes from {@code startOffset} of the stream, safe or best-effort. */
-  public record Tail(long startOffset, boolean safe, byte[] bytes) {}
 
   private final FileChannel channel;
   private final long capacity;
@@ -69,9 +73,7 @@ public final class RingJournal implements AutoCloseable {
     if (capacity <= 0) {
       throw new IllegalArgumentException("Ring capacity must be positive, got " + capacity + ".");
     }
-    var channel =
-        FileChannel.open(
-            path, StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
+    var channel = openOwnerOnly(path);
     if (channel.size() == 0) {
       var journal = new RingJournal(channel, capacity, 0, 0);
       journal.writeHeader();
@@ -112,7 +114,22 @@ public final class RingJournal implements AutoCloseable {
     return new RingJournal(channel, capacity, header.getLong(), header.getLong());
   }
 
+  private static FileChannel openOwnerOnly(Path path) throws IOException {
+    var options =
+        Set.of(StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
+    try {
+      return FileChannel.open(
+          path,
+          options,
+          PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
+    } catch (UnsupportedOperationException notPosix) {
+      return FileChannel.open(
+          path, StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
+    }
+  }
+
   /** Appends {@code buf[0..len)} to the ring and persists the header. */
+  @Override
   public void append(byte[] buf, int len) throws IOException {
     var offset = 0;
     while (offset < len) {
@@ -126,17 +143,12 @@ public final class RingJournal implements AutoCloseable {
   }
 
   /**
-   * Records that the stream is at a safe replay boundary right now — but keeps the OLDEST safe
-   * start still worth replaying: the stored mark only advances once it has fallen below {@code
-   * keepFloor} (the replay budget's edge). Advancing eagerly would mean "nothing to replay" after
-   * every quiet moment; a late attacher wants history, starting clean.
-   */
-  /**
    * Records that the stream is at a safe replay boundary right now. The journal keeps every such
    * boundary still inside the ring (a stride apart, so the set stays small); a replay of any width
    * then starts at the oldest boundary inside its window, so a late attacher gets the most history
    * the ring can offer, and never a screen that begins mid-sequence.
    */
+  @Override
   public void markSafe() throws IOException {
     var boundary = totalWritten;
     var start = windowStart();
@@ -158,7 +170,8 @@ public final class RingJournal implements AutoCloseable {
    * that window when there is one; otherwise from the window start, flagged unsafe so the client
    * clears its screen before applying.
    */
-  public Tail tail(int maxBytes) throws IOException {
+  @Override
+  public Journal.Tail tail(int maxBytes) throws IOException {
     var from = Math.max(windowStart(), totalWritten - maxBytes);
     var safe = false;
     for (var checkpoint : checkpoints) {
@@ -178,13 +191,15 @@ public final class RingJournal implements AutoCloseable {
       channel.read(slice, HEADER_BYTES + position);
       read += chunk;
     }
-    return new Tail(from, safe, bytes);
+    return new Journal.Tail(from, safe, bytes);
   }
 
+  @Override
   public long capacity() {
     return capacity;
   }
 
+  @Override
   public long totalWritten() {
     return totalWritten;
   }

--- a/sail-core/src/main/java/ai/singlr/sail/pty/SubscriberQueue.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/SubscriberQueue.java
@@ -14,46 +14,68 @@ import java.util.Deque;
  * and the first {@link #next()} after the pause has drained returns {@code Continued} — resume is
  * the consumer's act of catching up, not a race against the producer's next output. Deterministic
  * by construction, so the contract is provable single-threaded.
+ *
+ * <p>The backlog is bounded two ways at once, so neither a flood of tiny frames nor a few huge ones
+ * can pin heap: by count ({@code capacity} live messages) and by bytes ({@code maxLiveBytes} of
+ * live payload). Whichever trips first pauses the subscriber. Only live output counts; a forced
+ * ending or an installed resync may exceed either cap without tripping a second pause behind the
+ * first.
  */
 final class SubscriberQueue {
 
-  /** One queued message; {@code live} marks stream output that counts toward the backlog cap. */
-  private record Entry(PtyMessage message, boolean live) {}
+  static final int DEFAULT_MAX_LIVE_BYTES = 1 << 20;
+
+  /** One queued message; {@code live} marks stream output that counts toward the backlog caps. */
+  private record Entry(PtyMessage message, boolean live, int bytes) {}
 
   private final int capacity;
+  private final int maxLiveBytes;
   private final Deque<Entry> queue = new ArrayDeque<>();
   private int live;
+  private long liveBytes;
   private boolean paused;
 
   SubscriberQueue(int capacity) {
+    this(capacity, DEFAULT_MAX_LIVE_BYTES);
+  }
+
+  SubscriberQueue(int capacity, int maxLiveBytes) {
     this.capacity = capacity;
+    this.maxLiveBytes = maxLiveBytes;
+  }
+
+  private static int weightOf(PtyMessage message) {
+    return message instanceof PtyMessage.Output(var seq, var bytes) ? bytes.length : 0;
   }
 
   /**
-   * Offers a live message; a full backlog of live messages trips the pause, a paused queue drops
-   * silently. Only live messages count: a replay installed with {@link #replaceWith} or a forced
-   * message may exceed the cap without tripping a second pause behind the first (which would resync
-   * again, and again).
+   * Offers a live message; a full backlog of live messages or bytes trips the pause, a paused queue
+   * drops silently. Only live messages count: a replay installed with {@link #replaceWith} or a
+   * forced message may exceed a cap without tripping a second pause behind the first (which would
+   * resync again, and again).
    */
   synchronized void enqueue(PtyMessage message) {
     if (paused) {
       return;
     }
-    if (live >= capacity) {
+    var weight = weightOf(message);
+    if (live >= capacity || liveBytes + weight > maxLiveBytes) {
       paused = true;
       queue.clear();
       live = 0;
-      queue.add(new Entry(new PtyMessage.Paused(), false));
+      liveBytes = 0;
+      queue.add(new Entry(new PtyMessage.Paused(), false, 0));
     } else {
-      queue.add(new Entry(message, true));
+      queue.add(new Entry(message, true, weight));
       live++;
+      liveBytes += weight;
     }
     notifyAll();
   }
 
   /** Enqueues regardless of pause — endings and poison must always arrive. */
   synchronized void force(PtyMessage message) {
-    queue.add(new Entry(message, false));
+    queue.add(new Entry(message, false, 0));
     notifyAll();
   }
 
@@ -71,8 +93,9 @@ final class SubscriberQueue {
             .toList();
     queue.clear();
     live = 0;
-    messages.forEach(m -> queue.add(new Entry(m, false)));
-    terminal.forEach(m -> queue.add(new Entry(m, false)));
+    liveBytes = 0;
+    messages.forEach(m -> queue.add(new Entry(m, false, 0)));
+    terminal.forEach(m -> queue.add(new Entry(m, false, 0)));
     notifyAll();
   }
 
@@ -80,8 +103,9 @@ final class SubscriberQueue {
   synchronized void clearAnd(PtyMessage message) {
     queue.clear();
     live = 0;
+    liveBytes = 0;
     paused = false;
-    queue.add(new Entry(message, false));
+    queue.add(new Entry(message, false, 0));
     notifyAll();
   }
 
@@ -100,6 +124,7 @@ final class SubscriberQueue {
     var entry = queue.poll();
     if (entry.live()) {
       live--;
+      liveBytes -= entry.bytes();
     }
     return entry.message();
   }

--- a/sail-core/src/main/java/ai/singlr/sail/pty/SubscriberQueue.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/SubscriberQueue.java
@@ -73,8 +73,16 @@ final class SubscriberQueue {
     notifyAll();
   }
 
-  /** Enqueues regardless of pause — endings and poison must always arrive. */
+  /**
+   * Enqueues regardless of pause — endings and poison must always arrive. A state notification
+   * ({@code WriterChanged}, {@code Resized}) replaces any of its kind still pending: only the
+   * latest writer or geometry matters to a reader that is catching up, and a client can raise these
+   * at will (a TakeWrite storm), so they must not accumulate the way the caps forbid output to.
+   */
   synchronized void force(PtyMessage message) {
+    if (message instanceof PtyMessage.WriterChanged || message instanceof PtyMessage.Resized) {
+      queue.removeIf(entry -> entry.message().getClass() == message.getClass());
+    }
     queue.add(new Entry(message, false, 0));
     notifyAll();
   }

--- a/sail-core/src/test/java/ai/singlr/sail/engine/NameValidatorTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/engine/NameValidatorTest.java
@@ -259,4 +259,32 @@ class NameValidatorTest {
   void nullFdeHandleIsInvalid() {
     assertThrows(IllegalArgumentException.class, () -> NameValidator.requireValidFdeHandle(null));
   }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"resume-abc123", "room-oauth-flow.2", "MyShell", "s1", "a", "0", "a.b-c-d"})
+  void validSessionNames(String name) {
+    assertDoesNotThrow(() -> NameValidator.requireValidSessionName(name));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"../foo", "a/b", "..", "a..b", "has space", "", ".hidden", "-dash"})
+  void invalidSessionNames(String name) {
+    var ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> NameValidator.requireValidSessionName(name));
+    assertTrue(ex.getMessage().contains("Invalid session name"));
+  }
+
+  @Test
+  void nullSessionNameIsInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> NameValidator.requireValidSessionName(null));
+  }
+
+  @Test
+  void sessionNameExceedingMaxLengthIsInvalid() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> NameValidator.requireValidSessionName("a".repeat(81)));
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -451,6 +451,32 @@ class PtySessionTest {
   }
 
   @Test
+  void aChildThatStoppedReadingBoundsQueuedInputByBytesNotJustFrames() throws Exception {
+    try (var session = session("stty raw -echo; echo raw-ready; sleep 60")) {
+      var writer = new Collector();
+      var writerId = session.attach(writer, true, "uday");
+      writer.awaitOutput("raw-ready");
+
+      var chunk = new byte[256 * 1024];
+      var accepted = 0;
+      var refused = false;
+      for (var i = 0; i < 16 && !refused; i++) {
+        switch (session.input(writerId, i, chunk)) {
+          case ACCEPTED -> accepted++;
+          case BACKLOG -> refused = true;
+          case NOT_WRITER -> throw new AssertionError("the writer holds the token");
+        }
+      }
+
+      assertTrue(refused, "a child that stopped reading must back input up to BACKLOG");
+      assertTrue(
+          (long) accepted * chunk.length <= PtySession.MAX_INPUT_BACKLOG_BYTES,
+          "queued plus in-flight input exceeded the byte budget: " + accepted + " chunks");
+      assertTrue(session.live(), "backlog is refusable, never fatal");
+    }
+  }
+
+  @Test
   void aFailingEndEventStillReleasesTheSessionInsteadOfWedgingClose() throws Exception {
     var brittle =
         new PtyEvents() {

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -103,10 +103,23 @@ class PtySessionTest {
         24);
   }
 
+  /** A journal whose disk fills the moment {@code trigger} is appended (empty: at once). */
   private static final class FailingJournal implements Journal {
+    private final String trigger;
+
+    FailingJournal() {
+      this("");
+    }
+
+    FailingJournal(String trigger) {
+      this.trigger = trigger;
+    }
+
     @Override
     public void append(byte[] buf, int len) throws IOException {
-      throw new IOException("disk full");
+      if (new String(buf, 0, len, StandardCharsets.UTF_8).contains(trigger)) {
+        throw new IOException("disk full");
+      }
     }
 
     @Override
@@ -129,6 +142,38 @@ class PtySessionTest {
 
     @Override
     public void close() {}
+  }
+
+  @Test
+  void anIoErrorEndingReapsAChildThatIgnoresTermination() throws Exception {
+    var session =
+        PtySession.start(
+            origin("stubborn", "uday", "acme"),
+            PtyEvents.NONE,
+            List.of(
+                "sh",
+                "-c",
+                "trap '' HUP TERM; echo \"pid=$$;\"; read x; echo boom; while :; do sleep 1; done"),
+            Map.of("TERM", "dumb"),
+            Path.of("/tmp"),
+            new FailingJournal("boom"),
+            80,
+            24,
+            4096);
+    try {
+      var client = new Collector();
+      var id = session.attach(client, true, "uday");
+      client.awaitOutput(";");
+      var pid = Long.parseLong(client.outputText().replaceAll("(?s).*pid=(\\d+);.*", "$1"));
+      session.input(id, 1, "\n".getBytes(StandardCharsets.UTF_8));
+      assertTrue(client.ended.await(10, TimeUnit.SECONDS), "the failure ends the session");
+
+      assertFalse(
+          ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false),
+          "a child that shrugs off SIGHUP and SIGTERM is dead before the ending is published");
+    } finally {
+      session.close();
+    }
   }
 
   @Test

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -103,6 +103,71 @@ class PtySessionTest {
         24);
   }
 
+  private static final class FailingJournal implements Journal {
+    @Override
+    public void append(byte[] buf, int len) throws IOException {
+      throw new IOException("disk full");
+    }
+
+    @Override
+    public void markSafe() {}
+
+    @Override
+    public Tail tail(int maxBytes) {
+      return new Tail(0, true, new byte[0]);
+    }
+
+    @Override
+    public long capacity() {
+      return 64 * 1024;
+    }
+
+    @Override
+    public long totalWritten() {
+      return 0;
+    }
+
+    @Override
+    public void close() {}
+  }
+
+  @Test
+  void anInjectedJournalFailureEndsTheSessionInsteadOfWedging() throws Exception {
+    var session =
+        PtySession.start(
+            origin("wedge", "uday", "acme"),
+            PtyEvents.NONE,
+            List.of("sh", "-c", "read x; echo boom"),
+            Map.of("TERM", "dumb"),
+            Path.of("/tmp"),
+            new FailingJournal(),
+            80,
+            24,
+            4096);
+    try {
+      var client = new Collector();
+      var id = session.attach(client, true, "uday");
+      session.input(id, 1, "\n".getBytes(StandardCharsets.UTF_8));
+
+      assertTrue(
+          client.ended.await(10, TimeUnit.SECONDS),
+          "a journal that throws must end the session loudly, never wedge it");
+      assertFalse(session.live(), "the failed session is no longer live");
+      assertTrue(
+          client.messages.stream()
+              .anyMatch(
+                  m ->
+                      m instanceof PtyMessage.SessionEnded(var reason)
+                          && reason.contains("io-error")),
+          "every subscriber hears an io-error ending: " + client.messages);
+    } finally {
+      assertTimeoutPreemptively(
+          java.time.Duration.ofSeconds(10),
+          session::close,
+          "close must not hang after a journal failure ended the session");
+    }
+  }
+
   @Test
   void endDeliversTheNoticeAndTheReasonEvenToASubscriberStillDraining() throws Exception {
     var endings = new java.util.concurrent.ConcurrentLinkedQueue<String>();
@@ -310,7 +375,8 @@ class PtySessionTest {
       var firstId = session.attach(first, true, "uday");
       var secondId = session.attach(second, false, "uday");
 
-      assertFalse(
+      assertEquals(
+          PtySession.WriteOutcome.NOT_WRITER,
           session.input(secondId, 1, "nope\n".getBytes(StandardCharsets.UTF_8)),
           "a non-writer's input is refused, not fatal");
 
@@ -321,7 +387,8 @@ class PtySessionTest {
       }
       assertTrue(first.saw(PtyMessage.WriterChanged.class), "the old writer hears the takeover");
 
-      assertFalse(
+      assertEquals(
+          PtySession.WriteOutcome.NOT_WRITER,
           session.input(firstId, 2, "stale\n".getBytes(StandardCharsets.UTF_8)),
           "the demoted writer can no longer write");
       session.input(secondId, 3, "fresh\n".getBytes(StandardCharsets.UTF_8));

--- a/sail-core/src/test/java/ai/singlr/sail/pty/RingJournalTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/RingJournalTest.java
@@ -139,4 +139,17 @@ class RingJournalTest {
       assertArrayEquals(bytes("ccccc"), tail.bytes());
     }
   }
+
+  @Test
+  @org.junit.jupiter.api.condition.EnabledOnOs(org.junit.jupiter.api.condition.OS.LINUX)
+  void aFreshRingIsCreatedOwnerOnly() throws Exception {
+    var path = dir.resolve("private.ring");
+    try (var ring = RingJournal.open(path, 1024)) {
+      ring.append(bytes("secret"), 6);
+    }
+    assertEquals(
+        "rw-------",
+        java.nio.file.attribute.PosixFilePermissions.toString(Files.getPosixFilePermissions(path)),
+        "session bytes are as private as the socket that serves them");
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/pty/SubscriberQueueTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/SubscriberQueueTest.java
@@ -126,4 +126,26 @@ class SubscriberQueueTest {
         "five 64 KiB frames overrun the 256 KiB byte cap, pausing at 5 of 4096 slots — the byte cap"
             + " bounds heap where a frame count never could");
   }
+
+  @Test
+  void repeatedStateNotificationsCoalesceSoAStalledReaderCannotBeFloodedWithThem()
+      throws Exception {
+    var queue = new SubscriberQueue(4);
+    queue.enqueue(out(1));
+    queue.force(new PtyMessage.Resized(80, 24));
+    for (var i = 0; i < 100_000; i++) {
+      queue.force(new PtyMessage.WriterChanged("fde-" + i));
+    }
+    queue.force(new PtyMessage.Resized(100, 40));
+    queue.force(new PtyMessage.SessionEnded("gone"));
+
+    assertEquals(1, ((PtyMessage.Output) queue.next()).lastInputSeq(), "output is untouched");
+    assertEquals(
+        new PtyMessage.WriterChanged("fde-99999"),
+        queue.next(),
+        "only the latest writer is pending — a TakeWrite storm cannot grow the queue");
+    assertEquals(
+        new PtyMessage.Resized(100, 40), queue.next(), "only the latest geometry is pending");
+    assertInstanceOf(PtyMessage.SessionEnded.class, queue.next(), "the ending still arrives");
+  }
 }

--- a/sail-core/src/test/java/ai/singlr/sail/pty/SubscriberQueueTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/SubscriberQueueTest.java
@@ -111,4 +111,19 @@ class SubscriberQueueTest {
     assertInstanceOf(PtyMessage.Paused.class, queue.next());
     assertInstanceOf(PtyMessage.SessionEnded.class, queue.next(), "an ending outranks the pause");
   }
+
+  @Test
+  void theByteCapTripsThePauseLongBeforeTheCountCapWouldWithLargeFrames() throws Exception {
+    var queue = new SubscriberQueue(4096, 256 * 1024);
+    var big = new PtyMessage.Output(0, new byte[64 * 1024]);
+    for (var i = 0; i < 5; i++) {
+      queue.enqueue(big);
+    }
+
+    assertInstanceOf(
+        PtyMessage.Paused.class,
+        queue.next(),
+        "five 64 KiB frames overrun the 256 KiB byte cap, pausing at 5 of 4096 slots — the byte cap"
+            + " bounds heap where a frame count never could");
+  }
 }

--- a/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
@@ -6,6 +6,7 @@
 package ai.singlr.sail.pty;
 
 import ai.singlr.sail.common.Ids;
+import ai.singlr.sail.engine.NameValidator;
 import java.io.IOException;
 import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
@@ -24,6 +25,7 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * The per-container session host: owns every {@link PtySession}, serves the {@link PtyWire}
@@ -48,6 +50,15 @@ public final class PtySessionHost implements AutoCloseable {
   static final Duration CORPSE_RETENTION = Duration.ofMinutes(10);
   static final String DISPATCH_CREDENTIAL_FILE = "pty-dispatch.token";
 
+  /**
+   * The host's resource ceilings, each refused with an {@code Err} that names the cap: sessions one
+   * FDE may own at once, subscribers one session may fan out to, and connections the host serves at
+   * once. {@link #DEFAULTS} is production; tests inject smaller values.
+   */
+  public record Limits(int sessionsPerFde, int subscribersPerSession, int connections) {
+    public static final Limits DEFAULTS = new Limits(32, 16, 256);
+  }
+
   private final Path socketPath;
   private final Path sessionsDir;
   private final long journalCapacity;
@@ -55,8 +66,10 @@ public final class PtySessionHost implements AutoCloseable {
   private final PtyRooms rooms;
   private final PtyEvents events;
   private final String version;
+  private final Limits limits;
   private final Map<String, PtySession> sessions = new ConcurrentHashMap<>();
   private final String bootId = Ids.newId().toString();
+  private final AtomicInteger connections = new AtomicInteger();
   private volatile ServerSocketChannel server;
   private volatile byte[] dispatchCredential = new byte[0];
   private volatile boolean closed;
@@ -69,6 +82,26 @@ public final class PtySessionHost implements AutoCloseable {
       PtyRooms rooms,
       PtyEvents events,
       String version) {
+    this(
+        socketPath,
+        sessionsDir,
+        journalCapacity,
+        identity,
+        rooms,
+        events,
+        version,
+        Limits.DEFAULTS);
+  }
+
+  PtySessionHost(
+      Path socketPath,
+      Path sessionsDir,
+      long journalCapacity,
+      PtyIdentity.Resolver identity,
+      PtyRooms rooms,
+      PtyEvents events,
+      String version,
+      Limits limits) {
     this.socketPath = socketPath;
     this.sessionsDir = sessionsDir;
     this.journalCapacity = journalCapacity;
@@ -76,6 +109,7 @@ public final class PtySessionHost implements AutoCloseable {
     this.rooms = rooms;
     this.events = events;
     this.version = version;
+    this.limits = limits;
   }
 
   /**
@@ -90,6 +124,7 @@ public final class PtySessionHost implements AutoCloseable {
 
   public void start() throws IOException {
     Files.createDirectories(sessionsDir);
+    sweepOrphanRings();
     var socketDir = socketPath.getParent();
     if (socketDir != null) {
       Files.createDirectories(socketDir);
@@ -109,6 +144,38 @@ public final class PtySessionHost implements AutoCloseable {
    */
   public static Path dispatchCredentialOf(Path socket) {
     return socket.resolveSibling(DISPATCH_CREDENTIAL_FILE);
+  }
+
+  /**
+   * Deletes every {@code *.ring} left in the sessions directory. Sessions do not survive a host
+   * restart (there is no rehydration — the child is dead anyway), so any ring on disk at start is
+   * an orphan of a previous run; leaving them would leak 4 MB per distinct name forever and let a
+   * fresh create collide with a stranger's history that no {@link #admitted} check guards.
+   */
+  private void sweepOrphanRings() throws IOException {
+    try (var rings = Files.list(sessionsDir)) {
+      for (var ring : rings.filter(p -> p.getFileName().toString().endsWith(".ring")).toList()) {
+        Files.deleteIfExists(ring);
+      }
+    }
+  }
+
+  /**
+   * One structured line to the host's journald unit (stderr): the principal, the session, and why.
+   * The wire {@code Err} names only what the caller may see; this is where the host records the
+   * rest — every attach, every refusal, every last-resort exception — so a silent close leaves a
+   * trace.
+   */
+  private static void log(String event, String principal, String session, String reason) {
+    System.err.println(
+        "pty-host: "
+            + event
+            + " principal="
+            + principal
+            + " session="
+            + session
+            + " reason="
+            + reason);
   }
 
   private void mintDispatchCredential() throws IOException {
@@ -170,16 +237,29 @@ public final class PtySessionHost implements AutoCloseable {
   private void serve(SocketChannel channel) {
     PtySession attached = null;
     var subscriberId = -1L;
+    var principal = "?";
+    var overCap = connections.incrementAndGet() > limits.connections();
     try (channel) {
       PtyWire.handshake(channel, channel);
       PtyIdentity who;
       if (PtyWire.read(channel) instanceof PtyMessage.Hello(var token)) {
+        if (overCap) {
+          log("refused", principal, "-", "connection cap " + limits.connections());
+          reply(
+              channel,
+              new PtyMessage.Err(
+                  "The host is at its connection cap of "
+                      + limits.connections()
+                      + "; try again shortly."));
+          return;
+        }
         try {
           who = identify(token);
         } catch (IOException refused) {
           reply(channel, new PtyMessage.Err(refused.getMessage()));
           return;
         }
+        principal = who.fde();
         reply(channel, new PtyMessage.Welcome(bootId));
       } else {
         reply(channel, new PtyMessage.Err("The first frame must identify you: send Hello."));
@@ -205,21 +285,46 @@ public final class PtySessionHost implements AutoCloseable {
               break;
             }
             if (!admitted(who, session)) {
+              log("refused", principal, m.session(), "not admitted");
+              reply(
+                  channel,
+                  new PtyMessage.Err("Session '" + m.session() + "' is not yours to attach."));
+              break;
+            }
+            if (session.attachedCount() >= limits.subscribersPerSession()) {
+              log(
+                  "refused",
+                  principal,
+                  m.session(),
+                  "subscriber cap " + limits.subscribersPerSession());
               reply(
                   channel,
                   new PtyMessage.Err(
-                      "Session '" + m.session() + "' belongs to " + session.ownerFde() + "."));
+                      "Session '"
+                          + m.session()
+                          + "' is at its subscriber cap of "
+                          + limits.subscribersPerSession()
+                          + "."));
               break;
             }
             reply(channel, new PtyMessage.Ok());
             subscriberId = session.attach(msg -> reply(channel, msg), m.write(), who.fde());
             attached = session;
+            log("attached", principal, m.session(), m.write() ? "write" : "observe");
           }
           case PtyMessage.Input m -> {
             if (attached == null) {
               reply(channel, new PtyMessage.Err("Attach before writing."));
-            } else if (!attached.input(subscriberId, m.seq(), m.bytes())) {
-              reply(channel, new PtyMessage.Err("You do not hold the write token."));
+            } else {
+              switch (attached.input(subscriberId, m.seq(), m.bytes())) {
+                case NOT_WRITER ->
+                    reply(channel, new PtyMessage.Err("You do not hold the write token."));
+                case BACKLOG ->
+                    reply(
+                        channel,
+                        new PtyMessage.Err("Input backlog is full; the session is not reading."));
+                case ACCEPTED -> {}
+              }
             }
           }
           case PtyMessage.Resize m -> {
@@ -253,10 +358,16 @@ public final class PtySessionHost implements AutoCloseable {
           default -> reply(channel, new PtyMessage.Err("Unexpected client frame."));
         }
       }
-    } catch (IOException e) {
+    } catch (IOException disconnected) {
+      var unused = disconnected;
+    } catch (RuntimeException crashed) {
+      log("exception", principal, "-", crashed.toString());
+      reply(channel, new PtyMessage.Err("The host could not serve that request."));
+    } finally {
       if (attached != null) {
         attached.detach(subscriberId);
       }
+      connections.decrementAndGet();
     }
   }
 
@@ -303,14 +414,31 @@ public final class PtySessionHost implements AutoCloseable {
   }
 
   private PtyMessage create(PtyMessage.Create m, PtyIdentity who) {
+    Path cwd;
+    try {
+      NameValidator.requireValidSessionName(m.session());
+      if (m.project() != null && !m.project().isBlank()) {
+        NameValidator.requireValidProjectName(m.project());
+      }
+      requireValidGeometry(m.cols(), m.rows());
+      cwd = requireValidCwd(m.cwd());
+    } catch (IllegalArgumentException bad) {
+      log("refused", who.fde(), m.session(), bad.getMessage());
+      return new PtyMessage.Err(bad.getMessage());
+    }
     var existing = sessions.get(m.session());
     if (existing != null && !admitted(who, existing)) {
-      return new PtyMessage.Err(
-          "Session '" + m.session() + "' belongs to " + existing.ownerFde() + ".");
+      log("refused", who.fde(), m.session(), "not admitted");
+      return new PtyMessage.Err("Session '" + m.session() + "' is not yours.");
     }
     if (existing != null && existing.live()) {
       return new PtyMessage.Err(
           "Session '" + m.session() + "' is already running; attach or kill it.");
+    }
+    if (existing == null && ownedBy(who.fde()) >= limits.sessionsPerFde()) {
+      log("refused", who.fde(), m.session(), "session cap " + limits.sessionsPerFde());
+      return new PtyMessage.Err(
+          "You are at your session cap of " + limits.sessionsPerFde() + "; kill one first.");
     }
     var commandBytes = PtyWire.wireSize(m.command());
     if (commandBytes > PtyMessage.MAX_COMMAND_BYTES) {
@@ -354,7 +482,7 @@ public final class PtySessionHost implements AutoCloseable {
               events,
               childCommand(origin, env),
               env,
-              Path.of(m.cwd()),
+              cwd,
               ring,
               journalCapacity,
               m.cols(),
@@ -364,6 +492,29 @@ public final class PtySessionHost implements AutoCloseable {
     } catch (IOException e) {
       return new PtyMessage.Err("Could not start session '" + m.session() + "': " + e.getMessage());
     }
+  }
+
+  private static void requireValidGeometry(int cols, int rows) {
+    if (cols < 1 || cols > 65535 || rows < 1 || rows > 65535) {
+      throw new IllegalArgumentException(
+          "Invalid terminal size "
+              + cols
+              + "x"
+              + rows
+              + "; each of cols and rows must be 1..65535.");
+    }
+  }
+
+  private static Path requireValidCwd(String cwd) {
+    try {
+      return Path.of(java.util.Objects.requireNonNullElse(cwd, ""));
+    } catch (java.nio.file.InvalidPathException bad) {
+      throw new IllegalArgumentException("Invalid working directory: " + bad.getMessage());
+    }
+  }
+
+  private long ownedBy(String fde) {
+    return sessions.values().stream().filter(s -> s.ownerFde().equals(fde)).count();
   }
 
   /**
@@ -403,7 +554,8 @@ public final class PtySessionHost implements AutoCloseable {
       return new PtyMessage.Err("No session '" + name + "'.");
     }
     if (!admitted(who, session)) {
-      return new PtyMessage.Err("Session '" + name + "' belongs to " + session.ownerFde() + ".");
+      log("refused", who.fde(), name, "not admitted");
+      return new PtyMessage.Err("Session '" + name + "' is not yours.");
     }
     remove(name, session);
     return new PtyMessage.Ok();
@@ -428,6 +580,11 @@ public final class PtySessionHost implements AutoCloseable {
   private void remove(String name, PtySession session) {
     sessions.remove(name, session);
     session.close();
+    try {
+      Files.deleteIfExists(sessionsDir.resolve(name + ".ring"));
+    } catch (IOException e) {
+      log("ring-delete-failed", session.ownerFde(), name, e.toString());
+    }
   }
 
   /** One reaping pass at {@code nowNanos}: the mosh grace and retention rules, nothing else. */

--- a/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
@@ -51,9 +51,11 @@ public final class PtySessionHost implements AutoCloseable {
   static final String DISPATCH_CREDENTIAL_FILE = "pty-dispatch.token";
 
   /**
-   * The host's resource ceilings, each refused with an {@code Err} that names the cap: sessions one
-   * FDE may own at once, subscribers one session may fan out to, and connections the host serves at
-   * once. {@link #DEFAULTS} is production; tests inject smaller values.
+   * The host's resource ceilings: sessions one FDE may own at once and subscribers one session may
+   * fan out to, each refused with an {@code Err} that names the cap; and connections the host
+   * serves at once, an excess socket being closed before a byte of it is read, so a peer that opens
+   * many and never speaks holds no handler, descriptor, or frame past the cap. {@link #DEFAULTS} is
+   * production; tests inject smaller values.
    */
   public record Limits(int sessionsPerFde, int subscribersPerSession, int connections) {
     public static final Limits DEFAULTS = new Limits(32, 16, 256);
@@ -240,129 +242,130 @@ public final class PtySessionHost implements AutoCloseable {
     var principal = "?";
     var overCap = connections.incrementAndGet() > limits.connections();
     try (channel) {
-      PtyWire.handshake(channel, channel);
-      PtyIdentity who;
-      if (PtyWire.read(channel) instanceof PtyMessage.Hello(var token)) {
-        if (overCap) {
-          log("refused", principal, "-", "connection cap " + limits.connections());
-          reply(
-              channel,
-              new PtyMessage.Err(
-                  "The host is at its connection cap of "
-                      + limits.connections()
-                      + "; try again shortly."));
-          return;
-        }
-        try {
-          who = identify(token);
-        } catch (IOException refused) {
-          reply(channel, new PtyMessage.Err(refused.getMessage()));
-          return;
-        }
-        principal = who.fde();
-        reply(channel, new PtyMessage.Welcome(bootId));
-      } else {
-        reply(channel, new PtyMessage.Err("The first frame must identify you: send Hello."));
+      if (overCap) {
+        log("refused", principal, "-", "connection cap " + limits.connections());
         return;
       }
-      while (true) {
-        var message = PtyWire.read(channel);
-        if (who.dispatchAuthority() && !(message instanceof PtyMessage.Yield)) {
-          reply(channel, new PtyMessage.Err("The dispatch authority may only yield sessions."));
-          continue;
-        }
-        switch (message) {
-          case PtyMessage.Create m -> reply(channel, create(m, who));
-          case PtyMessage.Attach m -> {
-            if (attached != null) {
-              reply(channel, new PtyMessage.Err("This connection is already attached."));
-              break;
-            }
-            var session = sessions.get(m.session());
-            if (session == null || !session.live()) {
-              reply(
-                  channel, new PtyMessage.Err("No live session '" + m.session() + "' to attach."));
-              break;
-            }
-            if (!admitted(who, session)) {
-              log("refused", principal, m.session(), "not admitted");
-              reply(
-                  channel,
-                  new PtyMessage.Err("Session '" + m.session() + "' is not yours to attach."));
-              break;
-            }
-            if (session.attachedCount() >= limits.subscribersPerSession()) {
-              log(
-                  "refused",
-                  principal,
-                  m.session(),
-                  "subscriber cap " + limits.subscribersPerSession());
-              reply(
-                  channel,
-                  new PtyMessage.Err(
-                      "Session '"
-                          + m.session()
-                          + "' is at its subscriber cap of "
-                          + limits.subscribersPerSession()
-                          + "."));
-              break;
-            }
-            reply(channel, new PtyMessage.Ok());
-            subscriberId = session.attach(msg -> reply(channel, msg), m.write(), who.fde());
-            attached = session;
-            log("attached", principal, m.session(), m.write() ? "write" : "observe");
+      try {
+        PtyWire.handshake(channel, channel);
+        PtyIdentity who;
+        if (PtyWire.read(channel) instanceof PtyMessage.Hello(var token)) {
+          try {
+            who = identify(token);
+          } catch (IOException refused) {
+            reply(channel, new PtyMessage.Err(refused.getMessage()));
+            return;
           }
-          case PtyMessage.Input m -> {
-            if (attached == null) {
-              reply(channel, new PtyMessage.Err("Attach before writing."));
-            } else {
-              switch (attached.input(subscriberId, m.seq(), m.bytes())) {
-                case NOT_WRITER ->
-                    reply(channel, new PtyMessage.Err("You do not hold the write token."));
-                case BACKLOG ->
-                    reply(
-                        channel,
-                        new PtyMessage.Err("Input backlog is full; the session is not reading."));
-                case ACCEPTED -> {}
+          principal = who.fde();
+          reply(channel, new PtyMessage.Welcome(bootId));
+        } else {
+          reply(channel, new PtyMessage.Err("The first frame must identify you: send Hello."));
+          return;
+        }
+        while (true) {
+          var message = PtyWire.read(channel);
+          if (who.dispatchAuthority() && !(message instanceof PtyMessage.Yield)) {
+            reply(channel, new PtyMessage.Err("The dispatch authority may only yield sessions."));
+            continue;
+          }
+          switch (message) {
+            case PtyMessage.Create m -> reply(channel, create(m, who));
+            case PtyMessage.Attach m -> {
+              if (attached != null) {
+                reply(channel, new PtyMessage.Err("This connection is already attached."));
+                break;
+              }
+              var session = sessions.get(m.session());
+              if (session == null || !session.live()) {
+                reply(
+                    channel,
+                    new PtyMessage.Err("No live session '" + m.session() + "' to attach."));
+                break;
+              }
+              if (!admitted(who, session)) {
+                log("refused", principal, m.session(), "not admitted");
+                reply(
+                    channel,
+                    new PtyMessage.Err("Session '" + m.session() + "' is not yours to attach."));
+                break;
+              }
+              // The cap check and the registration it admits are one step, or concurrent attaches
+              // all take the last slot.
+              synchronized (session) {
+                if (session.attachedCount() >= limits.subscribersPerSession()) {
+                  log(
+                      "refused",
+                      principal,
+                      m.session(),
+                      "subscriber cap " + limits.subscribersPerSession());
+                  reply(
+                      channel,
+                      new PtyMessage.Err(
+                          "Session '"
+                              + m.session()
+                              + "' is at its subscriber cap of "
+                              + limits.subscribersPerSession()
+                              + "."));
+                  break;
+                }
+                reply(channel, new PtyMessage.Ok());
+                subscriberId = session.attach(msg -> reply(channel, msg), m.write(), who.fde());
+                attached = session;
+              }
+              log("attached", principal, m.session(), m.write() ? "write" : "observe");
+            }
+            case PtyMessage.Input m -> {
+              if (attached == null) {
+                reply(channel, new PtyMessage.Err("Attach before writing."));
+              } else {
+                switch (attached.input(subscriberId, m.seq(), m.bytes())) {
+                  case NOT_WRITER ->
+                      reply(channel, new PtyMessage.Err("You do not hold the write token."));
+                  case BACKLOG ->
+                      reply(
+                          channel,
+                          new PtyMessage.Err("Input backlog is full; the session is not reading."));
+                  case ACCEPTED -> {}
+                }
               }
             }
-          }
-          case PtyMessage.Resize m -> {
-            if (attached != null) {
-              var unused = attached.resize(subscriberId, m.cols(), m.rows());
+            case PtyMessage.Resize m -> {
+              if (attached != null) {
+                var unused = attached.resize(subscriberId, m.cols(), m.rows());
+              }
             }
-          }
-          case PtyMessage.TakeWrite m -> {
-            if (attached == null) {
-              reply(channel, new PtyMessage.Err("Attach before taking the write token."));
-            } else {
-              attached.takeWrite(subscriberId, who.fde());
+            case PtyMessage.TakeWrite m -> {
+              if (attached == null) {
+                reply(channel, new PtyMessage.Err("Attach before taking the write token."));
+              } else {
+                attached.takeWrite(subscriberId, who.fde());
+              }
             }
-          }
-          case PtyMessage.Detach m -> {
-            if (attached != null) {
-              attached.detach(subscriberId);
-              attached = null;
-              subscriberId = -1;
+            case PtyMessage.Detach m -> {
+              if (attached != null) {
+                attached.detach(subscriberId);
+                attached = null;
+                subscriberId = -1;
+              }
+              reply(channel, new PtyMessage.Ok());
             }
-            reply(channel, new PtyMessage.Ok());
+            case PtyMessage.ListSessions m -> reply(channel, listSessions(who, m));
+            case PtyMessage.Kill m -> reply(channel, kill(m.session(), who));
+            case PtyMessage.Yield m ->
+                reply(
+                    channel,
+                    who.dispatchAuthority()
+                        ? yieldSession(m.session(), m.reason())
+                        : new PtyMessage.Err("Yield requires host dispatch authority."));
+            default -> reply(channel, new PtyMessage.Err("Unexpected client frame."));
           }
-          case PtyMessage.ListSessions m -> reply(channel, listSessions(who, m));
-          case PtyMessage.Kill m -> reply(channel, kill(m.session(), who));
-          case PtyMessage.Yield m ->
-              reply(
-                  channel,
-                  who.dispatchAuthority()
-                      ? yieldSession(m.session(), m.reason())
-                      : new PtyMessage.Err("Yield requires host dispatch authority."));
-          default -> reply(channel, new PtyMessage.Err("Unexpected client frame."));
         }
+      } catch (RuntimeException crashed) {
+        log("exception", principal, "-", crashed.toString());
+        reply(channel, new PtyMessage.Err("The host could not serve that request."));
       }
     } catch (IOException disconnected) {
       var unused = disconnected;
-    } catch (RuntimeException crashed) {
-      log("exception", principal, "-", crashed.toString());
-      reply(channel, new PtyMessage.Err("The host could not serve that request."));
     } finally {
       if (attached != null) {
         attached.detach(subscriberId);
@@ -413,7 +416,11 @@ public final class PtySessionHost implements AutoCloseable {
         : ai.singlr.sail.engine.ContainerExec.asDevUserTty(project, env, origin.command());
   }
 
-  private PtyMessage create(PtyMessage.Create m, PtyIdentity who) {
+  /**
+   * Serialized: the per-FDE quota check and the registration of the session it admits must be one
+   * step, or concurrent creates each see the same spare slot and all spawn.
+   */
+  private synchronized PtyMessage create(PtyMessage.Create m, PtyIdentity who) {
     Path cwd;
     try {
       NameValidator.requireValidSessionName(m.session());

--- a/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
@@ -442,7 +442,8 @@ public final class PtySessionHost implements AutoCloseable {
       return new PtyMessage.Err(
           "Session '" + m.session() + "' is already running; attach or kill it.");
     }
-    if (existing == null && ownedBy(who.fde()) >= limits.sessionsPerFde()) {
+    var replacesOwn = existing != null && existing.ownerFde().equals(who.fde());
+    if (!replacesOwn && ownedBy(who.fde()) >= limits.sessionsPerFde()) {
       log("refused", who.fde(), m.session(), "session cap " + limits.sessionsPerFde());
       return new PtyMessage.Err(
           "You are at your session cap of " + limits.sessionsPerFde() + "; kill one first.");
@@ -573,7 +574,7 @@ public final class PtySessionHost implements AutoCloseable {
    * Ends a live session that a reservation displaced — the reason lands in the stream and on the
    * ended event. Idempotent: a session that is not live has nothing to end, so the answer is {@code
    * Ok}. Ownership is not consulted: the dispatch authority ends what the claim displaced,
-   * whichever FDE opened it.
+   * whichever FDE opened it. The ring goes with the session, as it does on a kill.
    */
   private PtyMessage yieldSession(String name, String reason) {
     var session = sessions.get(name);
@@ -582,6 +583,7 @@ public final class PtySessionHost implements AutoCloseable {
     }
     sessions.remove(name, session);
     session.end(reason);
+    deleteRing(sessionsDir.resolve(name + ".ring"), session.ownerFde(), name);
     return new PtyMessage.Ok();
   }
 

--- a/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
@@ -471,8 +471,8 @@ public final class PtySessionHost implements AutoCloseable {
     if (existing != null) {
       remove(m.session(), existing);
     }
+    var ring = sessionsDir.resolve(m.session() + ".ring");
     try {
-      var ring = sessionsDir.resolve(m.session() + ".ring");
       Files.deleteIfExists(ring);
       var origin =
           new PtySession.Origin(
@@ -497,6 +497,7 @@ public final class PtySessionHost implements AutoCloseable {
       sessions.put(m.session(), session);
       return new PtyMessage.Ok();
     } catch (IOException e) {
+      deleteRing(ring, who.fde(), m.session());
       return new PtyMessage.Err("Could not start session '" + m.session() + "': " + e.getMessage());
     }
   }
@@ -587,10 +588,14 @@ public final class PtySessionHost implements AutoCloseable {
   private void remove(String name, PtySession session) {
     sessions.remove(name, session);
     session.close();
+    deleteRing(sessionsDir.resolve(name + ".ring"), session.ownerFde(), name);
+  }
+
+  private void deleteRing(Path ring, String fde, String name) {
     try {
-      Files.deleteIfExists(sessionsDir.resolve(name + ".ring"));
+      Files.deleteIfExists(ring);
     } catch (IOException e) {
-      log("ring-delete-failed", session.ownerFde(), name, e.toString());
+      log("ring-delete-failed", fde, name, e.toString());
     }
   }
 

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
@@ -21,6 +21,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -34,6 +36,8 @@ class PtySessionHostTest {
   private PtySessionHost host;
   private final java.util.concurrent.ConcurrentLinkedQueue<String> events =
       new java.util.concurrent.ConcurrentLinkedQueue<>();
+  private volatile CountDownLatch startGate;
+  private final CountDownLatch startGated = new CountDownLatch(1);
 
   private static final PtyIdentity.Resolver RESOLVER =
       token ->
@@ -70,6 +74,15 @@ class PtySessionHostTest {
               @Override
               public void sessionStarted(PtySession.Origin origin) {
                 events.add("started:" + origin.name() + ":" + origin.ownerFde());
+                var gate = startGate;
+                if (gate != null) {
+                  startGated.countDown();
+                  try {
+                    gate.await();
+                  } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                  }
+                }
               }
 
               @Override
@@ -875,8 +888,120 @@ class PtySessionHostTest {
   void theHostRefusesConnectionsBeyondItsCap() throws Exception {
     try (var ignored = startHost(new PtySessionHost.Limits(8, 8, 1));
         var first = connect()) {
-      var refused = assertThrows(IOException.class, this::connect);
-      assertTrue(refused.getMessage().contains("connection cap of 1"), refused.getMessage());
+      assertThrows(IOException.class, this::connect);
+    }
+  }
+
+  @Test
+  void aSocketOverTheConnectionCapIsClosedBeforeItSpeaks() throws Exception {
+    try (var ignored = startHost(new PtySessionHost.Limits(8, 8, 1));
+        var first = connect();
+        var silent = SocketChannel.open(StandardProtocolFamily.UNIX)) {
+      silent.connect(UnixDomainSocketAddress.of(dir.resolve("host.sock")));
+      var read =
+          assertTimeoutPreemptively(
+              java.time.Duration.ofSeconds(10),
+              () -> silent.read(java.nio.ByteBuffer.allocate(PtyWire.MAGIC.length)),
+              "an over-cap socket must not be held waiting for its handshake");
+      assertEquals(-1, read, "the host closes an excess socket without reading or greeting it");
+    }
+  }
+
+  @Test
+  void concurrentCreatesCannotExceedThePerFdeSessionCap() throws Exception {
+    try (var ignored = startHost(new PtySessionHost.Limits(1, 8, 8));
+        var first = connect();
+        var second = connect()) {
+      startGate = new CountDownLatch(1);
+      PtyWire.write(
+          first,
+          new PtyMessage.Create("s0", List.of("sh", "-c", "read x"), "/tmp", "", "", 80, 24));
+      assertTrue(startGated.await(10, TimeUnit.SECONDS), "the first create is mid-admission");
+      PtyWire.write(second, new PtyMessage.ListSessions("", PtyMessage.PAGE_LIMIT));
+      PtyWire.write(
+          second,
+          new PtyMessage.Create("s1", List.of("sh", "-c", "read x"), "/tmp", "", "", 80, 24));
+      assertInstanceOf(PtyMessage.Sessions.class, PtyWire.read(second));
+      try (var fence = connect()) {
+        PtyWire.write(fence, new PtyMessage.ListSessions("", PtyMessage.PAGE_LIMIT));
+        assertInstanceOf(
+            PtyMessage.Sessions.class,
+            PtyWire.read(fence),
+            "the second create has had a whole round trip to reach admission before the gate opens");
+      }
+      startGate.countDown();
+
+      assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(first));
+      var refused = assertInstanceOf(PtyMessage.Err.class, PtyWire.read(second));
+      assertTrue(refused.message().contains("session cap of 1"), refused.message());
+      assertEquals(1, host.sessionCount(), "a create racing an admitted one spawns nothing");
+    }
+  }
+
+  @Test
+  void concurrentAttachesCannotExceedTheSubscriberCap() throws Exception {
+    try (var ignored = startHost(new PtySessionHost.Limits(8, 1, 16))) {
+      try (var owner = connect()) {
+        PtyWire.write(
+            owner,
+            new PtyMessage.Create("shared", List.of("sh", "-c", "read x"), "/tmp", "", "", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(owner));
+      }
+      var contenders = new java.util.ArrayList<SocketChannel>();
+      try {
+        for (var i = 0; i < 8; i++) {
+          contenders.add(connect());
+        }
+        var go = new CountDownLatch(1);
+        var replies = new java.util.concurrent.ConcurrentLinkedQueue<PtyMessage>();
+        var threads =
+            contenders.stream()
+                .map(
+                    channel ->
+                        Thread.ofVirtual()
+                            .start(
+                                () -> {
+                                  try {
+                                    go.await();
+                                    PtyWire.write(channel, new PtyMessage.Attach("shared", false));
+                                    replies.add(PtyWire.read(channel));
+                                  } catch (IOException | InterruptedException e) {
+                                    throw new AssertionError(e);
+                                  }
+                                }))
+                .toList();
+        go.countDown();
+        for (var thread : threads) {
+          thread.join();
+        }
+        assertEquals(
+            1,
+            replies.stream().filter(PtyMessage.Ok.class::isInstance).count(),
+            "exactly one contender takes the last slot: " + replies);
+        assertEquals(
+            7, replies.stream().filter(PtyMessage.Err.class::isInstance).count(), "" + replies);
+        try (var lister = connect()) {
+          assertEquals(1, listed(lister, "shared").attached());
+        }
+      } finally {
+        for (var channel : contenders) {
+          channel.close();
+        }
+      }
+    }
+  }
+
+  @Test
+  void aMalformedFrameIsAnsweredWithErrBeforeTheConnectionCloses() throws Exception {
+    try (var ignored = startHost();
+        var channel = connect()) {
+      var truncatedInput = java.nio.ByteBuffer.allocate(5).putInt(1).put((byte) 3).flip();
+      while (truncatedInput.hasRemaining()) {
+        channel.write(truncatedInput);
+      }
+      var refused = assertInstanceOf(PtyMessage.Err.class, PtyWire.read(channel));
+      assertTrue(refused.message().contains("could not serve"), refused.message());
+      assertThrows(IOException.class, () -> PtyWire.read(channel), "then the host hangs up");
     }
   }
 

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
@@ -771,6 +771,34 @@ class PtySessionHostTest {
   }
 
   @Test
+  void aCreateThatFailsToSpawnLeavesNoRingBehind() throws Exception {
+    try (var ignored = startHost(new PtySessionHost.Limits(1, 16, 256));
+        var channel = connect()) {
+      for (var i = 0; i < 5; i++) {
+        PtyWire.write(
+            channel,
+            new PtyMessage.Create(
+                "doomed" + i,
+                List.of("sh"),
+                dir.resolve("no-such-dir").toString(),
+                "",
+                "",
+                80,
+                24));
+        var refused = assertInstanceOf(PtyMessage.Err.class, PtyWire.read(channel));
+        assertTrue(refused.message().contains("Could not start session"), refused.message());
+      }
+      try (var rings = Files.list(dir.resolve("sessions"))) {
+        assertEquals(
+            List.of(),
+            rings.map(p -> p.getFileName().toString()).filter(n -> n.endsWith(".ring")).toList(),
+            "a failed create owns no session, so it must own no ring either");
+      }
+      assertEquals(0, host.sessionCount());
+    }
+  }
+
+  @Test
   void aSessionsRingIsDeletedWhenItIsKilledAndNoOrphanSurvivesAHostRestart() throws Exception {
     var ring = dir.resolve("sessions").resolve("ringed.ring");
     try (var ignored = startHost();

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -54,6 +55,10 @@ class PtySessionHostTest {
       };
 
   private PtySessionHost startHost() throws IOException {
+    return startHost(PtySessionHost.Limits.DEFAULTS);
+  }
+
+  private PtySessionHost startHost(PtySessionHost.Limits limits) throws IOException {
     host =
         new PtySessionHost(
             dir.resolve("host.sock"),
@@ -77,7 +82,8 @@ class PtySessionHostTest {
                 events.add("ended:" + origin.name());
               }
             },
-            "0.0.0-test");
+            "0.0.0-test",
+            limits);
     host.start();
     return host;
   }
@@ -720,6 +726,157 @@ class PtySessionHostTest {
               + " and the corpse of the other can still tell them apart");
       PtyWire.write(owner, new PtyMessage.Kill("again"));
       assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(owner));
+    }
+  }
+
+  @Test
+  void aPathIshSessionNameIsRefusedBeforeAnythingIsSpawned() throws Exception {
+    try (var ignored = startHost();
+        var channel = connect()) {
+      PtyWire.write(
+          channel, new PtyMessage.Create("../escape", List.of("sh"), "/tmp", "", "", 80, 24));
+      var refused = assertInstanceOf(PtyMessage.Err.class, PtyWire.read(channel));
+      assertTrue(refused.message().contains("Invalid session name"), refused.message());
+      assertFalse(
+          Files.exists(dir.resolve("sessions").resolve("../escape.ring").normalize()),
+          "a traversing name never touched the filesystem");
+      assertEquals(0, host.sessionCount());
+    }
+  }
+
+  @Test
+  void anInvalidProjectYieldsErrNotAConnectionDrop() throws Exception {
+    try (var ignored = startHost();
+        var channel = connect()) {
+      PtyWire.write(
+          channel, new PtyMessage.Create("s", List.of("sh"), "/tmp", "Bad Project", "", 80, 24));
+      assertInstanceOf(PtyMessage.Err.class, PtyWire.read(channel), "an Err, never a silent EOF");
+      PtyWire.write(channel, new PtyMessage.ListSessions("", PtyMessage.PAGE_LIMIT));
+      assertInstanceOf(
+          PtyMessage.Sessions.class, PtyWire.read(channel), "the connection survives the refusal");
+    }
+  }
+
+  @Test
+  void aSessionsRingIsDeletedWhenItIsKilledAndNoOrphanSurvivesAHostRestart() throws Exception {
+    var ring = dir.resolve("sessions").resolve("ringed.ring");
+    try (var ignored = startHost();
+        var channel = connect()) {
+      PtyWire.write(
+          channel,
+          new PtyMessage.Create("ringed", List.of("sh", "-c", "read x"), "/tmp", "", "", 80, 24));
+      assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
+      assertTrue(Files.exists(ring), "a live session has a ring on disk");
+
+      PtyWire.write(channel, new PtyMessage.Kill("ringed"));
+      assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
+      assertFalse(Files.exists(ring), "killing the session deletes its ring");
+    }
+
+    var orphan = dir.resolve("sessions").resolve("orphan.ring");
+    Files.write(orphan, "stale".getBytes(StandardCharsets.UTF_8));
+    try (var ignored = startHost()) {
+      assertFalse(Files.exists(orphan), "a restart sweeps every orphan ring — no rehydration");
+    }
+  }
+
+  @Test
+  void aStoppedChildWithAFloodingWriterDoesNotStallOtherConnections() throws Exception {
+    try (var ignored = startHost()) {
+      try (var flooder = connect()) {
+        PtyWire.write(
+            flooder,
+            new PtyMessage.Create(
+                "stuck", List.of("sh", "-c", "sleep 30"), "/tmp", "", "", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(flooder));
+        PtyWire.write(flooder, new PtyMessage.Attach("stuck", true));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(flooder));
+
+        var drain =
+            Thread.ofVirtual()
+                .start(
+                    () -> {
+                      try {
+                        while (true) {
+                          PtyWire.read(flooder);
+                        }
+                      } catch (IOException done) {
+                        var unused = done;
+                      }
+                    });
+        var big = new byte[16384];
+        for (var i = 0; i < 700; i++) {
+          PtyWire.write(flooder, new PtyMessage.Input(i, big));
+        }
+
+        try (var other = connect("tok-mady")) {
+          PtyWire.write(other, new PtyMessage.ListSessions("", PtyMessage.PAGE_LIMIT));
+          var reply =
+              assertTimeoutPreemptively(
+                  java.time.Duration.ofSeconds(10),
+                  () -> PtyWire.read(other),
+                  "a stuck writer must never pin the accept lane or a second connection");
+          assertInstanceOf(PtyMessage.Sessions.class, reply);
+        }
+        drain.interrupt();
+      }
+    }
+  }
+
+  @Test
+  void createRefusesBeyondThePerFdeSessionCap() throws Exception {
+    try (var ignored = startHost(new PtySessionHost.Limits(2, 8, 8));
+        var channel = connect()) {
+      for (var i = 0; i < 2; i++) {
+        PtyWire.write(
+            channel,
+            new PtyMessage.Create("s" + i, List.of("sh", "-c", "read x"), "/tmp", "", "", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
+      }
+      PtyWire.write(
+          channel,
+          new PtyMessage.Create("s2", List.of("sh", "-c", "read x"), "/tmp", "", "", 80, 24));
+      var refused = assertInstanceOf(PtyMessage.Err.class, PtyWire.read(channel));
+      assertTrue(refused.message().contains("session cap of 2"), refused.message());
+    }
+  }
+
+  @Test
+  void attachRefusesBeyondThePerSessionSubscriberCap() throws Exception {
+    try (var ignored = startHost(new PtySessionHost.Limits(8, 2, 8))) {
+      try (var owner = connect()) {
+        PtyWire.write(
+            owner,
+            new PtyMessage.Create("shared", List.of("sh", "-c", "read x"), "/tmp", "", "", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(owner));
+      }
+      var held = new java.util.ArrayList<SocketChannel>();
+      try {
+        for (var i = 0; i < 2; i++) {
+          var observer = connect();
+          held.add(observer);
+          PtyWire.write(observer, new PtyMessage.Attach("shared", false));
+          assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(observer));
+        }
+        try (var third = connect()) {
+          PtyWire.write(third, new PtyMessage.Attach("shared", false));
+          var refused = assertInstanceOf(PtyMessage.Err.class, PtyWire.read(third));
+          assertTrue(refused.message().contains("subscriber cap of 2"), refused.message());
+        }
+      } finally {
+        for (var channel : held) {
+          channel.close();
+        }
+      }
+    }
+  }
+
+  @Test
+  void theHostRefusesConnectionsBeyondItsCap() throws Exception {
+    try (var ignored = startHost(new PtySessionHost.Limits(8, 8, 1));
+        var first = connect()) {
+      var refused = assertThrows(IOException.class, this::connect);
+      assertTrue(refused.getMessage().contains("connection cap of 1"), refused.getMessage());
     }
   }
 

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
@@ -865,6 +865,68 @@ class PtySessionHostTest {
   }
 
   @Test
+  void aYieldedSessionsRingIsDeletedLikeAKilledOnes() throws Exception {
+    var ring = dir.resolve("sessions").resolve("resume-y.ring");
+    try (var ignored = startHost();
+        var owner = connect()) {
+      PtyWire.write(
+          owner,
+          new PtyMessage.Create("resume-y", List.of("sh", "-c", "read a"), "/tmp", "", "", 80, 24));
+      assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(owner));
+      assertTrue(Files.exists(ring), "a live session has a ring on disk");
+
+      try (var dispatch = connect(dispatchCredential())) {
+        PtyWire.write(dispatch, new PtyMessage.Yield("resume-y", "yielded to dispatch 2"));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(dispatch));
+      }
+      assertFalse(Files.exists(ring), "a yield leaves no ring behind, exactly like a kill");
+      assertEquals(0, host.sessionCount());
+    }
+  }
+
+  @Test
+  void recreatingAnotherOwnersCorpseCountsAgainstTheRecreatorsSessionCap() throws Exception {
+    try (var ignored = startHost(new PtySessionHost.Limits(1, 8, 8))) {
+      try (var uday = connect("tok-uday")) {
+        PtyWire.write(
+            uday,
+            new PtyMessage.Create("keep", List.of("sh", "-c", "exit 0"), "/tmp", "", "", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, readControl(uday));
+        awaitCorpse(uday, "keep");
+      }
+      try (var admin = connect("tok-root")) {
+        PtyWire.write(
+            admin,
+            new PtyMessage.Create("own", List.of("sh", "-c", "exit 0"), "/tmp", "", "", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, readControl(admin));
+        awaitCorpse(admin, "own");
+        PtyWire.write(
+            admin,
+            new PtyMessage.Create("own", List.of("sh", "-c", "read a"), "/tmp", "", "", 80, 24));
+        assertInstanceOf(
+            PtyMessage.Ok.class,
+            readControl(admin),
+            "recreating your own corpse replaces it and takes no extra slot");
+        PtyWire.write(
+            admin,
+            new PtyMessage.Create("keep", List.of("sh", "-c", "read a"), "/tmp", "", "", 80, 24));
+        var refused = assertInstanceOf(PtyMessage.Err.class, readControl(admin));
+        assertTrue(
+            refused.message().contains("session cap of 1"),
+            "another owner's corpse is a new session for the admin: " + refused.message());
+      }
+      try (var uday = connect("tok-uday")) {
+        PtyWire.write(uday, new PtyMessage.ListSessions("", PtyMessage.PAGE_LIMIT));
+        var listed = (PtyMessage.Sessions) readControl(uday);
+        assertEquals(
+            "keep",
+            listed.sessions().getFirst().name(),
+            "the refused recreate left the corpse intact");
+      }
+    }
+  }
+
+  @Test
   void createRefusesBeyondThePerFdeSessionCap() throws Exception {
     try (var ignored = startHost(new PtySessionHost.Limits(2, 8, 8));
         var channel = connect()) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AttachLoop.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AttachLoop.java
@@ -17,8 +17,9 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * The interactive half of {@code sail session attach}, free of terminal-mode side effects so it is
  * testable with plain streams: pumps stdin to {@code Input} frames (detaching on Ctrl-]), renders
- * {@code Output} bytes to stdout, narrates flow control inline. Returns the ending reason, or null
- * when the operator detached and the session lives on.
+ * {@code Output} bytes to stdout, narrates flow control and the host's refusals inline (a rejected
+ * keystroke is never silently lost). Returns the ending reason, or null when the operator detached
+ * and the session lives on.
  */
 public final class AttachLoop {
 
@@ -113,6 +114,10 @@ public final class AttachLoop {
                       .getBytes(StandardCharsets.UTF_8));
           case PtyMessage.Continued resumed ->
               stdout.write("\r\n[sail: output resumed]\r\n".getBytes(StandardCharsets.UTF_8));
+          case PtyMessage.Err(var refusal) -> {
+            stdout.write(("\r\n[sail: " + refusal + "]\r\n").getBytes(StandardCharsets.UTF_8));
+            stdout.flush();
+          }
           default -> {}
         }
       }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
@@ -142,4 +142,60 @@ class AttachLoopTest {
       }
     }
   }
+
+  @Test
+  void aRefusedInputIsNarratedInsteadOfSilentlyDropped() throws Exception {
+    try (var host =
+        new PtySessionHost(
+            dir.resolve("h.sock"),
+            dir.resolve("s"),
+            64 * 1024,
+            token -> new ai.singlr.sail.pty.PtyIdentity("uday", true),
+            ai.singlr.sail.pty.PtyRooms.NONE,
+            ai.singlr.sail.pty.PtyEvents.NONE,
+            "0.0.0-test")) {
+      host.start();
+      try (var client = SessionClient.connect(dir.resolve("h.sock"))) {
+        client.create("s1", List.of("sh", "-c", "read a"), "/tmp", "", "", 80, 24);
+        var channel = client.attach("s1", false);
+
+        var refused = new java.util.concurrent.CountDownLatch(1);
+        var stdout =
+            new ByteArrayOutputStream() {
+              @Override
+              public synchronized void write(byte[] b, int off, int len) {
+                super.write(b, off, len);
+                if (toString(StandardCharsets.UTF_8).contains("[sail: ")) {
+                  refused.countDown();
+                }
+              }
+            };
+        var stdinFeed = new PipedOutputStream();
+        var stdin = new PipedInputStream(stdinFeed);
+        var loop =
+            Thread.ofVirtual()
+                .start(
+                    () -> {
+                      try {
+                        AttachLoop.run(channel, stdin, stdout);
+                      } catch (java.io.IOException e) {
+                        throw new java.io.UncheckedIOException(e);
+                      }
+                    });
+        stdinFeed.write("x".getBytes(StandardCharsets.UTF_8));
+        stdinFeed.flush();
+
+        assertTrue(
+            refused.await(10, java.util.concurrent.TimeUnit.SECONDS),
+            "the host's Err reaches the operator's screen: " + stdout);
+        assertTrue(
+            stdout.toString(StandardCharsets.UTF_8).contains("You do not hold the write token"),
+            stdout.toString(StandardCharsets.UTF_8));
+
+        stdinFeed.write(new byte[] {AttachLoop.DETACH_KEY});
+        stdinFeed.flush();
+        loop.join();
+      }
+    }
+  }
 }


### PR DESCRIPTION
Hardens the per-container pty session host for a public v1, from an audit of its failure paths. **No wire change.**

## What changes

- **A pty or journal failure ends the session instead of wedging it.** `PtySession.gather` used to join a still-live child before closing the pty, so an I/O error (a full-disk journal append, a pty read error) left the session live forever, undrained and unreapable, until an explicit kill. It now closes the pty and kills the child first, then delivers `SessionEnded(reason=io-error)` to every subscriber. A small `Journal` interface was extracted so a failing journal can be injected in a test.
- **Ring files are deleted and never leak.** A session's `<name>.ring` is removed on kill, sweep, and re-create; every orphan ring is swept at host start (sessions do not survive a restart — there is no rehydration); and new rings are created owner-only (0600).
- **Input never pins a connection.** The write-token holder's keystrokes drain through a dedicated per-session platform writer thread over a bounded queue, so a child that stopped reading (Ctrl-S, a stopped job) backs up to an `Err("input backlog")` rather than pinning the caller's virtual thread in a blocking foreign write — one stuck writer can no longer freeze the accept lane or other connections.
- **Unchecked failures answer `Err`, not a silent close.** Session name, project, cwd, and terminal geometry are validated up front and refused with `Err`; any other runtime exception is a logged last resort that still answers `Err` and closes cleanly, so Mast reads a real refusal rather than a transport fault it retries forever.
- **Session names are validated as path segments** so `../foo` cannot escape the sessions directory or delete another session's history.
- **Backlog is bounded by bytes (1 MiB live) as well as frames**, and a resync replays a bounded 256 KiB tail instead of the whole 4 MB ring on the link that just proved too slow.
- **Resource caps**, each refused with an `Err` naming the cap: sessions per FDE (32), subscribers per session (16), connections per host (256). The caps are injectable so tests use small values.
- **The host logs one line per attach, refusal, and exception** (principal, session, reason) to its journald unit; wire `Err` strings no longer name another FDE's ownership.

## Review follow-ups (iteration 4, below the gate)

- **A dispatch yield deletes the session's ring**, exactly as a kill does. A yielded session left the map before anything could sweep it, so every yield leaked 4 MB on disk.
- **Recreating another owner's corpse counts against the recreator's cap.** The quota check skipped every existing name; replacing your own corpse still takes no extra slot, but an admin reusing someone else's name is opening a new session.

## Tests

Red-first tests per finding: an injected failing journal ends the session (no wedge); a ring is gone after kill and after host start; a path-ish name is refused; an invalid project yields `Err` not EOF; a stopped child with a flooding writer does not stall a second connection (latch on the second connection's reply, no sleeps); the byte cap trips at five 64 KiB frames though only five of 4096 slots are used; new rings are 0600; and the three caps each refuse with a naming `Err`.

`mvn clean verify` is green (3014 tests, all jacoco coverage checks met).
