### PR TITLE
pty: a reconnect from the same FDE keeps the keyboard — and its screen

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,7 +41,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install and initialize incus
+        # incus ships in Ubuntu 24.04 itself. The runner image also carries third-party apt
+        # sources (Chrome, Microsoft, ...) whose index fetches fail on their own schedule, and a
+        # plain update refreshes them all — so only Ubuntu's own sources are refreshed here.
         run: |
+          sudo find /etc/apt/sources.list.d -type f ! -name ubuntu.sources -delete
           sudo apt-get update
           sudo apt-get install -y incus
           sudo incus admin init --minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
     `/etc/ssh/sshd_config.d/10-sail.conf` (`ClientAliveInterval 15`, `ClientAliveCountMax 3`) is
     written on the host by `sail migrate` (so every `sail upgrade` converges it) and installed in
     every project container as part of sail's machinery; migrate now converges every running
-    container's machinery on upgrade.
+    Sail-provisioned container's machinery on upgrade (never a foreign Incus instance).
   - **`sail session attach` narrates the token holder** and a replay that starts mid-sequence
     instead of dropping the frames.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+- **A reconnect from the same FDE keeps the keyboard — and its screen.** A laptop that slept left
+  a ghost attachment on the box holding the write token; the returning pane attached as a silent
+  observer for up to two hours. Now (no wire version bump — every frame already existed):
+  - **Attach answers with the geometry, the replay, then the writer.** The host sends
+    `Resized(cols, rows)` — the pty's live size — before `ReplayBegin`, so the replay is parsed in
+    the geometry that produced it, and `WriterChanged(current)` right after `ReplayEnd`, so an
+    observer knows it is one.
+  - **Same-FDE reclaim.** `Attach(write)` takes the token when its holder is the same FDE on another
+    connection; the ghost hears `WriterChanged` and its next `Input` is refused. A different FDE
+    still waits (arbitration unchanged) and is told who holds it.
+  - **Revoked credentials are severed.** The host sweep re-resolves every admitted connection's
+    token and closes those the resolver now refuses.
+  - **sshd notices a vanished peer within a minute.** A managed
+    `/etc/ssh/sshd_config.d/10-sail.conf` (`ClientAliveInterval 15`, `ClientAliveCountMax 3`) is
+    written on the host by `sail migrate` (so every `sail upgrade` converges it) and installed in
+    every project container as part of sail's machinery; migrate now converges every running
+    container's machinery on upgrade.
+  - **`sail session attach` narrates the token holder** and a replay that starts mid-sequence
+    instead of dropping the frames.
+
 ## 0.40.0
 
 - **The pty host ends a session loudly instead of wedging, and never leaks its ring.** A hardening

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
   - **Attach answers with the geometry, the replay, then the writer.** The host sends
     `Resized(cols, rows)` — the pty's live size — before `ReplayBegin`, so the replay is parsed in
     the geometry that produced it, and `WriterChanged(current)` right after `ReplayEnd`, so an
-    observer knows it is one.
+    observer knows it is one. A resync after a flow-control pause is framed the same way, since the
+    overflow that paused the subscriber discarded whatever answer was still pending.
   - **Same-FDE reclaim.** `Attach(write)` takes the token when its holder is the same FDE on another
     connection; the ghost hears `WriterChanged` and its next `Input` is refused. A different FDE
     still waits (arbitration unchanged) and is told who holds it.

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -33,10 +33,12 @@ import java.util.concurrent.atomic.AtomicLong;
  * bounded in frames and bytes, drained by a dedicated platform writer thread (the mirror of the
  * gather thread), so a child that has stopped reading (Ctrl-S, a stopped job) backs up the queue —
  * answered {@code BACKLOG} — rather than pinning the caller's virtual thread inside a blocking
- * foreign write or growing the host heap. Attach replays the journal tail bracketed by {@code
- * ReplayBegin}/{@code ReplayEnd}, then streams. When the child exits — or a pty or journal failure
- * ends it — every subscriber hears {@code SessionEnded} and the corpse stays readable until the
- * host reaps it.
+ * foreign write or growing the host heap. Attach answers with the pty's live geometry ({@code
+ * Resized}), the journal tail bracketed by {@code ReplayBegin}/{@code ReplayEnd}, then who holds
+ * the write token ({@code WriterChanged}) — so the replay is parsed in the geometry that produced
+ * it and an observer knows it is one — and streams from there. When the child exits — or a pty or
+ * journal failure ends it — every subscriber hears {@code SessionEnded} and the corpse stays
+ * readable until the host reaps it.
  */
 public final class PtySession implements AutoCloseable {
 
@@ -124,19 +126,30 @@ public final class PtySession implements AutoCloseable {
   private final long createdAt = System.nanoTime();
   private volatile long writerId = -1;
   private volatile String writerFde = "";
+  private int cols;
+  private int rows;
   private volatile String endedReason;
   private volatile String yieldedReason;
   private volatile long endedAtNanos;
   private volatile boolean everAttached;
 
   private PtySession(
-      Origin origin, PtyEvents events, Pty pty, Process child, Journal journal, int queueCapacity) {
+      Origin origin,
+      PtyEvents events,
+      Pty pty,
+      Process child,
+      Journal journal,
+      int queueCapacity,
+      int cols,
+      int rows) {
     this.origin = origin;
     this.events = events;
     this.pty = pty;
     this.child = child;
     this.journal = journal;
     this.queueCapacity = queueCapacity;
+    this.cols = cols;
+    this.rows = rows;
     this.replayMax = (int) Math.min(journal.capacity(), Integer.MAX_VALUE);
   }
 
@@ -208,7 +221,7 @@ public final class PtySession implements AutoCloseable {
       journal.close();
       throw e;
     }
-    var session = new PtySession(origin, events, pty, child, journal, queueCapacity);
+    var session = new PtySession(origin, events, pty, child, journal, queueCapacity, cols, rows);
     Thread.ofPlatform().name("pty-gather-" + origin.name()).start(session::gather);
     session.writerThread =
         Thread.ofPlatform().name("pty-write-" + origin.name()).start(session::drainInput);
@@ -344,7 +357,15 @@ public final class PtySession implements AutoCloseable {
     return List.copyOf(messages);
   }
 
-  /** Attaches a client: replay first, live stream after, write token if free and requested. */
+  /**
+   * Attaches a client. Its queue is seeded, in order, with the pty's live geometry, the replay, and
+   * the write token's holder, then the live stream follows. A write request takes the token when it
+   * is free — or when its holder is this same FDE on another connection: a laptop that slept left a
+   * ghost attachment parked on the box holding the keyboard, and the same person coming back is the
+   * one who should have it. The displaced connection hears {@code WriterChanged} and its next input
+   * is refused. A different FDE's token is never taken here — that is {@link #takeWrite}, an
+   * explicit act — so the newcomer learns it is an observer instead.
+   */
   public long attach(Client client, boolean wantsWrite, String fde) throws IOException {
     if (endedReason != null) {
       throw new IOException("Session '" + name() + "' has ended: " + endedReason + ".");
@@ -353,6 +374,7 @@ public final class PtySession implements AutoCloseable {
     var subscriber =
         new Subscriber(subscriberIds.incrementAndGet(), client, new SubscriberQueue(queueCapacity));
     synchronized (fanout) {
+      subscriber.queue().force(new PtyMessage.Resized(cols, rows));
       replayMessages(replayMax).forEach(subscriber.queue()::force);
       subscribers.put(subscriber.id, subscriber);
       if (endedReason != null) {
@@ -360,9 +382,10 @@ public final class PtySession implements AutoCloseable {
       }
     }
     synchronized (this) {
-      if (wantsWrite && writerId < 0) {
-        writerId = subscriber.id;
-        writerFde = fde;
+      if (wantsWrite && (writerId < 0 || writerFde.equals(fde))) {
+        takeWrite(subscriber.id, fde);
+      } else {
+        subscriber.queue().force(new PtyMessage.WriterChanged(writerFde));
       }
     }
     emitQuietly(() -> events.sessionAttached(origin, fde));
@@ -429,17 +452,23 @@ public final class PtySession implements AutoCloseable {
   /**
    * Resizes on behalf of {@code subscriberId}; only the write-token holder may, and observers hear
    * the new geometry. Returns {@code false} — never throws — for a non-writer, so an observer's own
-   * window change is a silent no-op rather than a fatal error: the writer's window wins.
+   * window change is a silent no-op rather than a fatal error: the writer's window wins. The
+   * geometry changes under the fanout lock, so a concurrent attach either seeds its queue with the
+   * new size or is already subscribed when the broadcast goes out — never neither.
    */
   public boolean resize(long subscriberId, int cols, int rows) throws IOException {
     if (subscriberId != writerId) {
       return false;
     }
-    pty.resize(cols, rows);
-    var resized = new PtyMessage.Resized(cols, rows);
-    subscribers.values().stream()
-        .filter(subscriber -> subscriber.id() != subscriberId)
-        .forEach(subscriber -> subscriber.queue().force(resized));
+    synchronized (fanout) {
+      pty.resize(cols, rows);
+      this.cols = cols;
+      this.rows = rows;
+      var resized = new PtyMessage.Resized(cols, rows);
+      subscribers.values().stream()
+          .filter(subscriber -> subscriber.id() != subscriberId)
+          .forEach(subscriber -> subscriber.queue().force(resized));
+    }
     return true;
   }
 

--- a/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/PtySession.java
@@ -323,12 +323,19 @@ public final class PtySession implements AutoCloseable {
    * Re-baselines a subscriber whose pause dropped part of the stream: under the fanout lock, the
    * journal tail replaces whatever accumulated in its queue (those bytes are inside the snapshot),
    * so the client hears {@code Continued}, a bracketed replay, then live traffic — exactly-once
-   * against the journal, never a screen with its middle missing.
+   * against the journal, never a screen with its middle missing. The overflow that paused it
+   * cleared every pending frame, geometry and writer answers included, so the snapshot is framed
+   * the way an attach is — {@code Resized}, the replay, {@code WriterChanged} — and built under the
+   * session monitor, so a token transfer racing it is heard once, after it, never lost behind it.
    */
-  private void resync(Subscriber subscriber) {
+  private synchronized void resync(Subscriber subscriber) {
     synchronized (fanout) {
       try {
-        subscriber.queue().replaceWith(replayMessages(RESYNC_TAIL));
+        var snapshot = new java.util.ArrayList<PtyMessage>();
+        snapshot.add(new PtyMessage.Resized(cols, rows));
+        snapshot.addAll(replayMessages(RESYNC_TAIL));
+        snapshot.add(new PtyMessage.WriterChanged(writerFde));
+        subscriber.queue().replaceWith(snapshot);
       } catch (IOException e) {
         subscriber.queue().force(new PtyMessage.SessionEnded("resync failed: " + e.getMessage()));
       }
@@ -383,7 +390,7 @@ public final class PtySession implements AutoCloseable {
     }
     synchronized (this) {
       if (wantsWrite && (writerId < 0 || writerFde.equals(fde))) {
-        takeWrite(subscriber.id, fde);
+        grant(subscriber.id, fde);
       } else {
         subscriber.queue().force(new PtyMessage.WriterChanged(writerFde));
       }
@@ -443,6 +450,16 @@ public final class PtySession implements AutoCloseable {
     if (!subscribers.containsKey(subscriberId)) {
       throw new IllegalArgumentException("No attached subscriber " + subscriberId + ".");
     }
+    grant(subscriberId, fde);
+  }
+
+  /**
+   * Hands the token to a subscriber the caller vouches for and tells every subscriber. An attach
+   * grants to the subscriber it just made without looking it up: a session ending in that same
+   * instant has already cleared the roster and queued the ending, and the grant must not throw
+   * after the host said {@code Ok} — the ending is what the newcomer hears.
+   */
+  private void grant(long subscriberId, String fde) {
     writerId = subscriberId;
     writerFde = fde;
     var changed = new PtyMessage.WriterChanged(fde);

--- a/sail-core/src/main/java/ai/singlr/sail/pty/SubscriberQueue.java
+++ b/sail-core/src/main/java/ai/singlr/sail/pty/SubscriberQueue.java
@@ -75,16 +75,34 @@ final class SubscriberQueue {
 
   /**
    * Enqueues regardless of pause — endings and poison must always arrive. A state notification
-   * ({@code WriterChanged}, {@code Resized}) replaces any of its kind still pending: only the
-   * latest writer or geometry matters to a reader that is catching up, and a client can raise these
-   * at will (a TakeWrite storm), so they must not accumulate the way the caps forbid output to.
+   * ({@code WriterChanged}, {@code Resized}) replaces one of its kind still pending: a client can
+   * raise these at will (a TakeWrite storm), so they must not accumulate the way the caps forbid
+   * output to. Only the latest writer matters, wherever it sits. A geometry is different: bytes
+   * queued behind a {@code Resized} were produced in that geometry, so it is replaced only while
+   * nothing but control frames separate it from the newcomer — the attach prologue's {@code
+   * Resized} ahead of the replay survives a resize that lands before the sender drains it.
    */
   synchronized void force(PtyMessage message) {
-    if (message instanceof PtyMessage.WriterChanged || message instanceof PtyMessage.Resized) {
-      queue.removeIf(entry -> entry.message().getClass() == message.getClass());
+    if (message instanceof PtyMessage.WriterChanged) {
+      queue.removeIf(entry -> entry.message() instanceof PtyMessage.WriterChanged);
+    } else if (message instanceof PtyMessage.Resized) {
+      dropTrailingResized();
     }
     queue.add(new Entry(message, false, 0));
     notifyAll();
+  }
+
+  private void dropTrailingResized() {
+    var pending = queue.descendingIterator();
+    while (pending.hasNext()) {
+      var next = pending.next().message();
+      if (!(next instanceof PtyMessage.WriterChanged || next instanceof PtyMessage.Resized)) {
+        return;
+      }
+      if (next instanceof PtyMessage.Resized) {
+        pending.remove();
+      }
+    }
   }
 
   /**

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -171,7 +171,8 @@ class PtySessionTest {
             List.of(
                 "sh",
                 "-c",
-                "trap '' HUP TERM; echo \"pid=$$;\"; read x; echo boom; while :; do sleep 1; done"),
+                "trap '' HUP TERM; read go; echo \"pid=$$;\"; read x; echo boom;"
+                    + " while :; do sleep 1; done"),
             Map.of("TERM", "dumb"),
             Path.of("/tmp"),
             new FailingJournal("boom"),
@@ -181,9 +182,11 @@ class PtySessionTest {
     try {
       var client = new Collector();
       var id = session.attach(client, true, "uday");
+      // The journal fake replays nothing, so the child speaks only once this subscriber listens.
+      session.input(id, 1, "\n".getBytes(StandardCharsets.UTF_8));
       client.awaitOutput(";");
       var pid = Long.parseLong(client.outputText().replaceAll("(?s).*pid=(\\d+);.*", "$1"));
-      session.input(id, 1, "\n".getBytes(StandardCharsets.UTF_8));
+      session.input(id, 2, "\n".getBytes(StandardCharsets.UTF_8));
       assertTrue(client.ended.await(10, TimeUnit.SECONDS), "the failure ends the session");
 
       assertFalse(
@@ -379,7 +382,7 @@ class PtySessionTest {
       session.attach(observer, false, "uday");
       observer.awaitOutput("early-line");
       assertTrue(observer.saw(PtyMessage.ReplayBegin.class), "replay is bracketed");
-      assertTrue(observer.saw(PtyMessage.ReplayEnd.class));
+      observer.awaitFrame(PtyMessage.ReplayEnd.class);
 
       session.input(writerId, 1, "go\n".getBytes(StandardCharsets.UTF_8));
       observer.awaitOutput("late-line");
@@ -410,6 +413,7 @@ class PtySessionTest {
       var late = new Collector();
       session.attach(late, false, "uday");
       late.awaitOutput("BIG-DONE");
+      late.awaitFrame(PtyMessage.ReplayEnd.class);
 
       var text = late.outputText();
       assertTrue(text.chars().filter(c -> c == 'x').count() >= payload, "every byte replayed");
@@ -444,11 +448,7 @@ class PtySessionTest {
           "a non-writer's input is refused, not fatal");
 
       session.takeWrite(secondId, "mady");
-      var deadline = System.nanoTime() + 5_000_000_000L;
-      while (!first.saw(PtyMessage.WriterChanged.class) && System.nanoTime() < deadline) {
-        Thread.sleep(5);
-      }
-      assertTrue(first.saw(PtyMessage.WriterChanged.class), "the old writer hears the takeover");
+      first.awaitFrame(PtyMessage.WriterChanged.class);
 
       assertEquals(
           PtySession.WriteOutcome.NOT_WRITER,
@@ -581,10 +581,12 @@ class PtySessionTest {
 
   @Test
   void everySubscriberHearsTheEndingAndLateAttachIsRefused() throws Exception {
-    var session = session("echo bye; exit 3");
+    var session = session("read go; echo bye; exit 3");
     try {
       var client = new Collector();
-      session.attach(client, true, "uday");
+      var id = session.attach(client, true, "uday");
+      // The child exits only once this subscriber is attached, so the ending has someone to reach.
+      session.input(id, 1, "\n".getBytes(StandardCharsets.UTF_8));
       assertTrue(client.ended.await(10, TimeUnit.SECONDS), "the ending reaches subscribers");
       assertEquals("exited(3)", session.endedReason());
 

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -469,6 +469,65 @@ class PtySessionTest {
   }
 
   @Test
+  void aResizeRacingTheAttachCannotStripTheGeometryAheadOfTheReplay() throws Exception {
+    var onAttached = new java.util.concurrent.atomic.AtomicReference<Runnable>(() -> {});
+    var events =
+        new PtyEvents() {
+          @Override
+          public void sessionStarted(PtySession.Origin origin) {}
+
+          @Override
+          public void sessionAttached(PtySession.Origin origin, String fde) {
+            onAttached.get().run();
+          }
+
+          @Override
+          public void sessionEnded(PtySession.Origin origin, String reason) {}
+        };
+    try (var session =
+        PtySession.start(
+            origin("race", "uday", "acme"),
+            events,
+            List.of("sh", "-c", "echo wide-line; read a"),
+            Map.of("TERM", "dumb"),
+            Path.of("/tmp"),
+            dir.resolve("race.ring"),
+            64 * 1024,
+            80,
+            24)) {
+      var writer = new Collector();
+      var writerId = session.attach(writer, true, "uday");
+      writer.awaitOutput("wide-line");
+      assertTrue(session.resize(writerId, 126, 40));
+
+      // The attach event fires after the observer's queue is seeded and before its sender runs:
+      // the writer resizing in that window is the race.
+      onAttached.set(
+          () -> {
+            try {
+              session.resize(writerId, 100, 30);
+            } catch (IOException e) {
+              throw new RuntimeException(e);
+            }
+          });
+      var observer = new Collector();
+      session.attach(observer, false, "mady");
+      awaitFrame(observer, PtyMessage.WriterChanged.class);
+
+      var frames = List.copyOf(observer.messages);
+      assertEquals(
+          new PtyMessage.Resized(126, 40),
+          frames.getFirst(),
+          "the replay was produced at 126 columns, so that geometry precedes it: " + frames);
+      var kinds = frames.stream().map(m -> m.getClass().getSimpleName()).toList();
+      assertEquals("ReplayBegin", kinds.get(1), "then the replay: " + kinds);
+      assertTrue(
+          frames.indexOf(new PtyMessage.Resized(100, 30)) > kinds.indexOf("ReplayEnd"),
+          "and the racing resize lands after it, where the stream it governs begins: " + frames);
+    }
+  }
+
+  @Test
   void theSameFdeReclaimsTheTokenFromItsGhostWhileAnotherFdeWaits() throws Exception {
     try (var session = session("read a; echo got:$a; read b")) {
       var ghost = new Collector();

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -53,6 +55,9 @@ class PtySessionTest {
         }
       }
       messages.add(message);
+      synchronized (this) {
+        notifyAll();
+      }
       if (message instanceof PtyMessage.SessionEnded) {
         ended.countDown();
       }
@@ -76,12 +81,25 @@ class PtySessionTest {
     }
 
     void awaitOutput(String marker) throws InterruptedException {
+      await(
+          () -> outputText().contains(marker),
+          () -> "never saw '" + marker + "'; got: " + outputText());
+    }
+
+    void awaitFrame(Class<? extends PtyMessage> type) throws InterruptedException {
+      await(() -> saw(type), () -> "never saw " + type.getSimpleName() + "; got: " + messages);
+    }
+
+    /** Blocks on this collector's monitor until {@code condition} holds; each delivery wakes it. */
+    private synchronized void await(BooleanSupplier condition, Supplier<String> failure)
+        throws InterruptedException {
       var deadline = System.nanoTime() + 10_000_000_000L;
-      while (!outputText().contains(marker)) {
-        if (System.nanoTime() > deadline) {
-          throw new AssertionError("never saw '" + marker + "'; got: " + outputText());
+      while (!condition.getAsBoolean()) {
+        var remaining = deadline - System.nanoTime();
+        if (remaining <= 0) {
+          throw new AssertionError(failure.get());
         }
-        Thread.sleep(5);
+        TimeUnit.NANOSECONDS.timedWait(this, remaining);
       }
     }
   }
@@ -452,7 +470,7 @@ class PtySessionTest {
       var observer = new Collector();
       session.attach(observer, false, "uday");
       observer.awaitOutput("wide-line");
-      awaitFrame(observer, PtyMessage.WriterChanged.class);
+      observer.awaitFrame(PtyMessage.WriterChanged.class);
 
       var frames = List.copyOf(observer.messages);
       assertEquals(
@@ -512,7 +530,7 @@ class PtySessionTest {
           });
       var observer = new Collector();
       session.attach(observer, false, "mady");
-      awaitFrame(observer, PtyMessage.WriterChanged.class);
+      observer.awaitFrame(PtyMessage.WriterChanged.class);
 
       var frames = List.copyOf(observer.messages);
       assertEquals(
@@ -534,7 +552,7 @@ class PtySessionTest {
       var ghostId = session.attach(ghost, true, "uday");
       var returning = new Collector();
       var returningId = session.attach(returning, true, "uday");
-      awaitFrame(ghost, PtyMessage.WriterChanged.class);
+      ghost.awaitFrame(PtyMessage.WriterChanged.class);
 
       assertEquals(
           returningId, session.writerId(), "the same FDE's new connection holds the token");
@@ -547,7 +565,7 @@ class PtySessionTest {
 
       var other = new Collector();
       var otherId = session.attach(other, true, "mady");
-      awaitFrame(other, PtyMessage.WriterChanged.class);
+      other.awaitFrame(PtyMessage.WriterChanged.class);
       assertEquals(
           returningId, session.writerId(), "a different FDE never takes the token by attaching");
       assertEquals(
@@ -558,17 +576,6 @@ class PtySessionTest {
           new PtyMessage.WriterChanged("uday"),
           List.copyOf(other.messages).get(kinds.indexOf("ReplayEnd") + 1),
           "and is told who holds it right after the replay: " + other.messages);
-    }
-  }
-
-  private static void awaitFrame(Collector client, Class<? extends PtyMessage> type)
-      throws InterruptedException {
-    var deadline = System.nanoTime() + 10_000_000_000L;
-    while (!client.saw(type)) {
-      if (System.nanoTime() > deadline) {
-        throw new AssertionError("never saw " + type.getSimpleName() + "; got: " + client.messages);
-      }
-      Thread.sleep(5);
     }
   }
 
@@ -724,6 +731,65 @@ class PtySessionTest {
           "the ending must reach the subscriber despite the throwing sink");
     } finally {
       assertTimeoutPreemptively(java.time.Duration.ofSeconds(10), session::close);
+    }
+  }
+
+  @Test
+  void aResyncCarriesTheGeometryAndTheWriterTheOverflowDiscarded() throws Exception {
+    var session =
+        PtySession.start(
+            origin("resync-answer", "uday", "acme"),
+            PtyEvents.NONE,
+            List.of(
+                "sh",
+                "-c",
+                "read _; i=0; while [ $i -lt 300 ]; do printf '%01000d' $i; i=$((i+1)); done;"
+                    + " printf BURST-END; read _"),
+            Map.of("TERM", "dumb"),
+            Path.of("/tmp"),
+            dir.resolve("resync-answer.ring"),
+            1024 * 1024,
+            80,
+            24,
+            1);
+    try {
+      var client = new Collector();
+      var gate = new CountDownLatch(1);
+      client.gate = gate;
+      var id = session.attach(client, true, "uday");
+      // The sender is parked on the attach's first frame while the pty grows past the queue: the
+      // overflow clears the replay and the writer answer still pending behind that frame.
+      assertTrue(session.resize(id, 126, 40), "the writer sizes the pty before the burst");
+      session.input(id, 1, "\n".getBytes(StandardCharsets.UTF_8));
+      var deadline = System.nanoTime() + 10_000_000_000L;
+      while (session.journaledBytes() < 300_000) {
+        if (System.nanoTime() > deadline) {
+          throw new AssertionError("burst never landed; journaled=" + session.journaledBytes());
+        }
+        Thread.onSpinWait();
+      }
+
+      client.gate = null;
+      gate.countDown();
+      client.awaitOutput("BURST-END");
+      client.awaitFrame(PtyMessage.WriterChanged.class);
+
+      var frames = List.copyOf(client.messages);
+      var kinds = frames.stream().map(m -> m.getClass().getSimpleName()).toList();
+      var continuedAt = kinds.indexOf("Continued");
+      assertTrue(continuedAt >= 0, "the drain resumed the subscriber: " + kinds);
+      assertEquals(
+          new PtyMessage.Resized(126, 40),
+          frames.get(continuedAt + 1),
+          "the snapshot is parsed in the geometry that produced it: " + kinds);
+      assertEquals("ReplayBegin", kinds.get(continuedAt + 2), "then the replay: " + kinds);
+      var replayEndAt = kinds.subList(continuedAt, kinds.size()).indexOf("ReplayEnd") + continuedAt;
+      assertEquals(
+          new PtyMessage.WriterChanged("uday"),
+          frames.get(replayEndAt + 1),
+          "and the writer the overflow discarded is answered again after it: " + kinds);
+    } finally {
+      session.close();
     }
   }
 

--- a/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/PtySessionTest.java
@@ -405,7 +405,7 @@ class PtySessionTest {
           frames.stream().allMatch(f -> f.bytes().length <= PtySession.REPLAY_CHUNK),
           "every replay frame fits the chunk");
       var kinds = late.messages.stream().map(m -> m.getClass().getSimpleName()).toList();
-      assertEquals("ReplayBegin", kinds.getFirst(), "still bracketed: " + kinds);
+      assertEquals("ReplayBegin", kinds.get(1), "still bracketed, behind the geometry: " + kinds);
       assertTrue(
           kinds.indexOf("ReplayEnd") > kinds.lastIndexOf("Output") - 1,
           "ends the bracket after the tail");
@@ -438,6 +438,78 @@ class PtySessionTest {
           "the demoted writer can no longer write");
       session.input(secondId, 3, "fresh\n".getBytes(StandardCharsets.UTF_8));
       second.awaitOutput("done:fresh");
+    }
+  }
+
+  @Test
+  void attachAnswersWithTheGeometryThenTheReplayThenTheWriter() throws Exception {
+    try (var session = session("echo wide-line; read a")) {
+      var writer = new Collector();
+      var writerId = session.attach(writer, true, "uday");
+      writer.awaitOutput("wide-line");
+      assertTrue(session.resize(writerId, 126, 40), "the writer sizes the pty");
+
+      var observer = new Collector();
+      session.attach(observer, false, "uday");
+      observer.awaitOutput("wide-line");
+      awaitFrame(observer, PtyMessage.WriterChanged.class);
+
+      var frames = List.copyOf(observer.messages);
+      assertEquals(
+          new PtyMessage.Resized(126, 40),
+          frames.getFirst(),
+          "the pty's live geometry comes before anything else: " + frames);
+      var kinds = frames.stream().map(m -> m.getClass().getSimpleName()).toList();
+      assertEquals("ReplayBegin", kinds.get(1), "then the replay: " + kinds);
+      assertEquals(
+          new PtyMessage.WriterChanged("uday"),
+          frames.get(kinds.indexOf("ReplayEnd") + 1),
+          "and the token holder right after the replay: " + frames);
+    }
+  }
+
+  @Test
+  void theSameFdeReclaimsTheTokenFromItsGhostWhileAnotherFdeWaits() throws Exception {
+    try (var session = session("read a; echo got:$a; read b")) {
+      var ghost = new Collector();
+      var ghostId = session.attach(ghost, true, "uday");
+      var returning = new Collector();
+      var returningId = session.attach(returning, true, "uday");
+      awaitFrame(ghost, PtyMessage.WriterChanged.class);
+
+      assertEquals(
+          returningId, session.writerId(), "the same FDE's new connection holds the token");
+      assertEquals(
+          PtySession.WriteOutcome.NOT_WRITER,
+          session.input(ghostId, 1, "stale\n".getBytes(StandardCharsets.UTF_8)),
+          "the ghost's next keystroke is refused");
+      session.input(returningId, 2, "fresh\n".getBytes(StandardCharsets.UTF_8));
+      returning.awaitOutput("got:fresh");
+
+      var other = new Collector();
+      var otherId = session.attach(other, true, "mady");
+      awaitFrame(other, PtyMessage.WriterChanged.class);
+      assertEquals(
+          returningId, session.writerId(), "a different FDE never takes the token by attaching");
+      assertEquals(
+          PtySession.WriteOutcome.NOT_WRITER,
+          session.input(otherId, 3, "nope\n".getBytes(StandardCharsets.UTF_8)));
+      var kinds = other.messages.stream().map(m -> m.getClass().getSimpleName()).toList();
+      assertEquals(
+          new PtyMessage.WriterChanged("uday"),
+          List.copyOf(other.messages).get(kinds.indexOf("ReplayEnd") + 1),
+          "and is told who holds it right after the replay: " + other.messages);
+    }
+  }
+
+  private static void awaitFrame(Collector client, Class<? extends PtyMessage> type)
+      throws InterruptedException {
+    var deadline = System.nanoTime() + 10_000_000_000L;
+    while (!client.saw(type)) {
+      if (System.nanoTime() > deadline) {
+        throw new AssertionError("never saw " + type.getSimpleName() + "; got: " + client.messages);
+      }
+      Thread.sleep(5);
     }
   }
 

--- a/sail-core/src/test/java/ai/singlr/sail/pty/SubscriberQueueTest.java
+++ b/sail-core/src/test/java/ai/singlr/sail/pty/SubscriberQueueTest.java
@@ -148,4 +148,30 @@ class SubscriberQueueTest {
         new PtyMessage.Resized(100, 40), queue.next(), "only the latest geometry is pending");
     assertInstanceOf(PtyMessage.SessionEnded.class, queue.next(), "the ending still arrives");
   }
+
+  @Test
+  void aGeometryAheadOfPendingOutputSurvivesALaterResize() throws Exception {
+    var queue = new SubscriberQueue(4);
+    queue.force(new PtyMessage.Resized(126, 40));
+    queue.force(new PtyMessage.ReplayBegin(true));
+    queue.enqueue(out(1));
+    queue.force(new PtyMessage.ReplayEnd());
+    queue.force(new PtyMessage.WriterChanged("uday"));
+    queue.force(new PtyMessage.Resized(100, 40));
+    queue.force(new PtyMessage.Resized(90, 30));
+
+    assertEquals(
+        new PtyMessage.Resized(126, 40),
+        queue.next(),
+        "the replay behind it was produced at 126 columns: that geometry must reach the reader"
+            + " ahead of those bytes, whatever the writer does meanwhile");
+    assertInstanceOf(PtyMessage.ReplayBegin.class, queue.next());
+    assertEquals(1, ((PtyMessage.Output) queue.next()).lastInputSeq());
+    assertInstanceOf(PtyMessage.ReplayEnd.class, queue.next());
+    assertEquals(new PtyMessage.WriterChanged("uday"), queue.next());
+    assertEquals(
+        new PtyMessage.Resized(90, 30),
+        queue.next(),
+        "resizes with nothing but control frames between them still collapse to the latest");
+  }
 }

--- a/sail-harness/src/main/java/ai/singlr/sail/engine/SshdKeepalive.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/engine/SshdKeepalive.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * The sshd drop-in that makes a box notice a vanished peer. Ubuntu's sshd ships with no client
+ * keepalive, so a laptop that sleeps or changes networks leaves its SSH connection — and the pty
+ * session host attachment riding it, write token included — parked for TCP's two-hour keepalive.
+ * With {@code ClientAliveInterval 15} and {@code ClientAliveCountMax 3} the dead connection is
+ * closed within a minute. One payload serves both the host ({@code sail migrate} writes it on every
+ * upgrade) and every project container (installed with the rest of sail's machinery).
+ */
+public final class SshdKeepalive {
+
+  /** Where the drop-in lives; sshd's stock config includes {@code sshd_config.d/*.conf}. */
+  public static final String DROP_IN_PATH = "/etc/ssh/sshd_config.d/10-sail.conf";
+
+  private static final String CONTENT =
+      """
+      # Managed by sail. Notice a peer that vanished (a laptop that slept, a network that
+      # changed) within a minute, so no session keeps a keyboard for a connection that died.
+      ClientAliveInterval 15
+      ClientAliveCountMax 3
+      """;
+
+  /**
+   * The shell that installs the drop-in and reloads a running sshd: {@code $1} is the content,
+   * {@code $2} the path. A box without sshd running keeps the file for when it starts.
+   */
+  static final String INSTALL_SCRIPT =
+      """
+      set -eu
+      mkdir -p "$(dirname -- "$2")"
+      printf '%s' "$1" > "$2"
+      chmod 0644 "$2"
+      if systemctl is-active --quiet ssh; then systemctl reload ssh; fi
+      """;
+
+  private final ShellExec shell;
+
+  public SshdKeepalive(ShellExec shell) {
+    this.shell = Objects.requireNonNull(shell, "shell");
+  }
+
+  /** The drop-in's content. Pure function. */
+  public static String content() {
+    return CONTENT;
+  }
+
+  /** The command that installs the drop-in at {@code path} on the machine it runs on. */
+  public static List<String> installCommand(String path) {
+    return List.of("bash", "-c", INSTALL_SCRIPT, "bash", CONTENT, path);
+  }
+
+  /** Idempotently installs the drop-in inside {@code container} as root and reloads its sshd. */
+  public void install(String container) throws IOException, InterruptedException, TimeoutException {
+    NameValidator.requireValidProjectName(container);
+    var result = shell.exec(ContainerExec.asRoot(container, installCommand(DROP_IN_PATH)));
+    if (!result.ok()) {
+      throw new IOException(
+          "Failed to install " + DROP_IN_PATH + " in " + container + ": " + result.stderr());
+    }
+  }
+}

--- a/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
+++ b/sail-harness/src/main/java/ai/singlr/sail/pty/PtySessionHost.java
@@ -21,9 +21,11 @@ import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -35,7 +37,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  * traffic flows through the subscriber queue onto the same channel, serialized per connection.
  *
  * <p>Reaping is driven by {@link #sweep(long)} with an injected clock — the production timer thread
- * merely calls it; tests call it directly with synthetic time.
+ * merely calls it; tests call it directly with synthetic time. The same pass re-validates every
+ * admitted connection's credential: a token the resolver no longer honors (a revoked FDE session)
+ * severs the connections it admitted, so a revocation ends live attachments within one sweep rather
+ * than at the next reconnect.
  *
  * <p>Yielding is the one verb no FDE holds. A dispatch that reserves repos must end whichever
  * resumed conversation sits on them regardless of who opened it, so the host mints a random
@@ -70,11 +75,14 @@ public final class PtySessionHost implements AutoCloseable {
   private final String version;
   private final Limits limits;
   private final Map<String, PtySession> sessions = new ConcurrentHashMap<>();
+  private final Set<Admitted> admitted = ConcurrentHashMap.newKeySet();
   private final String bootId = Ids.newId().toString();
   private final AtomicInteger connections = new AtomicInteger();
   private volatile ServerSocketChannel server;
   private volatile byte[] dispatchCredential = new byte[0];
   private volatile boolean closed;
+
+  private record Admitted(SocketChannel channel, String token, String principal) {}
 
   public PtySessionHost(
       Path socketPath,
@@ -238,6 +246,7 @@ public final class PtySessionHost implements AutoCloseable {
 
   private void serve(SocketChannel channel) {
     PtySession attached = null;
+    Admitted me = null;
     var subscriberId = -1L;
     var principal = "?";
     var overCap = connections.incrementAndGet() > limits.connections();
@@ -257,6 +266,8 @@ public final class PtySessionHost implements AutoCloseable {
             return;
           }
           principal = who.fde();
+          me = new Admitted(channel, token, principal);
+          admitted.add(me);
           reply(channel, new PtyMessage.Welcome(bootId));
         } else {
           reply(channel, new PtyMessage.Err("The first frame must identify you: send Hello."));
@@ -369,6 +380,9 @@ public final class PtySessionHost implements AutoCloseable {
     } finally {
       if (attached != null) {
         attached.detach(subscriberId);
+      }
+      if (me != null) {
+        admitted.remove(me);
       }
       connections.decrementAndGet();
     }
@@ -601,8 +615,12 @@ public final class PtySessionHost implements AutoCloseable {
     }
   }
 
-  /** One reaping pass at {@code nowNanos}: the mosh grace and retention rules, nothing else. */
+  /**
+   * One reaping pass at {@code nowNanos}: revoked credentials severed, then the mosh grace and
+   * retention rules, nothing else.
+   */
   public void sweep(long nowNanos) {
+    severRevoked();
     sessions.forEach(
         (name, session) -> {
           if (session.live()
@@ -621,6 +639,38 @@ public final class PtySessionHost implements AutoCloseable {
 
   public int sessionCount() {
     return sessions.size();
+  }
+
+  /**
+   * Closes every connection whose credential the resolver now refuses; its serve loop fails on the
+   * next read and drops the attachment. Each distinct token is resolved once per pass. A resolver
+   * that cannot answer at all (the store is down) severs nothing — that is an outage, not a
+   * revocation.
+   */
+  private void severRevoked() {
+    var verdicts = new HashMap<String, Boolean>();
+    for (var connection : admitted) {
+      if (verdicts.computeIfAbsent(connection.token(), this::revoked)) {
+        log("severed", connection.principal(), "-", "credential revoked");
+        try {
+          connection.channel().close();
+        } catch (IOException ignored) {
+          var unused = ignored;
+        }
+      }
+    }
+  }
+
+  private boolean revoked(String token) {
+    try {
+      identify(token);
+      return false;
+    } catch (IOException refused) {
+      return true;
+    } catch (RuntimeException unavailable) {
+      log("revalidation-skipped", "-", "-", unavailable.toString());
+      return false;
+    }
   }
 
   private static void reply(SocketChannel channel, PtyMessage message) {

--- a/sail-harness/src/test/java/ai/singlr/sail/engine/SshdKeepaliveTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/engine/SshdKeepaliveTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Standard Applied Intelligence Labs
+ * SPDX-License-Identifier: MIT
+ */
+
+package ai.singlr.sail.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+@EnabledOnOs(OS.LINUX)
+class SshdKeepaliveTest {
+
+  @TempDir Path dir;
+
+  @Test
+  void theDropInTellsSshdToDropAVanishedPeerWithinAMinute() {
+    var content = SshdKeepalive.content();
+    assertTrue(content.contains("ClientAliveInterval 15\n"), content);
+    assertTrue(content.contains("ClientAliveCountMax 3\n"), content);
+  }
+
+  @Test
+  void installingWritesTheDropInAndReloadsARunningSshd() throws Exception {
+    var systemctlLog = fakeSystemctl(0);
+    var dropIn = dir.resolve("etc/ssh/sshd_config.d/10-sail.conf");
+
+    assertEquals(0, run(SshdKeepalive.installCommand(dropIn.toString())));
+
+    assertEquals(SshdKeepalive.content(), Files.readString(dropIn));
+    assertEquals("rw-r--r--", PosixFilePermissions.toString(Files.getPosixFilePermissions(dropIn)));
+    var calls = Files.readAllLines(systemctlLog);
+    assertEquals(List.of("is-active --quiet ssh", "reload ssh"), calls);
+  }
+
+  @Test
+  void aStoppedSshdKeepsTheDropInForWhenItStartsAndIsNotReloaded() throws Exception {
+    var systemctlLog = fakeSystemctl(3);
+    var dropIn = dir.resolve("10-sail.conf");
+
+    assertEquals(0, run(SshdKeepalive.installCommand(dropIn.toString())));
+
+    assertEquals(SshdKeepalive.content(), Files.readString(dropIn));
+    assertEquals(List.of("is-active --quiet ssh"), Files.readAllLines(systemctlLog));
+  }
+
+  @Test
+  void theContainerInstallRunsAsRootNotTheDevUser() throws Exception {
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
+
+    new SshdKeepalive(shell).install("light-grid");
+
+    var invocation = shell.invocations().getFirst();
+    assertTrue(invocation.startsWith("incus exec light-grid -- bash"), invocation);
+    assertFalse(invocation.contains("--user"), "sshd's config is root's: " + invocation);
+    assertTrue(invocation.contains(SshdKeepalive.DROP_IN_PATH), invocation);
+  }
+
+  private Path fakeSystemctl(int isActiveExit) throws Exception {
+    var bin = Files.createDirectories(dir.resolve("bin"));
+    var log = dir.resolve("systemctl.log");
+    var script =
+        """
+        #!/bin/sh
+        printf '%%s\\n' "$*" >> "%s"
+        case "$1" in is-active) exit %d ;; esac
+        exit 0
+        """
+            .formatted(log, isActiveExit);
+    Files.writeString(bin.resolve("systemctl"), script);
+    Files.setPosixFilePermissions(
+        bin.resolve("systemctl"), PosixFilePermissions.fromString("rwxr-xr-x"));
+    return log;
+  }
+
+  private int run(List<String> command) throws Exception {
+    var builder = new ProcessBuilder(command).redirectErrorStream(true);
+    builder.environment().put("PATH", dir.resolve("bin") + ":" + System.getenv("PATH"));
+    var process = builder.start();
+    var output = new String(process.getInputStream().readAllBytes());
+    assertTrue(process.waitFor(10, TimeUnit.SECONDS), "the install script hung: " + output);
+    return process.exitValue();
+  }
+}

--- a/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
+++ b/sail-harness/src/test/java/ai/singlr/sail/pty/PtySessionHostTest.java
@@ -39,14 +39,20 @@ class PtySessionHostTest {
   private volatile CountDownLatch startGate;
   private final CountDownLatch startGated = new CountDownLatch(1);
 
-  private static final PtyIdentity.Resolver RESOLVER =
-      token ->
-          switch (token) {
-            case "", "tok-uday" -> new PtyIdentity("uday", false);
-            case "tok-mady" -> new PtyIdentity("mady", false);
-            case "tok-root" -> new PtyIdentity("root", true);
-            default -> throw new IOException("Session token is not valid or has expired.");
-          };
+  private final java.util.Set<String> revoked = java.util.concurrent.ConcurrentHashMap.newKeySet();
+
+  private final PtyIdentity.Resolver resolver =
+      token -> {
+        if (revoked.contains(token)) {
+          throw new IOException("Session token is not valid or has expired.");
+        }
+        return switch (token) {
+          case "", "tok-uday" -> new PtyIdentity("uday", false);
+          case "tok-mady" -> new PtyIdentity("mady", false);
+          case "tok-root" -> new PtyIdentity("root", true);
+          default -> throw new IOException("Session token is not valid or has expired.");
+        };
+      };
 
   private static final PtyRooms ROOMS =
       (room, project, who) -> {
@@ -68,7 +74,7 @@ class PtySessionHostTest {
             dir.resolve("host.sock"),
             dir.resolve("sessions"),
             64 * 1024,
-            RESOLVER,
+            resolver,
             ROOMS,
             new PtyEvents() {
               @Override
@@ -135,6 +141,14 @@ class PtySessionHostTest {
       }
       return hostBootId;
     }
+  }
+
+  /**
+   * The frames every attach answers with before its replay: the pty's geometry, then the bracket.
+   */
+  private static void assertAttachPrologue(SocketChannel channel) throws IOException {
+    assertInstanceOf(PtyMessage.Resized.class, PtyWire.read(channel));
+    assertInstanceOf(PtyMessage.ReplayBegin.class, PtyWire.read(channel));
   }
 
   private static PtyMessage awaitText(SocketChannel channel, String marker) throws IOException {
@@ -244,7 +258,7 @@ class PtySessionHostTest {
         assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(owner));
         PtyWire.write(owner, new PtyMessage.Attach("resume-1", true));
         assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(owner));
-        assertInstanceOf(PtyMessage.ReplayBegin.class, PtyWire.read(owner));
+        assertAttachPrologue(owner);
         awaitText(owner, "up");
 
         for (var fde : List.of("tok-mady", "tok-uday", "tok-root")) {
@@ -338,7 +352,7 @@ class PtySessionHostTest {
 
         PtyWire.write(channel, new PtyMessage.Attach("pinned", true));
         assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
-        assertInstanceOf(PtyMessage.ReplayBegin.class, PtyWire.read(channel));
+        assertAttachPrologue(channel);
         awaitText(channel, "room=design-talk");
       }
     }
@@ -361,7 +375,7 @@ class PtySessionHostTest {
         assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
         PtyWire.write(channel, new PtyMessage.Attach("free", true));
         assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
-        assertInstanceOf(PtyMessage.ReplayBegin.class, PtyWire.read(channel));
+        assertAttachPrologue(channel);
         awaitText(channel, "room=[]");
       }
       try (var channel = connect()) {
@@ -502,6 +516,93 @@ class PtySessionHostTest {
   }
 
   @Test
+  void attachAnswersWithTheGeometryTheReplayAndTheWriterOnTheWire() throws Exception {
+    try (var ignored = startHost()) {
+      try (var writer = connect("tok-uday")) {
+        PtyWire.write(
+            writer,
+            new PtyMessage.Create(
+                "sized", List.of("sh", "-c", "echo hi; read a"), "/tmp", "", "", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, readControl(writer));
+        PtyWire.write(writer, new PtyMessage.Attach("sized", true));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(writer));
+        assertAttachPrologue(writer);
+        awaitText(writer, "hi");
+        PtyWire.write(writer, new PtyMessage.Resize(126, 40));
+
+        try (var observer = connect("tok-root")) {
+          PtyWire.write(observer, new PtyMessage.Attach("sized", true));
+          assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(observer));
+          var frames = new java.util.ArrayList<PtyMessage>();
+          PtyMessage frame;
+          do {
+            frame = PtyWire.read(observer);
+            frames.add(frame);
+          } while (!(frame instanceof PtyMessage.WriterChanged));
+          var kinds = frames.stream().map(m -> m.getClass().getSimpleName()).toList();
+          assertEquals(
+              new PtyMessage.Resized(126, 40),
+              frames.getFirst(),
+              "the writer's geometry is the first frame: " + kinds);
+          assertEquals("ReplayBegin", kinds.get(1), kinds.toString());
+          assertEquals(
+              List.of("ReplayEnd", "WriterChanged"),
+              kinds.subList(kinds.size() - 2, kinds.size()),
+              "the token holder is named right after the replay: " + kinds);
+          assertEquals(
+              new PtyMessage.WriterChanged("uday"),
+              frames.getLast(),
+              "a different FDE asking for write is told who holds it, not given it");
+        }
+      }
+    }
+  }
+
+  @Test
+  void aRevokedCredentialIsSeveredAtTheNextSweep() throws Exception {
+    try (var ignored = startHost()) {
+      try (var mady = connect("tok-mady")) {
+        PtyWire.write(
+            mady,
+            new PtyMessage.Create(
+                "hers", List.of("sh", "-c", "echo up; read a"), "/tmp", "", "", 80, 24));
+        assertInstanceOf(PtyMessage.Ok.class, readControl(mady));
+        PtyWire.write(mady, new PtyMessage.Attach("hers", true));
+        assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(mady));
+        awaitText(mady, "up");
+
+        revoked.add("tok-mady");
+        host.sweep(System.nanoTime());
+
+        assertThrows(
+            IOException.class,
+            () -> {
+              while (true) {
+                PtyWire.read(mady);
+              }
+            },
+            "the severed connection reads nothing more");
+        try (var admin = connect("tok-root")) {
+          var deadline = System.nanoTime() + 10_000_000_000L;
+          while (true) {
+            PtyWire.write(admin, new PtyMessage.ListSessions("", PtyMessage.PAGE_LIMIT));
+            var listed = (PtyMessage.Sessions) readControl(admin);
+            var hers = listed.sessions().stream().filter(s -> s.name().equals("hers")).findFirst();
+            if (hers.isPresent() && hers.get().attached() == 0) {
+              break;
+            }
+            if (System.nanoTime() > deadline) {
+              throw new AssertionError("the attachment was never dropped: " + listed);
+            }
+          }
+        }
+        assertThrows(
+            IOException.class, () -> connect("tok-mady"), "and the credential no longer admits");
+      }
+    }
+  }
+
+  @Test
   void aNonWritersInputIsRefusedWithoutKillingTheConnection() throws Exception {
     try (var ignored = startHost()) {
       try (var owner = connect("tok-uday")) {
@@ -602,7 +703,7 @@ class PtySessionHostTest {
 
         PtyWire.write(channel, new PtyMessage.Attach("s1", true));
         assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
-        assertInstanceOf(PtyMessage.ReplayBegin.class, PtyWire.read(channel));
+        assertAttachPrologue(channel);
         awaitText(channel, "hi");
 
         PtyWire.write(channel, new PtyMessage.Input(1, "world\n".getBytes(StandardCharsets.UTF_8)));
@@ -612,7 +713,7 @@ class PtySessionHostTest {
       try (var again = connect()) {
         PtyWire.write(again, new PtyMessage.Attach("s1", true));
         assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(again));
-        assertInstanceOf(PtyMessage.ReplayBegin.class, PtyWire.read(again));
+        assertAttachPrologue(again);
         awaitText(again, "bye:world");
       }
     }
@@ -640,7 +741,7 @@ class PtySessionHostTest {
 
         PtyWire.write(channel, new PtyMessage.Attach("dup", false));
         assertInstanceOf(PtyMessage.Ok.class, PtyWire.read(channel));
-        assertInstanceOf(PtyMessage.ReplayBegin.class, PtyWire.read(channel));
+        assertAttachPrologue(channel);
         var replayed = new StringBuilder();
         PtyMessage message;
         while (!((message = PtyWire.read(channel)) instanceof PtyMessage.ReplayEnd)) {

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/AttachLoop.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/AttachLoop.java
@@ -17,9 +17,9 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * The interactive half of {@code sail session attach}, free of terminal-mode side effects so it is
  * testable with plain streams: pumps stdin to {@code Input} frames (detaching on Ctrl-]), renders
- * {@code Output} bytes to stdout, narrates flow control and the host's refusals inline (a rejected
- * keystroke is never silently lost). Returns the ending reason, or null when the operator detached
- * and the session lives on.
+ * {@code Output} bytes to stdout, narrates flow control, the write token's holder, a replay that
+ * starts mid-sequence, and the host's refusals inline (a rejected keystroke is never silently
+ * lost). Returns the ending reason, or null when the operator detached and the session lives on.
  */
 public final class AttachLoop {
 
@@ -108,16 +108,19 @@ public final class AttachLoop {
           case PtyMessage.Ok ok -> {
             return null;
           }
-          case PtyMessage.Paused paused ->
-              stdout.write(
-                  "\r\n[sail: output paused — falling behind]\r\n"
-                      .getBytes(StandardCharsets.UTF_8));
-          case PtyMessage.Continued resumed ->
-              stdout.write("\r\n[sail: output resumed]\r\n".getBytes(StandardCharsets.UTF_8));
-          case PtyMessage.Err(var refusal) -> {
-            stdout.write(("\r\n[sail: " + refusal + "]\r\n").getBytes(StandardCharsets.UTF_8));
-            stdout.flush();
+          case PtyMessage.Paused paused -> narrate(stdout, "output paused — falling behind");
+          case PtyMessage.Continued resumed -> narrate(stdout, "output resumed");
+          case PtyMessage.WriterChanged(var fde) ->
+              narrate(
+                  stdout,
+                  fde.isBlank() ? "nobody holds the write token" : fde + " holds the write token");
+          case PtyMessage.ReplayBegin(var safe) -> {
+            if (!safe) {
+              narrate(
+                  stdout, "history resumes mid-sequence; the screen settles on the next redraw");
+            }
           }
+          case PtyMessage.Err(var refusal) -> narrate(stdout, refusal);
           default -> {}
         }
       }
@@ -127,5 +130,10 @@ public final class AttachLoop {
       pump.interrupt();
       resizer.interrupt();
     }
+  }
+
+  private static void narrate(OutputStream stdout, String line) throws IOException {
+    stdout.write(("\r\n[sail: " + line + "]\r\n").getBytes(StandardCharsets.UTF_8));
+    stdout.flush();
   }
 }

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -12,6 +12,7 @@ import ai.singlr.sail.engine.ContainerSailSetup;
 import ai.singlr.sail.engine.ContainerState;
 import ai.singlr.sail.engine.DemoSeeder;
 import ai.singlr.sail.engine.FileImporter;
+import ai.singlr.sail.engine.IncusDeviceManager;
 import ai.singlr.sail.engine.ProjectImporter;
 import ai.singlr.sail.engine.PtyHostUnit;
 import ai.singlr.sail.engine.SailPaths;
@@ -289,10 +290,13 @@ public final class MigrateCommand implements Runnable {
   }
 
   /**
-   * Brings every running project container's sail machinery — the event-socket bind mount and every
+   * Brings every running Sail container's machinery — the event-socket bind mount and every
    * sail-owned file, the sshd drop-in included — up to this binary's payloads, so an upgrade
-   * converges containers without waiting for the next dispatch to heal them. Needs root for the
-   * {@code incus} calls; a container that fails is named with the command that converges it.
+   * converges containers without waiting for the next dispatch to heal them. Only instances Sail
+   * itself provisioned qualify (the same provenance gate {@code project apply --all} trusts): a
+   * foreign container on the host must never be handed the API socket and box credential by an
+   * upgrade. Needs root for the {@code incus} calls; a container that fails is named with the
+   * command that converges it.
    *
    * <p>The socket's host directory is created (and made traversable) first, because {@code sail
    * upgrade} runs migrate <em>before</em> it restarts {@code sail-api} onto the new path — so the
@@ -323,7 +327,7 @@ public final class MigrateCommand implements Runnable {
       return;
     }
     var converged = 0;
-    for (var name : names) {
+    for (var name : sailManagedContainers(names, new IncusDeviceManager(shell))) {
       try {
         if (ContainerSailSetup.ensureInstalled(shell, name) == ContainerSailSetup.Result.UPDATED) {
           converged++;
@@ -343,6 +347,23 @@ public final class MigrateCommand implements Runnable {
       System.out.println(
           Ansi.AUTO.string(
               "  @|green ✓|@ converged sail machinery in " + converged + " container(s)"));
+    }
+  }
+
+  /**
+   * The instances among {@code names} that carry Sail's provenance marker. A probe that fails
+   * counts as foreign: migration converges what it can prove is Sail's and claims nothing else.
+   * Pure for testing.
+   */
+  static List<String> sailManagedContainers(List<String> names, IncusDeviceManager devices) {
+    return names.stream().filter(name -> sailManaged(name, devices)).toList();
+  }
+
+  private static boolean sailManaged(String name, IncusDeviceManager devices) {
+    try {
+      return ProjectApplyCommand.sailManaged(name, devices);
+    } catch (Exception e) {
+      return false;
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/commands/MigrateCommand.java
@@ -9,9 +9,9 @@ import ai.singlr.sail.common.Strings;
 import ai.singlr.sail.engine.AuthorizedKeysSync;
 import ai.singlr.sail.engine.ContainerManager;
 import ai.singlr.sail.engine.ContainerSailSetup;
+import ai.singlr.sail.engine.ContainerState;
 import ai.singlr.sail.engine.DemoSeeder;
 import ai.singlr.sail.engine.FileImporter;
-import ai.singlr.sail.engine.IncusDeviceManager;
 import ai.singlr.sail.engine.ProjectImporter;
 import ai.singlr.sail.engine.PtyHostUnit;
 import ai.singlr.sail.engine.SailPaths;
@@ -19,6 +19,7 @@ import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.ShellExecutor;
 import ai.singlr.sail.engine.Spinner;
 import ai.singlr.sail.engine.SshIdentityProvisioner;
+import ai.singlr.sail.engine.SshdKeepalive;
 import ai.singlr.sail.engine.SystemdServiceInstaller;
 import ai.singlr.sail.store.DataMigration;
 import ai.singlr.sail.store.DataMigrations;
@@ -39,7 +40,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.Model.CommandSpec;
@@ -97,7 +97,8 @@ public final class MigrateCommand implements Runnable {
       applyDataImports(db, jsonOutput);
       relocateHostConfig(jsonOutput);
       syncAuthorizedKeys(db, jsonOutput);
-      relocateContainerSockets(jsonOutput);
+      ensureSshdKeepalive(jsonOutput);
+      convergeContainers(jsonOutput);
       ensurePtyHostService(jsonOutput);
       return runs;
     }
@@ -248,20 +249,57 @@ public final class MigrateCommand implements Runnable {
   }
 
   /**
-   * Re-points every project container's event-socket bind mount from the legacy {@code /run/sail}
-   * location to the current {@link SailPaths#apiSocketHostDir()} after the socket moved off the
-   * volatile {@code /run} tmpfs. Idempotent and quiet: a container already on the new source is
-   * skipped, one without the device is left untouched (provisioning owns that). Needs root for the
-   * {@code incus} calls; {@link ContainerSailSetup#ensureInstalled} re-adds the device live and
-   * rewrites the in-container scripts to the new path.
-   *
-   * <p>The new host directory is created (and made traversable) first, because {@code sail upgrade}
-   * runs migrate <em>before</em> it restarts {@code sail-api} onto the new path — so the bind-mount
-   * source must exist here, or the re-pointed mounts would strand on a missing directory until the
-   * server start materializes it. The directory bind mount then surfaces the socket the moment the
-   * restart binds it.
+   * Writes the {@link SshdKeepalive} drop-in on the host and reloads sshd when it changed. Lives
+   * here for the same reason {@link #syncAuthorizedKeys} does: an upgrade is executed by the OLD
+   * binary, which re-execs the NEW binary's {@code migrate}, so this is the one step every upgrade
+   * path runs with new-binary code. Needs root; quiet and never fatal otherwise.
    */
-  private static void relocateContainerSockets(boolean jsonOutput) {
+  private static void ensureSshdKeepalive(boolean jsonOutput) {
+    ensureSshdKeepalive(
+        SailPaths.isRoot(),
+        new ShellExecutor(false),
+        Path.of(SshdKeepalive.DROP_IN_PATH),
+        jsonOutput);
+  }
+
+  static void ensureSshdKeepalive(boolean root, ShellExec shell, Path dropIn, boolean jsonOutput) {
+    if (!root) {
+      return;
+    }
+    try {
+      if (Files.exists(dropIn) && Files.readString(dropIn).equals(SshdKeepalive.content())) {
+        return;
+      }
+      var result = shell.exec(SshdKeepalive.installCommand(dropIn.toString()));
+      if (!result.ok()) {
+        throw new IOException(result.stderr());
+      }
+      if (!jsonOutput) {
+        System.out.println(Ansi.AUTO.string("  @|green ✓|@ sshd keepalive drop-in written"));
+      }
+    } catch (IOException | TimeoutException e) {
+      if (!jsonOutput) {
+        System.out.println(
+            Ansi.AUTO.string(
+                "  @|yellow ⚠|@ sshd keepalive drop-in not written: " + e.getMessage()));
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /**
+   * Brings every running project container's sail machinery — the event-socket bind mount and every
+   * sail-owned file, the sshd drop-in included — up to this binary's payloads, so an upgrade
+   * converges containers without waiting for the next dispatch to heal them. Needs root for the
+   * {@code incus} calls; a container that fails is named with the command that converges it.
+   *
+   * <p>The socket's host directory is created (and made traversable) first, because {@code sail
+   * upgrade} runs migrate <em>before</em> it restarts {@code sail-api} onto the new path — so the
+   * bind-mount source must exist here, or the re-pointed mounts would strand on a missing directory
+   * until the server start materializes it.
+   */
+  private static void convergeContainers(boolean jsonOutput) {
     if (!SailPaths.isRoot()) {
       return;
     }
@@ -273,60 +311,38 @@ public final class MigrateCommand implements Runnable {
       return;
     }
     var shell = new ShellExecutor(false);
-    var devices = new IncusDeviceManager(shell);
-    var desired = hostDir.toString();
     List<String> names;
     try {
       names =
           new ContainerManager(shell)
-              .listAll().stream().map(ContainerManager.ContainerInfo::name).toList();
+              .listAll().stream()
+                  .filter(info -> info.state() instanceof ContainerState.Running)
+                  .map(ContainerManager.ContainerInfo::name)
+                  .toList();
     } catch (Exception e) {
       return;
     }
-    var moved = 0;
-    for (var name : containersToRelocate(names, n -> currentSocketSource(devices, n), desired)) {
+    var converged = 0;
+    for (var name : names) {
       try {
-        ContainerSailSetup.ensureInstalled(shell, name);
-        moved++;
+        if (ContainerSailSetup.ensureInstalled(shell, name) == ContainerSailSetup.Result.UPDATED) {
+          converged++;
+        }
       } catch (Exception e) {
         System.err.println(
-            "  socket relocation for "
+            "  machinery for "
                 + name
-                + " failed: "
+                + " not converged: "
                 + e.getMessage()
                 + ". Converge with 'sudo sail project apply "
                 + name
                 + "'.");
       }
     }
-    if (!jsonOutput && moved > 0) {
+    if (!jsonOutput && converged > 0) {
       System.out.println(
           Ansi.AUTO.string(
-              "  @|green ✓|@ re-pointed " + moved + " container socket(s) to " + desired));
-    }
-  }
-
-  /**
-   * The containers whose event-socket device exists but still points at a source other than {@code
-   * desired}. A {@code null} source (no device) is skipped — provisioning, not migration, owns
-   * that. Pure for testing.
-   */
-  static List<String> containersToRelocate(
-      List<String> names, UnaryOperator<String> sourceOf, String desired) {
-    return names.stream()
-        .filter(
-            name -> {
-              var source = sourceOf.apply(name);
-              return source != null && !desired.equals(source);
-            })
-        .toList();
-  }
-
-  private static String currentSocketSource(IncusDeviceManager devices, String container) {
-    try {
-      return devices.currentEventSocketSource(container);
-    } catch (Exception e) {
-      return null;
+              "  @|green ✓|@ converged sail machinery in " + converged + " container(s)"));
     }
   }
 

--- a/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
+++ b/sail-infra/src/main/java/ai/singlr/sail/engine/ContainerSailSetup.java
@@ -85,6 +85,7 @@ public final class ContainerSailSetup {
     new SpecCliHelper(shell).install(container);
     new ClaudeCodeHookConfig(shell).install(container);
     new CodexHookConfig(shell).install(container);
+    new SshdKeepalive(shell).install(container);
     writeStamp(shell, container, expected);
     return Result.UPDATED;
   }
@@ -124,6 +125,7 @@ public final class ContainerSailSetup {
     files.put(SpecCliHelper.PROFILE_PATH, SpecCliHelper.profileLine());
     files.put(ClaudeCodeHookConfig.SETTINGS_PATH, ClaudeCodeHookConfig.render());
     files.put(CodexHookConfig.SETTINGS_PATH, CodexHookConfig.render());
+    files.put(SshdKeepalive.DROP_IN_PATH, SshdKeepalive.content());
     return files;
   }
 

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
@@ -52,9 +52,82 @@ class AttachLoopTest {
         var reason = AttachLoop.run(channel, stdin, stdout);
 
         assertEquals("exited(0)", reason);
-        assertTrue(stdout.toString(StandardCharsets.UTF_8).contains("pty-says:hello"));
+        var rendered = stdout.toString(StandardCharsets.UTF_8);
+        assertTrue(rendered.contains("pty-says:hello"));
+        assertTrue(
+            rendered.contains("[sail: uday holds the write token]"),
+            "the host's answer to the attach names the keyboard's holder: " + rendered);
       }
     }
+  }
+
+  @Test
+  void anObserverAndAMidSequenceReplayAreNarratedNotDropped() throws Exception {
+    var frames = new ByteArrayOutputStream();
+    var sink = java.nio.channels.Channels.newChannel(frames);
+    ai.singlr.sail.pty.PtyWire.write(sink, new ai.singlr.sail.pty.PtyMessage.ReplayBegin(false));
+    ai.singlr.sail.pty.PtyWire.write(
+        sink,
+        new ai.singlr.sail.pty.PtyMessage.Output(-1, "old\n".getBytes(StandardCharsets.UTF_8)));
+    ai.singlr.sail.pty.PtyWire.write(sink, new ai.singlr.sail.pty.PtyMessage.ReplayEnd());
+    ai.singlr.sail.pty.PtyWire.write(sink, new ai.singlr.sail.pty.PtyMessage.WriterChanged("mady"));
+    ai.singlr.sail.pty.PtyWire.write(sink, new ai.singlr.sail.pty.PtyMessage.WriterChanged(""));
+    ai.singlr.sail.pty.PtyWire.write(
+        sink, new ai.singlr.sail.pty.PtyMessage.SessionEnded("exited(0)"));
+    var stdout = new ByteArrayOutputStream();
+
+    var reason =
+        AttachLoop.run(new ScriptedChannel(frames.toByteArray()), new PipedInputStream(), stdout);
+
+    assertEquals("exited(0)", reason);
+    var rendered = stdout.toString(StandardCharsets.UTF_8);
+    var expectedOrder =
+        List.of(
+            "[sail: history resumes mid-sequence; the screen settles on the next redraw]",
+            "old",
+            "[sail: mady holds the write token]",
+            "[sail: nobody holds the write token]");
+    var at = -1;
+    for (var line : expectedOrder) {
+      var next = rendered.indexOf(line, at + 1);
+      assertTrue(next > at, "expected '" + line + "' in order in: " + rendered);
+      at = next;
+    }
+  }
+
+  /** A host that has already said everything it will: the frames, then end of stream. */
+  private static final class ScriptedChannel implements java.nio.channels.ByteChannel {
+    private final java.nio.ByteBuffer script;
+
+    ScriptedChannel(byte[] frames) {
+      this.script = java.nio.ByteBuffer.wrap(frames);
+    }
+
+    @Override
+    public int read(java.nio.ByteBuffer dst) {
+      if (!script.hasRemaining()) {
+        return -1;
+      }
+      var n = Math.min(dst.remaining(), script.remaining());
+      dst.put(script.slice(script.position(), n));
+      script.position(script.position() + n);
+      return n;
+    }
+
+    @Override
+    public int write(java.nio.ByteBuffer src) {
+      var n = src.remaining();
+      src.position(src.limit());
+      return n;
+    }
+
+    @Override
+    public boolean isOpen() {
+      return true;
+    }
+
+    @Override
+    public void close() {}
   }
 
   @Test

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/AttachLoopTest.java
@@ -238,7 +238,7 @@ class AttachLoopTest {
               @Override
               public synchronized void write(byte[] b, int off, int len) {
                 super.write(b, off, len);
-                if (toString(StandardCharsets.UTF_8).contains("[sail: ")) {
+                if (toString(StandardCharsets.UTF_8).contains("You do not hold the write token")) {
                   refused.countDown();
                 }
               }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.singlr.sail.engine.ScriptedShellExecutor;
 import ai.singlr.sail.engine.ShellExec;
+import ai.singlr.sail.engine.SshdKeepalive;
 import ai.singlr.sail.engine.SystemdServiceInstaller;
 import ai.singlr.sail.store.DataMigration;
 import ai.singlr.sail.store.LegacyDataMigration;
@@ -20,8 +21,6 @@ import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.function.UnaryOperator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -97,20 +96,25 @@ class MigrateCommandTest {
   }
 
   @Test
-  void containersToRelocateSelectsOnlyDevicesStillOnTheOldSource() {
-    UnaryOperator<String> sourceOf =
-        name ->
-            switch (name) {
-              case "old-box" -> "/run/sail";
-              case "new-box" -> "/var/lib/sail/run";
-              default -> null;
-            };
+  void ensureSshdKeepaliveWritesTheDropInAsRootAndLeavesACurrentOneAlone(@TempDir Path etc)
+      throws Exception {
+    var dropIn = etc.resolve("sshd_config.d/10-sail.conf");
+    var shell = new ScriptedShellExecutor(new ShellExec.Result(0, "", ""));
 
-    var targets =
-        MigrateCommand.containersToRelocate(
-            List.of("old-box", "new-box", "no-device"), sourceOf, "/var/lib/sail/run");
+    MigrateCommand.ensureSshdKeepalive(false, shell, dropIn, true);
+    assertTrue(shell.invocations().isEmpty(), "a non-root migrate never touches sshd");
 
-    assertEquals(
-        List.of("old-box"), targets, "only a device still on the old source is re-pointed");
+    MigrateCommand.ensureSshdKeepalive(true, shell, dropIn, true);
+    assertEquals(1, shell.invocations().size(), "root writes the drop-in and reloads sshd");
+    var install = shell.invocations().getFirst();
+    assertTrue(install.contains("ClientAliveInterval 15"), install);
+    assertTrue(install.contains("ClientAliveCountMax 3"), install);
+    assertTrue(install.contains(dropIn.toString()), install);
+    assertTrue(install.contains("systemctl reload ssh"), install);
+
+    Files.createDirectories(dropIn.getParent());
+    Files.writeString(dropIn, SshdKeepalive.content());
+    MigrateCommand.ensureSshdKeepalive(true, shell, dropIn, true);
+    assertEquals(1, shell.invocations().size(), "a drop-in already current is left alone");
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/commands/MigrateCommandTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.singlr.sail.engine.IncusDeviceManager;
 import ai.singlr.sail.engine.ScriptedShellExecutor;
 import ai.singlr.sail.engine.ShellExec;
 import ai.singlr.sail.engine.SshdKeepalive;
@@ -21,6 +22,7 @@ import ai.singlr.sail.store.SpecStore;
 import ai.singlr.sail.store.Sqlite;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -116,5 +118,23 @@ class MigrateCommandTest {
     Files.writeString(dropIn, SshdKeepalive.content());
     MigrateCommand.ensureSshdKeepalive(true, shell, dropIn, true);
     assertEquals(1, shell.invocations().size(), "a drop-in already current is left alone");
+  }
+
+  @Test
+  void migrationConvergesOnlyTheContainersSailProvisioned() {
+    var probe =
+        new ScriptedShellExecutor()
+            .onOk("incus config device get app sail-api-sock source", "/var/lib/sail/api");
+    var devices = new IncusDeviceManager(probe);
+
+    assertEquals(
+        List.of("app"),
+        MigrateCommand.sailManagedContainers(List.of("app", "stranger", "Not_A_Project"), devices),
+        "an upgrade converges Sail's containers; a foreign instance on the same host must never"
+            + " be handed the API socket, the box credential, or the provenance marker apply --all"
+            + " trusts");
+    assertTrue(
+        probe.invocations().stream().noneMatch(cmd -> cmd.contains("Not_A_Project")),
+        "an invalid name never reaches incus");
   }
 }

--- a/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerSailSetupTest.java
+++ b/sail-infra/src/test/java/ai/singlr/sail/engine/ContainerSailSetupTest.java
@@ -106,6 +106,28 @@ class ContainerSailSetupTest {
   }
 
   @Test
+  void theSshdKeepaliveDropInIsMachineryInstalledAsRootAndVerifiedLikeTheRest() throws Exception {
+    assertEquals(
+        SshdKeepalive.content(),
+        ContainerSailSetup.installedFiles().get(SshdKeepalive.DROP_IN_PATH),
+        "the drop-in is a fingerprinted payload: a stale container heals it on the next probe");
+    var shell =
+        new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
+            .onOk("config device get " + CONTAINER, "/run/sail\n")
+            .onFail(PROBE, "stale");
+
+    ContainerSailSetup.ensureInstalled(shell, CONTAINER);
+
+    var install =
+        shell.invocations().stream()
+            .filter(c -> c.contains(SshdKeepalive.DROP_IN_PATH) && !c.contains(PROBE))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(install.startsWith("incus exec " + CONTAINER + " -- bash"), install);
+    assertFalse(install.contains("--user 1000"), "sshd's config is root's to write: " + install);
+  }
+
+  @Test
   void aFailedVerificationInstallsEverythingAndStamps() throws Exception {
     var shell =
         new ScriptedShellExecutor(new ShellExec.Result(0, "", ""))
@@ -193,7 +215,8 @@ class ContainerSailSetupTest {
             SpecCliHelper.SCRIPT_PATH,
             SpecCliHelper.PROFILE_PATH,
             ClaudeCodeHookConfig.SETTINGS_PATH,
-            CodexHookConfig.SETTINGS_PATH),
+            CodexHookConfig.SETTINGS_PATH,
+            SshdKeepalive.DROP_IN_PATH),
         java.util.List.copyOf(files.keySet()),
         "the fingerprint must cover every sail-owned in-container file, in stable order — a"
             + " script riding in this list IS its rollout: the fingerprint changes and every"


### PR DESCRIPTION
## Why

A laptop sleeps or changes networks. Mast's russh keepalive drops the client side, but sshd on the box never learns the peer died (no `ClientAliveInterval`), so the old serve thread stays parked holding the write token. The returning pane attaches as a silent observer for up to two hours. And the attach replay carried no geometry, so a pane whose size differed from the pty's parsed the replay at the wrong width (the Claude Code staircase).

Spec: `sail-pty-write-reclaim`. Sail half; the Mast half is standardapplied/mast#106. No wire version bump — every frame already existed.

## What

- **Attach answers with the geometry, the replay, then the writer.** `PtySession.attach` seeds the subscriber with `Resized(cols, rows)` (the pty's live size, tracked by the session and updated under the fanout lock on resize) before `ReplayBegin`, and `WriterChanged(current)` right after `ReplayEnd`.
- **Same-FDE reclaim.** `Attach(write=true)` takes the token when its holder is the same FDE on another connection (via the existing `takeWrite` path, so the ghost and everyone else hear `WriterChanged`); the ghost's next `Input` is refused. A different FDE still waits and is told who holds it.
- **Revoked credentials are severed.** The host sweep re-resolves every admitted connection's token (once per distinct token) and closes those the resolver refuses. A resolver that cannot answer (store down) severs nothing.
- **sshd learns about dead peers.** New `SshdKeepalive` payload (`/etc/ssh/sshd_config.d/10-sail.conf`: `ClientAliveInterval 15`, `ClientAliveCountMax 3`). Installed as root in every container as part of the fingerprinted machinery; `sail migrate` writes it on the host (root only, reload sshd when changed) and now converges every running container's machinery on upgrade, replacing the socket-only relocation pass.
- **`sail session attach` narrates** the token holder and a mid-sequence replay instead of dropping the frames.

## Tests (red-first)

- `PtySessionTest`: attach delivers `Resized(126,40)` first, `ReplayBegin` second, `WriterChanged` right after `ReplayEnd`; same FDE reclaims from its ghost (ghost input refused, ghost hears `WriterChanged`), a different FDE gets no token and is told who holds it.
- `PtySessionHostTest`: the frame order on the wire; a revoked token is severed at the next sweep (read fails, attachment count drops, credential no longer admits).
- `SshdKeepaliveTest`: real bash install script against a shadowed `systemctl` (file written 0644, reload only when sshd is active); container install runs as root.
- `ContainerSailSetupTest` / `MigrateCommandTest`: the drop-in is a fingerprinted payload; the host step writes once, is root-only, and leaves a current drop-in alone.
- `AttachLoopTest`: scripted channel proves the narration order.

`mvn clean verify` green (3017 tests).

## Field checks (after `sail upgrade` on the fleet, before the Mast update)

- Box journal shows `sshd` closing an idle client within ~1 min after pulling the network.
- `cat /etc/ssh/sshd_config.d/10-sail.conf` on host and in a container.
- With the Mast half: sleep the Mac 2 min mid-Claude-Code → wake → screen intact, typing lands.

Fleet order: release sail first; `sail upgrade` restarts the pty host (live sessions end), then the Mast update.


## Post-review (pre-merge)

- **A resync answers like an attach** (b04d9201). The overflow that pauses a subscriber clears every pending frame — the attach's `Resized` and `WriterChanged` included — and `resync` reinstalled only the replay, so a pane that fell behind during its own attach never learned it held the token and stayed letterboxed (review iteration 2's below-gate medium). `resync` now frames its snapshot `Resized` → replay → `WriterChanged`, under the session monitor so a racing token transfer is heard after it. Red-first `PtySessionTest` reproduces the reviewer's exact sequence on the old code.
- **A grant never throws after `Ok`** (b04d9201). Attach granted through `takeWrite`, whose roster check throws when the session ended between the seed and the grant — after the host had already replied `Ok`, leaving the ending undelivered. The grant is a private step the attach vouches for.
- **Tests wait for the frame they assert** (1c613283). Monitor waits replace sleep-polling; four pre-existing assertion races they exposed (one hit CI's Incus lane) are fixed structurally. Under a full-core load, main fails two of these tests in four runs of five; this branch passes six of six.

`mvn clean verify` green (3018 tests).
